### PR TITLE
Add Knight-Questor Larissa Shadowstalker

### DIFF
--- a/src/army/stormcast_eternals/units.ts
+++ b/src/army/stormcast_eternals/units.ts
@@ -796,6 +796,36 @@ export const Units: TUnits = [
     ],
   },
   {
+    name: `Knight-Questor Larissa Shadowstalker`,
+    effects: [
+      {
+        name: `Deathstrike`,
+        desc: `If the unmodified hit roll for an attack made with this model's Stormstrike Glaive that targets a MONSTER is 6, that attack has a Damage characteristic of D6 instead of 1.`,
+        when: [COMBAT_PHASE],
+      },
+      {
+        name: `The Malleus Occulum`,
+        desc: `If your battle is taking place in Ulgu, the Realm of Shadow, you can re-roll charge rolls for this model.`,
+        when: [CHARGE_PHASE],
+      },
+      {
+        name: `The Malleus Occulum`,
+        desc: `If your battle is taking place in Ulgu, the Realm of Shadow, this model is unaffected by the Mystifying Miasma spell.`,
+        when: [HERO_PHASE],
+      },
+      {
+        name: `Protector Discipline`,
+        desc: `Add 1 to save rolls for attacks made with missile weapons that target this model.`,
+        when: [SHOOTING_PHASE],
+      },
+      {
+        name: `The Shadowstalker's Quarry`,
+        desc: `If this model is within 6" of an enemy MONSTER in the combat phase, it is eligible to fight and can move an extra 3" when it piles in, but must end that pile-in move within 1" of an enemy MONSTER. In addition, you can re-roll hit rolls for attacks made by this model if the target of the attack is a MONSTER.`,
+        when: [COMBAT_PHASE],
+      },
+    ],
+  },
+  {
     name: `Knight-Vexillor`,
     effects: [
       {


### PR DESCRIPTION
Store anniversary model. Doesn't have points, so not in warscroll builder. Also not in the app (including the non-Azyr reference bit). But there's a warscroll in the box, so she's usable in Open and Narrative.

https://www.tga.community/forums/topic/18313-aos-2-stormcast-eternals-discussion/?do=findComment&comment=371824

Uncertain about whether the second half of The Malleus Occulum should have the "If your battle is taking place in Ulgu..." bit. On the one hand, it's entirely redundant as that's the only time that spell will be in play. On the other hand, the player might not know off-hand what Mystifying Miasma is or when it would be in play, so keeping the condition in there helps them ignore it when not in Ulgu.