### PR TITLE
Added extended rosters to cities

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "pretty-quick": "2.0.0",
     "react-app-rewired": "2.1.3",
     "replace-in-file": "4.1.3",
-    "source-map-explorer": "2.1.0",    
+    "source-map-explorer": "2.1.0",
     "typescript": "^3.7.0-beta"
   }
 }

--- a/src/army/cities_of_sigmar/units.ts
+++ b/src/army/cities_of_sigmar/units.ts
@@ -15,6 +15,13 @@ import {
   START_OF_SETUP,
   START_OF_SHOOTING_PHASE,
 } from 'types/phases'
+import Stormcast from 'army/stormcast_eternals'
+import KharadronOverlords from 'army/kharadron_overlords'
+import Sylvaneth from 'army/sylvaneth'
+
+const getStormcastUnits = () => Stormcast.Units
+const getKharadronUnits = () => KharadronOverlords.Units
+const getSylvanethUnits = () => Sylvaneth.Units
 
 const DrummerEffect = {
   name: `Drummer`,
@@ -1421,7 +1428,7 @@ export const Units: TUnits = [
 
 // Allied units (usually this will involve writing a function to grab units from another army)
 // Check out Nurgle or Khorne for good examples
-export const AlliedUnits: TUnits = []
+export const AlliedUnits: TUnits = [...getStormcastUnits(), ...getKharadronUnits(), ...getSylvanethUnits()]
 
 // Battalions
 export const Battalions: TBattalions = [


### PR DESCRIPTION
Fixes #621 

Added in the extended rosters for Cities
- SCE 
- Sylvaneth for use in living cities
- KO for use in tempest eye
