### PR TITLE
Add a Notification Banner for CoS/Orruks

### DIFF
--- a/src/components/info/notification_banner.tsx
+++ b/src/components/info/notification_banner.tsx
@@ -12,7 +12,7 @@ interface IBannerProps {
  * @param props
  */
 export const NotificationBanner: React.FC<IBannerProps> = props => {
-  const { name, persistClose, children } = props
+  const { name, persistClose = true, children } = props
   const isHidden = persistClose ? getNotificationBanner(name) === 'hidden' : false
   const [isOn, setIsOn] = useState(!isHidden)
 

--- a/src/components/info/notification_banner.tsx
+++ b/src/components/info/notification_banner.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react'
+import { hideNotificationBanner, getNotificationBanner } from 'utils/localStore'
+
+interface IBannerProps {
+  name: string
+  persistClose?: boolean
+}
+
+/**
+ * Re-usable component that can broadcast application notifications
+ * Can be hidden - will be stored in local storage
+ * @param props
+ */
+export const NotificationBanner: React.FC<IBannerProps> = props => {
+  const { name, persistClose, children } = props
+  const isHidden = persistClose ? getNotificationBanner(name) === 'hidden' : false
+  const [isOn, setIsOn] = useState(!isHidden)
+
+  if (!isOn) return null
+
+  const handleClose = () => {
+    setIsOn(false)
+    persistClose && hideNotificationBanner(name)
+  }
+
+  return (
+    <div className="mb-2">
+      <div className={`alert alert-primary text-center fade show d-flex`} role="alert">
+        <div className={`flex-grow-1`}>{children}</div>
+        <div className={`align-self-start ml-2`}>
+          <button type="button" className="close" aria-label="Close" onClick={handleClose}>
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -31,7 +31,7 @@ const Home: React.FC = () => {
     <>
       <Header />
 
-      <NotificationBanner name="Orukk_CoS_WaitingForBooks" persistClose={true}>
+      <NotificationBanner name="Orruk_CoS_WaitingForBooks" persistClose={true}>
         Looking for{' '}
         <a href={'//github.com/daviseford/aos-reminders/pull/535'} target="_blank" rel="noopener noreferrer">
           Cities of Sigmar

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -31,7 +31,7 @@ const Home: React.FC = () => {
     <>
       <Header />
 
-      <NotificationBanner name="Orukk_CoS_Banner" persistClose={true}>
+      <NotificationBanner name="Orukk_CoS_WaitingForBooks" persistClose={true}>
         Looking for{' '}
         <a href={'//github.com/daviseford/aos-reminders/pull/535'} target="_blank" rel="noopener noreferrer">
           Cities of Sigmar

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -32,8 +32,15 @@ const Home: React.FC = () => {
       <Header />
 
       <NotificationBanner name="Orukk_CoS_Banner" persistClose={true}>
-        Looking for Cities of Sigmar or Orruk Warclans? Don't fret, our goblins are hard at work getting this
-        information updated.
+        Looking for{' '}
+        <a href={'//github.com/daviseford/aos-reminders/pull/535'} target="_blank" rel="noopener noreferrer">
+          Cities of Sigmar
+        </a>{' '}
+        or{' '}
+        <a href={'//github.com/daviseford/aos-reminders/pull/534'} target="_blank" rel="noopener noreferrer">
+          Orruk Warclans
+        </a>
+        ? Don't fret, our goblins are hard at work getting this information updated.
       </NotificationBanner>
 
       <Suspense fallback={<></>}>

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -3,6 +3,7 @@ import { logPageView } from 'utils/analytics'
 import { useSubscription } from 'context/useSubscription'
 import { Header } from 'components/page/homeHeader'
 import { LargeSpinner } from 'components/helpers/suspenseFallbacks'
+import { NotificationBanner } from 'components/info/notification_banner'
 
 const ArmyBuilder = lazy(() => import(/* webpackChunkName: 'army_builder' */ 'components/input/army_builder'))
 const AlliedArmies = lazy(() => import(/* webpackChunkName: 'ally_armies' */ 'components/input/ally_armies'))
@@ -29,6 +30,11 @@ const Home: React.FC = () => {
   return (
     <>
       <Header />
+
+      <NotificationBanner name="Orukk_CoS_Banner" persistClose={true}>
+        Looking for Cities of Sigmar or Orruk Warclans? Don't fret, our goblins are hard at work getting this
+        information updated.
+      </NotificationBanner>
 
       <Suspense fallback={<></>}>
         <LoadedArmyHeader />

--- a/src/utils/localStore.ts
+++ b/src/utils/localStore.ts
@@ -19,3 +19,9 @@ export const getLocalFavorite = () => {
   const localFavorite = localStorage.getItem(LOCAL_FAVORITE_KEY) as TSupportedFaction | null
   return localFavorite
 }
+
+export const hideNotificationBanner = (name: string) => {
+  localStorage.setItem(name, 'hidden')
+}
+
+export const getNotificationBanner = (name: string) => localStorage.getItem(name)


### PR DESCRIPTION
+ Adds a re-usable banner that can be hidden and saves its hidden state in localStorage so it doesn't pop up after it's been dismissed
+ Adds a banner telling users that Orruk/CoS are coming!