### PR TITLE
Add PageBreak to each phase (fixes #40)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,4 @@ typings/
 
 # Build
 build/
-.vscode/settings.json
+.vscode/

--- a/src/components/info/reminders.css
+++ b/src/components/info/reminders.css
@@ -1,7 +1,3 @@
-.Reminders {
-    padding: 40px;
-}
-
 .ReminderEntry {
     font-size: 1rem;
     padding-top: 0.5rem;
@@ -16,4 +12,14 @@
 }
 small {
     font-size: 12px;
+}
+
+.PageBreak {
+    /* https://www.w3schools.com/cssref/pr_print_pagebi.asp */
+    page-break-inside: avoid !important;
+}
+
+/* https://developer.mozilla.org/en-US/docs/Web/CSS/@page */
+@page {
+    margin: 20cm;
 }

--- a/src/components/info/reminders.tsx
+++ b/src/components/info/reminders.tsx
@@ -34,7 +34,7 @@ const Reminders = (props: IRemindersProps) => {
 
 const Entry = (props: { when: string; actions: ITurnAction[]; idx: number; factionName: TSupportedFaction }) => {
   return (
-    <div className="row d-block">
+    <div className="row d-block PageBreak">
       <div className="card border-dark my-3">
         <div className="card-header text-center">
           <h4 className="ReminderHeader">{titleCase(props.when)}</h4>


### PR DESCRIPTION
Per #40 , added `page-break-inside` properties to each phase to prevent breaking cards across pages.