### PR TITLE
Add Print Warning for Firefox users (also fixes #131)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "./",
   "dependencies": {
     "bootstrap": "^4.3.1",
+    "is_js": "^0.9.0",
     "lodash": "^4.17.15",
     "react": "^16.8.6",
     "react-copy-to-clipboard": "^5.0.1",

--- a/src/components/info/reminders.tsx
+++ b/src/components/info/reminders.tsx
@@ -90,13 +90,19 @@ const getTitle = ({
 const VisibilityToggle = (props: { isVisible: boolean; setVisibility: (e) => void }) => {
   const { isVisible, setVisibility } = props
   const VisibilityComponent = isVisible ? MdVisibility : MdVisibilityOff
-  const hideTip = `${isVisible ? `Hidden rules` : `This rule`} will not be printed.`
+  const tipProps = {
+    'data-for': `reminderTooltip`,
+    'data-tip': isVisible ? `Click to hide this rule.` : `This rule will not be printed.`,
+    'data-type': `info`,
+  }
   return (
     <>
-      <IconContext.Provider value={{ size: '1.3em' }}>
-        <VisibilityComponent onClick={setVisibility} data-tip={hideTip} />
-        <ReactTooltip place="bottom" type="info" effect="float" />
-      </IconContext.Provider>
+      <div {...tipProps}>
+        <IconContext.Provider value={{ size: '1.4em' }}>
+          <VisibilityComponent onClick={setVisibility} />
+        </IconContext.Provider>
+        <ReactTooltip id={`reminderTooltip`} />
+      </div>
     </>
   )
 }

--- a/src/components/input/toolbar.tsx
+++ b/src/components/input/toolbar.tsx
@@ -1,14 +1,19 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { factionNames, selections, army } from 'ducks'
-import { logPrintEvent } from 'utils/analytics'
-import { SUPPORTED_FACTIONS, TSupportedFaction } from 'meta/factions'
 import { without } from 'lodash'
-import { TUnits, IArmy } from 'types/army'
+import is from 'is_js'
 import { getArmy } from 'utils/getArmy'
+import { logPrintEvent } from 'utils/analytics'
+import { factionNames, selections, army } from 'ducks'
+import ReactTooltip from 'react-tooltip'
 import { FaPlus } from 'react-icons/fa'
+import { SUPPORTED_FACTIONS, TSupportedFaction } from 'meta/factions'
+import { TUnits, IArmy } from 'types/army'
+import { MdWarning } from 'react-icons/md'
+import { IconContext } from 'react-icons'
 
 const btnWrapperClass = `col-6 col-sm-4 col-md-4 col-lg-3 col-xl-3`
+const btnClass = `btn btn-outline-dark btn-block`
 
 interface IToolbarProps {
   allyFactionNames: TSupportedFaction[]
@@ -28,6 +33,14 @@ const ToolbarComponent = (props: IToolbarProps) => {
     updateAllyArmy({ factionName: newAllyFaction, Army: getArmy(newAllyFaction) as IArmy })
   }
 
+  const handlePrint = e => {
+    e.preventDefault()
+    logPrintEvent(factionName)
+    return window.print()
+  }
+
+  const PrintComponent = is.firefox() ? FirefoxPrintButton : PrintButton
+
   return (
     <div className="container d-print-none">
       <div className="row justify-content-center pt-3">
@@ -35,7 +48,7 @@ const ToolbarComponent = (props: IToolbarProps) => {
           <AddAllyButton setAllyClick={handleAllyClick} />
         </div>
         <div className={btnWrapperClass}>
-          <PrintButton factionName={factionName} />
+          <PrintComponent handlePrint={handlePrint} />
         </div>
       </div>
     </div>
@@ -74,17 +87,29 @@ const AddAllyButton = (props: IAddAllyButton) => {
   )
 }
 
-const PrintButton = (props: { factionName: TSupportedFaction }) => {
-  const handlePrint = e => {
-    e.preventDefault()
-    logPrintEvent(props.factionName)
-    return window.print()
+const PrintButton = (props: { handlePrint: (e: any) => void }) => {
+  return (
+    <button className={btnClass} onClick={props.handlePrint}>
+      Print Page
+    </button>
+  )
+}
+
+const FirefoxPrintButton = (props: { handlePrint: (e: any) => void }) => {
+  const tipProps = {
+    'data-for': 'firefoxPrintWarning',
+    'data-multiline': true,
+    'data-tip': `Warning: Firefox is known to not correctly print this app.<br />Switch to Chrome, Edge, or Safari.`,
+    'data-type': 'error',
   }
   return (
     <>
-      <button className="btn btn-outline-dark btn-block" onClick={handlePrint}>
-        Print Page
-      </button>
+      <IconContext.Provider value={{ className: 'text-warning', size: '1.5em' }}>
+        <button className={btnClass} onClick={props.handlePrint} {...tipProps}>
+          <MdWarning /> Print Page
+        </button>
+      </IconContext.Provider>
+      <ReactTooltip id={`firefoxPrintWarning`} />
     </>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5369,6 +5369,11 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
+is_js@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/is_js/-/is_js-0.9.0.tgz#0ab94540502ba7afa24c856aa985561669e9c52d"
+  integrity sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0=
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"


### PR DESCRIPTION
I've just added a warning to Firefox users. They make up 6% of the app's users, so I don't want to leave them stranded long-term, but doing this warning is quicker than any other solution I can think of.

Firefox users will see a warning sign on the "Print Page" button. If they hover over it, they will see the following pop-up:

<img width="476" alt="Screen Shot 2019-08-04 at 10 35 08 PM" src="https://user-images.githubusercontent.com/9663863/62434908-511d3200-b708-11e9-8980-e51e3e082687.png">
