### PR TITLE
Skaven Pestilens into Nurgle (fixes #452)

### DIFF
--- a/src/army/nurgle/units.ts
+++ b/src/army/nurgle/units.ts
@@ -24,10 +24,23 @@ import {
 import { getEverchosenUnits } from 'army/everchosen/units'
 import { MARK_NURGLE } from 'meta/alliances'
 import BeastsofChaos from 'army/beasts_of_chaos'
+import Skaven from 'army/skaven'
 import { filterBattalions, filterUnits } from 'utils/filterUtils'
 import { getTamurkhansUnits, getTamurkhansBattalions } from 'army/tamurkhans_horde/units'
 
 const SlaveUnits = getChaosSlaves(MARK_NURGLE)
+
+const getSkavenUnits = () => {
+  const listOfUnits = [
+    'Plagueclaw',
+    'Plague Censer Bearers',
+    'Plague Priest',
+    'Plague Priest on Plague Furnace',
+    'Plague Monks',
+    'Verminlord Corruptor',
+  ]
+  return filterUnits(Skaven.Units, listOfUnits)
+}
 
 const getBoCUnits = () => {
   const listOfUnits = [
@@ -59,6 +72,7 @@ export const AlliedUnits: TUnits = [
   ...SlaveUnits,
   ...getBoCUnits(),
   ...getEverchosenUnits(),
+  ...getSkavenUnits(),
 ]
 
 // Unit Names

--- a/src/army/slaves_to_darkness/units.ts
+++ b/src/army/slaves_to_darkness/units.ts
@@ -25,6 +25,8 @@ export const getSlavesUnits = () => {
     `Chaos Lord on Manticore`,
     `Chaos Marauder Horsemen`,
     `Chaos Marauders`,
+    `Chaos Sorcerer Lord on Manticore`,
+    `Chaos Sorcerer Lord`,
     `Chaos War Mammoth`,
     `Chaos Warriors`,
     `Chaos Warshrine`,


### PR DESCRIPTION
- Added skaven pestilens units to nurgle
- Added chaos sorcerer lord to list of slaves units to be exported to chaos gods

Fixes #452