### PR TITLE
Add Beasts of Chaos (fixes #197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Feel free to submit a PR for any incorrect/missing rules! I am only human, and t
 + [PixelTom](https://github.com/PixelTom)
 + [ctcodie](https://github.com/ctcodie)
 + [Cpt Asgard](https://github.com/CptAsgard)
++ [Liuseeker](https://github.com/LiuSeeker)
 + Lorax
 + [NiklassMM](https://github.com/NiklasMM)
 + [mmorrison](https://github.com/mmorrison)

--- a/clean.js
+++ b/clean.js
@@ -8,8 +8,9 @@ const replaceOptions = {
     /(?<=[name|desc|tag]: )` +(?=.+`)/g, // Remove leading whitespaces
     /(?<!:)(?<=[name|desc|tag]: `.+) +`/g, // Remove trailing whitespaces
     /(?<!:)(?<=desc: `.+\w)`/g, // Add a period to descriptions
+    /(?<=[desc]: `)[\w' ]+ has a casting value of+(?=.+`)/g, // Shorten casting descriptions
   ],
-  to: [`'`, `"`, '`', '`', '.`'],
+  to: [`'`, `"`, '`', '`', '.`', `Casting value of`],
 }
 
 /**

--- a/src/army/beasts_of_chaos/abilities.ts
+++ b/src/army/beasts_of_chaos/abilities.ts
@@ -1,0 +1,49 @@
+import { HERO_PHASE } from 'types/phases'
+import { IEffects } from 'types/data'
+
+// General Allegiance Abilities (always active regardless of army composition)
+const Abilities: IEffects[] = [
+  {
+    name: `The Herdstone`,
+    desc: `After territories have been chosen but before players begin to set up their armies, you can set up one HERDSTONE wholly within your territory, more than 12" from enemy territory and more than 1" from any other terrain features. If both players can set up a terrain feature in this manner, each player rolls a dice, rolling again in the case of a tie, and whoever rolls higher can choose the order in which the terrain features are set up.`,
+    when: [],
+  },
+  {
+    name: `Brayherd Ambush`,
+    desc: `Instead of setting up a BRAYHERD unit on the battlefield, you can place it to one side and say that it is set up in ambush as a reserve unit. You can set up one reserve unit in ambush for each BEASTS OF CHAOS unit you have set up on the battlefield. At the end of your first movement phase, you must set up all friendly reserve units that are in ambush on the battlefield, wholly within 6" of the edge of the battlefield and more than 9" from any enemy units. Any reserve units that cannot be set up are slain.`,
+    when: [],
+  },
+  {
+    name: `Creatures of the Storm`,
+    desc: `At the start of your hero phase, roll a dice. Each friendly THUNDERSCORN unit more than 3" from any enemy units can move a distance in inches equal to the roll, but cannot move within 3" of any enemy units.`,
+    when: [],
+  },
+  {
+    name: `Bloodgorge`,
+    desc: `At the end of the combat phase, if any attacks made by a WARHERD unit in that combat phase destroyed any enemy units, heal D3 wounds allocated to that WARHERD unit.`,
+    when: [],
+  },
+  {
+    name: `Gratfrays`,
+    desc: `If your army is a Beasts of Chaos army, you can give it a Greatfray keyword. All BEASTS OF CHAOS units in your army gain that keyword. You can either choose one of the Greatfrays listed below, or choose another Greatfray you have read about or created yourself. If you choose one from the list below, all units with that keyword benefit from the extra abilities listed for that Greatfray on the page indicated. If you choose a different Greatfray, simply pick the Greatfray that most closely matches the nature of your own.`,
+    when: [],
+  },
+  {
+    name: `Primordial Call`,
+    desc: `You can summon units of BEASTS OF CHAOS to the battlefield if you collect enough Primordial Call points. At the start of your hero phase, you receive 1 Primordial Call point. In addition, in your hero phase you can choose one friendly BEASTS OF CHAOS HERO within 3" of the HERDSTONE you set up at the start of the battle and say that they will enact a savage blood ritual. If you do so, pick a friendly BEASTS OF CHAOS unit within 3" of the HERDSTONE. That unit suffers D3 mortal wounds. For each mortal wound inflicted on that unit, you receive 1 Primordial Call point.
+    If you have 3 or more Primordial Call points at the end of your movement phase, you can summon one or more units from the following list onto the battlefield, and add them to your army. Each unit you summon costs a number of Primordial Call points, as shown on the list, and you can only summon a unit if you have enough Primordial Call points remaining to pay its cost. Summoned units must be set up wholly within 6" of the edge of the battlefield and more than 9" from any enemy units. Subtract the cost of the summoned unit from the number of Primordial Call points you have available immediately after it has been set up.`,
+    when: [],
+  },
+  {
+    name: `Herdstone: Entropic Lodestone`,
+    desc: `Subtract 1 from save rolls for attacks that target units within 6" of this terrain feature. At the start of each battle round after the first, add 6" to the range of this ability. BEASTS OF CHAOS units are not affected by this ability.`,
+    when: [],
+  },
+  {
+    name: `Herdstone: Locus of Savagery`,
+    desc: `BEASTS OF CHAOS units wholly within 6" of this terrain feature do not take battleshock tests. At the start of each battle round after the first, add 6" to the range of this ability.`,
+    when: [],
+  },
+]
+
+export default Abilities

--- a/src/army/beasts_of_chaos/abilities.ts
+++ b/src/army/beasts_of_chaos/abilities.ts
@@ -1,48 +1,66 @@
-import { HERO_PHASE } from 'types/phases'
-import { IEffects } from 'types/data'
+import {
+  BATTLESHOCK_PHASE,
+  DURING_GAME,
+  END_OF_COMBAT_PHASE,
+  END_OF_MOVEMENT_PHASE,
+  HERO_PHASE,
+  START_OF_HERO_PHASE,
+  START_OF_SETUP,
+  TURN_ONE_END_OF_MOVEMENT_PHASE,
+} from 'types/phases'
+import { TAbilities } from 'types/army'
 
 // General Allegiance Abilities (always active regardless of army composition)
-const Abilities: IEffects[] = [
+const Abilities: TAbilities = [
   {
-    name: `The Herdstone`,
+    name: `Herdstone`,
     desc: `After territories have been chosen but before players begin to set up their armies, you can set up one HERDSTONE wholly within your territory, more than 12" from enemy territory and more than 1" from any other terrain features. If both players can set up a terrain feature in this manner, each player rolls a dice, rolling again in the case of a tie, and whoever rolls higher can choose the order in which the terrain features are set up.`,
-    when: [],
+    when: [START_OF_SETUP],
   },
   {
     name: `Brayherd Ambush`,
-    desc: `Instead of setting up a BRAYHERD unit on the battlefield, you can place it to one side and say that it is set up in ambush as a reserve unit. You can set up one reserve unit in ambush for each BEASTS OF CHAOS unit you have set up on the battlefield. At the end of your first movement phase, you must set up all friendly reserve units that are in ambush on the battlefield, wholly within 6" of the edge of the battlefield and more than 9" from any enemy units. Any reserve units that cannot be set up are slain.`,
-    when: [],
+    desc: `Instead of setting up a BRAYHERD unit on the battlefield, you can place it to one side and say that it is set up in ambush as a reserve unit. You can set up one reserve unit in ambush for each BEASTS OF CHAOS unit you have set up on the battlefield.`,
+    when: [START_OF_SETUP],
+  },
+  {
+    name: `Brayherd Ambush`,
+    desc: `At the end of your first movement phase, you must set up all friendly reserve units that are in ambush on the battlefield, wholly within 6" of the edge of the battlefield and more than 9" from any enemy units. Any reserve units that cannot be set up are slain.`,
+    when: [TURN_ONE_END_OF_MOVEMENT_PHASE],
   },
   {
     name: `Creatures of the Storm`,
     desc: `At the start of your hero phase, roll a dice. Each friendly THUNDERSCORN unit more than 3" from any enemy units can move a distance in inches equal to the roll, but cannot move within 3" of any enemy units.`,
-    when: [],
+    when: [START_OF_HERO_PHASE],
   },
   {
     name: `Bloodgorge`,
     desc: `At the end of the combat phase, if any attacks made by a WARHERD unit in that combat phase destroyed any enemy units, heal D3 wounds allocated to that WARHERD unit.`,
-    when: [],
-  },
-  {
-    name: `Gratfrays`,
-    desc: `If your army is a Beasts of Chaos army, you can give it a Greatfray keyword. All BEASTS OF CHAOS units in your army gain that keyword. You can either choose one of the Greatfrays listed below, or choose another Greatfray you have read about or created yourself. If you choose one from the list below, all units with that keyword benefit from the extra abilities listed for that Greatfray on the page indicated. If you choose a different Greatfray, simply pick the Greatfray that most closely matches the nature of your own.`,
-    when: [],
+    when: [END_OF_COMBAT_PHASE],
   },
   {
     name: `Primordial Call`,
-    desc: `You can summon units of BEASTS OF CHAOS to the battlefield if you collect enough Primordial Call points. At the start of your hero phase, you receive 1 Primordial Call point. In addition, in your hero phase you can choose one friendly BEASTS OF CHAOS HERO within 3" of the HERDSTONE you set up at the start of the battle and say that they will enact a savage blood ritual. If you do so, pick a friendly BEASTS OF CHAOS unit within 3" of the HERDSTONE. That unit suffers D3 mortal wounds. For each mortal wound inflicted on that unit, you receive 1 Primordial Call point.
-    If you have 3 or more Primordial Call points at the end of your movement phase, you can summon one or more units from the following list onto the battlefield, and add them to your army. Each unit you summon costs a number of Primordial Call points, as shown on the list, and you can only summon a unit if you have enough Primordial Call points remaining to pay its cost. Summoned units must be set up wholly within 6" of the edge of the battlefield and more than 9" from any enemy units. Subtract the cost of the summoned unit from the number of Primordial Call points you have available immediately after it has been set up.`,
-    when: [],
+    desc: `You can summon units of BEASTS OF CHAOS to the battlefield if you collect enough Primordial Call points. At the start of your hero phase, you receive 1 Primordial Call point.`,
+    when: [START_OF_HERO_PHASE],
+  },
+  {
+    name: `Primordial Call`,
+    desc: `In your hero phase you can choose one friendly BEASTS OF CHAOS HERO within 3" of the HERDSTONE you set up at the start of the battle and say that they will enact a savage blood ritual. If you do so, pick a friendly BEASTS OF CHAOS unit within 3" of the HERDSTONE. That unit suffers D3 mortal wounds. For each mortal wound inflicted on that unit, you receive 1 Primordial Call point.`,
+    when: [HERO_PHASE],
+  },
+  {
+    name: `Primordial Call`,
+    desc: `If you have 3 or more Primordial Call points at the end of your movement phase, you can summon one or more units from the following list onto the battlefield, and add them to your army. Each unit you summon costs a number of Primordial Call points, as shown on the list, and you can only summon a unit if you have enough Primordial Call points remaining to pay its cost. Summoned units must be set up wholly within 6" of the edge of the battlefield and more than 9" from any enemy units. Subtract the cost of the summoned unit from the number of Primordial Call points you have available immediately after it has been set up.`,
+    when: [END_OF_MOVEMENT_PHASE],
   },
   {
     name: `Herdstone: Entropic Lodestone`,
     desc: `Subtract 1 from save rolls for attacks that target units within 6" of this terrain feature. At the start of each battle round after the first, add 6" to the range of this ability. BEASTS OF CHAOS units are not affected by this ability.`,
-    when: [],
+    when: [DURING_GAME],
   },
   {
     name: `Herdstone: Locus of Savagery`,
     desc: `BEASTS OF CHAOS units wholly within 6" of this terrain feature do not take battleshock tests. At the start of each battle round after the first, add 6" to the range of this ability.`,
-    when: [],
+    when: [BATTLESHOCK_PHASE],
   },
 ]
 

--- a/src/army/beasts_of_chaos/abilities.ts
+++ b/src/army/beasts_of_chaos/abilities.ts
@@ -10,7 +10,6 @@ import {
 } from 'types/phases'
 import { TAbilities } from 'types/army'
 
-// General Allegiance Abilities (always active regardless of army composition)
 const Abilities: TAbilities = [
   {
     name: `Herdstone`,

--- a/src/army/beasts_of_chaos/allegiances.ts
+++ b/src/army/beasts_of_chaos/allegiances.ts
@@ -1,0 +1,5 @@
+import { TAllegiances } from 'types/army'
+
+const Allegiances: TAllegiances = []
+
+export default Allegiances

--- a/src/army/beasts_of_chaos/artifacts.ts
+++ b/src/army/beasts_of_chaos/artifacts.ts
@@ -1,5 +1,13 @@
 import { TArtifacts } from 'types/army'
-import { HERO_PHASE } from 'types/phases'
+import {
+  CHARGE_PHASE,
+  COMBAT_PHASE,
+  DURING_GAME,
+  END_OF_MOVEMENT_PHASE,
+  HERO_PHASE,
+  SHOOTING_PHASE,
+  START_OF_HERO_PHASE,
+} from 'types/phases'
 
 const Artifacts: TArtifacts = [
   {
@@ -8,7 +16,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Ramhorn Helm (Brayherds)`,
         desc: `After the bearer completes a charge move, pick an enemy unit within 1" of them. That unit suffers D3 mortal wounds.`,
-        when: [],
+        when: [CHARGE_PHASE],
       },
     ],
   },
@@ -18,7 +26,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Brayblast Trumpet (Brayherds)`,
         desc: `Add 1 to hit rolls for attacks made by friendly BRAYHERD units while they are wholly within 18" of the bearer if those units used the Brayherd Ambush battle trait to set up on the battlefield in that turn.`,
-        when: [],
+        when: [COMBAT_PHASE, SHOOTING_PHASE],
       },
     ],
   },
@@ -28,7 +36,7 @@ const Artifacts: TArtifacts = [
       {
         name: `The Knowing Eye (Brayherds)`,
         desc: `At the start of your hero phase, roll a dice if the bearer is on the battlefield. On a 4+ you receive 1 additional command point.`,
-        when: [],
+        when: [START_OF_HERO_PHASE],
       },
     ],
   },
@@ -37,8 +45,8 @@ const Artifacts: TArtifacts = [
     effects: [
       {
         name: `Volcanic Axe (Brayherds)`,
-        desc: `Pick one of the bearer's melee weapons. Add 1 to that weapon's Damage characteristic. In addition, each time you make an unmodified hit roll of 6 for an attack made with that weapon, the target suffers 1 mortal wound after all of the bearer's attacks have been resolved.`,
-        when: [],
+        desc: `Add 1 to this weapon's Damage characteristic. In addition, each time you make an unmodified hit roll of 6 for an attack made with this weapon, the target suffers 1 mortal wound after all of the bearer's attacks have been resolved.`,
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -48,7 +56,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Bleating Gnarlstaf (Brayherds)`,
         desc: `If the bearer is within 1" of a terrain feature at the end of your movement phase, roll a dice. On a 3+ each enemy unit within 1" of that terrain feature suffers 1 mortal wound.`,
-        when: [],
+        when: [END_OF_MOVEMENT_PHASE],
       },
     ],
   },
@@ -58,7 +66,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Troggoth-hide Cloak (Brayherds)`,
         desc: `At the start of your hero phase, you can heal 1 wound that has been allocated to the bearer.`,
-        when: [],
+        when: [START_OF_HERO_PHASE],
       },
     ],
   },
@@ -67,8 +75,8 @@ const Artifacts: TArtifacts = [
     effects: [
       {
         name: `Cleaver of the Brass Bull (Warherds)`,
-        desc: `Pick one of the bearer's melee weapons. Improve that weapon's Rend characteristic by 1. In addition, if the unmodified hit roll for an attack made with that weapon is 6, add 1 to the Damage characteristic of that weapon for that attack.`,
-        when: [],
+        desc: `Improve this weapon's Rend characteristic by 1. In addition, if the unmodified hit roll for an attack made with that weapon is 6, add 1 to the Damage characteristic of that weapon for that attack.`,
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -78,7 +86,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Gilded Horns (Warherds)`,
         desc: `After the bearer has made a charge move, pick an enemy unit within 1" of the bearer and roll a number of dice equal to the charge roll for that charge move. For each roll of 5+, that enemy unit suffers 1 mortal wound.`,
-        when: [],
+        when: [CHARGE_PHASE],
       },
     ],
   },
@@ -88,7 +96,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Glyph-etched Talisman (Warherds)`,
         desc: `The bearer can attempt to unbind one spell in the enemy hero phase in the same manner as a WIZARD.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -98,7 +106,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Blackened Armour of Chaos (Warherds)`,
         desc: `Roll a dice each time you allocate a mortal wound to the bearer. On a 4+ that mortal wound is negated.`,
-        when: [],
+        when: [DURING_GAME],
       },
     ],
   },
@@ -108,7 +116,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Champion's Doomcloak (Warherds)`,
         desc: `Add 2 to charge rolls made for the bearer.`,
-        when: [],
+        when: [CHARGE_PHASE],
       },
     ],
   },
@@ -118,7 +126,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Herdstone Shard (Warherds)`,
         desc: `When BULLGOR units wholly within 6" of the bearer use their Bloodgreed ability, it activates on an unmodified roll of 5 or 6.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -127,8 +135,8 @@ const Artifacts: TArtifacts = [
     effects: [
       {
         name: `Ancestral Azyrite Blade (Thunderscorn)`,
-        desc: `Pick one of the bearer's melee weapons. Improve that weapon's Rend characteristic by 2.`,
-        when: [],
+        desc: `Improve this weapon's Rend characteristic by 2.`,
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -138,7 +146,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Lightning-chained Bracers (Thunderscorn)`,
         desc: `You can re-roll failed hit rolls for attacks made by the bearer.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -148,7 +156,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Thunderstrike Lodestone (Thunderscorn)`,
         desc: `Once per battle, if the bearer is on the battlefield, they can call down a bolt of lightning. If they do so, you can heal D3 wounds allocated to the bearer. In addition, roll a dice for each enemy unit within 1" of the bearer. On a 2+ that unit suffers 1 mortal wound.`,
-        when: [],
+        when: [DURING_GAME],
       },
     ],
   },
@@ -158,7 +166,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Horn of the Tempest (Thunderscorn)`,
         desc: `Friendly THUNDERSCORN units wholly within 18" of the bearer at the start of your charge phase can make a charge move in that phase even if they ran in the same turn.`,
-        when: [],
+        when: [CHARGE_PHASE],
       },
     ],
   },
@@ -168,7 +176,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Tanglehorn Familiars (Thunderscorn)`,
         desc: `Once per battle, at the start of the enemy hero phase, you can pick an enemy WIZARD within 12" of the bearer. That WIZARD cannot cast any spells that hero phase.`,
-        when: [],
+        when: [START_OF_HERO_PHASE],
       },
     ],
   },
@@ -178,7 +186,7 @@ const Artifacts: TArtifacts = [
       {
         name: `Ruinous Icon (Thunderscorn)`,
         desc: `Each time the bearer is affected by a spell or endless spell, roll a dice. On a 4+ ignore the effects of that spell on the bearer.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },

--- a/src/army/beasts_of_chaos/artifacts.ts
+++ b/src/army/beasts_of_chaos/artifacts.ts
@@ -1,0 +1,188 @@
+import { TArtifacts } from 'types/army'
+import { HERO_PHASE } from 'types/phases'
+
+const Artifacts: TArtifacts = [
+  {
+    name: `Ramhorn Helm (Brayherds)`,
+    effects: [
+      {
+        name: `Ramhorn Helm (Brayherds)`,
+        desc: `After the bearer completes a charge move, pick an enemy unit within 1" of them. That unit suffers D3 mortal wounds.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Brayblast Trumpet (Brayherds)`,
+    effects: [
+      {
+        name: `Brayblast Trumpet (Brayherds)`,
+        desc: `Add 1 to hit rolls for attacks made by friendly BRAYHERD units while they are wholly within 18" of the bearer if those units used the Brayherd Ambush battle trait to set up on the battlefield in that turn.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `The Knowing Eye (Brayherds)`,
+    effects: [
+      {
+        name: `The Knowing Eye (Brayherds)`,
+        desc: `At the start of your hero phase, roll a dice if the bearer is on the battlefield. On a 4+ you receive 1 additional command point.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Volcanic Axe (Brayherds)`,
+    effects: [
+      {
+        name: `Volcanic Axe (Brayherds)`,
+        desc: `Pick one of the bearer’s melee weapons. Add 1 to that weapon’s Damage characteristic. In addition, each time you make an unmodified hit roll of 6 for an attack made with that weapon, the target suffers 1 mortal wound after all of the bearer’s attacks have been resolved.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Bleating Gnarlstaf (Brayherds)`,
+    effects: [
+      {
+        name: `Bleating Gnarlstaf (Brayherds)`,
+        desc: `If the bearer is within 1" of a terrain feature at the end of your movement phase, roll a dice. On a 3+ each enemy unit within 1" of that terrain feature suffers 1 mortal wound.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Troggoth-hide Cloak (Brayherds)`,
+    effects: [
+      {
+        name: `Troggoth-hide Cloak (Brayherds)`,
+        desc: `At the start of your hero phase, you can heal 1 wound that has been allocated to the bearer.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Cleaver of the Brass Bull (Warherds)`,
+    effects: [
+      {
+        name: `Cleaver of the Brass Bull (Warherds)`,
+        desc: `Pick one of the bearer’s melee weapons. Improve that weapon’s Rend characteristic by 1. In addition, if the unmodified hit roll for an attack made with that weapon is 6, add 1 to the Damage characteristic of that weapon for that attack.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Gilded Horns (Warherds)`,
+    effects: [
+      {
+        name: `Gilded Horns (Warherds)`,
+        desc: `After the bearer has made a charge move, pick an enemy unit within 1" of the bearer and roll a number of dice equal to the charge roll for that charge move. For each roll of 5+, that enemy unit suffers 1 mortal wound.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Glyph-etched Talisman (Warherds)`,
+    effects: [
+      {
+        name: `Glyph-etched Talisman (Warherds)`,
+        desc: `The bearer can attempt to unbind one spell in the enemy hero phase in the same manner as a WIZARD.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Blackened Armour of Chaos (Warherds)`,
+    effects: [
+      {
+        name: `Blackened Armour of Chaos (Warherds)`,
+        desc: `Roll a dice each time you allocate a mortal wound to the bearer. On a 4+ that mortal wound is negated.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Champion’s Doomcloak (Warherds)`,
+    effects: [
+      {
+        name: `Champion’s Doomcloak (Warherds)`,
+        desc: `Add 2 to charge rolls made for the bearer.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Herdstone Shard (Warherds)`,
+    effects: [
+      {
+        name: `Herdstone Shard (Warherds)`,
+        desc: `When BULLGOR units wholly within 6" of the bearer use their Bloodgreed ability, it activates on an unmodified roll of 5 or 6.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Ancestral Azyrite Blade (Thunderscorn)`,
+    effects: [
+      {
+        name: `Ancestral Azyrite Blade (Thunderscorn)`,
+        desc: `Pick one of the bearer’s melee weapons. Improve that weapon’s Rend characteristic by 2.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Lightning-chained Bracers (Thunderscorn)`,
+    effects: [
+      {
+        name: `Lightning-chained Bracers (Thunderscorn)`,
+        desc: `You can re-roll failed hit rolls for attacks made by the bearer.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Thunderstrike Lodestone (Thunderscorn)`,
+    effects: [
+      {
+        name: `Thunderstrike Lodestone (Thunderscorn)`,
+        desc: `Once per battle, if the bearer is on the battlefield, they can call down a bolt of lightning. If they do so, you can heal D3 wounds allocated to the bearer. In addition, roll a dice for each enemy unit within 1" of the bearer. On a 2+ that unit suffers 1 mortal wound.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Horn of the Tempest (Thunderscorn)`,
+    effects: [
+      {
+        name: `Horn of the Tempest (Thunderscorn)`,
+        desc: `Friendly THUNDERSCORN units wholly within 18" of the bearer at the start of your charge phase can make a charge move in that phase even if they ran in the same turn.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Tanglehorn Familiars (Thunderscorn)`,
+    effects: [
+      {
+        name: `Tanglehorn Familiars (Thunderscorn)`,
+        desc: `Once per battle, at the start of the enemy hero phase, you can pick an enemy WIZARD within 12" of the bearer. That WIZARD cannot cast any spells that hero phase.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Ruinous Icon (Thunderscorn)`,
+    effects: [
+      {
+        name: `Ruinous Icon (Thunderscorn)`,
+        desc: `Each time the bearer is affected by a spell or endless spell, roll a dice. On a 4+ ignore the effects of that spell on the bearer.`,
+        when: [],
+      },
+    ],
+  },
+  
+]
+
+export default Artifacts

--- a/src/army/beasts_of_chaos/artifacts.ts
+++ b/src/army/beasts_of_chaos/artifacts.ts
@@ -37,7 +37,7 @@ const Artifacts: TArtifacts = [
     effects: [
       {
         name: `Volcanic Axe (Brayherds)`,
-        desc: `Pick one of the bearer’s melee weapons. Add 1 to that weapon’s Damage characteristic. In addition, each time you make an unmodified hit roll of 6 for an attack made with that weapon, the target suffers 1 mortal wound after all of the bearer’s attacks have been resolved.`,
+        desc: `Pick one of the bearer's melee weapons. Add 1 to that weapon's Damage characteristic. In addition, each time you make an unmodified hit roll of 6 for an attack made with that weapon, the target suffers 1 mortal wound after all of the bearer's attacks have been resolved.`,
         when: [],
       },
     ],
@@ -67,7 +67,7 @@ const Artifacts: TArtifacts = [
     effects: [
       {
         name: `Cleaver of the Brass Bull (Warherds)`,
-        desc: `Pick one of the bearer’s melee weapons. Improve that weapon’s Rend characteristic by 1. In addition, if the unmodified hit roll for an attack made with that weapon is 6, add 1 to the Damage characteristic of that weapon for that attack.`,
+        desc: `Pick one of the bearer's melee weapons. Improve that weapon's Rend characteristic by 1. In addition, if the unmodified hit roll for an attack made with that weapon is 6, add 1 to the Damage characteristic of that weapon for that attack.`,
         when: [],
       },
     ],
@@ -103,10 +103,10 @@ const Artifacts: TArtifacts = [
     ],
   },
   {
-    name: `Champion’s Doomcloak (Warherds)`,
+    name: `Champion's Doomcloak (Warherds)`,
     effects: [
       {
-        name: `Champion’s Doomcloak (Warherds)`,
+        name: `Champion's Doomcloak (Warherds)`,
         desc: `Add 2 to charge rolls made for the bearer.`,
         when: [],
       },
@@ -127,7 +127,7 @@ const Artifacts: TArtifacts = [
     effects: [
       {
         name: `Ancestral Azyrite Blade (Thunderscorn)`,
-        desc: `Pick one of the bearer’s melee weapons. Improve that weapon’s Rend characteristic by 2.`,
+        desc: `Pick one of the bearer's melee weapons. Improve that weapon's Rend characteristic by 2.`,
         when: [],
       },
     ],
@@ -182,7 +182,6 @@ const Artifacts: TArtifacts = [
       },
     ],
   },
-  
 ]
 
 export default Artifacts

--- a/src/army/beasts_of_chaos/endless_spells.ts
+++ b/src/army/beasts_of_chaos/endless_spells.ts
@@ -8,7 +8,7 @@ export const EndlessSpells: TEndlessSpells = [
     effects: [
       {
         name: `Summon Ravening Direflock`,
-        desc: `Summon Ravening Direflock has a casting value of 5. Only BEASTS OF CHAOS WIZARDS can attempt to cast this spell. If successfully cast, set up a Ravening Direflock model wholly within 12" of the caster and more than 3" from any units, then set up the second and third Ravening Direflock models wholly within 6" of the first and more than 3" from any units.`,
+        desc: `Casting value of 5. Only BEASTS OF CHAOS WIZARDS can attempt to cast this spell. If successfully cast, set up a Ravening Direflock model wholly within 12" of the caster and more than 3" from any units, then set up the second and third Ravening Direflock models wholly within 6" of the first and more than 3" from any units.`,
         when: [],
       },
       {
@@ -28,7 +28,7 @@ export const EndlessSpells: TEndlessSpells = [
     effects: [
       {
         name: `Summon Doomblast Dirgehorn`,
-        desc: `Summon Doomblast Dirgehorn has a casting value of 6. Only BEASTS OF CHAOS WIZARDS can attempt to cast this spell. If successfully cast, set up a Doomblast Dirgehorn model wholly within 12" of the caster.`,
+        desc: `Casting value of 6. Only BEASTS OF CHAOS WIZARDS can attempt to cast this spell. If successfully cast, set up a Doomblast Dirgehorn model wholly within 12" of the caster.`,
         when: [],
       },
       {
@@ -38,7 +38,7 @@ export const EndlessSpells: TEndlessSpells = [
       },
       {
         name: `Rising Discord`,
-        desc: `At the start of each battle round after this model is set up, add 3" to the range of this model’s Booming Cacophony ability. If this model is dispelled, the next time it is set up on the battlefield, the range of this ability starts at 3".`,
+        desc: `At the start of each battle round after this model is set up, add 3" to the range of this model's Booming Cacophony ability. If this model is dispelled, the next time it is set up on the battlefield, the range of this ability starts at 3".`,
         when: [],
       },
     ],
@@ -48,7 +48,7 @@ export const EndlessSpells: TEndlessSpells = [
     effects: [
       {
         name: `Summon Wildfire Taurus`,
-        desc: `Summon Wildfire Taurus has a casting value of 6. Only BEASTS OF CHAOS WIZARDS can attempt to cast this spell. If successfully cast, set up a Wildfire Taurus model wholly within 12" of the caster.`,
+        desc: `Casting value of 6. Only BEASTS OF CHAOS WIZARDS can attempt to cast this spell. If successfully cast, set up a Wildfire Taurus model wholly within 12" of the caster.`,
         when: [],
       },
       {

--- a/src/army/beasts_of_chaos/endless_spells.ts
+++ b/src/army/beasts_of_chaos/endless_spells.ts
@@ -1,0 +1,73 @@
+import { START_OF_ROUND } from 'types/phases'
+import { TEndlessSpells } from 'types/army'
+
+// Endless spells go here
+export const EndlessSpells: TEndlessSpells = [
+  {
+    name: `Ravening Direflock`,
+    effects: [
+      {
+        name: `Summon Ravening Direflock`,
+        desc: `Summon Ravening Direflock has a casting value of 5. Only BEASTS OF CHAOS WIZARDS can attempt to cast this spell. If successfully cast, set up a Ravening Direflock model wholly within 12" of the caster and more than 3" from any units, then set up the second and third Ravening Direflock models wholly within 6" of the first and more than 3" from any units.`,
+        when: [],
+      },
+      {
+        name: `Harbingers of Dark Omens`,
+        desc: `Subtract 2 from the Bravery characteristic of units while they are within 6" of any Ravening Direflock models. BEASTS OF CHAOS units are not affected by this ability.`,
+        when: [],
+      },
+      {
+        name: `Black-souled Cowardice`,
+        desc: `If a unit finishes a move within 1" of a Ravening Direflock model, remove that Ravening Direflock model from the battlefield. The player whose turn is taking place must set it up again exactly 3D6" from its previous location and more than 3" from any units, and then set up the two remaining Ravening Direflock models wholly within 6" of the first model and more than 3" from any units.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Doomblast Dirgehorn`,
+    effects: [
+      {
+        name: `Summon Doomblast Dirgehorn`,
+        desc: `Summon Doomblast Dirgehorn has a casting value of 6. Only BEASTS OF CHAOS WIZARDS can attempt to cast this spell. If successfully cast, set up a Doomblast Dirgehorn model wholly within 12" of the caster.`,
+        when: [],
+      },
+      {
+        name: `Booming Cacophony`,
+        desc: `Subtract 1 from hit rolls for attacks made by units within 3" of this model. BEASTS OF CHAOS models are not affected by this ability.`,
+        when: [],
+      },
+      {
+        name: `Rising Discord`,
+        desc: `At the start of each battle round after this model is set up, add 3" to the range of this model’s Booming Cacophony ability. If this model is dispelled, the next time it is set up on the battlefield, the range of this ability starts at 3".`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Wildfire Taurus`,
+    effects: [
+      {
+        name: `Summon Wildfire Taurus`,
+        desc: `Summon Wildfire Taurus has a casting value of 6. Only BEASTS OF CHAOS WIZARDS can attempt to cast this spell. If successfully cast, set up a Wildfire Taurus model wholly within 12" of the caster.`,
+        when: [],
+      },
+      {
+        name: `Predatory`,
+        desc: `The Wildfire Taurus is a predatory endless spell. It can move up to 12" and can fly.`,
+        when: [],
+      },
+      {
+        name: `Raging Stampede`,
+        desc: `When this model is set up, the player who set it up can immediately make a move with it.`,
+        when: [],
+      },
+      {
+        name: `Whirlwind of Destruction`,
+        desc: `After this model has moved, each unit that it moved over, and each other unit that is within 1" of it at the end of its move, suffers D3 mortal wounds. If a unit has 10 or more models it suffers D6 mortal wounds instead. If this spell inflicts any wounds on a unit, that unit fights at the end of the next combat phase, after the players have picked any other units to fight in that phase.`,
+        when: [],
+      },
+    ],
+  },
+]
+
+export default EndlessSpells

--- a/src/army/beasts_of_chaos/endless_spells.ts
+++ b/src/army/beasts_of_chaos/endless_spells.ts
@@ -9,7 +9,6 @@ import {
   START_OF_TURN,
 } from 'types/phases'
 
-// Endless spells go here
 export const EndlessSpells: TEndlessSpells = [
   {
     name: `Ravening Direflock`,

--- a/src/army/beasts_of_chaos/endless_spells.ts
+++ b/src/army/beasts_of_chaos/endless_spells.ts
@@ -1,5 +1,13 @@
-import { START_OF_ROUND } from 'types/phases'
 import { TEndlessSpells } from 'types/army'
+import {
+  BATTLESHOCK_PHASE,
+  COMBAT_PHASE,
+  HERO_PHASE,
+  MOVEMENT_PHASE,
+  SHOOTING_PHASE,
+  START_OF_ROUND,
+  START_OF_TURN,
+} from 'types/phases'
 
 // Endless spells go here
 export const EndlessSpells: TEndlessSpells = [
@@ -9,17 +17,17 @@ export const EndlessSpells: TEndlessSpells = [
       {
         name: `Summon Ravening Direflock`,
         desc: `Casting value of 5. Only BEASTS OF CHAOS WIZARDS can attempt to cast this spell. If successfully cast, set up a Ravening Direflock model wholly within 12" of the caster and more than 3" from any units, then set up the second and third Ravening Direflock models wholly within 6" of the first and more than 3" from any units.`,
-        when: [],
+        when: [HERO_PHASE],
       },
       {
         name: `Harbingers of Dark Omens`,
         desc: `Subtract 2 from the Bravery characteristic of units while they are within 6" of any Ravening Direflock models. BEASTS OF CHAOS units are not affected by this ability.`,
-        when: [],
+        when: [BATTLESHOCK_PHASE],
       },
       {
         name: `Black-souled Cowardice`,
         desc: `If a unit finishes a move within 1" of a Ravening Direflock model, remove that Ravening Direflock model from the battlefield. The player whose turn is taking place must set it up again exactly 3D6" from its previous location and more than 3" from any units, and then set up the two remaining Ravening Direflock models wholly within 6" of the first model and more than 3" from any units.`,
-        when: [],
+        when: [MOVEMENT_PHASE],
       },
     ],
   },
@@ -29,17 +37,17 @@ export const EndlessSpells: TEndlessSpells = [
       {
         name: `Summon Doomblast Dirgehorn`,
         desc: `Casting value of 6. Only BEASTS OF CHAOS WIZARDS can attempt to cast this spell. If successfully cast, set up a Doomblast Dirgehorn model wholly within 12" of the caster.`,
-        when: [],
+        when: [HERO_PHASE],
       },
       {
         name: `Booming Cacophony`,
         desc: `Subtract 1 from hit rolls for attacks made by units within 3" of this model. BEASTS OF CHAOS models are not affected by this ability.`,
-        when: [],
+        when: [COMBAT_PHASE, SHOOTING_PHASE],
       },
       {
         name: `Rising Discord`,
         desc: `At the start of each battle round after this model is set up, add 3" to the range of this model's Booming Cacophony ability. If this model is dispelled, the next time it is set up on the battlefield, the range of this ability starts at 3".`,
-        when: [],
+        when: [START_OF_ROUND],
       },
     ],
   },
@@ -49,22 +57,22 @@ export const EndlessSpells: TEndlessSpells = [
       {
         name: `Summon Wildfire Taurus`,
         desc: `Casting value of 6. Only BEASTS OF CHAOS WIZARDS can attempt to cast this spell. If successfully cast, set up a Wildfire Taurus model wholly within 12" of the caster.`,
-        when: [],
+        when: [HERO_PHASE],
       },
       {
         name: `Predatory`,
         desc: `The Wildfire Taurus is a predatory endless spell. It can move up to 12" and can fly.`,
-        when: [],
+        when: [START_OF_TURN],
       },
       {
         name: `Raging Stampede`,
         desc: `When this model is set up, the player who set it up can immediately make a move with it.`,
-        when: [],
+        when: [HERO_PHASE],
       },
       {
         name: `Whirlwind of Destruction`,
         desc: `After this model has moved, each unit that it moved over, and each other unit that is within 1" of it at the end of its move, suffers D3 mortal wounds. If a unit has 10 or more models it suffers D6 mortal wounds instead. If this spell inflicts any wounds on a unit, that unit fights at the end of the next combat phase, after the players have picked any other units to fight in that phase.`,
-        when: [],
+        when: [START_OF_TURN],
       },
     ],
   },

--- a/src/army/beasts_of_chaos/index.ts
+++ b/src/army/beasts_of_chaos/index.ts
@@ -6,8 +6,4 @@ import EndlessSpells from './endless_spells'
 import Spells from './spells'
 import Traits from './traits'
 
-// Copy paste this directory to kickstart a new army
-// Remember to add your army to:
-//      - meta/factions.ts
-//      - meta/army_list.ts
 export default { Abilities, Allegiances, Artifacts, Battalions, EndlessSpells, Spells, Traits, Units }

--- a/src/army/beasts_of_chaos/index.ts
+++ b/src/army/beasts_of_chaos/index.ts
@@ -1,0 +1,13 @@
+import { Battalions, Units } from './units'
+import Abilities from './abilities'
+import Allegiances from './allegiances'
+import Artifacts from './artifacts'
+import EndlessSpells from './endless_spells'
+import Spells from './spells'
+import Traits from './traits'
+
+// Copy paste this directory to kickstart a new army
+// Remember to add your army to:
+//      - meta/factions.ts
+//      - meta/army_list.ts
+export default { Abilities, Allegiances, Artifacts, Battalions, EndlessSpells, Spells, Traits, Units }

--- a/src/army/beasts_of_chaos/spells.ts
+++ b/src/army/beasts_of_chaos/spells.ts
@@ -27,7 +27,7 @@ const Spells: TSpells = [
     effects: [
       {
         name: `Savage Dominion (Brayherd Wizard)`,
-        desc: `Casting value of 5. If successfully cast, pick an enemy MONSTER unit that is a single model within 18" of the caster and visible to them, and roll 2D6. If the roll is equal to or greater than that model's Bravery characteristic, it immediately moves 3" towards the closest model. You can then pick a unit within 1" of that MONSTER and roll a number of dice equal to the MONSTER's Wounds characteristic. For each 4+, that unit suffers 1 mortal wound.`,
+        desc: `Casting value of 5. If successfully cast, pick an enemy Monster unit that is a single model within 18" of the caster and visible to them, and roll 2D6. If the roll is equal to or greater than that model's Bravery characteristic, you can move it 3" towards the closest other model. You can then pick 1 other unit within 1" of that Monster and roll a number of dice equal to the Monster's Wounds characteristic. For each 4+, that unit suffers 1 mortal wound.`,
         when: [HERO_PHASE],
       },
     ],

--- a/src/army/beasts_of_chaos/spells.ts
+++ b/src/army/beasts_of_chaos/spells.ts
@@ -1,7 +1,6 @@
 import { HERO_PHASE } from 'types/phases'
 import { TSpells } from 'types/army'
 
-// Spells, Prayers, etc. go here
 const Spells: TSpells = [
   {
     name: `Viletide (Brayherd Wizard)`,
@@ -9,7 +8,7 @@ const Spells: TSpells = [
       {
         name: `Viletide (Brayherd Wizard)`,
         desc: `Casting value of 6. If successfully cast, pick an enemy unit within 12" of the caster that is visible to them. That unit suffers D3 mortal wounds. If the unit is within 6" of the caster, it suffers D6 mortal wounds instead.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -19,7 +18,7 @@ const Spells: TSpells = [
       {
         name: `Vicious Stranglethorns (Brayherd Wizard)`,
         desc: `Casting value of 7. If successfully cast, pick a terrain feature wholly within 24" of the caster that is visible to them. Each enemy unit within 3" of that terrain feature suffers D3 mortal wounds.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -29,7 +28,7 @@ const Spells: TSpells = [
       {
         name: `Savage Dominion (Brayherd Wizard)`,
         desc: `Casting value of 5. If successfully cast, pick an enemy MONSTER unit that is a single model within 18" of the caster and visible to them, and roll 2D6. If the roll is equal to or greater than that model's Bravery characteristic, it immediately moves 3" towards the closest model. You can then pick a unit within 1" of that MONSTER and roll a number of dice equal to the MONSTER's Wounds characteristic. For each 4+, that unit suffers 1 mortal wound.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -39,7 +38,7 @@ const Spells: TSpells = [
       {
         name: `Tendrils of Atrophy (Brayherd Wizard)`,
         desc: `Casting value of 6. If successfully cast, pick an enemy unit within 12" of the caster that is visible to them. Until your next hero phase, subtract 1 from save rolls for attacks that target that unit.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -49,7 +48,7 @@ const Spells: TSpells = [
       {
         name: `Wild Rampage (Brayherd Wizard)`,
         desc: `Casting value of 6. If successfully cast, pick a friendly unit within 12" of the caster that is visible to them. Until your next hero phase, you can re-roll failed wound rolls for attacks with melee weapons made by this unit. However, subtract 1 from save rolls for attacks that target this unit.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -59,7 +58,7 @@ const Spells: TSpells = [
       {
         name: `Titanic Fury (Brayherd Wizard)`,
         desc: `Casting value of 7. If successfully cast, pick a friendly BEASTS OF CHAOS MONSTER within 12" of the caster that is visible to them. Until your next hero phase, add 1 to the Attacks characteristic of that MONSTER's melee weapons.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -69,7 +68,7 @@ const Spells: TSpells = [
       {
         name: `Thunderwave (Thunderscorn Wizard)`,
         desc: `Casting value of 7. If successfully cast, each unit within 3" of the caster suffers D3 mortal wounds. THUNDERSCORN units are not affected by this spell.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -79,7 +78,7 @@ const Spells: TSpells = [
       {
         name: `Hailstorm (Thunderscorn Wizard)`,
         desc: `Casting value of 6. If successfully cast, pick an enemy unit within 21" of the caster that is visible to them. Until your next hero phase, halve the Move characteristic of, and run and charge rolls for, that unit.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -89,7 +88,7 @@ const Spells: TSpells = [
       {
         name: `Sundering Blades (Thunderscorn Wizard)`,
         desc: `Casting value of 7. If successfully cast, pick a friendly unit wholly within 18" of the caster that is visible to them. Until your next hero phase, improve the Rend characteristic of that unit's melee weapons by 1.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },

--- a/src/army/beasts_of_chaos/spells.ts
+++ b/src/army/beasts_of_chaos/spells.ts
@@ -8,7 +8,7 @@ const Spells: TSpells = [
     effects: [
       {
         name: `Viletide (Brayherd Wizard)`,
-        desc: `Viletide has a casting value of 6. If successfully cast, pick an enemy unit within 12" of the caster that is visible to them. That unit suffers D3 mortal wounds. If the unit is within 6" of the caster, it suffers D6 mortal wounds instead.`,
+        desc: `Casting value of 6. If successfully cast, pick an enemy unit within 12" of the caster that is visible to them. That unit suffers D3 mortal wounds. If the unit is within 6" of the caster, it suffers D6 mortal wounds instead.`,
         when: [],
       },
     ],
@@ -18,7 +18,7 @@ const Spells: TSpells = [
     effects: [
       {
         name: `Vicious Stranglethorns (Brayherd Wizard)`,
-        desc: `Vicious Stranglethorns has a casting value of 7. If successfully cast, pick a terrain feature wholly within 24" of the caster that is visible to them. Each enemy unit within 3" of that terrain feature suffers D3 mortal wounds.`,
+        desc: `Casting value of 7. If successfully cast, pick a terrain feature wholly within 24" of the caster that is visible to them. Each enemy unit within 3" of that terrain feature suffers D3 mortal wounds.`,
         when: [],
       },
     ],
@@ -28,7 +28,7 @@ const Spells: TSpells = [
     effects: [
       {
         name: `Savage Dominion (Brayherd Wizard)`,
-        desc: `Savage Dominion has a casting value of 5. If successfully cast, pick an enemy MONSTER unit that is a single model within 18" of the caster and visible to them, and roll 2D6. If the roll is equal to or greater than that model’s Bravery characteristic, it immediately moves 3" towards the closest model. You can then pick a unit within 1" of that MONSTER and roll a number of dice equal to the MONSTER’s Wounds characteristic. For each 4+, that unit suffers 1 mortal wound.`,
+        desc: `Casting value of 5. If successfully cast, pick an enemy MONSTER unit that is a single model within 18" of the caster and visible to them, and roll 2D6. If the roll is equal to or greater than that model's Bravery characteristic, it immediately moves 3" towards the closest model. You can then pick a unit within 1" of that MONSTER and roll a number of dice equal to the MONSTER's Wounds characteristic. For each 4+, that unit suffers 1 mortal wound.`,
         when: [],
       },
     ],
@@ -38,7 +38,7 @@ const Spells: TSpells = [
     effects: [
       {
         name: `Tendrils of Atrophy (Brayherd Wizard)`,
-        desc: `Tendrils of Atrophy has a casting value of 6. If successfully cast, pick an enemy unit within 12" of the caster that is visible to them. Until your next hero phase, subtract 1 from save rolls for attacks that target that unit.`,
+        desc: `Casting value of 6. If successfully cast, pick an enemy unit within 12" of the caster that is visible to them. Until your next hero phase, subtract 1 from save rolls for attacks that target that unit.`,
         when: [],
       },
     ],
@@ -48,7 +48,7 @@ const Spells: TSpells = [
     effects: [
       {
         name: `Wild Rampage (Brayherd Wizard)`,
-        desc: `Wild Rampage has a casting value of 6. If successfully cast, pick a friendly unit within 12" of the caster that is visible to them. Until your next hero phase, you can re-roll failed wound rolls for attacks with melee weapons made by this unit. However, subtract 1 from save rolls for attacks that target this unit.`,
+        desc: `Casting value of 6. If successfully cast, pick a friendly unit within 12" of the caster that is visible to them. Until your next hero phase, you can re-roll failed wound rolls for attacks with melee weapons made by this unit. However, subtract 1 from save rolls for attacks that target this unit.`,
         when: [],
       },
     ],
@@ -58,7 +58,7 @@ const Spells: TSpells = [
     effects: [
       {
         name: `Titanic Fury (Brayherd Wizard)`,
-        desc: `Titanic Fury has a casting value of 7. If successfully cast, pick a friendly BEASTS OF CHAOS MONSTER within 12" of the caster that is visible to them. Until your next hero phase, add 1 to the Attacks characteristic of that MONSTER’s melee weapons.`,
+        desc: `Casting value of 7. If successfully cast, pick a friendly BEASTS OF CHAOS MONSTER within 12" of the caster that is visible to them. Until your next hero phase, add 1 to the Attacks characteristic of that MONSTER's melee weapons.`,
         when: [],
       },
     ],
@@ -68,7 +68,7 @@ const Spells: TSpells = [
     effects: [
       {
         name: `Thunderwave (Thunderscorn Wizard)`,
-        desc: `Thunderwave has a casting value of 7. If successfully cast, each unit within 3" of the caster suffers D3 mortal wounds. THUNDERSCORN units are not affected by this spell.`,
+        desc: `Casting value of 7. If successfully cast, each unit within 3" of the caster suffers D3 mortal wounds. THUNDERSCORN units are not affected by this spell.`,
         when: [],
       },
     ],
@@ -78,7 +78,7 @@ const Spells: TSpells = [
     effects: [
       {
         name: `Hailstorm (Thunderscorn Wizard)`,
-        desc: `Hailstorm has a casting value of 6. If successfully cast, pick an enemy unit within 21" of the caster that is visible to them. Until your next hero phase, halve the Move characteristic of, and run and charge rolls for, that unit.`,
+        desc: `Casting value of 6. If successfully cast, pick an enemy unit within 21" of the caster that is visible to them. Until your next hero phase, halve the Move characteristic of, and run and charge rolls for, that unit.`,
         when: [],
       },
     ],
@@ -88,7 +88,7 @@ const Spells: TSpells = [
     effects: [
       {
         name: `Sundering Blades (Thunderscorn Wizard)`,
-        desc: `Sundering Blades has a casting value of 7. If successfully cast, pick a friendly unit wholly within 18" of the caster that is visible to them. Until your next hero phase, improve the Rend characteristic of that unit’s melee weapons by 1.`,
+        desc: `Casting value of 7. If successfully cast, pick a friendly unit wholly within 18" of the caster that is visible to them. Until your next hero phase, improve the Rend characteristic of that unit's melee weapons by 1.`,
         when: [],
       },
     ],

--- a/src/army/beasts_of_chaos/spells.ts
+++ b/src/army/beasts_of_chaos/spells.ts
@@ -1,0 +1,98 @@
+import { HERO_PHASE } from 'types/phases'
+import { TSpells } from 'types/army'
+
+// Spells, Prayers, etc. go here
+const Spells: TSpells = [
+  {
+    name: `Viletide (Brayherd Wizard)`,
+    effects: [
+      {
+        name: `Viletide (Brayherd Wizard)`,
+        desc: `Viletide has a casting value of 6. If successfully cast, pick an enemy unit within 12" of the caster that is visible to them. That unit suffers D3 mortal wounds. If the unit is within 6" of the caster, it suffers D6 mortal wounds instead.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Vicious Stranglethorns (Brayherd Wizard)`,
+    effects: [
+      {
+        name: `Vicious Stranglethorns (Brayherd Wizard)`,
+        desc: `Vicious Stranglethorns has a casting value of 7. If successfully cast, pick a terrain feature wholly within 24" of the caster that is visible to them. Each enemy unit within 3" of that terrain feature suffers D3 mortal wounds.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Savage Dominion (Brayherd Wizard)`,
+    effects: [
+      {
+        name: `Savage Dominion (Brayherd Wizard)`,
+        desc: `Savage Dominion has a casting value of 5. If successfully cast, pick an enemy MONSTER unit that is a single model within 18" of the caster and visible to them, and roll 2D6. If the roll is equal to or greater than that model’s Bravery characteristic, it immediately moves 3" towards the closest model. You can then pick a unit within 1" of that MONSTER and roll a number of dice equal to the MONSTER’s Wounds characteristic. For each 4+, that unit suffers 1 mortal wound.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Tendrils of Atrophy (Brayherd Wizard)`,
+    effects: [
+      {
+        name: `Tendrils of Atrophy (Brayherd Wizard)`,
+        desc: `Tendrils of Atrophy has a casting value of 6. If successfully cast, pick an enemy unit within 12" of the caster that is visible to them. Until your next hero phase, subtract 1 from save rolls for attacks that target that unit.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Wild Rampage (Brayherd Wizard)`,
+    effects: [
+      {
+        name: `Wild Rampage (Brayherd Wizard)`,
+        desc: `Wild Rampage has a casting value of 6. If successfully cast, pick a friendly unit within 12" of the caster that is visible to them. Until your next hero phase, you can re-roll failed wound rolls for attacks with melee weapons made by this unit. However, subtract 1 from save rolls for attacks that target this unit.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Titanic Fury (Brayherd Wizard)`,
+    effects: [
+      {
+        name: `Titanic Fury (Brayherd Wizard)`,
+        desc: `Titanic Fury has a casting value of 7. If successfully cast, pick a friendly BEASTS OF CHAOS MONSTER within 12" of the caster that is visible to them. Until your next hero phase, add 1 to the Attacks characteristic of that MONSTER’s melee weapons.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Thunderwave (Thunderscorn Wizard)`,
+    effects: [
+      {
+        name: `Thunderwave (Thunderscorn Wizard)`,
+        desc: `Thunderwave has a casting value of 7. If successfully cast, each unit within 3" of the caster suffers D3 mortal wounds. THUNDERSCORN units are not affected by this spell.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Hailstorm (Thunderscorn Wizard)`,
+    effects: [
+      {
+        name: `Hailstorm (Thunderscorn Wizard)`,
+        desc: `Hailstorm has a casting value of 6. If successfully cast, pick an enemy unit within 21" of the caster that is visible to them. Until your next hero phase, halve the Move characteristic of, and run and charge rolls for, that unit.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Sundering Blades (Thunderscorn Wizard)`,
+    effects: [
+      {
+        name: `Sundering Blades (Thunderscorn Wizard)`,
+        desc: `Sundering Blades has a casting value of 7. If successfully cast, pick a friendly unit wholly within 18" of the caster that is visible to them. Until your next hero phase, improve the Rend characteristic of that unit’s melee weapons by 1.`,
+        when: [],
+      },
+    ],
+  },
+]
+
+export default Spells

--- a/src/army/beasts_of_chaos/traits.ts
+++ b/src/army/beasts_of_chaos/traits.ts
@@ -1,0 +1,188 @@
+import { TCommandTraits } from 'types/army'
+import { HERO_PHASE } from 'types/phases'
+
+const CommandTraits: TCommandTraits = [
+  {
+    name: `Bestial Cunning (Brayherd)`,
+    effects: [
+      {
+        name: `Bestial Cunning (Brayherd)`,
+        desc: `Up to half (rounding down) of the friendly reserve units set up in ambush (see Brayherd Ambush, page 61) can arrive in your second movement phase instead of your first.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Indomitable Beast (Brayherd)`,
+    effects: [
+      {
+        name: `Indomitable Beast (Brayherd)`,
+        desc: `Add 1 to this general’s Wounds characteristic.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Apex Predator (Brayherd)`,
+    effects: [
+      {
+        name: `Apex Predator (Brayherd)`,
+        desc: `Re-roll wound rolls of 1 for attacks made by this general.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Malevolent Despoiler (Brayherd)`,
+    effects: [
+      {
+        name: `Malevolent Despoiler (Brayherd)`,
+        desc: `Enemy units cannot receive the benefit of cover while they are within 12" of this general.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Oracle of the Dark Tongue (Brayherd)`,
+    effects: [
+      {
+        name: `Oracle of the Dark Tongue (Brayherd)`,
+        desc: `Subtract 1 from the Bravery characteristic of enemy units while they are within 12" of this general.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Shadowpelt (Brayherd)`,
+    effects: [
+      {
+        name: `Shadowpelt (Brayherd)`,
+        desc: `Subtract 1 from hit rolls for attacks that target this general made by models more than 3" away from the general.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Eater of Heroes (Warherd)`,
+    effects: [
+      {
+        name: `Eater of Heroes (Warherd)`,
+        desc: `You can re-roll failed hit rolls for attacks made by this general that target an enemy HERO.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Rampant Juggernaut (Warherd)`,
+    effects: [
+      {
+        name: `Rampant Juggernaut (Warherd)`,
+        desc: `You can re-roll charge rolls made for friendly WARHERD units wholly within 12" of this general.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Gorger (Warherd)`,
+    effects: [
+      {
+        name: `Gorger (Warherd)`,
+        desc: `Do not roll a D3 to determine the number of wounds healed by the Bloodgorge battle trait (pg 61) for friendly WARHERD units that are wholly within 12" of this general. Instead, the battle trait heals 3 wounds allocated to that unit.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Gouge-tusks (Warherd)`,
+    effects: [
+      {
+        name: `Gouge-tusks (Warherd)`,
+        desc: `At the end of the combat phase, pick an enemy unit within 3" of this general and roll a dice. On a 1, nothing happens. On a 2-5, that unit suffers 1 mortal wound. On a 6 that unit suffers D3 mortal wounds.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Roaring Brute (Warherd)`,
+    effects: [
+      {
+        name: `Roaring Brute (Warherd)`,
+        desc: `Subtract 1 from the Bravery characteristic of enemy units while they are within 12" of this general.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Rugged Hide (Warherd)`,
+    effects: [
+      {
+        name: `Rugged Hide (Warherd)`,
+        desc: `Worsen the Rend characteristic of attacks that target this general by 1 (to a minimum of ‘-’).`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Tempestuous Tyrant (Thunderscorn)`,
+    effects: [
+      {
+        name: `Tempestuous Tyrant (Thunderscorn)`,
+        desc: `You can re-roll failed wound rolls for attacks made by this general that target a MONSTER.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Magnetic Monstrosity (Thunderscorn)`,
+    effects: [
+      {
+        name: `Magnetic Monstrosity (Thunderscorn)`,
+        desc: `Enemy units cannot retreat while they are within 3" of this general.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Father of the Storm (Thunderscorn)`,
+    effects: [
+      {
+        name: `Father of the Storm (Thunderscorn)`,
+        desc: `When you use the Creatures of the Storm battle trait, you can re-roll the dice that determines how far units can move if this general is on the battlefield.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Lightning-fast Monstrosity (Thunderscorn)`,
+    effects: [
+      {
+        name: `Lightning-fast Monstrosity (Thunderscorn)`,
+        desc: `This general fights at the start of the combat phase if it made a charge move in the same turn, before the players start picking any other units to fight in that combat phase.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Adamantine Scales (Thunderscorn)`,
+    effects: [
+      {
+        name: `Adamantine Scales (Thunderscorn)`,
+        desc: `Add 1 to the Save characteristic of this general.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Ancient Beyond Knowing (Thunderscorn)`,
+    effects: [
+      {
+        name: `Ancient Beyond Knowing (Thunderscorn)`,
+        desc: `At the start of the first battle round, you receive D3 additional command points.`,
+        when: [],
+      },
+    ],
+  },
+  
+]
+
+export default CommandTraits

--- a/src/army/beasts_of_chaos/traits.ts
+++ b/src/army/beasts_of_chaos/traits.ts
@@ -17,7 +17,7 @@ const CommandTraits: TCommandTraits = [
     effects: [
       {
         name: `Indomitable Beast (Brayherd)`,
-        desc: `Add 1 to this general’s Wounds characteristic.`,
+        desc: `Add 1 to this general's Wounds characteristic.`,
         when: [],
       },
     ],
@@ -117,7 +117,7 @@ const CommandTraits: TCommandTraits = [
     effects: [
       {
         name: `Rugged Hide (Warherd)`,
-        desc: `Worsen the Rend characteristic of attacks that target this general by 1 (to a minimum of ‘-’).`,
+        desc: `Worsen the Rend characteristic of attacks that target this general by 1 (to a minimum of '-').`,
         when: [],
       },
     ],
@@ -182,7 +182,6 @@ const CommandTraits: TCommandTraits = [
       },
     ],
   },
-  
 ]
 
 export default CommandTraits

--- a/src/army/beasts_of_chaos/traits.ts
+++ b/src/army/beasts_of_chaos/traits.ts
@@ -1,14 +1,26 @@
-import { TCommandTraits } from 'types/army'
-import { HERO_PHASE } from 'types/phases'
+import { TTraits } from 'types/army'
+import {
+  BATTLESHOCK_PHASE,
+  CHARGE_PHASE,
+  COMBAT_PHASE,
+  DURING_GAME,
+  END_OF_COMBAT_PHASE,
+  MOVEMENT_PHASE,
+  SHOOTING_PHASE,
+  START_OF_COMBAT_PHASE,
+  START_OF_HERO_PHASE,
+  TURN_ONE_START_OF_ROUND,
+  TURN_TWO_MOVEMENT_PHASE,
+} from 'types/phases'
 
-const CommandTraits: TCommandTraits = [
+const CommandTraits: TTraits = [
   {
     name: `Bestial Cunning (Brayherd)`,
     effects: [
       {
         name: `Bestial Cunning (Brayherd)`,
         desc: `Up to half (rounding down) of the friendly reserve units set up in ambush (see Brayherd Ambush, page 61) can arrive in your second movement phase instead of your first.`,
-        when: [],
+        when: [TURN_TWO_MOVEMENT_PHASE],
       },
     ],
   },
@@ -18,7 +30,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Indomitable Beast (Brayherd)`,
         desc: `Add 1 to this general's Wounds characteristic.`,
-        when: [],
+        when: [DURING_GAME],
       },
     ],
   },
@@ -28,7 +40,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Apex Predator (Brayherd)`,
         desc: `Re-roll wound rolls of 1 for attacks made by this general.`,
-        when: [],
+        when: [COMBAT_PHASE, SHOOTING_PHASE],
       },
     ],
   },
@@ -38,7 +50,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Malevolent Despoiler (Brayherd)`,
         desc: `Enemy units cannot receive the benefit of cover while they are within 12" of this general.`,
-        when: [],
+        when: [COMBAT_PHASE, SHOOTING_PHASE],
       },
     ],
   },
@@ -48,7 +60,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Oracle of the Dark Tongue (Brayherd)`,
         desc: `Subtract 1 from the Bravery characteristic of enemy units while they are within 12" of this general.`,
-        when: [],
+        when: [BATTLESHOCK_PHASE],
       },
     ],
   },
@@ -58,7 +70,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Shadowpelt (Brayherd)`,
         desc: `Subtract 1 from hit rolls for attacks that target this general made by models more than 3" away from the general.`,
-        when: [],
+        when: [SHOOTING_PHASE],
       },
     ],
   },
@@ -68,7 +80,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Eater of Heroes (Warherd)`,
         desc: `You can re-roll failed hit rolls for attacks made by this general that target an enemy HERO.`,
-        when: [],
+        when: [COMBAT_PHASE, SHOOTING_PHASE],
       },
     ],
   },
@@ -78,7 +90,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Rampant Juggernaut (Warherd)`,
         desc: `You can re-roll charge rolls made for friendly WARHERD units wholly within 12" of this general.`,
-        when: [],
+        when: [CHARGE_PHASE],
       },
     ],
   },
@@ -88,7 +100,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Gorger (Warherd)`,
         desc: `Do not roll a D3 to determine the number of wounds healed by the Bloodgorge battle trait (pg 61) for friendly WARHERD units that are wholly within 12" of this general. Instead, the battle trait heals 3 wounds allocated to that unit.`,
-        when: [],
+        when: [END_OF_COMBAT_PHASE],
       },
     ],
   },
@@ -98,7 +110,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Gouge-tusks (Warherd)`,
         desc: `At the end of the combat phase, pick an enemy unit within 3" of this general and roll a dice. On a 1, nothing happens. On a 2-5, that unit suffers 1 mortal wound. On a 6 that unit suffers D3 mortal wounds.`,
-        when: [],
+        when: [END_OF_COMBAT_PHASE],
       },
     ],
   },
@@ -108,7 +120,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Roaring Brute (Warherd)`,
         desc: `Subtract 1 from the Bravery characteristic of enemy units while they are within 12" of this general.`,
-        when: [],
+        when: [BATTLESHOCK_PHASE],
       },
     ],
   },
@@ -118,7 +130,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Rugged Hide (Warherd)`,
         desc: `Worsen the Rend characteristic of attacks that target this general by 1 (to a minimum of '-').`,
-        when: [],
+        when: [COMBAT_PHASE, SHOOTING_PHASE],
       },
     ],
   },
@@ -128,7 +140,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Tempestuous Tyrant (Thunderscorn)`,
         desc: `You can re-roll failed wound rolls for attacks made by this general that target a MONSTER.`,
-        when: [],
+        when: [COMBAT_PHASE, SHOOTING_PHASE],
       },
     ],
   },
@@ -138,7 +150,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Magnetic Monstrosity (Thunderscorn)`,
         desc: `Enemy units cannot retreat while they are within 3" of this general.`,
-        when: [],
+        when: [MOVEMENT_PHASE],
       },
     ],
   },
@@ -148,7 +160,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Father of the Storm (Thunderscorn)`,
         desc: `When you use the Creatures of the Storm battle trait, you can re-roll the dice that determines how far units can move if this general is on the battlefield.`,
-        when: [],
+        when: [START_OF_HERO_PHASE],
       },
     ],
   },
@@ -158,7 +170,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Lightning-fast Monstrosity (Thunderscorn)`,
         desc: `This general fights at the start of the combat phase if it made a charge move in the same turn, before the players start picking any other units to fight in that combat phase.`,
-        when: [],
+        when: [START_OF_COMBAT_PHASE],
       },
     ],
   },
@@ -168,7 +180,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Adamantine Scales (Thunderscorn)`,
         desc: `Add 1 to the Save characteristic of this general.`,
-        when: [],
+        when: [COMBAT_PHASE, SHOOTING_PHASE],
       },
     ],
   },
@@ -178,7 +190,7 @@ const CommandTraits: TCommandTraits = [
       {
         name: `Ancient Beyond Knowing (Thunderscorn)`,
         desc: `At the start of the first battle round, you receive D3 additional command points.`,
-        when: [],
+        when: [TURN_ONE_START_OF_ROUND],
       },
     ],
   },

--- a/src/army/beasts_of_chaos/units.ts
+++ b/src/army/beasts_of_chaos/units.ts
@@ -1,0 +1,658 @@
+import { TBattalions, TUnits } from 'types/army'
+import { 
+  HERO_PHASE, 
+  START_OF_MOVEMENT_PHASE, 
+} from 'types/phases'
+
+// Unit Names
+export const Units: TUnits = [
+  {
+    name: `Beastlord`,
+    effects: [
+      {
+        name: `Dual Axes`,
+        desc: `You can re-roll hit rolls of 1 for attacks made with Paired Man-ripper Axes.`,
+        when: [],
+      },
+      {
+        name: `Hatred of Heroes`,
+        desc: `You can re-roll failed wound rolls for attacks made by this model that target a HERO.`,
+        when: [],
+      },
+      {
+        name: `Grisly Trophy`,
+        desc: `You can use this command ability in the combat phase if any attacks made by a friendly BEASTLORD with this command ability resulted in an enemy model being slain that phase. If you do so, until the end of that phase, you can re-roll wound rolls for attacks made by friendly BRAYHERD units wholly within 18" of that BEASTLORD . If any attacks made by that BEASTLORD resulted in an enemy HERO or MONSTER being slain that phase, you can re-roll both hit rolls and wound rolls for attacks made by friendly BRAYHERD units wholly within 18" of that BEASTLORD instead.`,
+        when: [],
+        command_ability: true,
+      }
+    ],
+  },
+  {
+    name: `Great Bray-Shaman`,
+    effects: [
+      {
+        name: `Infuse with Bestial Vigour`,
+        desc: `At the start of your movement phase, add 3" to the Move characteristic of models in friendly BRAYHERD units wholly within 12" of any friendly GREAT BRAY-SHAMANS until the end of that phase.`,
+        when: [],
+      },
+      {
+        name: `Magic`,
+        desc: `Great Bray-Shaman is a WIZARD. It can attempt to cast one spell in your hero phase, and attempt to unbind one spell in the enemy hero phase. It knows the Arcane Bolt, Mystic Shield and Devolve spells.`,
+        when: [],
+      },
+      {
+        name: `Devolve`,
+        desc: `Devolve has a casting value of 7. If successfully cast, pick an enemy unit within 18" of the caster that is visible to them and not within 3" of any friendly units. Your opponent must move that unit up to 2D6" so that each model in the unit ends its move as close as possible to a model from the friendly unit that was closest to it at the start of the move.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Gors`,
+    effects: [
+      {
+        name: `Foe-Render`,
+        desc: `The leader of this unit is a Foe-render. Add 1 to the Attacks characteristic of a Foe-render’s Gor Blade(s).`,
+        when: [],
+      },
+      {
+        name: `Brayhorn`,
+        desc: `1 in every 10 models in this unit can have a Brayhorn. A unit that includes any Brayhorns can run and still charge later in the same turn.`,
+        when: [],
+      },
+      {
+        name: `Banner Bearer`,
+        desc: `1 in every 10 models in this unit can be a Banner Bearer. A unit that includes any Banner Bearers can move an extra 1" when it runs or piles in.`,
+        when: [],
+      },
+      {
+        name: `Rend and Tear`,
+        desc: `You can re-roll hit rolls of 1 for attacks made with a pair of Gor Blades.`,
+        when: [],
+      },
+      {
+        name: `Beastshield`,
+        desc: `Add 1 to save rolls for attacks made with melee weapons that target a unit with Beastshields.`,
+        when: [],
+      },
+      {
+        name: `Anarchy and Mayhem`,
+        desc: `Add 1 to the Attacks characteristic of this unit’s melee weapons while it has 20 or more models.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Ungors`,
+    effects: [
+      {
+        name: `Halfhorn`,
+        desc: `The leader of this unit is a Halfhorn. Add 1 to the Attacks characteristic of a Halfhorn’s Ungor Blade or Gnarled Shortspear.`,
+        when: [],
+      },
+      {
+        name: `Brayhorn`,
+        desc: `1 in every 10 models in this unit can have a Brayhorn. A unit that includes any Brayhorns can run and still charge later in the same turn.`,
+        when: [],
+      },
+      {
+        name: `Banner Bearer`,
+        desc: `1 in every 10 models in this unit can be a Banner Bearer. A unit that includes any Banner Bearers can move an extra 1" when it runs or piles in.`,
+        when: [],
+      },
+      {
+        name: `Baying Hatred`,
+        desc: `You can re-roll hit rolls of 1 for attacks made by this unit while it has 20 or more models, or re-roll hit rolls of 1 and 2 for attacks made by this unit while it has 30 or more models.`,
+        when: [],
+      },
+      {
+        name: `Half-shields`,
+        desc: `Add 1 to save rolls for attacks made with melee weapons that target this unit.`,
+        when: [],
+      },
+    ],
+  },
+  
+  {
+    name: `Ungor Raiders`,
+    effects: [
+      {
+        name: `Halfhorn`,
+        desc: `The leader of this unit is a Halfhorn. Add 1 to the Attacks characteristic of a Halfhorn’s Ungor Blade or Gnarled Shortspear.`,
+        when: [],
+      },
+      {
+        name: `Brayhorn`,
+        desc: `1 in every 10 models in this unit can have a Brayhorn. A unit that includes any Brayhorns can run and still charge later in the same turn.`,
+        when: [],
+      },
+      {
+        name: `Banner Bearer`,
+        desc: `1 in every 10 models in this unit can be a Banner Bearer. A unit that includes any Banner Bearers can move an extra 1" when it runs or piles in.`,
+        when: [],
+      },
+      {
+        name: `Vile Invaders`,
+        desc: `After armies are set up, but before the first battle round begins, this unit can move up to 6".`,
+        when: [],
+      },
+      {
+        name: `Baying Anger`,
+        desc: `You can re-roll hit rolls of 1 for attacks made by this unit with missile weapons while it has 20 or more models, or re-roll hit rolls of 1 and 2 for attacks made by this unit with missile weapons while it has 30 or more models.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Bestigors`,
+    effects: [
+      {
+        name: `Gouge-Horn`,
+        desc: `The leader of this unit is a Gouge-horn. Add 1 to the Attacks characteristic of a Gouge-horn’s Despoiler Axe.`,
+        when: [],
+      },
+      {
+        name: `Brayhorn`,
+        desc: `1 in every 10 models in this unit can have a Brayhorn. A unit that includes any Brayhorns can run and still charge later in the same turn.`,
+        when: [],
+      },
+      {
+        name: `Banner Bearer`,
+        desc: `1 in every 10 models in this unit can be a Banner Bearer. A unit that includes any Banner Bearers can move an extra 1" when it runs or piles in.`,
+        when: [],
+      },
+      {
+        name: `Despoilers`,
+        desc: `Add 1 to hit rolls for attacks made by this unit that target enemy units with 10 or more models. In addition, you can re-roll hit rolls of 1 for attacks by this unit that target ORDER units.`,
+        when: [],
+      },
+      {
+        name: `Bestial Charge`,
+        desc: `Add 1 to the Attacks characteristic of this unit’s melee weapons in a turn in which it made a charge move.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Tuskgor Chariots`,
+    effects: [
+      {
+        name: `Tuskgor Charge`,
+        desc: `You can re-roll charge rolls for this unit. In addition, add 1 to the Attacks characteristic of this unit’s melee weapons in a turn in which it made a charge move.`,
+        when: [],
+      },
+      {
+        name: `Despoilers`,
+        desc: `Add 1 to hit rolls for attacks made by this unit that target enemy units with 10 or more models. In addition, you can re-roll hit rolls of 1 for attacks by this unit that target ORDER units.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Doombull`,
+    effects: [
+      {
+        name: `Bloodgreed`,
+        desc: `Each unmodified wound roll of 6 for attacks made by this unit inflicts 1 mortal wound on the target in addition to any normal damage.`,
+        when: [],
+      },
+      {
+        name: `Slaughterer’s Call`,
+        desc: `You can use this command ability at the start of the combat phase. If you do so, pick a friendly WARHERD unit wholly within 12" of a friendly model with this command ability. Add 1 to wound rolls for attacks made by that unit until the end of that phase.`,
+        when: [],
+        command_ability: true,
+      },
+    ],
+  },
+  {
+    name: `Cygor`,
+    effects: [
+      {
+        name: `Soul-eater`,
+        desc: `This model can attempt to unbind 2 spells in the enemy hero phase in the same manner as a WIZARD. In addition, each time it unbinds a spell, the caster suffers 1 mortal wound and you can heal 1 wound allocated to this model.`,
+        when: [],
+      },
+      {
+        name: `Ghostsight`,
+        desc: `You can re-roll failed hit rolls for attacks made by this model that target a WIZARD.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Ghorgon`,
+    effects: [
+      {
+        name: `Ravenous Bloodgreed`,
+        desc: `Each unmodified wound roll of 6 for attacks made by this model inflicts D3 mortal wounds on the target in addition to any normal damage.`,
+        when: [],
+      },
+      {
+        name: `Swallow Whole`,
+        desc: `Each time this model attacks, you can pick an enemy model within 1" of this model after all of this model’s attacks have been resolved and roll a dice. If the roll is equal to or greater than that enemy model’s Wounds characteristic, it is slain.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Bullgors`,
+    effects: [
+      {
+        name: `Bloodkine`,
+        desc: `The leader of this unit is a Bloodkine. Add 1 to the Attacks characteristic of a Bloodkine’s Bullgor Axe(s) or Bullgor Great Axe.`,
+        when: [],
+      },
+      {
+        name: `Warherd Drummer`,
+        desc: `1 in every 3 models in this unit can be a Warherd Drummer. Add 1 to charge rolls for a unit that includes any Warherd Drummers.`,
+        when: [],
+      },
+      {
+        name: `Warherd Banner Bearer`,
+        desc: `1 in every 3 models in this unit can be a Warherd Banner Bearer. Add 1 to the Bravery characteristic of a unit that includes any Warherd Banner Bearers for each enemy unit within 12" of that unit.`,
+        when: [],
+      },
+      {
+        name: `Bloodgreed`,
+        desc: `Each unmodified wound roll of 6 for attacks made by this unit inflicts 1 mortal wound on the target in addition to any normal damage.`,
+        when: [],
+      },
+      {
+        name: `Dual Axes`,
+        desc: `You can re-roll hit rolls of 1 for attacks made with a pair of Bullgor Axes.`,
+        when: [],
+      },
+      {
+        name: `Bullshields`,
+        desc: `Add 1 to save rolls for attacks made with melee weapons that target a unit with Bullshields.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Centigors`,
+    effects: [
+      {
+        name: `Gorehoof`,
+        desc: `The leader of this unit is a Gorehoof. Add 1 to the Attacks characteristic of a Gorehoof’s Centigor Spear.`,
+        when: [],
+      },
+      {
+        name: `Brayhorn`,
+        desc: `1 in every 5 models in this unit can have a Brayhorn. A unit that includes any Brayhorns can run and still charge later in the same turn.`,
+        when: [],
+      },
+      {
+        name: `Banner Bearer`,
+        desc: `1 in every 5 models in this unit can be a Banner Bearer. A unit that includes any Banner Bearers can move an extra 1" when it runs or piles in.`,
+        when: [],
+      },
+      {
+        name: `Beastbucklers`,
+        desc: `Add 1 to save rolls for attacks made with melee weapons that target a unit with Beastbucklers.`,
+        when: [],
+      },
+      {
+        name: `Charging Spear`,
+        desc: `You can re-roll failed wound rolls for attacks made with this unit’s Centigor Spears if it made a charge move in the same turn.`,
+        when: [],
+      },
+      {
+        name: `Drunken Revelry`,
+        desc: `At the start of your hero phase, you can say that this unit is drinking wildly. If you do so, until your next hero phase, add 1 to hit rolls for attacks made by this unit and attacks that target this unit.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Dragon Ogor Shaggoth`,
+    effects: [
+      {
+        name: `Beneath the Tempest`,
+        desc: `If the roll-off at the start of a battle round to determine who takes the first turn is a tie, roll a dice for each THUNDERSCORN unit on the battlefield. On a 4+ heal D3 wounds allocated to that unit.`,
+        when: [],
+      },
+      {
+        name: `Magic`,
+        desc: `Dragon Ogor Shaggoth is a WIZARD. It can attempt to cast one spell in your hero phase, and attempt to unbind one spell in the enemy hero phase. It knows the Arcane Bolt, Mystic Shield and Summon Lightning spells.`,
+        when: [],
+      },
+      {
+        name: `Summon Lightning`,
+        desc: `Summon Lightning has a casting value of 7. If successfully cast, pick a friendly THUNDERSCORN unit wholly within 20" of the caster and visible to them. You can heal D3 wounds allocated to that unit. In addition, you can re-roll failed wound rolls for attacks made by that unit until your next hero phase.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Dragon Ogors`,
+    effects: [
+      {
+        name: `Storm Rage`,
+        desc: `You can re-roll hit rolls of 1 for this unit while it is wholly within 12" of a friendly DRAGON OGOR SHAGGOTH.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Cahos Warhounds`,
+    effects: [
+      {
+        name: `Outrunners of Chaos`,
+        desc: `In your movement phase, if you declare that this unit will run, do not make a run roll. Instead, add 6" to the Move characteristic of all models in this unit for that phase.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Chaos Spawn`,
+    effects: [
+      {
+        name: `Curse of the Dark Gods`,
+        desc: `You can choose one of the following keywords for this unit the first time it is set up: KHORNE, NURGLE, SLAANESH or TZEENTCH.`,
+        when: [],
+      },
+      {
+        name: `Writhing Tentacles`,
+        desc: `If you roll a double when determining the number of attacks made by a CHAOS SPAWN ’s Freakish Mutations, add 1 to hit and wound rolls for attacks made by that model until the end of the phase.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Jabberslythe`,
+    effects: [
+      {
+        name: `Aura of Madness`,
+        desc: `At the start of your hero phase, roll a dice for each enemy unit that is within 6" of any friendly JABBERSLYTHES . On a 6 that unit cannot attempt to cast or unbind spells, move, or attack until the start of your next hero phase.`,
+        when: [],
+      },
+      {
+        name: `Spurting Bile Blood`,
+        desc: `Roll a dice each time a wound is allocated to this model that was inflicted by a melee weapon. On a 4+ the attacking unit suffers 1 mortal wound after all of its attacks have been resolved.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Cockatrice`,
+    effects: [
+      {
+        name: `Petrifying Gaze`,
+        desc: `Do not use the attack sequence for an attack made with a Cockatrice’s Petrifying Gaze. Instead, roll a dice. On a 4+ the target suffers D6 mortal wounds.`,
+        when: [],
+      },
+      {
+        name: `Maddened Ferocity`,
+        desc: `A Cockatrice has an Attacks characteristic of 8 instead of 4 with its Sword-like Talons if it made a charge move in the same turn.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Chimera`,
+    effects: [
+      {
+        name: `Draconic Head’s Fiery Breath`,
+        desc: `Do not use the attack sequence for an attack made with a Chimera’s Fiery Breath. Instead the target suffers the number of mortal wounds shown on the Damage table above.`,
+        when: [],
+      },
+      {
+        name: `Vicious Charge`,
+        desc: `Add 2 to charge rolls for this model`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Chaos Gargant`,
+    effects: [
+      {
+        name: `Timber!`,
+        desc: `If this model is slain, before removing the model from the battlefield the players must roll off. The player who wins the roll-off picks a point on the battlefield 3" from this model. Each unit within 2" of that point suffers D3 mortal wounds. This model is then removed from the battlefield.`,
+        when: [],
+      },
+      {
+        name: `Stuff ’Em In Me Bag`,
+        desc: `After this model piles in, you can pick an enemy model within 3" of this model and roll a dice. If the roll is equal to or greater than double that enemy model’s Wounds characteristic, it is slain.`,
+        when: [],
+      },
+      {
+        name: `Drunken Stagger`,
+        desc: `If a charge roll for this model is a double, this model cannot make a charge move that phase. In addition, the players must roll off. The player who wins the roll-off picks a point on the battlefield 3" from this model. Each unit within 2" of that point suffers D3 mortal wounds.`,
+        when: [],
+      },
+      {
+        name: `Whipped into a Frenzy`,
+        desc: `At the start of the combat phase, if this model is within 3" of any friendly BEASTS OF CHAOS HEROES, you can whip it into a frenzy. If you do so, this model suffers 1 mortal wound, but you can add 1 to the Attacks characteristic of this model’s melee weapons until the end of that phase.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Razorgors`,
+    effects: [
+      {
+        name: `Uncontrollable Stampede`,
+        desc: `You can re-roll charge rolls for this unit. In addition, if this unit made a charge move in the same turn, an unmodified hit roll of 6 for an attack made by this unit inflicts 1 mortal wound on the target in addition to any normal damage.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Tzaangor Skyfires`,
+    effects: [
+      {
+        name: `Guided by the Future`,
+        desc: `In the combat phase, you can re-roll failed hit and wound rolls for attacks made by this unit if no enemy units within 3" of this unit have already fought in that phase.`,
+        when: [],
+      },
+      {
+        name: `Judgement from Afar`,
+        desc: `An unmodified hit roll of 6 for an attack made with an Arrow of Fate inflicts D3 mortal wounds on the target and the attack sequence ends (do not make a wound or save roll).`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Tzaangor Shaman`,
+    effects: [
+      {
+        name: `Sorcerous Elixir`,
+        desc: `Once per battle, in your hero phase, this model can attempt to cast one additional spell. If it does so, you can re-roll one or both of the dice when you make the casting roll for that spell.`,
+        when: [],
+      },
+      {
+        name: `Visions of the Future`,
+        desc: `Add 1 to hit rolls for attacks made with a friendly TZAANGOR SKYFIRE unit’s Arrows of Fate while that unit is wholly within 12" of a friendly TZAANGOR SHAMAN.`,
+        when: [],
+      },
+      {
+        name: `Visions of the Past`,
+        desc: `Add 1 to hit rolls for attacks made with a friendly TZAANGOR ENLIGHTENED unit’s Tzeentchian Spears and Vicious Beaks while that unit is wholly within 12" of a friendly TZAANGOR SHAMAN.`,
+        when: [],
+      },
+      {
+        name: `Magic`,
+        desc: `This model is a WIZARD. It can attempt to cast one spell in your hero phase, and attempt to unbind one spell in the enemy hero phase. It knows the Arcane Bolt, Mystic Shield and Boon of Mutation spells.`,
+        when: [],
+      },
+      {
+        name: `Boon of Mutation`,
+        desc: `Boon of Mutation has a casting value of 7. If successfully cast, pick an enemy unit within 18" of the caster and visible to them. That unit suffers D3 mortal wounds. For each enemy model slain by these mortal wounds, you can add 1 new TZAANGOR model to a single friendly TZAANGORS unit. Each new TZAANGOR model must be set up wholly within 12" of the caster and within 1" of the unit they are being added to.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Tzaangor Enlightened`,
+    effects: [
+      {
+        name: `Babbling Stream of Secrets`,
+        desc: `If an enemy unit fails a battleshock test within 9" of any friendly TZAANGOR ENLIGHTENED units, add 1 to the number of models that flee.`,
+        when: [],
+      },
+      {
+        name: `Guided by the Past`,
+        desc: `In the combat phase, you can re-roll failed hit and wound rolls for attacks made by this unit if one or more enemy units within 3" of this unit have already fought in that phase.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Tzaangors`,
+    effects: [
+      {
+        name: `Tzaangor Mutant`,
+        desc: `1 in every 5 models in this unit can be a Tzaangor Mutant armed with a pair of Savage Blades and a Vicious Beak. Add 1 to the Attacks characteristic of a Tzaangor Mutant’s pair of Savage Blades.`,
+        when: [],
+      },
+      {
+        name: `Twistbray`,
+        desc: `The leader of this unit is a Twistbray. Add 1 to hit rolls for attacks made with a Twistbray’s melee weapons.`,
+        when: [],
+      },
+      {
+        name: `Icon Bearers`,
+        desc: `1 in every 10 models in this unit can be an Icon Bearer. While this unit has any Icon Bearers, it can use the Ornate Totems ability.`,
+        when: [],
+      },
+      {
+        name: `Brayhorn`,
+        desc: `1 in every 10 models in this unit can have a Brayhorn. A unit that includes any Brayhorns can run and still charge later in the same turn.`,
+        when: [],
+      },
+      {
+        name: `Destined Mayhem`,
+        desc: `Add 1 to wound rolls for attacks made by this unit with melee weapons while this unit is wholly within 12" of any friendly ARCANITE HEROES.`,
+        when: [],
+      },
+      {
+        name: `Arcanite Shield`,
+        desc: `Roll a dice each time you allocate a wound or mortal wound to a friendly TZAANGORS unit that has any models armed with Arcanite Shields. On a 6+ that wound or mortal wound is negated.`,
+        when: [],
+      },
+      {
+        name: `Paired Savage Blades`,
+        desc: `Add 1 to hit rolls for attacks made with a pair of Savage Blades.`,
+        when: [],
+      },
+      {
+        name: `Savagery Unleashed`,
+        desc: `Add 1 to the Attacks characteristic of this unit’s melee weapons if it has at least 9 models when the attacks are being made.`,
+        when: [],
+      },
+      {
+        name: `Ornate Totems`,
+        desc: `While this unit has one or more Icon Bearers, at the start of your hero phase you can pick an enemy unit within 18" of this unit and visible to it. Then, roll a number of dice equal to the number of WIZARD units that are within 9" of this unit. For each 4+ that enemy unit suffers 1 mortal wound.`,
+        when: [],
+      },
+    ],
+  },
+  
+]
+
+// Battalions
+export const Battalions: TBattalions = [
+  {
+    name: `Marauding Brayherd`,
+    effects: [
+      {
+        name: `Ferocious Despoilers`,
+        desc: `Add 1 to charge rolls for friendly BRAYHERD units from this battalion that were set up on the battlefield during the same turn.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Hungering Warherd`,
+    effects: [
+      {
+        name: `Bloodscent`,
+        desc: `Units from this battalion can move an extra 3" when they pile in.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Thuderscorn Stormherd`,
+    effects: [
+      {
+        name: `Raging Storm`,
+        desc: `In your hero phase, you can roll a dice for each unit from this battalion that is on the battlefield. On a 4+ you can heal 1 wound allocated to that unit.
+        After rolling a dice for each unit from this battalion, roll a dice for each enemy unit within 1" of any models from this battalion. On a 4+ that enemy unit suffers 1 mortal wound.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Desolating Beastherd`,
+    effects: [
+      {
+        name: `Bringers of the Wild`,
+        desc: `If the unmodified hit roll for an attack made by a unit from this battalion that is wholly within enemy territory is 6, that attack scores 2 hits on that target instead of 1. Make a wound and save roll for each hit.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Brass Despoilers`,
+    effects: [
+      {
+        name: `Martial Ferocity`,
+        desc: `You can re-roll hit rolls of 1 for attacks made by units from this battalion while they are wholly within 9" of another unit from the same battalion. In addition, once per battle, in your hero phase, you can choose to unleash this battalion’s bestial rage. If you do so, until your next hero phase you can re-roll failed wound rolls for attacks made by units from this battalion while they are wholly within 9" of another unit from the same battalion`,
+        when: [],
+      },
+      {
+        name: `Followers of the Brass Bull`,
+        desc: `Units from this battalion gain the KHORNE keyword.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Phantasmagoria of Fate`,
+    effects: [
+      {
+        name: `Devourers of the Arcane`,
+        desc: `Units from this battalion that do not have the WIZARD keyword can attempt to unbind one spell in the enemy hero phase in the same manner as a WIZARD if they are within 9" of the caster.`,
+        when: [],
+      },
+      {
+        name: `Covens of the Changer`,
+        desc: `Units from this battalion gain the TZEENTCH keyword.`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Pestilent Throng`,
+    effects: [
+      {
+        name: `Entropic Deluge`,
+        desc: `If a unit from this battalion is destroyed, roll a dice for each enemy unit within 7". On a 2+ that enemy unit suffers 1 mortal wound.`,
+        when: [],
+      },
+      {
+        name: `Vectors of the Plague God`,
+        desc: `Units from this battalion gain the NURGLE keyword`,
+        when: [],
+      },
+    ],
+  },
+  {
+    name: `Depraved Drove`,
+    effects: [
+      {
+        name: `Covetous Fury`,
+        desc: `You can re-roll failed charge rolls made for units from this battalion while they are within 12" of an enemy HERO with an artefact of power. In addition, you can re-roll hit rolls for attacks made with melee weapons by models from this battalion that target an enemy HERO with an artefact of power`,
+        when: [],
+      },
+      {
+        name: `Marked by the Decadent Fiend`,
+        desc: `Units from this battalion gain the SLAANESH keyword.`,
+        when: [],
+      },
+    ],
+  },
+]

--- a/src/army/beasts_of_chaos/units.ts
+++ b/src/army/beasts_of_chaos/units.ts
@@ -1,8 +1,5 @@
 import { TBattalions, TUnits } from 'types/army'
-import { 
-  HERO_PHASE, 
-  START_OF_MOVEMENT_PHASE, 
-} from 'types/phases'
+import { HERO_PHASE, START_OF_MOVEMENT_PHASE } from 'types/phases'
 
 // Unit Names
 export const Units: TUnits = [
@@ -24,7 +21,7 @@ export const Units: TUnits = [
         desc: `You can use this command ability in the combat phase if any attacks made by a friendly BEASTLORD with this command ability resulted in an enemy model being slain that phase. If you do so, until the end of that phase, you can re-roll wound rolls for attacks made by friendly BRAYHERD units wholly within 18" of that BEASTLORD . If any attacks made by that BEASTLORD resulted in an enemy HERO or MONSTER being slain that phase, you can re-roll both hit rolls and wound rolls for attacks made by friendly BRAYHERD units wholly within 18" of that BEASTLORD instead.`,
         when: [],
         command_ability: true,
-      }
+      },
     ],
   },
   {
@@ -42,7 +39,7 @@ export const Units: TUnits = [
       },
       {
         name: `Devolve`,
-        desc: `Devolve has a casting value of 7. If successfully cast, pick an enemy unit within 18" of the caster that is visible to them and not within 3" of any friendly units. Your opponent must move that unit up to 2D6" so that each model in the unit ends its move as close as possible to a model from the friendly unit that was closest to it at the start of the move.`,
+        desc: `Casting value of 7. If successfully cast, pick an enemy unit within 18" of the caster that is visible to them and not within 3" of any friendly units. Your opponent must move that unit up to 2D6" so that each model in the unit ends its move as close as possible to a model from the friendly unit that was closest to it at the start of the move.`,
         when: [],
       },
     ],
@@ -52,7 +49,7 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Foe-Render`,
-        desc: `The leader of this unit is a Foe-render. Add 1 to the Attacks characteristic of a Foe-render’s Gor Blade(s).`,
+        desc: `The leader of this unit is a Foe-render. Add 1 to the Attacks characteristic of a Foe-render's Gor Blade(s).`,
         when: [],
       },
       {
@@ -77,7 +74,7 @@ export const Units: TUnits = [
       },
       {
         name: `Anarchy and Mayhem`,
-        desc: `Add 1 to the Attacks characteristic of this unit’s melee weapons while it has 20 or more models.`,
+        desc: `Add 1 to the Attacks characteristic of this unit's melee weapons while it has 20 or more models.`,
         when: [],
       },
     ],
@@ -87,7 +84,7 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Halfhorn`,
-        desc: `The leader of this unit is a Halfhorn. Add 1 to the Attacks characteristic of a Halfhorn’s Ungor Blade or Gnarled Shortspear.`,
+        desc: `The leader of this unit is a Halfhorn. Add 1 to the Attacks characteristic of a Halfhorn's Ungor Blade or Gnarled Shortspear.`,
         when: [],
       },
       {
@@ -112,13 +109,13 @@ export const Units: TUnits = [
       },
     ],
   },
-  
+
   {
     name: `Ungor Raiders`,
     effects: [
       {
         name: `Halfhorn`,
-        desc: `The leader of this unit is a Halfhorn. Add 1 to the Attacks characteristic of a Halfhorn’s Ungor Blade or Gnarled Shortspear.`,
+        desc: `The leader of this unit is a Halfhorn. Add 1 to the Attacks characteristic of a Halfhorn's Ungor Blade or Gnarled Shortspear.`,
         when: [],
       },
       {
@@ -148,7 +145,7 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Gouge-Horn`,
-        desc: `The leader of this unit is a Gouge-horn. Add 1 to the Attacks characteristic of a Gouge-horn’s Despoiler Axe.`,
+        desc: `The leader of this unit is a Gouge-horn. Add 1 to the Attacks characteristic of a Gouge-horn's Despoiler Axe.`,
         when: [],
       },
       {
@@ -168,7 +165,7 @@ export const Units: TUnits = [
       },
       {
         name: `Bestial Charge`,
-        desc: `Add 1 to the Attacks characteristic of this unit’s melee weapons in a turn in which it made a charge move.`,
+        desc: `Add 1 to the Attacks characteristic of this unit's melee weapons in a turn in which it made a charge move.`,
         when: [],
       },
     ],
@@ -178,7 +175,7 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Tuskgor Charge`,
-        desc: `You can re-roll charge rolls for this unit. In addition, add 1 to the Attacks characteristic of this unit’s melee weapons in a turn in which it made a charge move.`,
+        desc: `You can re-roll charge rolls for this unit. In addition, add 1 to the Attacks characteristic of this unit's melee weapons in a turn in which it made a charge move.`,
         when: [],
       },
       {
@@ -197,7 +194,7 @@ export const Units: TUnits = [
         when: [],
       },
       {
-        name: `Slaughterer’s Call`,
+        name: `Slaughterer's Call`,
         desc: `You can use this command ability at the start of the combat phase. If you do so, pick a friendly WARHERD unit wholly within 12" of a friendly model with this command ability. Add 1 to wound rolls for attacks made by that unit until the end of that phase.`,
         when: [],
         command_ability: true,
@@ -229,7 +226,7 @@ export const Units: TUnits = [
       },
       {
         name: `Swallow Whole`,
-        desc: `Each time this model attacks, you can pick an enemy model within 1" of this model after all of this model’s attacks have been resolved and roll a dice. If the roll is equal to or greater than that enemy model’s Wounds characteristic, it is slain.`,
+        desc: `Each time this model attacks, you can pick an enemy model within 1" of this model after all of this model's attacks have been resolved and roll a dice. If the roll is equal to or greater than that enemy model's Wounds characteristic, it is slain.`,
         when: [],
       },
     ],
@@ -239,7 +236,7 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Bloodkine`,
-        desc: `The leader of this unit is a Bloodkine. Add 1 to the Attacks characteristic of a Bloodkine’s Bullgor Axe(s) or Bullgor Great Axe.`,
+        desc: `The leader of this unit is a Bloodkine. Add 1 to the Attacks characteristic of a Bloodkine's Bullgor Axe(s) or Bullgor Great Axe.`,
         when: [],
       },
       {
@@ -274,7 +271,7 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Gorehoof`,
-        desc: `The leader of this unit is a Gorehoof. Add 1 to the Attacks characteristic of a Gorehoof’s Centigor Spear.`,
+        desc: `The leader of this unit is a Gorehoof. Add 1 to the Attacks characteristic of a Gorehoof's Centigor Spear.`,
         when: [],
       },
       {
@@ -294,7 +291,7 @@ export const Units: TUnits = [
       },
       {
         name: `Charging Spear`,
-        desc: `You can re-roll failed wound rolls for attacks made with this unit’s Centigor Spears if it made a charge move in the same turn.`,
+        desc: `You can re-roll failed wound rolls for attacks made with this unit's Centigor Spears if it made a charge move in the same turn.`,
         when: [],
       },
       {
@@ -319,7 +316,7 @@ export const Units: TUnits = [
       },
       {
         name: `Summon Lightning`,
-        desc: `Summon Lightning has a casting value of 7. If successfully cast, pick a friendly THUNDERSCORN unit wholly within 20" of the caster and visible to them. You can heal D3 wounds allocated to that unit. In addition, you can re-roll failed wound rolls for attacks made by that unit until your next hero phase.`,
+        desc: `Casting value of 7. If successfully cast, pick a friendly THUNDERSCORN unit wholly within 20" of the caster and visible to them. You can heal D3 wounds allocated to that unit. In addition, you can re-roll failed wound rolls for attacks made by that unit until your next hero phase.`,
         when: [],
       },
     ],
@@ -354,7 +351,7 @@ export const Units: TUnits = [
       },
       {
         name: `Writhing Tentacles`,
-        desc: `If you roll a double when determining the number of attacks made by a CHAOS SPAWN ’s Freakish Mutations, add 1 to hit and wound rolls for attacks made by that model until the end of the phase.`,
+        desc: `If you roll a double when determining the number of attacks made by a CHAOS SPAWN 's Freakish Mutations, add 1 to hit and wound rolls for attacks made by that model until the end of the phase.`,
         when: [],
       },
     ],
@@ -379,7 +376,7 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Petrifying Gaze`,
-        desc: `Do not use the attack sequence for an attack made with a Cockatrice’s Petrifying Gaze. Instead, roll a dice. On a 4+ the target suffers D6 mortal wounds.`,
+        desc: `Do not use the attack sequence for an attack made with a Cockatrice's Petrifying Gaze. Instead, roll a dice. On a 4+ the target suffers D6 mortal wounds.`,
         when: [],
       },
       {
@@ -393,13 +390,13 @@ export const Units: TUnits = [
     name: `Chimera`,
     effects: [
       {
-        name: `Draconic Head’s Fiery Breath`,
-        desc: `Do not use the attack sequence for an attack made with a Chimera’s Fiery Breath. Instead the target suffers the number of mortal wounds shown on the Damage table above.`,
+        name: `Draconic Head's Fiery Breath`,
+        desc: `Do not use the attack sequence for an attack made with a Chimera's Fiery Breath. Instead the target suffers the number of mortal wounds shown on the Damage table above.`,
         when: [],
       },
       {
         name: `Vicious Charge`,
-        desc: `Add 2 to charge rolls for this model`,
+        desc: `Add 2 to charge rolls for this model.`,
         when: [],
       },
     ],
@@ -413,8 +410,8 @@ export const Units: TUnits = [
         when: [],
       },
       {
-        name: `Stuff ’Em In Me Bag`,
-        desc: `After this model piles in, you can pick an enemy model within 3" of this model and roll a dice. If the roll is equal to or greater than double that enemy model’s Wounds characteristic, it is slain.`,
+        name: `Stuff 'Em In Me Bag`,
+        desc: `After this model piles in, you can pick an enemy model within 3" of this model and roll a dice. If the roll is equal to or greater than double that enemy model's Wounds characteristic, it is slain.`,
         when: [],
       },
       {
@@ -424,7 +421,7 @@ export const Units: TUnits = [
       },
       {
         name: `Whipped into a Frenzy`,
-        desc: `At the start of the combat phase, if this model is within 3" of any friendly BEASTS OF CHAOS HEROES, you can whip it into a frenzy. If you do so, this model suffers 1 mortal wound, but you can add 1 to the Attacks characteristic of this model’s melee weapons until the end of that phase.`,
+        desc: `At the start of the combat phase, if this model is within 3" of any friendly BEASTS OF CHAOS HEROES, you can whip it into a frenzy. If you do so, this model suffers 1 mortal wound, but you can add 1 to the Attacks characteristic of this model's melee weapons until the end of that phase.`,
         when: [],
       },
     ],
@@ -464,12 +461,12 @@ export const Units: TUnits = [
       },
       {
         name: `Visions of the Future`,
-        desc: `Add 1 to hit rolls for attacks made with a friendly TZAANGOR SKYFIRE unit’s Arrows of Fate while that unit is wholly within 12" of a friendly TZAANGOR SHAMAN.`,
+        desc: `Add 1 to hit rolls for attacks made with a friendly TZAANGOR SKYFIRE unit's Arrows of Fate while that unit is wholly within 12" of a friendly TZAANGOR SHAMAN.`,
         when: [],
       },
       {
         name: `Visions of the Past`,
-        desc: `Add 1 to hit rolls for attacks made with a friendly TZAANGOR ENLIGHTENED unit’s Tzeentchian Spears and Vicious Beaks while that unit is wholly within 12" of a friendly TZAANGOR SHAMAN.`,
+        desc: `Add 1 to hit rolls for attacks made with a friendly TZAANGOR ENLIGHTENED unit's Tzeentchian Spears and Vicious Beaks while that unit is wholly within 12" of a friendly TZAANGOR SHAMAN.`,
         when: [],
       },
       {
@@ -479,7 +476,7 @@ export const Units: TUnits = [
       },
       {
         name: `Boon of Mutation`,
-        desc: `Boon of Mutation has a casting value of 7. If successfully cast, pick an enemy unit within 18" of the caster and visible to them. That unit suffers D3 mortal wounds. For each enemy model slain by these mortal wounds, you can add 1 new TZAANGOR model to a single friendly TZAANGORS unit. Each new TZAANGOR model must be set up wholly within 12" of the caster and within 1" of the unit they are being added to.`,
+        desc: `Casting value of 7. If successfully cast, pick an enemy unit within 18" of the caster and visible to them. That unit suffers D3 mortal wounds. For each enemy model slain by these mortal wounds, you can add 1 new TZAANGOR model to a single friendly TZAANGORS unit. Each new TZAANGOR model must be set up wholly within 12" of the caster and within 1" of the unit they are being added to.`,
         when: [],
       },
     ],
@@ -504,12 +501,12 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Tzaangor Mutant`,
-        desc: `1 in every 5 models in this unit can be a Tzaangor Mutant armed with a pair of Savage Blades and a Vicious Beak. Add 1 to the Attacks characteristic of a Tzaangor Mutant’s pair of Savage Blades.`,
+        desc: `1 in every 5 models in this unit can be a Tzaangor Mutant armed with a pair of Savage Blades and a Vicious Beak. Add 1 to the Attacks characteristic of a Tzaangor Mutant's pair of Savage Blades.`,
         when: [],
       },
       {
         name: `Twistbray`,
-        desc: `The leader of this unit is a Twistbray. Add 1 to hit rolls for attacks made with a Twistbray’s melee weapons.`,
+        desc: `The leader of this unit is a Twistbray. Add 1 to hit rolls for attacks made with a Twistbray's melee weapons.`,
         when: [],
       },
       {
@@ -539,7 +536,7 @@ export const Units: TUnits = [
       },
       {
         name: `Savagery Unleashed`,
-        desc: `Add 1 to the Attacks characteristic of this unit’s melee weapons if it has at least 9 models when the attacks are being made.`,
+        desc: `Add 1 to the Attacks characteristic of this unit's melee weapons if it has at least 9 models when the attacks are being made.`,
         when: [],
       },
       {
@@ -549,7 +546,6 @@ export const Units: TUnits = [
       },
     ],
   },
-  
 ]
 
 // Battalions
@@ -600,7 +596,7 @@ export const Battalions: TBattalions = [
     effects: [
       {
         name: `Martial Ferocity`,
-        desc: `You can re-roll hit rolls of 1 for attacks made by units from this battalion while they are wholly within 9" of another unit from the same battalion. In addition, once per battle, in your hero phase, you can choose to unleash this battalion’s bestial rage. If you do so, until your next hero phase you can re-roll failed wound rolls for attacks made by units from this battalion while they are wholly within 9" of another unit from the same battalion`,
+        desc: `You can re-roll hit rolls of 1 for attacks made by units from this battalion while they are wholly within 9" of another unit from the same battalion. In addition, once per battle, in your hero phase, you can choose to unleash this battalion's bestial rage. If you do so, until your next hero phase you can re-roll failed wound rolls for attacks made by units from this battalion while they are wholly within 9" of another unit from the same battalion.`,
         when: [],
       },
       {
@@ -635,7 +631,7 @@ export const Battalions: TBattalions = [
       },
       {
         name: `Vectors of the Plague God`,
-        desc: `Units from this battalion gain the NURGLE keyword`,
+        desc: `Units from this battalion gain the NURGLE keyword.`,
         when: [],
       },
     ],
@@ -645,7 +641,7 @@ export const Battalions: TBattalions = [
     effects: [
       {
         name: `Covetous Fury`,
-        desc: `You can re-roll failed charge rolls made for units from this battalion while they are within 12" of an enemy HERO with an artefact of power. In addition, you can re-roll hit rolls for attacks made with melee weapons by models from this battalion that target an enemy HERO with an artefact of power`,
+        desc: `You can re-roll failed charge rolls made for units from this battalion while they are within 12" of an enemy HERO with an artefact of power. In addition, you can re-roll hit rolls for attacks made with melee weapons by models from this battalion that target an enemy HERO with an artefact of power.`,
         when: [],
       },
       {

--- a/src/army/beasts_of_chaos/units.ts
+++ b/src/army/beasts_of_chaos/units.ts
@@ -1,15 +1,16 @@
 import { TBattalions, TUnits } from 'types/army'
 import {
-  COMBAT_PHASE,
-  START_OF_MOVEMENT_PHASE,
-  HERO_PHASE,
+  BATTLESHOCK_PHASE,
   CHARGE_PHASE,
-  MOVEMENT_PHASE,
+  COMBAT_PHASE,
+  DURING_GAME,
   END_OF_SETUP,
+  HERO_PHASE,
+  MOVEMENT_PHASE,
   SHOOTING_PHASE,
   START_OF_COMBAT_PHASE,
-  BATTLESHOCK_PHASE,
   START_OF_HERO_PHASE,
+  START_OF_MOVEMENT_PHASE,
   START_OF_TURN,
 } from 'types/phases'
 
@@ -327,14 +328,9 @@ export const Units: TUnits = [
     name: `Chaos Spawn`,
     effects: [
       {
-        name: `Curse of the Dark Gods`,
-        desc: `You can choose one of the following keywords for this unit the first time it is set up: KHORNE, NURGLE, SLAANESH or TZEENTCH.`,
-        when: [],
-      },
-      {
         name: `Writhing Tentacles`,
-        desc: `If you roll a double when determining the number of attacks made by a CHAOS SPAWN 's Freakish Mutations, add 1 to hit and wound rolls for attacks made by that model until the end of the phase.`,
-        when: [],
+        desc: `If you roll a double when determining the number of attacks made by a CHAOS SPAWN's Freakish Mutations, add 1 to hit and wound rolls for attacks made by that model until the end of the phase.`,
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -344,12 +340,12 @@ export const Units: TUnits = [
       {
         name: `Aura of Madness`,
         desc: `At the start of your hero phase, roll a dice for each enemy unit that is within 6" of any friendly JABBERSLYTHES . On a 6 that unit cannot attempt to cast or unbind spells, move, or attack until the start of your next hero phase.`,
-        when: [],
+        when: [START_OF_HERO_PHASE],
       },
       {
         name: `Spurting Bile Blood`,
         desc: `Roll a dice each time a wound is allocated to this model that was inflicted by a melee weapon. On a 4+ the attacking unit suffers 1 mortal wound after all of its attacks have been resolved.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -359,12 +355,12 @@ export const Units: TUnits = [
       {
         name: `Petrifying Gaze`,
         desc: `Do not use the attack sequence for an attack made with a Cockatrice's Petrifying Gaze. Instead, roll a dice. On a 4+ the target suffers D6 mortal wounds.`,
-        when: [],
+        when: [SHOOTING_PHASE],
       },
       {
         name: `Maddened Ferocity`,
         desc: `A Cockatrice has an Attacks characteristic of 8 instead of 4 with its Sword-like Talons if it made a charge move in the same turn.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -374,12 +370,12 @@ export const Units: TUnits = [
       {
         name: `Draconic Head's Fiery Breath`,
         desc: `Do not use the attack sequence for an attack made with a Chimera's Fiery Breath. Instead the target suffers the number of mortal wounds shown on the Damage table above.`,
-        when: [],
+        when: [SHOOTING_PHASE],
       },
       {
         name: `Vicious Charge`,
         desc: `Add 2 to charge rolls for this model.`,
-        when: [],
+        when: [CHARGE_PHASE],
       },
     ],
   },
@@ -389,22 +385,22 @@ export const Units: TUnits = [
       {
         name: `Timber!`,
         desc: `If this model is slain, before removing the model from the battlefield the players must roll off. The player who wins the roll-off picks a point on the battlefield 3" from this model. Each unit within 2" of that point suffers D3 mortal wounds. This model is then removed from the battlefield.`,
-        when: [],
+        when: [DURING_GAME],
       },
       {
         name: `Stuff 'Em In Me Bag`,
         desc: `After this model piles in, you can pick an enemy model within 3" of this model and roll a dice. If the roll is equal to or greater than double that enemy model's Wounds characteristic, it is slain.`,
-        when: [],
+        when: [CHARGE_PHASE],
       },
       {
         name: `Drunken Stagger`,
         desc: `If a charge roll for this model is a double, this model cannot make a charge move that phase. In addition, the players must roll off. The player who wins the roll-off picks a point on the battlefield 3" from this model. Each unit within 2" of that point suffers D3 mortal wounds.`,
-        when: [],
+        when: [CHARGE_PHASE],
       },
       {
         name: `Whipped into a Frenzy`,
         desc: `At the start of the combat phase, if this model is within 3" of any friendly BEASTS OF CHAOS HEROES, you can whip it into a frenzy. If you do so, this model suffers 1 mortal wound, but you can add 1 to the Attacks characteristic of this model's melee weapons until the end of that phase.`,
-        when: [],
+        when: [START_OF_COMBAT_PHASE],
       },
     ],
   },
@@ -414,7 +410,7 @@ export const Units: TUnits = [
       {
         name: `Uncontrollable Stampede`,
         desc: `You can re-roll charge rolls for this unit. In addition, if this unit made a charge move in the same turn, an unmodified hit roll of 6 for an attack made by this unit inflicts 1 mortal wound on the target in addition to any normal damage.`,
-        when: [],
+        when: [CHARGE_PHASE],
       },
     ],
   },
@@ -424,12 +420,12 @@ export const Units: TUnits = [
       {
         name: `Guided by the Future`,
         desc: `In the combat phase, you can re-roll failed hit and wound rolls for attacks made by this unit if no enemy units within 3" of this unit have already fought in that phase.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Judgement from Afar`,
         desc: `An unmodified hit roll of 6 for an attack made with an Arrow of Fate inflicts D3 mortal wounds on the target and the attack sequence ends (do not make a wound or save roll).`,
-        when: [],
+        when: [SHOOTING_PHASE],
       },
     ],
   },
@@ -439,27 +435,27 @@ export const Units: TUnits = [
       {
         name: `Sorcerous Elixir`,
         desc: `Once per battle, in your hero phase, this model can attempt to cast one additional spell. If it does so, you can re-roll one or both of the dice when you make the casting roll for that spell.`,
-        when: [],
+        when: [HERO_PHASE],
       },
       {
         name: `Visions of the Future`,
         desc: `Add 1 to hit rolls for attacks made with a friendly TZAANGOR SKYFIRE unit's Arrows of Fate while that unit is wholly within 12" of a friendly TZAANGOR SHAMAN.`,
-        when: [],
+        when: [SHOOTING_PHASE],
       },
       {
         name: `Visions of the Past`,
         desc: `Add 1 to hit rolls for attacks made with a friendly TZAANGOR ENLIGHTENED unit's Tzeentchian Spears and Vicious Beaks while that unit is wholly within 12" of a friendly TZAANGOR SHAMAN.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Magic`,
         desc: `This model is a WIZARD. It can attempt to cast one spell in your hero phase, and attempt to unbind one spell in the enemy hero phase. It knows the Arcane Bolt, Mystic Shield and Boon of Mutation spells.`,
-        when: [],
+        when: [HERO_PHASE],
       },
       {
         name: `Boon of Mutation`,
         desc: `Casting value of 7. If successfully cast, pick an enemy unit within 18" of the caster and visible to them. That unit suffers D3 mortal wounds. For each enemy model slain by these mortal wounds, you can add 1 new TZAANGOR model to a single friendly TZAANGORS unit. Each new TZAANGOR model must be set up wholly within 12" of the caster and within 1" of the unit they are being added to.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -469,12 +465,12 @@ export const Units: TUnits = [
       {
         name: `Babbling Stream of Secrets`,
         desc: `If an enemy unit fails a battleshock test within 9" of any friendly TZAANGOR ENLIGHTENED units, add 1 to the number of models that flee.`,
-        when: [],
+        when: [BATTLESHOCK_PHASE],
       },
       {
         name: `Guided by the Past`,
         desc: `In the combat phase, you can re-roll failed hit and wound rolls for attacks made by this unit if one or more enemy units within 3" of this unit have already fought in that phase.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -482,49 +478,44 @@ export const Units: TUnits = [
     name: `Tzaangors`,
     effects: [
       {
-        name: `Tzaangor Mutant`,
-        desc: `1 in every 5 models in this unit can be a Tzaangor Mutant armed with a pair of Savage Blades and a Vicious Beak. Add 1 to the Attacks characteristic of a Tzaangor Mutant's pair of Savage Blades.`,
-        when: [],
-      },
-      {
         name: `Twistbray`,
         desc: `The leader of this unit is a Twistbray. Add 1 to hit rolls for attacks made with a Twistbray's melee weapons.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Icon Bearers`,
         desc: `1 in every 10 models in this unit can be an Icon Bearer. While this unit has any Icon Bearers, it can use the Ornate Totems ability.`,
-        when: [],
+        when: [START_OF_HERO_PHASE],
       },
       {
         name: `Brayhorn`,
         desc: `1 in every 10 models in this unit can have a Brayhorn. A unit that includes any Brayhorns can run and still charge later in the same turn.`,
-        when: [],
+        when: [MOVEMENT_PHASE, CHARGE_PHASE],
       },
       {
         name: `Destined Mayhem`,
         desc: `Add 1 to wound rolls for attacks made by this unit with melee weapons while this unit is wholly within 12" of any friendly ARCANITE HEROES.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Arcanite Shield`,
         desc: `Roll a dice each time you allocate a wound or mortal wound to a friendly TZAANGORS unit that has any models armed with Arcanite Shields. On a 6+ that wound or mortal wound is negated.`,
-        when: [],
+        when: [COMBAT_PHASE, SHOOTING_PHASE],
       },
       {
         name: `Paired Savage Blades`,
         desc: `Add 1 to hit rolls for attacks made with a pair of Savage Blades.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Savagery Unleashed`,
         desc: `Add 1 to the Attacks characteristic of this unit's melee weapons if it has at least 9 models when the attacks are being made.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Ornate Totems`,
         desc: `While this unit has one or more Icon Bearers, at the start of your hero phase you can pick an enemy unit within 18" of this unit and visible to it. Then, roll a number of dice equal to the number of WIZARD units that are within 9" of this unit. For each 4+ that enemy unit suffers 1 mortal wound.`,
-        when: [],
+        when: [START_OF_HERO_PHASE],
       },
     ],
   },
@@ -538,7 +529,7 @@ export const Battalions: TBattalions = [
       {
         name: `Ferocious Despoilers`,
         desc: `Add 1 to charge rolls for friendly BRAYHERD units from this battalion that were set up on the battlefield during the same turn.`,
-        when: [],
+        when: [CHARGE_PHASE],
       },
     ],
   },
@@ -548,7 +539,7 @@ export const Battalions: TBattalions = [
       {
         name: `Bloodscent`,
         desc: `Units from this battalion can move an extra 3" when they pile in.`,
-        when: [],
+        when: [CHARGE_PHASE],
       },
     ],
   },
@@ -557,9 +548,8 @@ export const Battalions: TBattalions = [
     effects: [
       {
         name: `Raging Storm`,
-        desc: `In your hero phase, you can roll a dice for each unit from this battalion that is on the battlefield. On a 4+ you can heal 1 wound allocated to that unit.
-        After rolling a dice for each unit from this battalion, roll a dice for each enemy unit within 1" of any models from this battalion. On a 4+ that enemy unit suffers 1 mortal wound.`,
-        when: [],
+        desc: `In your hero phase, you can roll a dice for each unit from this battalion that is on the battlefield. On a 4+ you can heal 1 wound allocated to that unit. After rolling a dice for each unit from this battalion, roll a dice for each enemy unit within 1" of any models from this battalion. On a 4+ that enemy unit suffers 1 mortal wound.`,
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -569,7 +559,7 @@ export const Battalions: TBattalions = [
       {
         name: `Bringers of the Wild`,
         desc: `If the unmodified hit roll for an attack made by a unit from this battalion that is wholly within enemy territory is 6, that attack scores 2 hits on that target instead of 1. Make a wound and save roll for each hit.`,
-        when: [],
+        when: [COMBAT_PHASE, SHOOTING_PHASE],
       },
     ],
   },
@@ -579,12 +569,7 @@ export const Battalions: TBattalions = [
       {
         name: `Martial Ferocity`,
         desc: `You can re-roll hit rolls of 1 for attacks made by units from this battalion while they are wholly within 9" of another unit from the same battalion. In addition, once per battle, in your hero phase, you can choose to unleash this battalion's bestial rage. If you do so, until your next hero phase you can re-roll failed wound rolls for attacks made by units from this battalion while they are wholly within 9" of another unit from the same battalion.`,
-        when: [],
-      },
-      {
-        name: `Followers of the Brass Bull`,
-        desc: `Units from this battalion gain the KHORNE keyword.`,
-        when: [],
+        when: [COMBAT_PHASE, SHOOTING_PHASE],
       },
     ],
   },
@@ -594,12 +579,7 @@ export const Battalions: TBattalions = [
       {
         name: `Devourers of the Arcane`,
         desc: `Units from this battalion that do not have the WIZARD keyword can attempt to unbind one spell in the enemy hero phase in the same manner as a WIZARD if they are within 9" of the caster.`,
-        when: [],
-      },
-      {
-        name: `Covens of the Changer`,
-        desc: `Units from this battalion gain the TZEENTCH keyword.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -609,12 +589,7 @@ export const Battalions: TBattalions = [
       {
         name: `Entropic Deluge`,
         desc: `If a unit from this battalion is destroyed, roll a dice for each enemy unit within 7". On a 2+ that enemy unit suffers 1 mortal wound.`,
-        when: [],
-      },
-      {
-        name: `Vectors of the Plague God`,
-        desc: `Units from this battalion gain the NURGLE keyword.`,
-        when: [],
+        when: [DURING_GAME],
       },
     ],
   },
@@ -624,12 +599,7 @@ export const Battalions: TBattalions = [
       {
         name: `Covetous Fury`,
         desc: `You can re-roll failed charge rolls made for units from this battalion while they are within 12" of an enemy HERO with an artefact of power. In addition, you can re-roll hit rolls for attacks made with melee weapons by models from this battalion that target an enemy HERO with an artefact of power.`,
-        when: [],
-      },
-      {
-        name: `Marked by the Decadent Fiend`,
-        desc: `Units from this battalion gain the SLAANESH keyword.`,
-        when: [],
+        when: [CHARGE_PHASE],
       },
     ],
   },

--- a/src/army/beasts_of_chaos/units.ts
+++ b/src/army/beasts_of_chaos/units.ts
@@ -1,5 +1,17 @@
 import { TBattalions, TUnits } from 'types/army'
-import { HERO_PHASE, START_OF_MOVEMENT_PHASE } from 'types/phases'
+import {
+  COMBAT_PHASE,
+  START_OF_MOVEMENT_PHASE,
+  HERO_PHASE,
+  CHARGE_PHASE,
+  MOVEMENT_PHASE,
+  END_OF_SETUP,
+  SHOOTING_PHASE,
+  START_OF_COMBAT_PHASE,
+  BATTLESHOCK_PHASE,
+  START_OF_HERO_PHASE,
+  START_OF_TURN,
+} from 'types/phases'
 
 // Unit Names
 export const Units: TUnits = [
@@ -9,17 +21,17 @@ export const Units: TUnits = [
       {
         name: `Dual Axes`,
         desc: `You can re-roll hit rolls of 1 for attacks made with Paired Man-ripper Axes.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Hatred of Heroes`,
         desc: `You can re-roll failed wound rolls for attacks made by this model that target a HERO.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Grisly Trophy`,
         desc: `You can use this command ability in the combat phase if any attacks made by a friendly BEASTLORD with this command ability resulted in an enemy model being slain that phase. If you do so, until the end of that phase, you can re-roll wound rolls for attacks made by friendly BRAYHERD units wholly within 18" of that BEASTLORD . If any attacks made by that BEASTLORD resulted in an enemy HERO or MONSTER being slain that phase, you can re-roll both hit rolls and wound rolls for attacks made by friendly BRAYHERD units wholly within 18" of that BEASTLORD instead.`,
-        when: [],
+        when: [COMBAT_PHASE],
         command_ability: true,
       },
     ],
@@ -30,17 +42,17 @@ export const Units: TUnits = [
       {
         name: `Infuse with Bestial Vigour`,
         desc: `At the start of your movement phase, add 3" to the Move characteristic of models in friendly BRAYHERD units wholly within 12" of any friendly GREAT BRAY-SHAMANS until the end of that phase.`,
-        when: [],
+        when: [START_OF_MOVEMENT_PHASE],
       },
       {
         name: `Magic`,
         desc: `Great Bray-Shaman is a WIZARD. It can attempt to cast one spell in your hero phase, and attempt to unbind one spell in the enemy hero phase. It knows the Arcane Bolt, Mystic Shield and Devolve spells.`,
-        when: [],
+        when: [HERO_PHASE],
       },
       {
         name: `Devolve`,
         desc: `Casting value of 7. If successfully cast, pick an enemy unit within 18" of the caster that is visible to them and not within 3" of any friendly units. Your opponent must move that unit up to 2D6" so that each model in the unit ends its move as close as possible to a model from the friendly unit that was closest to it at the start of the move.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -48,34 +60,29 @@ export const Units: TUnits = [
     name: `Gors`,
     effects: [
       {
-        name: `Foe-Render`,
-        desc: `The leader of this unit is a Foe-render. Add 1 to the Attacks characteristic of a Foe-render's Gor Blade(s).`,
-        when: [],
-      },
-      {
         name: `Brayhorn`,
         desc: `1 in every 10 models in this unit can have a Brayhorn. A unit that includes any Brayhorns can run and still charge later in the same turn.`,
-        when: [],
+        when: [MOVEMENT_PHASE, CHARGE_PHASE],
       },
       {
         name: `Banner Bearer`,
         desc: `1 in every 10 models in this unit can be a Banner Bearer. A unit that includes any Banner Bearers can move an extra 1" when it runs or piles in.`,
-        when: [],
+        when: [MOVEMENT_PHASE, CHARGE_PHASE],
       },
       {
         name: `Rend and Tear`,
         desc: `You can re-roll hit rolls of 1 for attacks made with a pair of Gor Blades.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Beastshield`,
         desc: `Add 1 to save rolls for attacks made with melee weapons that target a unit with Beastshields.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Anarchy and Mayhem`,
         desc: `Add 1 to the Attacks characteristic of this unit's melee weapons while it has 20 or more models.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -83,29 +90,24 @@ export const Units: TUnits = [
     name: `Ungors`,
     effects: [
       {
-        name: `Halfhorn`,
-        desc: `The leader of this unit is a Halfhorn. Add 1 to the Attacks characteristic of a Halfhorn's Ungor Blade or Gnarled Shortspear.`,
-        when: [],
-      },
-      {
         name: `Brayhorn`,
         desc: `1 in every 10 models in this unit can have a Brayhorn. A unit that includes any Brayhorns can run and still charge later in the same turn.`,
-        when: [],
+        when: [MOVEMENT_PHASE, CHARGE_PHASE],
       },
       {
         name: `Banner Bearer`,
         desc: `1 in every 10 models in this unit can be a Banner Bearer. A unit that includes any Banner Bearers can move an extra 1" when it runs or piles in.`,
-        when: [],
+        when: [MOVEMENT_PHASE, CHARGE_PHASE],
       },
       {
         name: `Baying Hatred`,
         desc: `You can re-roll hit rolls of 1 for attacks made by this unit while it has 20 or more models, or re-roll hit rolls of 1 and 2 for attacks made by this unit while it has 30 or more models.`,
-        when: [],
+        when: [COMBAT_PHASE, SHOOTING_PHASE],
       },
       {
         name: `Half-shields`,
         desc: `Add 1 to save rolls for attacks made with melee weapons that target this unit.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -114,29 +116,24 @@ export const Units: TUnits = [
     name: `Ungor Raiders`,
     effects: [
       {
-        name: `Halfhorn`,
-        desc: `The leader of this unit is a Halfhorn. Add 1 to the Attacks characteristic of a Halfhorn's Ungor Blade or Gnarled Shortspear.`,
-        when: [],
-      },
-      {
         name: `Brayhorn`,
         desc: `1 in every 10 models in this unit can have a Brayhorn. A unit that includes any Brayhorns can run and still charge later in the same turn.`,
-        when: [],
+        when: [MOVEMENT_PHASE, CHARGE_PHASE],
       },
       {
         name: `Banner Bearer`,
         desc: `1 in every 10 models in this unit can be a Banner Bearer. A unit that includes any Banner Bearers can move an extra 1" when it runs or piles in.`,
-        when: [],
+        when: [MOVEMENT_PHASE, CHARGE_PHASE],
       },
       {
         name: `Vile Invaders`,
         desc: `After armies are set up, but before the first battle round begins, this unit can move up to 6".`,
-        when: [],
+        when: [END_OF_SETUP],
       },
       {
         name: `Baying Anger`,
         desc: `You can re-roll hit rolls of 1 for attacks made by this unit with missile weapons while it has 20 or more models, or re-roll hit rolls of 1 and 2 for attacks made by this unit with missile weapons while it has 30 or more models.`,
-        when: [],
+        when: [SHOOTING_PHASE],
       },
     ],
   },
@@ -144,29 +141,24 @@ export const Units: TUnits = [
     name: `Bestigors`,
     effects: [
       {
-        name: `Gouge-Horn`,
-        desc: `The leader of this unit is a Gouge-horn. Add 1 to the Attacks characteristic of a Gouge-horn's Despoiler Axe.`,
-        when: [],
-      },
-      {
         name: `Brayhorn`,
         desc: `1 in every 10 models in this unit can have a Brayhorn. A unit that includes any Brayhorns can run and still charge later in the same turn.`,
-        when: [],
+        when: [MOVEMENT_PHASE, CHARGE_PHASE],
       },
       {
         name: `Banner Bearer`,
         desc: `1 in every 10 models in this unit can be a Banner Bearer. A unit that includes any Banner Bearers can move an extra 1" when it runs or piles in.`,
-        when: [],
+        when: [MOVEMENT_PHASE, CHARGE_PHASE],
       },
       {
         name: `Despoilers`,
         desc: `Add 1 to hit rolls for attacks made by this unit that target enemy units with 10 or more models. In addition, you can re-roll hit rolls of 1 for attacks by this unit that target ORDER units.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Bestial Charge`,
         desc: `Add 1 to the Attacks characteristic of this unit's melee weapons in a turn in which it made a charge move.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -176,12 +168,12 @@ export const Units: TUnits = [
       {
         name: `Tuskgor Charge`,
         desc: `You can re-roll charge rolls for this unit. In addition, add 1 to the Attacks characteristic of this unit's melee weapons in a turn in which it made a charge move.`,
-        when: [],
+        when: [CHARGE_PHASE, COMBAT_PHASE],
       },
       {
         name: `Despoilers`,
         desc: `Add 1 to hit rolls for attacks made by this unit that target enemy units with 10 or more models. In addition, you can re-roll hit rolls of 1 for attacks by this unit that target ORDER units.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -191,12 +183,12 @@ export const Units: TUnits = [
       {
         name: `Bloodgreed`,
         desc: `Each unmodified wound roll of 6 for attacks made by this unit inflicts 1 mortal wound on the target in addition to any normal damage.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Slaughterer's Call`,
         desc: `You can use this command ability at the start of the combat phase. If you do so, pick a friendly WARHERD unit wholly within 12" of a friendly model with this command ability. Add 1 to wound rolls for attacks made by that unit until the end of that phase.`,
-        when: [],
+        when: [START_OF_COMBAT_PHASE],
         command_ability: true,
       },
     ],
@@ -207,12 +199,12 @@ export const Units: TUnits = [
       {
         name: `Soul-eater`,
         desc: `This model can attempt to unbind 2 spells in the enemy hero phase in the same manner as a WIZARD. In addition, each time it unbinds a spell, the caster suffers 1 mortal wound and you can heal 1 wound allocated to this model.`,
-        when: [],
+        when: [HERO_PHASE],
       },
       {
         name: `Ghostsight`,
         desc: `You can re-roll failed hit rolls for attacks made by this model that target a WIZARD.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -222,12 +214,12 @@ export const Units: TUnits = [
       {
         name: `Ravenous Bloodgreed`,
         desc: `Each unmodified wound roll of 6 for attacks made by this model inflicts D3 mortal wounds on the target in addition to any normal damage.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Swallow Whole`,
         desc: `Each time this model attacks, you can pick an enemy model within 1" of this model after all of this model's attacks have been resolved and roll a dice. If the roll is equal to or greater than that enemy model's Wounds characteristic, it is slain.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -235,34 +227,29 @@ export const Units: TUnits = [
     name: `Bullgors`,
     effects: [
       {
-        name: `Bloodkine`,
-        desc: `The leader of this unit is a Bloodkine. Add 1 to the Attacks characteristic of a Bloodkine's Bullgor Axe(s) or Bullgor Great Axe.`,
-        when: [],
-      },
-      {
         name: `Warherd Drummer`,
         desc: `1 in every 3 models in this unit can be a Warherd Drummer. Add 1 to charge rolls for a unit that includes any Warherd Drummers.`,
-        when: [],
+        when: [CHARGE_PHASE],
       },
       {
         name: `Warherd Banner Bearer`,
         desc: `1 in every 3 models in this unit can be a Warherd Banner Bearer. Add 1 to the Bravery characteristic of a unit that includes any Warherd Banner Bearers for each enemy unit within 12" of that unit.`,
-        when: [],
+        when: [BATTLESHOCK_PHASE],
       },
       {
         name: `Bloodgreed`,
         desc: `Each unmodified wound roll of 6 for attacks made by this unit inflicts 1 mortal wound on the target in addition to any normal damage.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Dual Axes`,
         desc: `You can re-roll hit rolls of 1 for attacks made with a pair of Bullgor Axes.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Bullshields`,
         desc: `Add 1 to save rolls for attacks made with melee weapons that target a unit with Bullshields.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
     ],
   },
@@ -270,34 +257,29 @@ export const Units: TUnits = [
     name: `Centigors`,
     effects: [
       {
-        name: `Gorehoof`,
-        desc: `The leader of this unit is a Gorehoof. Add 1 to the Attacks characteristic of a Gorehoof's Centigor Spear.`,
-        when: [],
-      },
-      {
         name: `Brayhorn`,
         desc: `1 in every 5 models in this unit can have a Brayhorn. A unit that includes any Brayhorns can run and still charge later in the same turn.`,
-        when: [],
+        when: [CHARGE_PHASE, MOVEMENT_PHASE],
       },
       {
         name: `Banner Bearer`,
         desc: `1 in every 5 models in this unit can be a Banner Bearer. A unit that includes any Banner Bearers can move an extra 1" when it runs or piles in.`,
-        when: [],
+        when: [CHARGE_PHASE, MOVEMENT_PHASE],
       },
       {
         name: `Beastbucklers`,
         desc: `Add 1 to save rolls for attacks made with melee weapons that target a unit with Beastbucklers.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Charging Spear`,
         desc: `You can re-roll failed wound rolls for attacks made with this unit's Centigor Spears if it made a charge move in the same turn.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
       {
         name: `Drunken Revelry`,
         desc: `At the start of your hero phase, you can say that this unit is drinking wildly. If you do so, until your next hero phase, add 1 to hit rolls for attacks made by this unit and attacks that target this unit.`,
-        when: [],
+        when: [START_OF_HERO_PHASE],
       },
     ],
   },
@@ -307,17 +289,17 @@ export const Units: TUnits = [
       {
         name: `Beneath the Tempest`,
         desc: `If the roll-off at the start of a battle round to determine who takes the first turn is a tie, roll a dice for each THUNDERSCORN unit on the battlefield. On a 4+ heal D3 wounds allocated to that unit.`,
-        when: [],
+        when: [START_OF_TURN],
       },
       {
         name: `Magic`,
         desc: `Dragon Ogor Shaggoth is a WIZARD. It can attempt to cast one spell in your hero phase, and attempt to unbind one spell in the enemy hero phase. It knows the Arcane Bolt, Mystic Shield and Summon Lightning spells.`,
-        when: [],
+        when: [HERO_PHASE],
       },
       {
         name: `Summon Lightning`,
         desc: `Casting value of 7. If successfully cast, pick a friendly THUNDERSCORN unit wholly within 20" of the caster and visible to them. You can heal D3 wounds allocated to that unit. In addition, you can re-roll failed wound rolls for attacks made by that unit until your next hero phase.`,
-        when: [],
+        when: [HERO_PHASE],
       },
     ],
   },
@@ -327,17 +309,17 @@ export const Units: TUnits = [
       {
         name: `Storm Rage`,
         desc: `You can re-roll hit rolls of 1 for this unit while it is wholly within 12" of a friendly DRAGON OGOR SHAGGOTH.`,
-        when: [],
+        when: [COMBAT_PHASE],
       },
     ],
   },
   {
-    name: `Cahos Warhounds`,
+    name: `Chaos Warhounds`,
     effects: [
       {
         name: `Outrunners of Chaos`,
         desc: `In your movement phase, if you declare that this unit will run, do not make a run roll. Instead, add 6" to the Move characteristic of all models in this unit for that phase.`,
-        when: [],
+        when: [MOVEMENT_PHASE],
       },
     ],
   },

--- a/src/meta/army_list.ts
+++ b/src/meta/army_list.ts
@@ -61,7 +61,7 @@ export const ArmyList: TArmyList = {
     GrandAlliance: DESTRUCTION,
   },
   [BEASTS_OF_CHAOS]: {
-    Army: { ...BeastsOfChaos},
+    Army: { ...BeastsOfChaos },
     GrandAlliance: CHAOS,
   },
   [DAUGHTERS_OF_KHAINE]: {

--- a/src/meta/army_list.ts
+++ b/src/meta/army_list.ts
@@ -2,6 +2,7 @@ import { CHAOS, DEATH, DESTRUCTION, ORDER, TGrandAlliances } from './alliances'
 import { IArmyWithoutGame } from 'types/army'
 import {
   BEASTCLAW_RAIDERS,
+  BEASTS_OF_CHAOS,
   DAUGHTERS_OF_KHAINE,
   DISPOSSESSED,
   EVERCHOSEN,
@@ -29,6 +30,7 @@ import {
 } from './factions'
 
 import BeastclawRaiders from 'army/beastclaw_raiders'
+import BeastsOfChaos from 'army/beasts_of_chaos'
 import DaughtersOfKhaine from 'army/daughters_of_khaine'
 import Dispossessed from 'army/dispossessed'
 import Everchosen from 'army/everchosen'
@@ -57,6 +59,10 @@ export const ArmyList: TArmyList = {
   [BEASTCLAW_RAIDERS]: {
     Army: { ...BeastclawRaiders },
     GrandAlliance: DESTRUCTION,
+  },
+  [BEASTS_OF_CHAOS]: {
+    Army: { ...BeastsOfChaos},
+    GrandAlliance: CHAOS,
   },
   [DAUGHTERS_OF_KHAINE]: {
     Army: { ...DaughtersOfKhaine },

--- a/src/meta/factions.ts
+++ b/src/meta/factions.ts
@@ -2,7 +2,7 @@ import { sortBy } from 'lodash'
 
 // Supported Faction Types
 export type TBeastclawRaiders = 'BEASTCLAW_RAIDERS'
-export type TBeastsOfChaos = "BEASTS_OF_CHAOS"
+export type TBeastsOfChaos = 'BEASTS_OF_CHAOS'
 export type TDaughtersOfKhaine = 'DAUGHTERS_OF_KHAINE'
 export type TDispossessed = 'DISPOSSESSED'
 export type TEverchosen = 'EVERCHOSEN'
@@ -29,7 +29,7 @@ export type TTzeentch = 'TZEENTCH'
 
 // Exported Faction Names
 export const BEASTCLAW_RAIDERS: TBeastclawRaiders = 'BEASTCLAW_RAIDERS'
-export const BEASTS_OF_CHAOS: TBeastsOfChaos = "BEASTS_OF_CHAOS"
+export const BEASTS_OF_CHAOS: TBeastsOfChaos = 'BEASTS_OF_CHAOS'
 export const DAUGHTERS_OF_KHAINE: TDaughtersOfKhaine = 'DAUGHTERS_OF_KHAINE'
 export const DISPOSSESSED: TDispossessed = 'DISPOSSESSED'
 export const EVERCHOSEN: TEverchosen = 'EVERCHOSEN'

--- a/src/meta/factions.ts
+++ b/src/meta/factions.ts
@@ -2,6 +2,7 @@ import { sortBy } from 'lodash'
 
 // Supported Faction Types
 export type TBeastclawRaiders = 'BEASTCLAW_RAIDERS'
+export type TBeastsOfChaos = "BEASTS_OF_CHAOS"
 export type TDaughtersOfKhaine = 'DAUGHTERS_OF_KHAINE'
 export type TDispossessed = 'DISPOSSESSED'
 export type TEverchosen = 'EVERCHOSEN'
@@ -28,6 +29,7 @@ export type TTzeentch = 'TZEENTCH'
 
 // Exported Faction Names
 export const BEASTCLAW_RAIDERS: TBeastclawRaiders = 'BEASTCLAW_RAIDERS'
+export const BEASTS_OF_CHAOS: TBeastsOfChaos = "BEASTS_OF_CHAOS"
 export const DAUGHTERS_OF_KHAINE: TDaughtersOfKhaine = 'DAUGHTERS_OF_KHAINE'
 export const DISPOSSESSED: TDispossessed = 'DISPOSSESSED'
 export const EVERCHOSEN: TEverchosen = 'EVERCHOSEN'
@@ -55,6 +57,7 @@ export const TZEENTCH: TTzeentch = 'TZEENTCH'
 // Supported Factions
 export type TSupportedFaction =
   | TBeastclawRaiders
+  | TBeastsOfChaos
   | TDaughtersOfKhaine
   | TDispossessed
   | TEverchosen
@@ -81,6 +84,7 @@ export type TSupportedFaction =
 
 export const SUPPORTED_FACTIONS: TSupportedFaction[] = sortBy([
   BEASTCLAW_RAIDERS,
+  BEASTS_OF_CHAOS,
   DAUGHTERS_OF_KHAINE,
   DISPOSSESSED,
   EVERCHOSEN,


### PR DESCRIPTION
Added army/beasts_of_chaos, with abilities, allegiances, artifacts, endless_spells, index, spells, traits and units based in the Beasts of Chaos Battletome.
Also included the BoC in the meta/army_list and meta/factions.

The missing things are all the 'when' fields in all army/beasts_of_chaos/*.ts
If missing something something besides that, notify me.