### PR TITLE
Fix wording for Shock and Awe allegiance ability

### DIFF
--- a/src/army/stormcast_eternals/abilities.ts
+++ b/src/army/stormcast_eternals/abilities.ts
@@ -10,7 +10,7 @@ const Abilities: TAbilities = [
   },
   {
     name: `Shock and Awe`,
-    desc: `Subtract 1 from hit rolls for attacks that target any unit setup this turn via SCIONS OF THE STORM.`,
+    desc: `Subtract 1 from hit rolls for attacks that target any unit setup this turn.`,
     when: [COMBAT_PHASE, SHOOTING_PHASE],
   },
 ]


### PR DESCRIPTION
There's no mention in the Shock and Awe ability that it only applies to Scions of the Storm