### PR TITLE
Fix trait typos for imports

### DIFF
--- a/src/army/ironjawz/traits.ts
+++ b/src/army/ironjawz/traits.ts
@@ -53,10 +53,10 @@ const CommandTraits: TTraits = [
     ],
   },
   {
-    name: `Mighty Waagh!`,
+    name: `Mighty Waaagh!`,
     effects: [
       {
-        name: `Mighty Waagh!`,
+        name: `Mighty Waaagh!`,
         desc: `Your Ironjawz Waagh! ability increases range from 18" to 24".`,
         when: [START_OF_COMBAT_PHASE],
       },

--- a/src/army/legion_of_blood/traits.ts
+++ b/src/army/legion_of_blood/traits.ts
@@ -9,10 +9,10 @@ import {
 
 const CommandTraits: TTraits = [
   {
-    name: `Swift Strike`,
+    name: `Swift Strikes`,
     effects: [
       {
-        name: `Swift Strike`,
+        name: `Swift Strikes`,
         desc: `Each time you make a hit roll of 6+ in the combat phase for this general, you can make one additional hit roll for the same weapon against the same target.`,
         when: [COMBAT_PHASE],
       },

--- a/src/army/legions_of_nagash/traits.ts
+++ b/src/army/legions_of_nagash/traits.ts
@@ -136,10 +136,10 @@ const CommandTraits: TTraits = [
     ],
   },
   {
-    name: `Swift Strike (Legion of Blood)`,
+    name: `Swift Strikes (Legion of Blood)`,
     effects: [
       {
-        name: `Swift Strike (Legion of Blood)`,
+        name: `Swift Strikes (Legion of Blood)`,
         desc: `Each time you make a hit roll of 6+ in the combat phase for this general, you can make one additional hit roll for the same weapon against the same target.`,
         when: [COMBAT_PHASE],
       },


### PR DESCRIPTION
Should address the following two from #517 

`failedImport-Warscroll Builder-Mighty Waaagh!`
`failedImport-Warscroll Builder-Swift Strikes`