### PR TITLE
Change canonical spelling of Gore-gruntas and redo mappings

### DIFF
--- a/src/army/ironjawz/units.ts
+++ b/src/army/ironjawz/units.ts
@@ -166,7 +166,7 @@ export const Units: TUnits = [
     ],
   },
   {
-    name: `Orruk Gore Gruntas`,
+    name: `Orruk Gore-gruntas`,
     effects: [
       {
         name: `Gore-grunta Charge`,

--- a/src/tests/warscroll/warscrollPdf.test.ts
+++ b/src/tests/warscroll/warscrollPdf.test.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import {
   BIG_WAAAGH,
   CITIES_OF_SIGMAR,
+  IRONJAWZ,
   KHARADRON_OVERLORDS,
   NIGHTHAUNT,
   ORDER_GRAND_ALLIANCE,
@@ -271,6 +272,33 @@ describe('getWarscrollArmyFromPdf', () => {
         'Khinerai Heartrenders',
         'Sisters of Slaughter',
         'Avatar of Khaine',
+      ],
+    })
+  })
+
+  it('reads an Ironjawz warscroll pdf correctly', () => {
+    const pdfText = getFile('Ironjawz.pdf')
+    const parsedText = parsePdf(pdfText)
+    const warscrollTxt = getWarscrollArmyFromPdf(parsedText)
+
+    expect(warscrollTxt.factionName).toEqual(IRONJAWZ)
+    expect(warscrollTxt.selections).toEqual({
+      allegiances: ['Da Choppas'],
+      artifacts: ['Destroyer'],
+      battalions: [],
+      commands: [],
+      endless_spells: [],
+      scenery: [],
+      spells: [],
+      traits: ['Checked Out', "Fast 'Un"],
+      triumphs: [],
+      units: [
+        'Gordrakk the Fist of Gork',
+        'Megaboss on Maw-Krusha',
+        "Ironskull's Boyz",
+        'Orruk Ardboys',
+        'Orruk Brutes',
+        'Orruk Gore-gruntas',
       ],
     })
   })

--- a/src/utils/import/options.ts
+++ b/src/utils/import/options.ts
@@ -74,6 +74,7 @@ const warscrollTypoMap: TNameMap = {
   'Midnight Tome - Soul Cage': 'Midnight Tome',
   'Midnight Tome - Spectral Tether': 'Midnight Tome',
   'Midnight Tome - Spirit Drain': 'Midnight Tome',
+  'Orruk Gore Gruntas': 'Orruk Gore-gruntas',
   'Rune of Ulgu - Mindrazor': 'Rune of Ulgu',
   'Rune of Ulgu - Mirror Dance': 'Rune of Ulgu',
   'Rune of Ulgu - Pit of Shades': 'Rune of Ulgu',
@@ -102,7 +103,6 @@ const azyrTypoMap: TNameMap = {
   'Hellstriders with Hellscourges': 'Hellstriders',
   'Keen Clawed': 'Keen-clawed (Mount)',
   'Madcap Shamans': 'Madcap Shaman',
-  'Orruk Gore Gruntas': 'Orruk Gore-Gruntas',
 }
 
 // Battlescribe on the left - AoS Reminders on the right


### PR DESCRIPTION
Our data matched wsb but not Azyr.
The Azyr typo map was the wrong way around, so wasn't doing any good.

This updates us to use the spelling from the book, which is what Azyr has.
Therefore the mapping that was backwards for Azyr is now the correct one for wsb 😅 

**Updates a live unit name so will need migrating**