### PR TITLE
Dispossessed

### DIFF
--- a/src/army/dispossessed/abilities.ts
+++ b/src/army/dispossessed/abilities.ts
@@ -1,12 +1,34 @@
-import { HERO_PHASE } from 'types/phases'
-import { IEffects } from 'types/data'
+import { HERO_PHASE, DURING_GAME, END_OF_SETUP } from '../../types/phases'
+import { IEffects } from '../../types/data'
 
 // General Allegiance Abilities (always active regardless of army composition)
 const Abilities: IEffects[] = [
   {
-    name: ``,
-    desc: ``,
-    when: [HERO_PHASE],
+    name: `Stubborn to the End`,
+    desc: `If you roll a 1, 2 or 3 (before modifiers are applied) when taking a battleshock test for a friendly DISPOSSESSED unit, that unit is treated as having passed the battleshock test irrespective of any modifiers to the battleshock test or their Bravery characteristic.`,
+    when: [DURING_GAME],
+  },
+  {
+    name: `Grudgebound`,
+    desc: `After set-up is complete, but before the battle begins, choose or roll for a grudge from the table on the right. The rules for that grudge apply to all friendly DISPOSSESSED units for the duration of the battle.
+    
+    1 - Stuck-up: You can re-roll hit rolls of 1 for friendly DISPOSSESSED units if the target of the attack is an enemy HERO. 
+    
+    2 Speed Merchants: You can re-roll hit rolls of 1 for friendly DISPOSSESSED units if the target of the attack has a Move characteristic of 10+.
+    
+    3 Monstrous Cheaters: You can re-roll hit rolls of 1 for friendly DISPOSSESSED units if the target of the attack is an enemy MONSTER. 
+    
+    4 Cowardly Hordes: You can re-roll hit rolls of 1 for friendly DISPOSSESSED units if the target of the attack is in an enemy unit that had twenty or more models when it was set up. 
+    
+    5 Shoddy Craftsmanship: You can re-roll hit rolls of 1 for friendly DISPOSSESSED units if the target of the attack has a Save characteristic of 2+, 3+, or 4+ . 
+    
+    6 Sneaky Ambushers: You can re-roll hit rolls of 1 for friendly DISPOSSESSED units if the target of the attack is in cover, or did not start the battle set up on the battlefield.`,
+    when: [END_OF_SETUP],
+  },
+  {
+    name: `Grudgebound`,
+    desc: `Refer to the grudge you chose (or rolled for) in the "End of Setup" section.`,
+    when: [DURING_GAME],
   },
 ]
 

