### PR TITLE
Fix typo in Sigmarite Dais

### DIFF
--- a/src/army/generic/scenery.ts
+++ b/src/army/generic/scenery.ts
@@ -333,7 +333,7 @@ const OfficialScenery: TScenery = [
     ],
   },
   {
-    name: `Sigmarite Dias`,
+    name: `Sigmarite Dais`,
     effects: [
       {
         name: `Bastion of Order`,


### PR DESCRIPTION
I don't think this scenery piece is in either Azyr or warscrollbuilder, so there shouldn't be any import issues I don't think.