### PR TITLE
Mark mount traits and display them as such in the reminder

### DIFF
--- a/src/army/fyreslayers/traits.ts
+++ b/src/army/fyreslayers/traits.ts
@@ -131,62 +131,68 @@ const CommandTraits: TTraits = [
     ],
   },
   {
-    name: `Cinder-crest Youngblood (Mount)`,
+    name: `Cinder-crest Youngblood`,
     effects: [
       {
         name: `Cinder-crest Youngblood`,
         desc: `When you use this model's Lashing Tail ability subtract 1 from the dice roll that determines if the target unit suffers D3 mortal wounds. If this model made a charge move in the same turn, subtract 2 instead.`,
         when: [COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Flame-scale Youngblood (Mount)`,
+    name: `Flame-scale Youngblood`,
     effects: [
       {
         name: `Flame-scale Youngblood`,
         desc: `After this model has made a charge move, pick 1 enemy unit within 1" of this model and roll a number of dice equal to the charge roll for that charge move. For each 6 that enemy unit suffers 1 mortal wound.`,
         when: [CHARGE_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Fire-claw Adult (Mount)`,
+    name: `Fire-claw Adult`,
     effects: [
       {
         name: `Fire-claw Adult`,
         desc: `If the unmodified wound roll for an attack made with this mount's melee weapons is 6, that attack has a rend characteristic of -3.`,
         when: [COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Lava-Tongue Adult (Mount)`,
+    name: `Lava-Tongue Adult`,
     effects: [
       {
         name: `Lava-Tongue Adult`,
         desc: `When you use this model's Roaring Fyrestream ability, subtract 1 from the dice roll that determines if the target unit suffers mortal wounds. If this model is wholly within your territory or within 6" of an objective, subtract 2 instead.`,
         when: [SHOOTING_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Coal-heart Ancient (Mount)`,
+    name: `Coal-heart Ancient`,
     effects: [
       {
         name: `Coal-heart Ancient`,
         desc: `Worsen the rend of melee weapons that attack this target by 1 to a minimum of 0.`,
         when: [COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Ash-horn Ancient (Mount)`,
+    name: `Ash-horn Ancient`,
     effects: [
       {
         name: `Ash-horn Ancient`,
         desc: `You can re-roll save rolls of 1 for attacks that target this model and friendly MAGMADROTHS within 6".`,
         when: [SHOOTING_PHASE, COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },

--- a/src/army/ironjawz/traits.ts
+++ b/src/army/ironjawz/traits.ts
@@ -103,62 +103,68 @@ const CommandTraits: TTraits = [
     ],
   },
   {
-    name: `Big 'Un (Mount)`,
+    name: `Big 'Un`,
     effects: [
       {
         name: `Big 'Un`,
         desc: `+1 to the wound characteristic to this model.`,
         when: [DURING_GAME],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Fast 'Un (Mount)`,
+    name: `Fast 'Un`,
     effects: [
       {
         name: `Fast 'Un`,
         desc: `Add +2 to the movement characteristic of this model.`,
         when: [MOVEMENT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Mean 'Un (Mount)`,
+    name: `Mean 'Un`,
     effects: [
       {
         name: `Mean 'Un`,
         desc: `Add 1 to the damage characteristic of this model's Mighty Fists and Tail attacks.`,
         when: [COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Heavy 'Un (Mount)`,
+    name: `Heavy 'Un`,
     effects: [
       {
         name: `Heavy 'Un`,
         desc: `Add 1 to the dice rolls for the Destructive Bulk ability.`,
         when: [CHARGE_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Loud 'Un (Mount)`,
+    name: `Loud 'Un`,
     effects: [
       {
         name: `Loud 'Un`,
         desc: `Once per battle, give -1 to hit for enemies within 3".`,
         when: [START_OF_COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Weird 'Un (Mount)`,
+    name: `Weird 'Un`,
     effects: [
       {
         name: `Weird 'Un`,
         desc: `You may ignore spell and endless spell effects on this model with a dice roll of a 4+.`,
         when: [HERO_PHASE],
+        mount_trait: true,
       },
     ],
   },

--- a/src/army/ogor_mawtribes/traits.ts
+++ b/src/army/ogor_mawtribes/traits.ts
@@ -256,62 +256,68 @@ const CommandTraits: TTraits = [
     ],
   },
   {
-    name: `Fleet of Hoof (Mount)`,
+    name: `Fleet of Hoof`,
     effects: [
       {
         name: `Fleet of Hoof`,
         desc: `You can re-roll one or both of the dice when making charge rolls for this model.`,
         when: [CHARGE_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Fleshgreed (Mount)`,
+    name: `Fleshgreed`,
     effects: [
       {
         name: `Fleshgreed`,
         desc: `At the start of each hero phase, if this model is eating, you can heal 1 wound allocated to this model.`,
         when: [START_OF_HERO_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Rimefrost Hide (Mount)`,
+    name: `Rimefrost Hide`,
     effects: [
       {
         name: `Rimefrost Hide`,
         desc: `Worsen the Rend characteristic of melee weapons that target this model by 1 (to a minimum of '-').`,
         when: [COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Gvarnak (Mount)`,
+    name: `Gvarnak`,
     effects: [
       {
         name: `Gvarnak`,
         desc: `Add 1 to this model's Wounds characteristic.`,
         when: [DURING_GAME],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Matriarch (Mount)`,
+    name: `Matriarch`,
     effects: [
       {
         name: `Matriarch`,
         desc: `Add 1 to charge rolls for friendly THUNDERTUSKS while they are wholly within 12" of this model.`,
         when: [CHARGE_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Alvagr Ancient (Mount)`,
+    name: `Alvagr Ancient`,
     effects: [
       {
         name: `Alvagr Ancient`,
         desc: `If this model has not made a charge move in the same turn, enemy units that are within 3" of this model at the start of the combat phase fight at the end of that combat phase.`,
         when: [START_OF_COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },

--- a/src/army/stormcast_eternals/traits.ts
+++ b/src/army/stormcast_eternals/traits.ts
@@ -74,182 +74,200 @@ const CommandTraits: TTraits = [
     ],
   },
   {
-    name: `Lithe-Limbed (Mount)`,
+    name: `Lithe-Limbed`,
     effects: [
       {
-        name: `Lithe-Limbed (Mount)`,
+        name: `Lithe-Limbed`,
         desc: `Add 1 to the move characteristic of this model.`,
         when: [MOVEMENT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Keen-clawed (Mount)`,
+    name: `Keen-clawed`,
     effects: [
       {
-        name: `Keen-clawed (Mount)`,
+        name: `Keen-clawed`,
         desc: `If the unmodified wound roll for an attack made with this mount's melee weapons is 6, that attack has a rend characteristic of -3.`,
         when: [COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Savage Loyalty (Mount)`,
+    name: `Savage Loyalty`,
     effects: [
       {
-        name: `Savage Loyalty (Mount)`,
+        name: `Savage Loyalty`,
         desc: `If this model is slain by wounds or mortal wounds inflicted by an attack made with an enemy unit's melee weapons, roll a D6. On a 4+ that enemy unit suffers D3 mortal wounds.`,
         when: [COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Drake-kin (Mount)`,
+    name: `Drake-kin`,
     effects: [
       {
-        name: `Drake-kin (Mount)`,
+        name: `Drake-kin`,
         desc: `Before determining damage for an attack that targets this model that has a Damage characteristic of any value other than 1, roll a D6. On a 5+ change the Damage characteristic of that attack to 1.`,
         when: [DURING_GAME],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Thunder Caller (Mount)`,
+    name: `Thunder Caller`,
     effects: [
       {
-        name: `Thunder Caller (Mount)`,
+        name: `Thunder Caller`,
         desc: `This model's Storm Breath ability has a range of 16" rather than 12".`,
         when: [SHOOTING_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Pack Leader (Mount)`,
+    name: `Pack Leader`,
     effects: [
       {
-        name: `Pack Leader (Mount)`,
+        name: `Pack Leader`,
         desc: `Add 2 to the Attacks characteristic oof this model's Claws and Fangs while this model is within 6" of any friendly DRACOTHIAN GUARD models.`,
         when: [COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Storm-winged (Mount)`,
+    name: `Storm-winged`,
     effects: [
       {
-        name: `Storm-winged (Mount)`,
+        name: `Storm-winged`,
         desc: `After this model has moved, you can pick 1 enemy unit that has any models that this model passed across, and roll a D6. On a 2+ that unit suffers D3 mortal wounds.`,
         when: [MOVEMENT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Thunderlord (Mount)`,
+    name: `Thunderlord`,
     effects: [
       {
-        name: `Thunderlord (Mount)`,
+        name: `Thunderlord`,
         desc: `The Roiling Thunderhead from this model's Lord of the Heavens ability has a range of 24" instead of 18".`,
         when: [SHOOTING_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Star-branded (Mount)`,
+    name: `Star-branded`,
     effects: [
       {
-        name: `Star-branded (Mount)`,
+        name: `Star-branded`,
         desc: `Subtract 1 from the number of wounds allocated to this model (to a minimum of 0) when determining which row on its damage table to use.`,
         when: [COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Wind Runner (Mount)`,
+    name: `Wind Runner`,
     effects: [
       {
-        name: `Wind Runner (Mount)`,
+        name: `Wind Runner`,
         desc: `When this model Rides the Winds Aetheric, roll an extra dice when determining the distance it can move.`,
         when: [MOVEMENT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Aethereal Stalker (Mount)`,
+    name: `Aethereal Stalker`,
     effects: [
       {
-        name: `Aethereal Stalker (Mount)`,
+        name: `Aethereal Stalker`,
         desc: `When this model is set up, choose an enemy unit. You can re-roll failed hit and wound rolls for attacks made with this model's Gryph-charger's Razor Beak and Claws that target that enemy unit.`,
         when: [DURING_SETUP, COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Indefatigable (Mount)`,
+    name: `Indefatigable`,
     effects: [
       {
-        name: `Indefatigable (Mount)`,
+        name: `Indefatigable`,
         desc: `You can re-roll run rolls for this model.`,
         when: [MOVEMENT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Swiftwing (Mount)`,
+    name: `Swiftwing`,
     effects: [
       {
-        name: `Swiftwing (Mount)`,
+        name: `Swiftwing`,
         desc: `You can re-roll run rolls for this model.`,
         when: [MOVEMENT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Lashing Tail (Mount)`,
+    name: `Lashing Tail`,
     effects: [
       {
-        name: `Lashing Tail (Mount)`,
+        name: `Lashing Tail`,
         desc: `At the end of the combat phase, you can pick an enemy unit within 3" of this model and roll a D6. On a 4+ that unit suffers 1 mortal wound.`,
         when: [END_OF_COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Steel Pinions (Mount)`,
+    name: `Steel Pinions`,
     effects: [
       {
-        name: `Steel Pinions (Mount)`,
+        name: `Steel Pinions`,
         desc: `On a 6+, an allocated wound or mortal wound is negated.`,
         when: [DURING_GAME],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Bounding Leap (Mount)`,
+    name: `Bounding Leap`,
     effects: [
       {
-        name: `Bounding Leap (Mount)`,
+        name: `Bounding Leap`,
         desc: `This model is eligible to fight in the combat phase if it is within 6" of an enemy unit instead of 3", and it can move an extra 3" when it piles in.`,
         when: [COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Pride Leader (Mount)`,
+    name: `Pride Leader`,
     effects: [
       {
-        name: `Pride Leader (Mount)`,
+        name: `Pride Leader`,
         desc: `Add 1 to hit rolls for attacks made by friendly DRACOLINE units while they are wholly within 9" of this model.`,
         when: [COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },
   {
-    name: `Ear-bursting Roar (Mount)`,
+    name: `Ear-bursting Roar`,
     effects: [
       {
-        name: `Ear-bursting Roar (Mount)`,
+        name: `Ear-bursting Roar`,
         desc: `At the start of the combat phase you can pick an enemy unit within 3" oof this model and roll a D6. On a 4+ subtract 1 from hit rolls for attacks made by that unit until the end of that phase.`,
         when: [START_OF_COMBAT_PHASE],
+        mount_trait: true,
       },
     ],
   },

--- a/src/tests/azyr/getAzyrArmy.test.ts
+++ b/src/tests/azyr/getAzyrArmy.test.ts
@@ -425,7 +425,7 @@ describe('getAzyrArmyFromPdf', () => {
     const pages = handleAzyrPages(Stormcast4)
     const res = getAzyrArmyFromPdf(pages)
     expect(res.factionName).toEqual(STORMCAST_ETERNALS)
-    expect(res.selections.traits).toEqual(['Keen-clawed (Mount)', 'Lithe-Limbed (Mount)'])
+    expect(res.selections.traits).toEqual(['Keen-clawed', 'Lithe-Limbed'])
   })
 
   it('handles Slaanesh1', () => {
@@ -640,7 +640,7 @@ describe('getAzyrArmyFromPdf', () => {
         endless_spells: ['Runic Fyrewall'],
         scenery: [],
         spells: ['Prayer of Ash'],
-        traits: ['Warrior Indominate', 'Fire-claw Adult (Mount)'],
+        traits: ['Warrior Indominate', 'Fire-claw Adult'],
         triumphs: [],
         units: [
           'Fjul-Grimnir',

--- a/src/tests/warscroll/warscrollPdf.test.ts
+++ b/src/tests/warscroll/warscrollPdf.test.ts
@@ -144,7 +144,7 @@ describe('getWarscrollArmyFromPdf', () => {
         'Brutal Beast Spirits (Bonesplitterz)',
         'Bone Krusha (Bonesplitterz)',
       ],
-      traits: ["Fast 'Un (Mount) (Ironjawz)", "Dead Kunnin' (Bonesplitterz)", "Weird 'Un (Mount) (Ironjawz)"],
+      traits: ["Fast 'Un (Ironjawz)", "Dead Kunnin' (Bonesplitterz)", "Weird 'Un (Ironjawz)"],
       triumphs: [],
       units: [
         'Gordrakk the Fist of Gork',
@@ -309,7 +309,7 @@ describe('getWarscrollArmyFromPdf', () => {
       endless_spells: [],
       scenery: [],
       spells: [],
-      traits: ['Checked Out', "Fast 'Un (Mount)"],
+      traits: ['Checked Out', "Fast 'Un"],
       triumphs: [],
       units: [
         'Gordrakk the Fist of Gork',

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -6,6 +6,7 @@ export type TEntryProperties =
   | 'command_ability'
   | 'command_trait'
   | 'endless_spell'
+  | 'mount_trait'
   | 'scenery'
   | 'spell'
   | 'triumph'
@@ -16,6 +17,7 @@ export const ENTRY_PROPERTIES: TEntryProperties[] = [
   'command_ability',
   'command_trait',
   'endless_spell',
+  'mount_trait',
   'scenery',
   'spell',
   'triumph',

--- a/src/utils/import/options.ts
+++ b/src/utils/import/options.ts
@@ -87,7 +87,7 @@ const azyrTypoMap: TNameMap = {
   'Greywater Artillery Battery': 'Greywater Artillery Company',
   'Hellstriders with Claw-spears': 'Hellstriders',
   'Hellstriders with Hellscourges': 'Hellstriders',
-  'Keen Clawed': 'Keen-clawed (Mount)',
+  'Keen Clawed': 'Keen-clawed',
   'Madcap Shamans': 'Madcap Shaman',
   'The Brazen Rune': 'Brazen Rune',
 }

--- a/src/utils/textUtils.ts
+++ b/src/utils/textUtils.ts
@@ -22,6 +22,7 @@ export const getActionTitle = ({
   command_trait,
   condition,
   endless_spell,
+  mount_trait,
   name,
   scenery,
   spell,
@@ -34,6 +35,7 @@ export const getActionTitle = ({
   if (command_ability) return `Command Ability${suffix}`
   if (command_trait) return `Command Trait${suffix}`
   if (endless_spell) return `Endless Spell${suffix}`
+  if (mount_trait) return `Mount Trait${suffix}`
   if (scenery) return `Scenery${suffix}`
   if (spell) return `Spell${suffix}`
   if (triumph) return `Triumph${suffix}`


### PR DESCRIPTION
Marks all traits that had `(Mount)` in the name, and removes that
Other traits will need identifying and tagging

This change was kinda guesswork, but it seemed to work...