--- a/src/army/dispossessed/abilities.ts
+++ b/src/army/dispossessed/abilities.ts
@@ -1,5 +1,5 @@
-import { HERO_PHASE, DURING_GAME, END_OF_SETUP } from '../../types/phases'
-import { IEffects } from '../../types/data'
+import { DURING_GAME, END_OF_SETUP } from 'types/phases'
+import { IEffects } from 'types/data'
 
 // General Allegiance Abilities (always active regardless of army composition)
 const Abilities: IEffects[] = [

--- a/src/army/dispossessed/abilities.ts
+++ b/src/army/dispossessed/abilities.ts
@@ -1,0 +1,13 @@
+import { HERO_PHASE } from 'types/phases'
+import { IEffects } from 'types/data'
+
+// General Allegiance Abilities (always active regardless of army composition)
+const Abilities: IEffects[] = [
+  {
+    name: ``,
+    desc: ``,
+    when: [HERO_PHASE],
+  },
+]
+
+export default Abilities

--- a/src/army/dispossessed/artifacts.ts
+++ b/src/army/dispossessed/artifacts.ts
@@ -1,0 +1,17 @@
+import { TArtifacts } from 'types/army'
+import { HERO_PHASE } from 'types/phases'
+
+const Artifacts: TArtifacts = [
+  {
+    name: ``,
+    effects: [
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+]
+
+export default Artifacts

--- a/src/army/dispossessed/artifacts.ts
+++ b/src/army/dispossessed/artifacts.ts
@@ -1,14 +1,13 @@
-import { TArtifacts } from '../../types/army'
+import { TArtifacts } from 'types/army'
 import {
-  HERO_PHASE,
   DURING_GAME,
   END_OF_MOVEMENT_PHASE,
-  START_OF_MOVEMENT_PHASE,
-  START_OF_SHOOTING_PHASE,
   END_OF_SETUP,
   START_OF_COMBAT_PHASE,
   START_OF_HERO_PHASE,
-} from '../../types/phases'
+  START_OF_MOVEMENT_PHASE,
+  START_OF_SHOOTING_PHASE,
+} from 'types/phases'
 
 const Artifacts: TArtifacts = [
   {

--- a/src/army/dispossessed/artifacts.ts
+++ b/src/army/dispossessed/artifacts.ts
@@ -1,14 +1,83 @@
-import { TArtifacts } from 'types/army'
-import { HERO_PHASE } from 'types/phases'
+import { TArtifacts } from '../../types/army'
+import {
+  HERO_PHASE,
+  DURING_GAME,
+  END_OF_MOVEMENT_PHASE,
+  START_OF_MOVEMENT_PHASE,
+  START_OF_SHOOTING_PHASE,
+  END_OF_SETUP,
+  START_OF_COMBAT_PHASE,
+  START_OF_HERO_PHASE,
+} from '../../types/phases'
 
 const Artifacts: TArtifacts = [
   {
-    name: ``,
+    name: `Heavy Metal Ingot`,
     effects: [
       {
-        name: ``,
-        desc: ``,
-        when: [HERO_PHASE],
+        name: `Heavy Metal Ingot`,
+        desc: `You can re-roll failed save rolls for the bearer as long as they have not made a move in the same turn.`,
+        when: [DURING_GAME],
+      },
+    ],
+  },
+  {
+    name: `Ancestral Pickaxe`,
+    effects: [
+      {
+        name: `Ancestral Pickaxe`,
+        desc: `Once per the battle, at the start of your movement phase, you can remove the bearer and up to 1 other friendly DISPOSSESSED unit within 6" of the bearer from the battlefield. They may be set up at the end of your next movement phase.`,
+        when: [START_OF_MOVEMENT_PHASE],
+      },
+      {
+        name: `Ancestral Pickaxe`,
+        desc: `Units removed in your last movement phase may be set up anywhere on the battlefield, wholly within 6" of each other and more than 9" away from enemy models.`,
+        when: [END_OF_MOVEMENT_PHASE],
+      },
+    ],
+  },
+  {
+    name: `Teardrop of Grungni`,
+    effects: [
+      {
+        name: `Teardrop of Grungni`,
+        desc: `Once per battle, at the start of your shooting phase, pick an enemy unit within 6" of the bearer. That unit suffers D3 mortal wounds. In addition, if the target is a HERO or MONSTER, it must halve its Move characteristic in its next movement phase.`,
+        when: [START_OF_SHOOTING_PHASE],
+      },
+    ],
+  },
+  {
+    name: `Grudge Rune`,
+    effects: [
+      {
+        name: `Grudge Rune`,
+        desc: `After set up is complete but before the battle begins, pick an enemy HERO. You can re-roll failed hit and wound rolls for the bearer if the target of the attack is the enemy HERO you picked.`,
+        when: [END_OF_SETUP],
+      },
+      {
+        name: `Grudge Rune`,
+        desc: `You can re-roll failed hit and wound rolls for the bearer if the target of the attack is the enemy HERO you picked before the battle begun.`,
+        when: [DURING_GAME],
+      },
+    ],
+  },
+  {
+    name: `Piledriver Gauntlets`,
+    effects: [
+      {
+        name: `Piledriver Gauntlets`,
+        desc: `At the start of the combat phase, you can declare that the bearer will strike the ground instead of attacking. If you do so, in that combat phase, subtract 1 from hit rolls for attacks made by enemy models that are within 6" of the bearer when they attack.`,
+        when: [START_OF_COMBAT_PHASE],
+      },
+    ],
+  },
+  {
+    name: `Resounding Gromrilhorn`,
+    effects: [
+      {
+        name: `Resounding Gromrilhorn`,
+        desc: `Once per battle, at the start of your hero phase, the bearer can use this artefact. If they do so, add 2 to the Bravery characteristic of friendly DISPOSSESSED units until your next hero phase.`,
+        when: [START_OF_HERO_PHASE],
       },
     ],
   },

--- a/src/army/dispossessed/index.ts
+++ b/src/army/dispossessed/index.ts
@@ -1,0 +1,10 @@
+import { Battalions, Units } from './units'
+import Abilities from './abilities'
+import Artifacts from './artifacts'
+import Traits from './traits'
+
+// Copy paste this directory to kickstart a new army
+// Remember to add your army to:
+//      - meta/factions.ts
+//      - meta/army_list.ts
+export default { Abilities, Artifacts, Battalions, Traits, Units }

--- a/src/army/dispossessed/index.ts
+++ b/src/army/dispossessed/index.ts
@@ -3,8 +3,4 @@ import Abilities from './abilities'
 import Artifacts from './artifacts'
 import Traits from './traits'
 
-// Copy paste this directory to kickstart a new army
-// Remember to add your army to:
-//      - meta/factions.ts
-//      - meta/army_list.ts
 export default { Abilities, Artifacts, Battalions, Traits, Units }

--- a/src/army/dispossessed/traits.ts
+++ b/src/army/dispossessed/traits.ts
@@ -1,0 +1,17 @@
+import { TCommandTraits } from 'types/army'
+import { HERO_PHASE } from 'types/phases'
+
+const CommandTraits: TCommandTraits = [
+  {
+    name: ``,
+    effects: [
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+]
+
+export default CommandTraits

--- a/src/army/dispossessed/traits.ts
+++ b/src/army/dispossessed/traits.ts
@@ -1,13 +1,63 @@
-import { TCommandTraits } from 'types/army'
-import { HERO_PHASE } from 'types/phases'
+import { TCommandTraits } from '../../types/army'
+import { HERO_PHASE, DURING_GAME, COMBAT_PHASE } from '../../types/phases'
 
 const CommandTraits: TCommandTraits = [
   {
-    name: ``,
+    name: `Resolute`,
     effects: [
       {
-        name: ``,
-        desc: ``,
+        name: `Resolute`,
+        desc: `Friendly DISPOSSESSED units wholly within 12" of this general pass battleshock tests on a roll of 1 to 4, rather than only on a roll of 1 to 3 (see the Stubborn to the End battle trait).`,
+        when: [DURING_GAME],
+      },
+    ],
+  },
+  {
+    name: `Resilient`,
+    effects: [
+      {
+        name: `Resilient`,
+        desc: `Add 1 to this general’s Wounds characteristic.`,
+        when: [DURING_GAME],
+      },
+    ],
+  },
+  {
+    name: `Siegemaster`,
+    effects: [
+      {
+        name: `Siegemaster`,
+        desc: `Do not add 1 to the save rolls of enemy units that are in cover if they are attacked by this general or a friendly DISPOSSESSED unit wholly within 12" of this general.`,
+        when: [DURING_GAME],
+      },
+    ],
+  },
+  {
+    name: `Unforgiving`,
+    effects: [
+      {
+        name: `Unforgiving`,
+        desc: `Add 1 to wound rolls for attacks made by this general if the target is from a unit that has inflicted any wounds on this general. `,
+        when: [DURING_GAME],
+      },
+    ],
+  },
+  {
+    name: `Battle Fury`,
+    effects: [
+      {
+        name: `Battle Fury`,
+        desc: `Roll a dice after this general completes their attacks in the combat phase; on a roll of 6+ they can fight again (do not roll again after completing the second set of attacks).`,
+        when: [COMBAT_PHASE],
+      },
+    ],
+  },
+  {
+    name: `Grudgebearer`,
+    effects: [
+      {
+        name: `Grudgebearer`,
+        desc: `Once per battle, if your general has not been slain, you can pick a new grudge in your hero phase to replace the original grudge you chose for your army (see "End of Setup").`,
         when: [HERO_PHASE],
       },
     ],

--- a/src/army/dispossessed/traits.ts
+++ b/src/army/dispossessed/traits.ts
@@ -1,5 +1,5 @@
-import { TCommandTraits } from '../../types/army'
-import { HERO_PHASE, DURING_GAME, COMBAT_PHASE } from '../../types/phases'
+import { TCommandTraits } from 'types/army'
+import { HERO_PHASE, DURING_GAME, COMBAT_PHASE } from 'types/phases'
 
 const CommandTraits: TCommandTraits = [
   {

--- a/src/army/dispossessed/traits.ts
+++ b/src/army/dispossessed/traits.ts
@@ -17,7 +17,7 @@ const CommandTraits: TCommandTraits = [
     effects: [
       {
         name: `Resilient`,
-        desc: `Add 1 to this general’s Wounds characteristic.`,
+        desc: `Add 1 to this general's Wounds characteristic.`,
         when: [DURING_GAME],
       },
     ],

--- a/src/army/dispossessed/units.ts
+++ b/src/army/dispossessed/units.ts
@@ -243,7 +243,7 @@ export const Units: TUnits = [
       },
       {
         name: `Precision Fire`,
-        desc: `You can adsd 1 to all hit rolls for a Thunderer if its unit has 20 or more models and there are no enemy models within`,
+        desc: `You can adsd 1 to all hit rolls for a Thunderer if its unit has 20 or more models and there are no enemy models within 3".`,
         when: [SHOOTING_PHASE],
       },
       {

--- a/src/army/dispossessed/units.ts
+++ b/src/army/dispossessed/units.ts
@@ -1,5 +1,12 @@
 import { TBattalions, TUnits } from '../../types/army'
-import { HERO_PHASE, DURING_GAME, COMBAT_PHASE, MOVEMENT_PHASE, BATTLESHOCK_PHASE } from '../../types/phases'
+import {
+  HERO_PHASE,
+  DURING_GAME,
+  COMBAT_PHASE,
+  MOVEMENT_PHASE,
+  BATTLESHOCK_PHASE,
+  SHOOTING_PHASE,
+} from '../../types/phases'
 
 // Unit Names
 export const Units: TUnits = [
@@ -99,24 +106,24 @@ export const Units: TUnits = [
         when: [HERO_PHASE],
       },
       {
-        name: `Drummer`,
+        name: `Drummers`,
         desc: `Models in this unit can be Drummers. When a unit containing any Drummers runs, the can 'Sound the Advance'. If they do so, do not roll a dice to see how far the unit runs; instead, they can move up to an extra 4".`,
         when: [MOVEMENT_PHASE],
       },
       {
-        name: ``,
-        desc: ``,
-        when: [HERO_PHASE],
+        name: `Cinderblast Bomb`,
+        desc: `Once per battle, a model with a Cinderblast Bomb can throw it in your shooting phase. To do so pick a unit within 6" and roll a dice; on a 2 or more, that unit suffers D3 mortal wounds.`,
+        when: [SHOOTING_PHASE],
       },
       {
-        name: ``,
-        desc: ``,
-        when: [HERO_PHASE],
+        name: `Gromril Shields`,
+        desc: `This unit can create a shield wall instead of running or charging in its turn. If it does so, re-roll all failed save rolls for the unit in the combat phase until its next movement phase.`,
+        when: [MOVEMENT_PHASE],
       },
       {
-        name: ``,
-        desc: ``,
-        when: [HERO_PHASE],
+        name: `Forge-proven Gromril Armour`,
+        desc: `When you make save rolls for this unit, ignore the enemy's Rend characteristic unless it is -2 or better.`,
+        when: [DURING_GAME],
       },
     ],
   },
@@ -124,9 +131,34 @@ export const Units: TUnits = [
     name: `Irondrakes`,
     effects: [
       {
-        name: ``,
-        desc: ``,
+        name: `Icon Bearer`,
+        desc: `Models in this unit may be Icon Bearers. Roll a dice if an enemy spell affects a unit with any Icon Bearers. On a roll of 5 or more, that spell has no effect on the unit (but it will affect other units normally).`,
         when: [HERO_PHASE],
+      },
+      {
+        name: `Hornblowers`,
+        desc: `Models in this unit can be Hornblowers. When a unit containing any Hornblowers runs, the can 'Sound the Advance'. If they do so, do not roll a dice to see how far the unit runs; instead, they can move up to an extra 4".`,
+        when: [MOVEMENT_PHASE],
+      },
+      {
+        name: `Forge-proven Gromril Armour`,
+        desc: `When you make save rolls for this unit, ignore the enemy's Rend characteristic unless it is -2 or better.`,
+        when: [DURING_GAME],
+      },
+      {
+        name: `Grudgehammer Torpedo`,
+        desc: `A Grudgehammer Torpedo inflicts D6 Damage instead of D3 if the target has the MONSTER keyword.`,
+        when: [SHOOTING_PHASE],
+      },
+      {
+        name: `Cinderblast Bomb`,
+        desc: `Once per battle, a model with a Cinderblast Bomb can throw it in your shooting phase. To do so pick a unit within 6" and roll a dice; on a 2 or more, that unit suffers D3 mortal wounds.`,
+        when: [SHOOTING_PHASE],
+      },
+      {
+        name: `Blaze Away`,
+        desc: `You can add 1 to the Attacks characteristic of this unit's missile weapons if it has at least 10 models and is more than 3" from of any enemy units.`,
+        when: [SHOOTING_PHASE],
       },
     ],
   },
@@ -134,8 +166,29 @@ export const Units: TUnits = [
     name: `Longbeards`,
     effects: [
       {
-        name: ``,
-        desc: ``,
+        name: `Throng Musician`,
+        desc: `Models in this unit can be Hornblowers or Drummers. When a unit containing any Hornblowers or Drummers runs, they can ‘Sound the Advance’. If they do so, do not roll a dice to see how far the unit runs; instead, they can move up to an extra 4". `,
+        when: [MOVEMENT_PHASE],
+      },
+      {
+        name: `Standard Bearer`,
+        desc: `Models in this unit may be Standard Bearers. If you fail a battleshock test for a unit that has any Standard Bearers, halve the number of models that flee (rounding up).`,
+        when: [BATTLESHOCK_PHASE],
+      },
+      {
+        name: `Gromril Shields`,
+        desc: `This unit can create a shield wall instead of running or charging in its turn. If it does so, re-roll all failed save rolls for the unit in the combat phase until its next movement phase.`,
+        when: [MOVEMENT_PHASE],
+      },
+      {
+        name: `Old Grumblers`,
+        desc: `Longbeards are always grumbling about something, from the hardships they endured when they were younger and how the youth of today don't respect their elders, to how expensive beer is these days. In your hero phase, this unit will complain about something in a suitably duardin manner. When they do, pick one of the grumblings listed below. The effects last until your next hero phase.
+        
+        'I thought duardin were made of sterner stuff!': Roll a dice each time a DISPOSSESSED model from your army flees whilst within 8" of this unit; on a 5 or more that model stands firm under the Longbeards' stern gaze and does not flee.
+        
+        'Who does this beardling think he is?': Friendly DISPOSSESSED HEROES within 8" of this unit are treated as if they were your general when working out the range of command abilities.
+        
+        'Grots are weedier these days!': You can re-roll wound rolls of 1 for DISPOSSESSED models from your army that are within 8" of this unit when they attack in the combat phase.`,
         when: [HERO_PHASE],
       },
     ],
@@ -144,9 +197,29 @@ export const Units: TUnits = [
     name: `Quarrellers`,
     effects: [
       {
-        name: ``,
-        desc: ``,
+        name: `Drummers`,
+        desc: `Models in this unit can be Drummers. When a unit containing any Drummers runs, the can 'Sound the Advance'. If they do so, do not roll a dice to see how far the unit runs; instead, they can move up to an extra 4".`,
+        when: [MOVEMENT_PHASE],
+      },
+      {
+        name: `Standard Bearer: Runic Icon`,
+        desc: `Roll a dice if an enemy spell affects a unit with any Runic Icons. On a roll of 5 or more, that spell has no effect on the unit (but it will affect other units normally).`,
         when: [HERO_PHASE],
+      },
+      {
+        name: `Standard Bearer: Clan Banner`,
+        desc: `If you fail a battleshock test for a unit that has any Clan Banners, halve the number of models that flee (rounding up).`,
+        when: [BATTLESHOCK_PHASE],
+      },
+      {
+        name: `Volley Fire`,
+        desc: `You can add 1 to the Attacks characteristic of this unit's missile weapons if it has at least 20 models and is more than 3" from any enemy units.`,
+        when: [SHOOTING_PHASE],
+      },
+      {
+        name: `Duardin Bucklers`,
+        desc: `If a unit is equipped with Duardin Bucklers, it can create a shield wall instead of running or charging in its turn. If it does so, re-roll all failed save rolls for the unit in the combat phase until its next movement phase.`,
+        when: [MOVEMENT_PHASE],
       },
     ],
   },
@@ -154,9 +227,29 @@ export const Units: TUnits = [
     name: `Thunderers`,
     effects: [
       {
-        name: ``,
-        desc: ``,
+        name: `Drummers`,
+        desc: `Models in this unit can be Drummers. When a unit containing any Drummers runs, the can 'Sound the Advance'. If they do so, do not roll a dice to see how far the unit runs; instead, they can move up to an extra 4".`,
+        when: [MOVEMENT_PHASE],
+      },
+      {
+        name: `Standard Bearer: Runic Icon`,
+        desc: `Roll a dice if an enemy spell affects a unit with any Runic Icons. On a roll of 5 or more, that spell has no effect on the unit (but it will affect other units normally).`,
         when: [HERO_PHASE],
+      },
+      {
+        name: `Standard Bearer: Clan Banner`,
+        desc: `If you fail a battleshock test for a unit that has any Clan Banners, halve the number of models that flee (rounding up).`,
+        when: [BATTLESHOCK_PHASE],
+      },
+      {
+        name: `Precision Fire`,
+        desc: `You can adsd 1 to all hit rolls for a Thunderer if its unit has 20 or more models and there are no enemy models within`,
+        when: [SHOOTING_PHASE],
+      },
+      {
+        name: `Duardin Bucklers`,
+        desc: `If a unit is equipped with Duardin Bucklers, it can create a shield wall instead of running or charging in its turn. If it does so, re-roll all failed save rolls for the unit in the combat phase until its next movement phase.`,
+        when: [MOVEMENT_PHASE],
       },
     ],
   },
@@ -164,9 +257,29 @@ export const Units: TUnits = [
     name: `Warriors`,
     effects: [
       {
-        name: ``,
-        desc: ``,
+        name: `Hornblowers`,
+        desc: `Models in this unit can be Hornblowers. When a unit containing any Hornblowers runs, the can 'Sound the Advance'. If they do so, do not roll a dice to see how far the unit runs; instead, they can move up to an extra 4".`,
+        when: [MOVEMENT_PHASE],
+      },
+      {
+        name: `Standard Bearer: Runic Icon`,
+        desc: `Roll a dice if an enemy spell affects a unit with any Runic Icons. On a roll of 5 or more, that spell has no effect on the unit (but it will affect other units normally).`,
         when: [HERO_PHASE],
+      },
+      {
+        name: `Standard Bearer: Clan Banner`,
+        desc: `If you fail a battleshock test for a unit that has any Clan Banners, halve the number of models that flee (rounding up).`,
+        when: [BATTLESHOCK_PHASE],
+      },
+      {
+        name: `Resolute in Defence`,
+        desc: `You can re-roll failed wound rolls of 1 when attacking with a Warrior in your opponent's combat phase. You can instead re-roll all failed wound rolls for a Warrior if its unit has 20 or more models when it attacks in your opponent's combat phase.`,
+        when: [COMBAT_PHASE],
+      },
+      {
+        name: `Duardin Bucklers`,
+        desc: `If a unit is equipped with Duardin Bucklers, it can create a shield wall instead of running or charging in its turn. If it does so, re-roll all failed save rolls for the unit in the combat phase until its next movement phase.`,
+        when: [MOVEMENT_PHASE],
       },
     ],
   },
@@ -178,9 +291,14 @@ export const Battalions: TBattalions = [
     name: `Grudgebound War Throng`,
     effects: [
       {
-        name: ``,
-        desc: ``,
-        when: [HERO_PHASE],
+        name: `Ancient Grudges`,
+        desc: `The warriors of a Grudgebound War Throng hold deep-rooted grudges. When a Grudgebound War Throng goes to war, these sparks of bitterness are fanned into seething flames of vengeance that will only be extinguished when old scores are settled. You can re-roll all hit rolls of 1 for models in a Grudgebound War Throng.`,
+        when: [DURING_GAME],
+      },
+      {
+        name: `Stubborn to the End`,
+        desc: `The Dispossessed are renowned for their stubborn refusal to admit defeat, especially in the face of overwhelming odds. If you roll a 1, 2 or a 3 when taking a battleshock test for a unit in a Grudgebound War Throng, that unit stubbornly refuses to yield and is treated as having passed the battleshock test irrespective of any penalties on their Bravery or the number of casualties they have suffered that turn.`,
+        when: [BATTLESHOCK_PHASE],
       },
     ],
   },

--- a/src/army/dispossessed/units.ts
+++ b/src/army/dispossessed/units.ts
@@ -1,8 +1,5 @@
 import { TBattalions, TUnits } from '../../types/army'
-import { 
-  HERO_PHASE,
-  DURING_GAME
-} from '../../types/phases'
+import { HERO_PHASE, DURING_GAME } from '../../types/phases'
 
 // Unit Names
 export const Units: TUnits = [
@@ -23,8 +20,8 @@ export const Units: TUnits = [
         name: `Ancestral Grudge`,
         desc: `If a Warden King uses this ability, pick one enemy unit within 16". Until your next hero phase, you can add 1 to wound rolls for all attacks made by DISPOSSESSED models that target that unit.`,
         // Doesn't state HERO_PHASE specifically, potentially could be DURING_GAME?
-        when: [HERO_PHASE], 
-        command: true
+        when: [HERO_PHASE],
+        command: true,
       },
     ],
   },

--- a/src/army/dispossessed/units.ts
+++ b/src/army/dispossessed/units.ts
@@ -1,0 +1,30 @@
+import { TBattalions, TUnits } from 'types/army'
+import { HERO_PHASE } from 'types/phases'
+
+// Unit Names
+export const Units: TUnits = [
+  {
+    name: ``,
+    effects: [
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+]
+
+// Battalions
+export const Battalions: TBattalions = [
+  {
+    name: ``,
+    effects: [
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+]

--- a/src/army/dispossessed/units.ts
+++ b/src/army/dispossessed/units.ts
@@ -1,5 +1,8 @@
-import { TBattalions, TUnits } from 'types/army'
-import { HERO_PHASE } from 'types/phases'
+import { TBattalions, TUnits } from '../../types/army'
+import { 
+  HERO_PHASE,
+  DURING_GAME
+} from '../../types/phases'
 
 // Unit Names
 export const Units: TUnits = [
@@ -7,9 +10,21 @@ export const Units: TUnits = [
     name: `Warden King`,
     effects: [
       {
-        name: ``,
-        desc: ``,
+        name: `Ancestor Shield`,
+        desc: `You can re-roll all failed saves for a Warden King.`,
+        when: [DURING_GAME],
+      },
+      {
+        name: `Oath Stone`,
+        desc: `In the hero phase, a Warden King can stand atop his oath stone to increase the resolve of his followers. If he does so, he cannot move until his next hero phase, but all DISPOSSESSED units from your army within 18" in the battleshock phase may use the Warden King’s Bravery instead of their own.`,
         when: [HERO_PHASE],
+      },
+      {
+        name: `Ancestral Grudge`,
+        desc: `If a Warden King uses this ability, pick one enemy unit within 16". Until your next hero phase, you can add 1 to wound rolls for all attacks made by DISPOSSESSED models that target that unit.`,
+        // Doesn't state HERO_PHASE specifically, potentially could be DURING_GAME?
+        when: [HERO_PHASE], 
+        command: true
       },
     ],
   },
@@ -17,8 +32,18 @@ export const Units: TUnits = [
     name: `Runelord`,
     effects: [
       {
-        name: ``,
-        desc: ``,
+        name: `Runes of Spellbreaking`,
+        desc: `A Runelord can attempt to unbind one enemy spell in the enemy hero phase as if he were a wizard. You can add 2 to any unbinding rolls for a Runelord.`,
+        when: [HERO_PHASE],
+      },
+      {
+        name: `Rune Lore`,
+        desc: `In your hero phase a Runelord can pray to the Ancestor Gods to imbue his allies’ weapons and armour with power. If he does so, pick a DISPOSSESSED unit within 16", select a power and roll a dice; on a 1 the Runelord has failed and nothing happens. On a roll of 2 or more the runes hammered into his allies’ wargear glow white-hot with rune magic and the power takes effect.
+        
+        Ancestral Shield: Until your next hero phase, you can roll a dice whenever a model in this unit suffers a wound or a mortal wound. On a 6, that wound or mortal wound is ignored. 
+        
+        Forgefire: Until your next hero phase, increase the Rend characteristics of the unit’s weapons by 1 (i.e. ‘-’ becomes -1, -1 becomes -2 and so on).
+        `,
         when: [HERO_PHASE],
       },
     ],

--- a/src/army/dispossessed/units.ts
+++ b/src/army/dispossessed/units.ts
@@ -13,7 +13,7 @@ export const Units: TUnits = [
       },
       {
         name: `Oath Stone`,
-        desc: `In the hero phase, a Warden King can stand atop his oath stone to increase the resolve of his followers. If he does so, he cannot move until his next hero phase, but all DISPOSSESSED units from your army within 18" in the battleshock phase may use the Warden King’s Bravery instead of their own.`,
+        desc: `In the hero phase, a Warden King can stand atop his oath stone to increase the resolve of his followers. If he does so, he cannot move until his next hero phase, but all DISPOSSESSED units from your army within 18" in the battleshock phase may use the Warden King's Bravery instead of their own.`,
         when: [HERO_PHASE],
       },
       {
@@ -34,11 +34,11 @@ export const Units: TUnits = [
       },
       {
         name: `Rune Lore`,
-        desc: `In your hero phase a Runelord can pray to the Ancestor Gods to imbue his allies’ weapons and armour with power. If he does so, pick a DISPOSSESSED unit within 16", select a power and roll a dice; on a 1 the Runelord has failed and nothing happens. On a roll of 2 or more the runes hammered into his allies’ wargear glow white-hot with rune magic and the power takes effect.
+        desc: `In your hero phase a Runelord can pray to the Ancestor Gods to imbue his allies' weapons and armour with power. If he does so, pick a DISPOSSESSED unit within 16", select a power and roll a dice; on a 1 the Runelord has failed and nothing happens. On a roll of 2 or more the runes hammered into his allies' wargear glow white-hot with rune magic and the power takes effect.
         
         Ancestral Shield: Until your next hero phase, you can roll a dice whenever a model in this unit suffers a wound or a mortal wound. On a 6, that wound or mortal wound is ignored. 
         
-        Forgefire: Until your next hero phase, increase the Rend characteristics of the unit’s weapons by 1 (i.e. ‘-’ becomes -1, -1 becomes -2 and so on).
+        Forgefire: Until your next hero phase, increase the Rend characteristics of the unit's weapons by 1 (i.e. ‘-' becomes -1, -1 becomes -2 and so on).
         `,
         when: [HERO_PHASE],
       },
@@ -74,7 +74,7 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Throng Musician`,
-        desc: `Models in this unit can be Hornblowers or Drummers. When a unit containing any Hornblowers or Drummers runs, they can ‘Sound the Advance’. If they do so, do not roll a dice to see how far the unit runs; instead, they can move up to an extra 4". `,
+        desc: `Models in this unit can be Hornblowers or Drummers. When a unit containing any Hornblowers or Drummers runs, they can ‘Sound the Advance'. If they do so, do not roll a dice to see how far the unit runs; instead, they can move up to an extra 4". `,
         when: [MOVEMENT_PHASE],
       },
       {
@@ -159,7 +159,7 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Throng Musician`,
-        desc: `Models in this unit can be Hornblowers or Drummers. When a unit containing any Hornblowers or Drummers runs, they can ‘Sound the Advance’. If they do so, do not roll a dice to see how far the unit runs; instead, they can move up to an extra 4". `,
+        desc: `Models in this unit can be Hornblowers or Drummers. When a unit containing any Hornblowers or Drummers runs, they can ‘Sound the Advance'. If they do so, do not roll a dice to see how far the unit runs; instead, they can move up to an extra 4". `,
         when: [MOVEMENT_PHASE],
       },
       {

--- a/src/army/dispossessed/units.ts
+++ b/src/army/dispossessed/units.ts
@@ -4,7 +4,97 @@ import { HERO_PHASE } from 'types/phases'
 // Unit Names
 export const Units: TUnits = [
   {
-    name: ``,
+    name: `Warden King`,
+    effects: [
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+  {
+    name: `Runelord`,
+    effects: [
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+  {
+    name: `Unforged`,
+    effects: [
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+  {
+    name: `Hammerers`,
+    effects: [
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+  {
+    name: `Ironbreakers`,
+    effects: [
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+  {
+    name: `Irondrakes`,
+    effects: [
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+  {
+    name: `Longbeards`,
+    effects: [
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+  {
+    name: `Quarrellers`,
+    effects: [
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+  {
+    name: `Thunderers`,
+    effects: [
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+  {
+    name: `Warriors`,
     effects: [
       {
         name: ``,
@@ -18,7 +108,7 @@ export const Units: TUnits = [
 // Battalions
 export const Battalions: TBattalions = [
   {
-    name: ``,
+    name: `Grudgebound War Throng`,
     effects: [
       {
         name: ``,

--- a/src/army/dispossessed/units.ts
+++ b/src/army/dispossessed/units.ts
@@ -1,12 +1,5 @@
-import { TBattalions, TUnits } from '../../types/army'
-import {
-  HERO_PHASE,
-  DURING_GAME,
-  COMBAT_PHASE,
-  MOVEMENT_PHASE,
-  BATTLESHOCK_PHASE,
-  SHOOTING_PHASE,
-} from '../../types/phases'
+import { TBattalions, TUnits } from 'types/army'
+import { BATTLESHOCK_PHASE, COMBAT_PHASE, DURING_GAME, HERO_PHASE, MOVEMENT_PHASE, SHOOTING_PHASE } from 'types/phases'
 
 // Unit Names
 export const Units: TUnits = [
@@ -26,8 +19,7 @@ export const Units: TUnits = [
       {
         name: `Ancestral Grudge`,
         desc: `If a Warden King uses this ability, pick one enemy unit within 16". Until your next hero phase, you can add 1 to wound rolls for all attacks made by DISPOSSESSED models that target that unit.`,
-        // Doesn't state HERO_PHASE specifically, potentially could be DURING_GAME?
-        when: [HERO_PHASE],
+        when: [DURING_GAME],
         command: true,
       },
     ],

--- a/src/army/dispossessed/units.ts
+++ b/src/army/dispossessed/units.ts
@@ -1,5 +1,5 @@
 import { TBattalions, TUnits } from '../../types/army'
-import { HERO_PHASE, DURING_GAME } from '../../types/phases'
+import { HERO_PHASE, DURING_GAME, COMBAT_PHASE, MOVEMENT_PHASE, BATTLESHOCK_PHASE } from '../../types/phases'
 
 // Unit Names
 export const Units: TUnits = [
@@ -49,9 +49,24 @@ export const Units: TUnits = [
     name: `Unforged`,
     effects: [
       {
-        name: ``,
-        desc: ``,
-        when: [HERO_PHASE],
+        name: `Runic Axes`,
+        desc: `The Unforged launches a deadly flurry of blows. You can re-roll all hit rolls of 1 for an Unforged.`,
+        when: [DURING_GAME],
+      },
+      {
+        name: `Epic Deathblow`,
+        desc: `If an Unforged is slain in the combat phase, roll a dice before it is removed. On a roll of 4 or more, you can inflict D3 mortal wounds on the enemy unit that struck the fatal blow (inflict D6 mortal wounds instead if a Chaos model struck the final blow).`,
+        when: [COMBAT_PHASE],
+      },
+      {
+        name: `Nemesis`,
+        desc: `Attacks made by an Unforged inflict double Damage against CHAOS units.`,
+        when: [DURING_GAME],
+      },
+      {
+        name: `The Bigger They Are...`,
+        desc: `You can add 1 to any wound rolls for an Unforged if the target of the attack has a Wounds characteristic of more than 1.`,
+        when: [DURING_GAME],
       },
     ],
   },
@@ -59,15 +74,45 @@ export const Units: TUnits = [
     name: `Hammerers`,
     effects: [
       {
-        name: ``,
-        desc: ``,
-        when: [HERO_PHASE],
+        name: `Throng Musician`,
+        desc: `Models in this unit can be Hornblowers or Drummers. When a unit containing any Hornblowers or Drummers runs, they can ‘Sound the Advance’. If they do so, do not roll a dice to see how far the unit runs; instead, they can move up to an extra 4". `,
+        when: [MOVEMENT_PHASE],
+      },
+      {
+        name: `Standard Bearer`,
+        desc: `Models in this unit may be Standard Bearers. If you fail a battleshock test for a unit that has any Standard Bearers, halve the number of models that flee (rounding up).`,
+        when: [BATTLESHOCK_PHASE],
+      },
+      {
+        name: `Kingsguard`,
+        desc: `You do not need to take battleshock tests for this unit if it is within 16" of a DISPOSSESSED HERO from your army in the battleshock phase.`,
+        when: [BATTLESHOCK_PHASE],
       },
     ],
   },
   {
     name: `Ironbreakers`,
     effects: [
+      {
+        name: `Icon Bearer`,
+        desc: `Models in this unit may be Icon Bearers. Roll a dice if an enemy spell affects a unit with any Icon Bearers. On a roll of 5 or more, that spell has no effect on the unit (but it will affect other units normally).`,
+        when: [HERO_PHASE],
+      },
+      {
+        name: `Drummer`,
+        desc: `Models in this unit can be Drummers. When a unit containing any Drummers runs, the can 'Sound the Advance'. If they do so, do not roll a dice to see how far the unit runs; instead, they can move up to an extra 4".`,
+        when: [MOVEMENT_PHASE],
+      },
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
+      {
+        name: ``,
+        desc: ``,
+        when: [HERO_PHASE],
+      },
       {
         name: ``,
         desc: ``,

--- a/src/meta/army_list.ts
+++ b/src/meta/army_list.ts
@@ -7,6 +7,7 @@ import {
   SERAPHON,
   SKAVEN,
   SYLVANETH,
+  DISPOSSESSED,
   TSupportedFaction,
 } from './factions'
 import { CHAOS, DEATH, DESTRUCTION, ORDER, TGrandAlliances } from './alliances'
@@ -20,6 +21,7 @@ import Ironjawz from '../army/ironjawz'
 import Seraphon from '../army/seraphon'
 import Skaven from '../army/skaven'
 import Sylvaneth from '../army/sylvaneth'
+import Dispossessed from '../army/dispossessed'
 
 const ArmyList: TArmyList = {
   [BEASTCLAW_RAIDERS]: {
@@ -52,6 +54,10 @@ const ArmyList: TArmyList = {
   },
   [SYLVANETH]: {
     Army: { ...Sylvaneth },
+    GrandAlliance: ORDER,
+  },
+  [DISPOSSESSED]: {
+    Army: { ...Dispossessed },
     GrandAlliance: ORDER,
   },
 }

--- a/src/meta/factions.ts
+++ b/src/meta/factions.ts
@@ -9,6 +9,7 @@ export type TIronjawz = 'IRONJAWZ'
 export type TSeraphon = 'SERAPHON'
 export type TSkaven = 'SKAVEN'
 export type TSylvaneth = 'SYLVANETH'
+export type TDispossessed = 'DISPOSSESSED'
 
 // Exported Faction Names
 export const BEASTCLAW_RAIDERS: TBeastclawRaiders = 'BEASTCLAW_RAIDERS'
@@ -19,6 +20,7 @@ export const IRONJAWZ: TIronjawz = 'IRONJAWZ'
 export const SERAPHON: TSeraphon = 'SERAPHON'
 export const SKAVEN: TSkaven = 'SKAVEN'
 export const SYLVANETH: TSylvaneth = 'SYLVANETH'
+export const DISPOSSESSED: TDispossessed = 'DISPOSSESSED'
 
 // Supported Factions
 export type TSupportedFaction =
@@ -30,6 +32,7 @@ export type TSupportedFaction =
   | TSeraphon
   | TSkaven
   | TSylvaneth
+  | TDispossessed
 
 export const SUPPORTED_FACTIONS: TSupportedFaction[] = sortBy([
   BEASTCLAW_RAIDERS,
@@ -40,4 +43,5 @@ export const SUPPORTED_FACTIONS: TSupportedFaction[] = sortBy([
   SERAPHON,
   SKAVEN,
   SYLVANETH,
+  DISPOSSESSED,
 ])


### PR DESCRIPTION
#### What does this PR do?
Adds everyone's favourite battletome-less beardos!

#### Relative URL issue
The imports at the top of the files seemed to not point to the correct folders,  for example, in `abilities.ts` it was:

```
import { HERO_PHASE } from 'types/phases'
```

When to me, it should be

```
import { HERO_PHASE } from '../../types/phases'
```

But maybe I didn't set it up correctly on my end. If that's the case let me know and I'll fix that.

### Notes
- I didn't add veteran abilities like "can attack 2 times instead of 1" or "can take X, Y, or Z weapons". It seemed like those were omitted in the other armies.
- If this PR is fine I wouldn't mind doing Kharadron Overlords next