### PR TITLE
Stop appending _reminders to default pdf filename a second time

### DIFF
--- a/src/components/print/pdfModal.tsx
+++ b/src/components/print/pdfModal.tsx
@@ -33,7 +33,7 @@ export const DownloadPDFModal: React.FC<IModalComponentProps> = props => {
   const [processing, setProcessing] = useState(false)
 
   useEffect(() => {
-    setFileName(getDefaultName(defaultName))
+    setFileName(defaultName)
   }, [factionName, defaultName])
 
   const handleUpdateName = (e: any) => {


### PR DESCRIPTION
Only seemed to happen when the filename isn't changed in the modal

When clicking `Download`, the `_reminders` suffix would again be
appended, so the filename seen in the native save dialog was of the
form Faction_Reminders_Reminders.pdf