### PR TITLE
Set SelectMulti inputs to stay open after selections

### DIFF
--- a/src/components/input/select.tsx
+++ b/src/components/input/select.tsx
@@ -62,6 +62,7 @@ export const SelectMulti = (props: ISelectMultiProps) => {
       <Select
         value={selectValues}
         defaultValue={hasDefault ? options[0] : null}
+        closeMenuOnSelect={false}
         isClearable={isClearable}
         isMulti={true}
         isSearchable={true}


### PR DESCRIPTION
My first thought was to try to make it so you could hold Ctrl or Cmd to select multiple at a time, but while looking at how it might be implemented I found this built-in option and I like the behaviour so PRing it to see what you think of it.