### PR TITLE
Fixing merged entries (fixes #183) (#182)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![Codeship Status for daviseford/aos-reminders](https://app.codeship.com/projects/c0b303b0-94f9-0137-ac21-1aa1838f71d2/status?branch=master)](https://app.codeship.com/projects/357042)
+
+## Discord
+
+[https://discord.gg/2nt9Fxp](https://discord.gg/2nt9Fxp)
+
 ## How to Contribute
 
 If you want to add an army or edit an existing army, please do so! Use the `src/army/sample_army/` folder as a reference for how things are added!
@@ -38,10 +44,6 @@ Feel free to submit a PR for any incorrect/missing rules! I am only human, and t
 + [T-Nightingale](https://github.com/T-Nightingale)
   + Added Print button
 
-## Discord
-
-https://discord.gg/2nt9Fxp
-
 ## Available Scripts
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
@@ -67,8 +69,6 @@ You will also see any lint errors in the console.
 Launches the test runner in the interactive watch mode.
 
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-_Note: We currently do not have any unit tests. Don't worry about this command for now_
 
 ### `yarn build`
 
@@ -96,8 +96,6 @@ I have set this repository up to automatically take care of some chores when you
 4. Finally, we use `pretty-quick` to format the code according to the repository standards.
 
 ## Deployment
-
-[![Codeship Status for daviseford/aos-reminders](https://app.codeship.com/projects/c0b303b0-94f9-0137-ac21-1aa1838f71d2/status?branch=master)](https://app.codeship.com/projects/357042)
 
 This repository is automatically deployed using CodeShip.
 

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
-
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
-});

--- a/src/tests/__mock.ts
+++ b/src/tests/__mock.ts
@@ -1,0 +1,17 @@
+import { STORMCAST_ETERNALS } from '../meta/factions'
+import { IArmy } from '../types/army'
+import { ISelections } from '../types/selections'
+
+interface ISelectionsFactoryOptions {
+  artifacts?: string[]
+  battalions?: string[]
+  endless_spells?: string[]
+  spells?: string[]
+  traits?: string[]
+  units?: string[]
+}
+
+export const selectionsFactory = (options: ISelectionsFactoryOptions): ISelections => {
+  const { artifacts = [], battalions = [], endless_spells = [], spells = [], traits = [], units = [] } = options
+  return { artifacts, battalions, endless_spells, spells, traits, units }
+}

--- a/src/tests/__mock.ts
+++ b/src/tests/__mock.ts
@@ -1,6 +1,5 @@
-import { STORMCAST_ETERNALS } from '../meta/factions'
 import { IArmy } from '../types/army'
-import { ISelections } from '../types/selections'
+import { ISelections, IAllySelections } from '../types/selections'
 
 interface ISelectionsFactoryOptions {
   artifacts?: string[]
@@ -15,3 +14,5 @@ export const selectionsFactory = (options: ISelectionsFactoryOptions): ISelectio
   const { artifacts = [], battalions = [], endless_spells = [], spells = [], traits = [], units = [] } = options
   return { artifacts, battalions, endless_spells, spells, traits, units }
 }
+
+export const allySelectionsFactory = (units: string[] = []): IAllySelections => ({ units })

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -1,0 +1,32 @@
+import { selectionsFactory } from './__mock'
+import { getArmy } from '../utils/getArmy'
+import { STORMCAST_ETERNALS } from '../meta/factions'
+import { IArmy } from '../types/army'
+import { processReminders } from 'utils/processReminders'
+import { HERO_PHASE, SHOOTING_PHASE, COMBAT_PHASE } from 'types/phases'
+
+describe('processReminder', () => {
+  const factionName = STORMCAST_ETERNALS
+  const army = getArmy(factionName) as IArmy
+  it('should merge similar abilities (issue #183)', () => {
+    const selections = selectionsFactory({ units: ['Drakesworn Templar', 'Lord-Celestant on Stardrake'] })
+    const reminders = processReminders(army, factionName, selections, null, [])
+
+    // The test case defined for me in issue #183
+    const mergedHeroAbility = reminders[HERO_PHASE].find(
+      ({ condition }) => condition === 'Drakesworn Templar, Lord-Celestant on Stardrake'
+    )
+    expect(mergedHeroAbility).toBeDefined()
+
+    // Two more expected merged abilities
+    const mergedCombatAbilities = reminders[COMBAT_PHASE].filter(
+      ({ condition }) => condition === 'Drakesworn Templar, Lord-Celestant on Stardrake'
+    )
+    expect(mergedCombatAbilities.length).toEqual(2)
+
+    // Test case because this was an indicator of breaking before
+    const skyboltBow = reminders[SHOOTING_PHASE].find(({ name }) => name === 'Skybolt Bow')
+    expect(skyboltBow).toBeDefined()
+    expect(skyboltBow && skyboltBow.condition).toEqual('Drakesworn Templar')
+  })
+})

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -1,16 +1,38 @@
-import { selectionsFactory } from './__mock'
-import { getArmy } from '../utils/getArmy'
-import { STORMCAST_ETERNALS } from '../meta/factions'
-import { IArmy } from '../types/army'
+import { selectionsFactory, allySelectionsFactory } from './__mock'
 import { processReminders } from 'utils/processReminders'
-import { HERO_PHASE, SHOOTING_PHASE, COMBAT_PHASE } from 'types/phases'
+import seraphon from 'army/seraphon'
+import ironjawz from 'army/ironjawz'
+import sylvaneth from 'army/sylvaneth'
+import { STORMCAST_ETERNALS, BEASTCLAW_RAIDERS, DISPOSSESSED, IRONJAWZ, SERAPHON, SYLVANETH } from '../meta/factions'
+import { RealmscapeFeatures } from 'army/malign_sorcery'
+import { getArmy } from '../utils/getArmy'
+import { IArmy, TAllyData } from '../types/army'
+import { HERO_PHASE, SHOOTING_PHASE, COMBAT_PHASE, START_OF_HERO_PHASE } from 'types/phases'
+import artifacts from 'army/grand_alliances/destruction/artifacts'
+import { Battalions } from 'army/stormcast_eternals/units'
+import { ITurnAction } from 'types/data'
 
 describe('processReminder', () => {
-  const factionName = STORMCAST_ETERNALS
-  const army = getArmy(factionName) as IArmy
+  it('should work with no selections', () => {
+    const army = getArmy(BEASTCLAW_RAIDERS) as IArmy
+    const selections = selectionsFactory({})
+    const reminders = processReminders(army, BEASTCLAW_RAIDERS, selections, null, [])
+
+    const heroPhaseEntry = reminders[START_OF_HERO_PHASE][0]
+    expect(heroPhaseEntry.name).toEqual(`The Everwinter's Blessing`)
+    expect(heroPhaseEntry.condition).toEqual(`Beastclaw Raiders Allegiance`)
+    expect(heroPhaseEntry.allegiance_ability).toEqual(true)
+
+    const combatPhaseEntry = reminders[COMBAT_PHASE][0]
+    expect(combatPhaseEntry.name).toEqual(`Beastclaw Stampede`)
+    expect(combatPhaseEntry.condition).toEqual(`Beastclaw Raiders Allegiance`)
+    expect(combatPhaseEntry.allegiance_ability).toEqual(true)
+  })
+
   it('should merge similar abilities (issue #183)', () => {
+    const army = getArmy(STORMCAST_ETERNALS) as IArmy
     const selections = selectionsFactory({ units: ['Drakesworn Templar', 'Lord-Celestant on Stardrake'] })
-    const reminders = processReminders(army, factionName, selections, null, [])
+    const reminders = processReminders(army, STORMCAST_ETERNALS, selections, null, [])
 
     // The test case defined for me in issue #183
     const mergedHeroAbility = reminders[HERO_PHASE].find(
@@ -28,5 +50,56 @@ describe('processReminder', () => {
     const skyboltBow = reminders[SHOOTING_PHASE].find(({ name }) => name === 'Skybolt Bow')
     expect(skyboltBow).toBeDefined()
     expect(skyboltBow && skyboltBow.condition).toEqual('Drakesworn Templar')
+  })
+
+  it('should work with a loaded army,  multiple allies, and realmscape', () => {
+    const allyUnits = [ironjawz.Units[0], ironjawz.Units[1], seraphon.Units[0]]
+    const allyData: TAllyData = [
+      { allyArmy: getArmy(DISPOSSESSED) as IArmy, allySelections: allySelectionsFactory() },
+      {
+        allyArmy: getArmy(IRONJAWZ) as IArmy,
+        allySelections: allySelectionsFactory([allyUnits[0].name, allyUnits[1].name]),
+      },
+      { allyArmy: getArmy(SERAPHON) as IArmy, allySelections: allySelectionsFactory([allyUnits[2].name]) },
+    ]
+    const army = getArmy(SYLVANETH) as IArmy
+
+    const artifact = sylvaneth.Artifacts[0]
+    const battalion = sylvaneth.Battalions[0]
+    const endless_spells = sylvaneth.EndlessSpells[0]
+    const spell1 = sylvaneth.Spells[0]
+    const spell2 = sylvaneth.Spells[1]
+    const trait = sylvaneth.Traits[0]
+    const unit = sylvaneth.Units[0]
+
+    const selections = selectionsFactory({
+      artifacts: [artifact.name],
+      battalions: [battalion.name],
+      endless_spells: [endless_spells.name],
+      spells: [spell1.name, spell2.name],
+      traits: [trait.name],
+      units: [unit.name],
+    })
+    const realmscape_feature = RealmscapeFeatures[0]
+    const reminders = processReminders(army, SYLVANETH, selections, realmscape_feature.name, allyData)
+
+    const testEntries = [trait, unit, artifact, battalion, endless_spells, spell1, spell2, ...allyUnits]
+    testEntries.forEach(entry => {
+      const effect = reminders[entry.effects[0].when[0]].find(({ condition }) => condition === entry.name)
+      expect(effect).toBeDefined()
+    })
+
+    // Check for Allegiance ability
+    const ability = sylvaneth.Abilities[0]
+    const abilityEffect = reminders[ability.when[0]].find(({ name }) => {
+      return name === ability.name
+    })
+    expect(abilityEffect).toBeDefined()
+    expect((abilityEffect as ITurnAction).condition).toEqual(`Sylvaneth Allegiance`)
+
+    // Check for Realmscape info
+    const realmscapeEffect = reminders[realmscape_feature.when[0]].find(({ name }) => name === realmscape_feature.name)
+    expect(realmscapeEffect).toBeDefined()
+    expect((realmscapeEffect as ITurnAction).condition).toEqual('Realmscape Feature')
   })
 })

--- a/src/types/army.ts
+++ b/src/types/army.ts
@@ -1,7 +1,13 @@
 import { IEffects, IEntry } from './data'
 import { TGameStructure } from 'meta/game_structure'
+import { IAllySelections } from './selections'
 
 export type TAllyArmies = { [key: string]: IArmy }
+
+export type TAllyData = {
+  allyArmy: IArmy
+  allySelections: IAllySelections
+}[]
 
 export type TAbilities = IEffects[]
 export type TArtifacts = IEntry[]

--- a/src/utils/processReminders.ts
+++ b/src/utils/processReminders.ts
@@ -1,11 +1,12 @@
-import { flatten } from 'lodash'
-import { Game, TGameStructure } from 'meta/game_structure'
-import { ISelections, IAllySelections } from 'types/selections'
-import { TSupportedFaction } from 'meta/factions'
-import { IEffects, IReminder, ITurnAction } from 'types/data'
-import { IArmy } from 'types/army'
+import { flatten, sortBy, split, join } from 'lodash'
+import produce from 'immer'
 import { titleCase } from './titleCase'
 import { RealmscapeFeatures } from 'army/malign_sorcery'
+import { Game, TGameStructure } from 'meta/game_structure'
+import { TSupportedFaction } from 'meta/factions'
+import { IArmy } from 'types/army'
+import { IEffects, IReminder, ITurnAction } from 'types/data'
+import { ISelections, IAllySelections } from 'types/selections'
 
 type TProcessReminders = (
   army: IArmy,
@@ -70,19 +71,48 @@ export const processReminders: TProcessReminders = (army, factionName, selection
 
 const processConditions = (game: TGameStructure, selections: ISelections | IAllySelections, startVal = {}) => {
   const conditions = flatten(Object.values(selections))
-  const reminders = Object.keys(game).reduce((accum, key) => {
-    const phase = game[key]
-    const addToAccum = (actions: ITurnAction[], when: string) => {
-      actions.forEach((y: ITurnAction) => {
-        if (conditions.includes(y.condition)) {
-          accum[when] = accum[when] ? accum[when].concat(y) : [y]
-        }
-      })
-    }
-    if (phase.length) {
-      addToAccum(phase, key)
-    }
+
+  const reminders = Object.keys(game).reduce((accum: { [key: string]: ITurnAction[] }, when) => {
+    if (!game[when].length) return accum
+
+    game[when].forEach((action: ITurnAction) => {
+      if (conditions.includes(action.condition)) {
+        accum[when] = processCondition(accum[when] || [], action)
+      }
+    })
+
     return accum
   }, startVal)
+
   return reminders
 }
+
+/**
+ * Check to see if we've already added this rule for a different unit
+ * If so, combine the entries
+ * We use Immer to make sure we don't accidently mutate anything
+ * @param phase
+ * @param action
+ */
+const processCondition = produce((phase: ITurnAction[], action: ITurnAction) => {
+  // If this is the first action for a given phase, just return it
+  if (!phase.length) {
+    phase.push(action)
+    return phase
+  }
+
+  // See if we can find a matching action already in the phase
+  const idx = phase.findIndex(x => x.name === action.name)
+
+  // If there's not a matching action, add this action to the existing phase
+  if (idx === -1) {
+    phase.concat(action)
+    return phase
+  }
+
+  // If there is a matching action, merge the entries!
+  // Split the string in order to sort alphabetically in case of multiple matches :)
+  const sep = `, `
+  phase[idx].condition = join(sortBy(split(phase[idx].condition, sep).concat(action.condition)), sep)
+  return phase
+})

--- a/src/utils/processReminders.ts
+++ b/src/utils/processReminders.ts
@@ -4,7 +4,7 @@ import { titleCase } from './titleCase'
 import { RealmscapeFeatures } from 'army/malign_sorcery'
 import { Game, TGameStructure } from 'meta/game_structure'
 import { TSupportedFaction } from 'meta/factions'
-import { IArmy } from 'types/army'
+import { IArmy, TAllyData } from 'types/army'
 import { IEffects, IReminder, ITurnAction } from 'types/data'
 import { ISelections, IAllySelections } from 'types/selections'
 
@@ -13,10 +13,7 @@ type TProcessReminders = (
   factionName: TSupportedFaction,
   selections: ISelections,
   realmscape_feature: string | null,
-  allyData: Array<{
-    allyArmy: IArmy
-    allySelections: IAllySelections
-  }>
+  allyData: TAllyData
 ) => IReminder
 
 export const processReminders: TProcessReminders = (army, factionName, selections, realmscape_feature, allyData) => {

--- a/src/utils/processReminders.ts
+++ b/src/utils/processReminders.ts
@@ -77,7 +77,7 @@ const processConditions = (game: TGameStructure, selections: ISelections | IAlly
 
     game[when].forEach((action: ITurnAction) => {
       if (conditions.includes(action.condition)) {
-        accum[when] = processCondition(accum[when] || [], action)
+        accum[when] = accum[when] ? processCondition(accum[when], action) : [action]
       }
     })
 
@@ -95,12 +95,6 @@ const processConditions = (game: TGameStructure, selections: ISelections | IAlly
  * @param action
  */
 const processCondition = produce((phase: ITurnAction[], action: ITurnAction) => {
-  // If this is the first action for a given phase, just return it
-  if (!phase.length) {
-    phase.push(action)
-    return phase
-  }
-
   // See if we can find a matching action already in the phase
   const idx = phase.findIndex(x => x.name === action.name)
 

--- a/src/utils/processReminders.ts
+++ b/src/utils/processReminders.ts
@@ -12,7 +12,7 @@ type TProcessReminders = (
   army: IArmy,
   factionName: TSupportedFaction,
   selections: ISelections,
-  realmscape_feature: string,
+  realmscape_feature: string | null,
   allyData: Array<{
     allyArmy: IArmy
     allySelections: IAllySelections

--- a/src/utils/processReminders.ts
+++ b/src/utils/processReminders.ts
@@ -100,7 +100,7 @@ const processCondition = produce((phase: ITurnAction[], action: ITurnAction) => 
 
   // If there's not a matching action, add this action to the existing phase
   if (idx === -1) {
-    phase.concat(action)
+    phase.push(action)
     return phase
   }
 


### PR DESCRIPTION
+ When two units share a similar effect name, their entry is combined.

(cherry picked from commit 53cd40e49d3c969c0b51a0312db22e71bf6230c0)

+ This commit introduced bugs. This branch fixes them.
+ I also added tests for the bug.