### PR TITLE
Import ignore side effect selections

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "1.6.0",
     "bootstrap": "4.4.1",
-    "core-js": "3.4.5",
+    "core-js": "3.4.7",
     "jspdf": "1.5.3",
     "lodash": "4.17.15",
     "luxon": "1.21.3",
@@ -31,7 +31,7 @@
     "redux": "4.0.4",
     "redux-starter-kit": "1.0.1",
     "string.prototype.matchall": "4.0.0",
-    "superagent": "5.1.1"
+    "superagent": "5.1.2"
   },
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
@@ -71,7 +71,7 @@
     "@types/parse5": "5.0.2",
     "@types/pdfjs-dist": "2.1.2",
     "@types/qs": "6.9.0",
-    "@types/react": "16.9.13",
+    "@types/react": "16.9.14",
     "@types/react-copy-to-clipboard": "4.3.0",
     "@types/react-dom": "16.9.4",
     "@types/react-modal": "3.10.0",

--- a/src/army/gloomspite/shared.ts
+++ b/src/army/gloomspite/shared.ts
@@ -3,7 +3,7 @@ import { START_OF_COMBAT_PHASE } from 'types/phases'
 
 export const StabEmGoodEffect: TEffects = {
   name: `I'm Da Boss, Now Stab 'Em Good!`,
-  desc: `You can use this command ability at the start of the combat phase. If you do so, pick 1 friendly Moonclan Grot unit wholly within 12" of a friendly model with this command ability, or wholly within 24" of a model with this command ability that is your general.'The same unit cannot be picked to be affected by this command ability more than once per phase.`,
+  desc: `You can use this command ability at the start of the combat phase. If you do so, pick 1 friendly Moonclan Grot unit wholly within 12" of a friendly model with this command ability, or wholly within 24" of a model with this command ability that is your general. The same unit cannot be picked to be affected by this command ability more than once per phase.`,
   when: [START_OF_COMBAT_PHASE],
   command_ability: true,
 }

--- a/src/army/gloomspite/shared.ts
+++ b/src/army/gloomspite/shared.ts
@@ -1,0 +1,9 @@
+import { TEffects } from 'types/data'
+import { START_OF_COMBAT_PHASE } from 'types/phases'
+
+export const StabEmGoodEffect: TEffects = {
+  name: `I'm Da Boss, Now Stab 'Em Good!`,
+  desc: `You can use this command ability at the start of the combat phase. If you do so, pick 1 friendly Moonclan Grot unit wholly within 12" of a friendly model with this command ability, or wholly within 24" of a model with this command ability that is your general.'The same unit cannot be picked to be affected by this command ability more than once per phase.`,
+  when: [START_OF_COMBAT_PHASE],
+  command_ability: true,
+}

--- a/src/army/gloomspite/traits.ts
+++ b/src/army/gloomspite/traits.ts
@@ -1,4 +1,5 @@
 import { TTraits } from 'types/army'
+import { StabEmGoodEffect } from './shared'
 import {
   BATTLESHOCK_PHASE,
   COMBAT_PHASE,
@@ -121,6 +122,7 @@ const CommandTraits: TTraits = [
         desc: `This general has the I'm Da Boss, Now Stab 'Em Good! command ability from the Loonboss warscroll.`,
         when: [START_OF_COMBAT_PHASE],
       },
+      StabEmGoodEffect,
     ],
   },
   {

--- a/src/army/gloomspite/units.ts
+++ b/src/army/gloomspite/units.ts
@@ -1,4 +1,5 @@
 import { TBattalions, TUnits } from 'types/army'
+import { StabEmGoodEffect } from './shared'
 import {
   BATTLESHOCK_PHASE,
   CHARGE_PHASE,
@@ -29,12 +30,7 @@ const LoonbossEffects = [
     desc: `Subtract 1 from hit rolls for attacks that target this model.`,
     when: [COMBAT_PHASE, SHOOTING_PHASE],
   },
-  {
-    name: `I'm Da Boss, Now Stab 'Em Good!`,
-    desc: `You can use this command ability at the start of the combat phase. If you do so, pick 1 friendly Moonclan Grot unit wholly within 12" of a friendly model with this command ability, or wholly within 24" of a model with this command ability that is your general.'The same unit cannot be picked to be affected by this command ability more than once per phase.`,
-    when: [START_OF_COMBAT_PHASE],
-    command_ability: true,
-  },
+  StabEmGoodEffect,
 ]
 const GrotBaseEffects = [
   {

--- a/src/components/input/army_builder_cards.ts
+++ b/src/components/input/army_builder_cards.ts
@@ -25,7 +25,7 @@ export const getArmyBuilderCards: TCardOrder = (army, props, realmFeatureItems) 
       title: 'Traits',
       values: selections.traits,
       type: 'multi',
-      sideEffects: {},
+      sideEffects: getSideEffects(army.Traits),
     },
     {
       items: army.Artifacts,

--- a/src/ducks/selections.ts
+++ b/src/ducks/selections.ts
@@ -90,6 +90,7 @@ const updateSpells = (state: IStore['selections'], action: TAction) => {
   state.selections.spells = action.payload
 }
 const updateTraits = (state: IStore['selections'], action: TAction) => {
+  handleSideEffects(state, action.payload, 'traits')
   state.selections.traits = action.payload
 }
 const updateTriumphs = (state: IStore['selections'], action: TAction) => {

--- a/src/tests/azyr/getAzyrArmy.test.ts
+++ b/src/tests/azyr/getAzyrArmy.test.ts
@@ -157,7 +157,7 @@ describe('getAzyrArmyFromPdf', () => {
     expect(res.selections.allegiances).toEqual(['Boulderhead (Mawtribe)'])
     expect(res.selections.artifacts).toEqual(['Brand of the Svard'])
     expect(res.selections.spells).toEqual(['Pulverising Hailstorm'])
-    expect(res.selections.traits).toEqual(['Lord of Beasts', 'Belligerent Charger', 'Fleshgreed'])
+    expect(res.selections.traits).toEqual(['Belligerent Charger', 'Fleshgreed', 'Lord of Beasts'])
     expect(res.selections.units).toEqual([
       'Frostlord on Stonehorn',
       'Huskard on Thundertusk',
@@ -361,13 +361,13 @@ describe('getAzyrArmyFromPdf', () => {
       realmscape: null,
       selections: {
         allegiances: ['Gristlegore (Grand Court)'],
-        artifacts: ['Ghurish Mawshard', 'The Grim Garland (Royal Treasury)'],
+        artifacts: ['The Grim Garland (Royal Treasury)', 'Ghurish Mawshard'],
         battalions: ['Royal Menagerie'],
         commands: ['Call to War', 'Summon Men-at-arms'],
         endless_spells: ['Cadaverous Barricade', 'Aethervoid Pendulum'],
         scenery: [],
         spells: ['Monstrous Vigour', 'Blood Feast'],
-        traits: ['Savage Strike', 'The Feast Day (Delusion)'],
+        traits: ['The Feast Day (Delusion)', 'Savage Strike'],
         triumphs: [],
         units: ['Abhorrant Ghoul King', 'Royal Terrorgheist'],
       },
@@ -562,8 +562,8 @@ describe('getAzyrArmyFromPdf', () => {
     expect(res.selections.traits).toEqual([
       'ARTYCLE: Respect Your Commanders',
       'AMENDMENT: Trust Aethermatics, Not Superstition',
-      'FOOTNOTE: Through Knowledge, Power',
       'FOOTNOTE: Without Our Ships, We Are Naught',
+      'FOOTNOTE: Through Knowledge, Power',
       'Champion of Progress',
     ])
 
@@ -747,8 +747,8 @@ describe('getAzyrArmyFromPdf', () => {
         traits: [
           'ARTYCLE: Settle the Grudges',
           'AMENDMENT: Trust to Your Guns',
-          'FOOTNOTE: Honour the Gods, Just in Case',
           'FOOTNOTE: These Are Just Guidelines',
+          'FOOTNOTE: Honour the Gods, Just in Case',
         ],
         triumphs: [],
         units: [
@@ -860,7 +860,7 @@ describe('getAzyrArmyFromPdf', () => {
         endless_spells: ['Runic Fyrewall'],
         scenery: [],
         spells: ['Prayer of Ash'],
-        traits: ['Warrior Indominate', 'Fire-claw Adult'],
+        traits: ['Fire-claw Adult', 'Warrior Indominate'],
         triumphs: [],
         units: [
           'Fjul-Grimnir',

--- a/src/tests/battlescribe/battlescribeHTML.test.ts
+++ b/src/tests/battlescribe/battlescribeHTML.test.ts
@@ -360,7 +360,7 @@ describe('getBattlescribeArmy', () => {
     const res = getBattlescribeArmy(parsedText)
 
     expect(res.factionName).toEqual(GLOOMSPITE_GITZ)
-    expect(res.selections.commands).toEqual(['Instinctive Leader', "I'm Da Boss, Now Stab 'Em Good!"])
+    expect(res.selections.commands).toEqual(['Instinctive Leader'])
     expect(res.selections.spells).toEqual([
       'Arcane Bolt',
       'Mystic Shield',

--- a/src/tests/battlescribe/battlescribeHTML.test.ts
+++ b/src/tests/battlescribe/battlescribeHTML.test.ts
@@ -260,7 +260,7 @@ describe('getBattlescribeArmy', () => {
     const res = getBattlescribeArmy(parsedText)
 
     expect(res.factionName).toEqual(DAUGHTERS_OF_KHAINE)
-    expect(res.selections.spells).toEqual(['Arcane Bolt', "Arnzipal's Black Horror", 'Mystic Shield'])
+    expect(res.selections.spells).toEqual(['Arcane Bolt', 'Mystic Shield', "Arnzipal's Black Horror"])
     expect(res.selections.allegiances).toEqual([
       'Hagg Nar (Temple)',
       'Draichi Ganeth (Temple)',
@@ -558,10 +558,10 @@ describe('getBattlescribeArmy', () => {
         spells: [
           'Arcane Bolt',
           'Mystic Shield',
-          'Summon Lightning',
           'Thunderwave (Thunderscorn Wizard)',
-          'Devolve',
           'Vicious Stranglethorns (Brayherd Wizard)',
+          'Summon Lightning',
+          'Devolve',
           'Boon of Mutation',
         ],
         traits: [],
@@ -631,9 +631,9 @@ describe('getBattlescribeArmy', () => {
       scenery: [],
       spells: [
         'Arcane Bolt',
-        'Enfeebling Foe',
         'Mystic Shield',
         'The Withering (Wizard)',
+        'Enfeebling Foe',
         "Arnzipal's Black Horror",
         'Doomfire',
       ],
@@ -807,12 +807,12 @@ describe('getBattlescribeArmy', () => {
     expect(res.selections.endless_spells).toEqual(['Lauchon the Soulseeker'])
     expect(res.selections.traits).toEqual([
       'ARTYCLE: Respect Your Commanders',
-      'FOOTNOTE: Through Knowledge, Power',
       'AMENDMENT: Trust Aethermatics, Not Superstition',
       'AMENDMENT: Prosecute Wars With All Haste',
       'ARTYCLE: Seek New Prospects',
-      'FOOTNOTE: Who Strikes First, Strikes Hardest',
+      'FOOTNOTE: Through Knowledge, Power',
       'Champion of Progress',
+      'FOOTNOTE: Who Strikes First, Strikes Hardest',
       'Opportunistic Privateers',
     ])
     expect(res.selections.scenery).toEqual(['Penumbral Engine'])
@@ -827,10 +827,10 @@ describe('getBattlescribeArmy', () => {
     expect(res.selections.allegiances).toEqual(['Barak-Urbaz, The Market City (Skyport)'])
     expect(res.selections.commands).toEqual([
       'Invoke the Code',
-      'First Rule of Grungsson',
       'Invoke the Code - Lead by Example',
       'Invoke the Code - Look out for the Boss',
       'Invoke the Code - Talk Softly, Carry a Big Hammer',
+      'First Rule of Grungsson',
     ])
     expect(res.selections.endless_spells).toEqual(['Geminids of Uhl-Gysh', 'Shards of Valagharr'])
     expect(res.selections.traits).toEqual([
@@ -882,15 +882,15 @@ describe('getBattlescribeArmy', () => {
 
     expect(res.factionName).toEqual(SYLVANETH)
     expect(res.selections.allegiances).toEqual(['Winterleaf (Glade)'])
-    expect(res.selections.artifacts).toEqual(['Frozen Kernel', 'Spiritsong Stave'])
+    expect(res.selections.artifacts).toEqual(['Spiritsong Stave', 'Frozen Kernel'])
     expect(res.selections.battalions).toEqual(['Outcasts'])
-    expect(res.selections.commands).toEqual(['Call to Battle', 'Heed the Spirit-song', 'Branch Blizzard'])
+    expect(res.selections.commands).toEqual(['Branch Blizzard', 'Call to Battle', 'Heed the Spirit-song'])
     expect(res.selections.scenery).toEqual(['Awakened Wyldwood'])
     expect(res.selections.spells).toEqual([
       'Arcane Bolt',
       'Mystic Shield',
-      'Roused to Wrath',
       'Verdant Blessing',
+      'Roused to Wrath',
       'Primal Terror',
       'Awakening the Wood',
     ])

--- a/src/tests/battlescribe/battlescribeHTML.test.ts
+++ b/src/tests/battlescribe/battlescribeHTML.test.ts
@@ -364,8 +364,8 @@ describe('getBattlescribeArmy', () => {
     expect(res.selections.spells).toEqual([
       'Arcane Bolt',
       'Mystic Shield',
-      'Spore Maws',
       'The Great Green Spite',
+      'Spore Maws',
     ])
     expect(res.selections.units).toEqual([
       'Dankhold Troggboss',

--- a/src/tests/warscroll/warscrollPdf.test.ts
+++ b/src/tests/warscroll/warscrollPdf.test.ts
@@ -6,6 +6,7 @@ import {
   BIG_WAAAGH,
   CITIES_OF_SIGMAR,
   DAUGHTERS_OF_KHAINE,
+  DESTRUCTION_GRAND_ALLIANCE,
   FYRESLAYERS,
   IRONJAWZ,
   KHARADRON_OVERLORDS,
@@ -431,6 +432,26 @@ describe('getWarscrollArmyFromPdf', () => {
       traits: [],
       triumphs: [],
       units: ['Lord-Arcanum on Celestial Dracoline'],
+    })
+  })
+
+  it('correctly imports the Loonboss and its command ability', () => {
+    const pdfText = getFile('Loonboss')
+    const parsedText = parsePdf(pdfText)
+    const warscrollTxt = getWarscrollArmyFromPdf(parsedText)
+
+    expect(warscrollTxt.factionName).toEqual(DESTRUCTION_GRAND_ALLIANCE)
+    expect(warscrollTxt.selections).toEqual({
+      allegiances: [],
+      artifacts: [],
+      battalions: [],
+      commands: ["I'm Da Boss, Now Stab 'Em Good!"],
+      endless_spells: [],
+      scenery: [],
+      spells: [],
+      traits: [],
+      triumphs: [],
+      units: ['Loonboss'],
     })
   })
 

--- a/src/tests/warscroll/warscrollPdf.test.ts
+++ b/src/tests/warscroll/warscrollPdf.test.ts
@@ -361,7 +361,7 @@ describe('getWarscrollArmyFromPdf', () => {
       endless_spells: [],
       scenery: [],
       spells: [],
-      traits: ['Checked Out', "Fast 'Un"],
+      traits: ["Fast 'Un", 'Checked Out'],
       triumphs: [],
       units: [
         'Gordrakk the Fist of Gork',

--- a/src/tests/warscroll/warscrollPdf.test.ts
+++ b/src/tests/warscroll/warscrollPdf.test.ts
@@ -8,6 +8,7 @@ import {
   DAUGHTERS_OF_KHAINE,
   DESTRUCTION_GRAND_ALLIANCE,
   FYRESLAYERS,
+  GLOOMSPITE_GITZ,
   IRONJAWZ,
   KHARADRON_OVERLORDS,
   NIGHTHAUNT,
@@ -452,6 +453,26 @@ describe('getWarscrollArmyFromPdf', () => {
       traits: [],
       triumphs: [],
       units: ['Loonboss'],
+    })
+  })
+
+  it('adds the command ability that the Boss Shaman trait gives you', () => {
+    const pdfText = getFile('BossShaman')
+    const parsedText = parsePdf(pdfText)
+    const warscrollTxt = getWarscrollArmyFromPdf(parsedText)
+
+    expect(warscrollTxt.factionName).toEqual(GLOOMSPITE_GITZ)
+    expect(warscrollTxt.selections).toEqual({
+      allegiances: [],
+      artifacts: [],
+      battalions: [],
+      commands: ["I'm Da Boss, Now Stab 'Em Good!"],
+      endless_spells: [],
+      scenery: [],
+      spells: ['Spore Maws'],
+      traits: ['Boss Shaman'],
+      triumphs: [],
+      units: ['Fungoid Cave-Shaman'],
     })
   })
 

--- a/src/tests/warscroll/warscrollPdf.test.ts
+++ b/src/tests/warscroll/warscrollPdf.test.ts
@@ -374,7 +374,7 @@ describe('getWarscrollArmyFromPdf', () => {
     })
   })
 
-  xit('correctly imports the Drakesworn Templar without mistaking its lance for a spell', () => {
+  it('correctly imports the Drakesworn Templar without mistaking its lance for a spell', () => {
     const pdfText = getFile('Drakesworn')
     const parsedText = parsePdf(pdfText)
     const warscrollTxt = getWarscrollArmyFromPdf(parsedText)
@@ -414,7 +414,7 @@ describe('getWarscrollArmyFromPdf', () => {
     })
   })
 
-  xit('correctly imports the LAoCD and its Storm Lance spell', () => {
+  it('correctly imports the LAoCD and its Storm Lance spell', () => {
     const pdfText = getFile('LAoCD')
     const parsedText = parsePdf(pdfText)
     const warscrollTxt = getWarscrollArmyFromPdf(parsedText)
@@ -424,7 +424,7 @@ describe('getWarscrollArmyFromPdf', () => {
       allegiances: [],
       artifacts: [],
       battalions: [],
-      commands: [],
+      commands: ['Pack Alpha'],
       endless_spells: [],
       scenery: [],
       spells: ['Storm Lance'],

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -28,6 +28,7 @@ export const ENTRY_PROPERTIES: TEntryProperties[] = [
 export type TEntry = {
   name: string
   effects: TEffects[]
+  fromEffect?: boolean
 } & {
   [prop in TEntryProperties]?: boolean
 }

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -28,7 +28,7 @@ export const ENTRY_PROPERTIES: TEntryProperties[] = [
 export type TEntry = {
   name: string
   effects: TEffects[]
-  fromEffect?: boolean
+  isSideEffect?: boolean
 } & {
   [prop in TEntryProperties]?: boolean
 }

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -137,7 +137,7 @@ export const logIgnoredImport = (value: string, type: TImportParsers) => {
   if (value) {
     logToGA({
       category: 'Event',
-      action: `ignoredImport-${type}-${value}`,
+      action: `IgnoredImport-${type}-${value}`,
       label: 'IgnoredImport',
     })
   }

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -133,6 +133,16 @@ export const logFailedImport = (value: string, type: TImportParsers) => {
   }
 }
 
+export const logIgnoredImport = (value: string, type: TImportParsers) => {
+  if (value) {
+    logToGA({
+      category: 'Event',
+      action: `ignoredImport-${type}-${value}`,
+      label: 'IgnoredImport',
+    })
+  }
+}
+
 export const logDisplay = (element: string) => {
   if (element) {
     logToGA({

--- a/src/utils/getArmy/getCollection.ts
+++ b/src/utils/getArmy/getCollection.ts
@@ -71,6 +71,7 @@ const effectToEntry = (effect: TEffects): TEntry => {
   return {
     name: effect.name,
     effects: [effect],
+    fromEffect: true,
   }
 }
 

--- a/src/utils/getArmy/getCollection.ts
+++ b/src/utils/getArmy/getCollection.ts
@@ -71,7 +71,7 @@ const effectToEntry = (effect: TEffects): TEntry => {
   return {
     name: effect.name,
     effects: [effect],
-    fromEffect: true,
+    isSideEffect: true,
   }
 }
 

--- a/src/utils/import/addSideEffectsToImport.ts
+++ b/src/utils/import/addSideEffectsToImport.ts
@@ -13,6 +13,7 @@ export const addSideEffectsToImport = (selections: ISelections, Army: IArmy): IS
   const sideEffects = {
     allegiances: getSideEffects(Army.Allegiances),
     battalions: getSideEffects(Army.Battalions),
+    traits: getSideEffects(Army.Traits),
     units: getSideEffects(Army.Units),
   }
 

--- a/src/utils/import/index.ts
+++ b/src/utils/import/index.ts
@@ -79,7 +79,8 @@ export const importErrorChecker = (army: IImportedArmy, parser: TImportParsers):
     ...errorFreeSelections,
   }
 
-  const selectionsWithoutSideEffects = removeSideEffectsFromImport(mergedSelections, Army)
+  // Remove explicitly-included selections that are actually side-effects, then add relevant side-effects
+  const selectionsWithoutSideEffects = removeSideEffectsFromImport(mergedSelections, Army, parser)
   const selectionsWithSideEffects = addSideEffectsToImport(selectionsWithoutSideEffects, Army)
 
   return {

--- a/src/utils/import/index.ts
+++ b/src/utils/import/index.ts
@@ -10,6 +10,7 @@ import { importSelectionLookup } from 'utils/import/selectionLookup'
 import { checkErrorsForAllegianceAbilities } from 'utils/import/checkErrors'
 import { addAmbiguousSelectionErrors } from 'utils/import/ambiguousSelections'
 import { addSideEffectsToImport } from 'utils/import/addSideEffectsToImport'
+import { removeSideEffectsFromImport } from 'utils/import/removeSideEffectsFromImport'
 import { TSupportedFaction } from 'meta/factions'
 import { IArmy } from 'types/army'
 import { TImportParsers, IImportedArmy, TImportError } from 'types/import'
@@ -78,7 +79,8 @@ export const importErrorChecker = (army: IImportedArmy, parser: TImportParsers):
     ...errorFreeSelections,
   }
 
-  const selectionsWithSideEffects = addSideEffectsToImport(mergedSelections, Army)
+  const selectionsWithoutSideEffects = removeSideEffectsFromImport(mergedSelections, Army)
+  const selectionsWithSideEffects = addSideEffectsToImport(selectionsWithoutSideEffects, Army)
 
   return {
     ...army,

--- a/src/utils/import/removeSideEffectsFromImport.ts
+++ b/src/utils/import/removeSideEffectsFromImport.ts
@@ -1,8 +1,6 @@
 import { difference } from 'lodash'
 import { IArmy } from 'types/army'
 import { ISelections } from 'types/selections'
-import { mapTwoListsToDict } from 'utils/mapTwoListsToDict'
-import { TEntry } from 'types/data'
 
 /**
  * Remove side effects (such as spells, artifacts, etc) to our imported selections
@@ -26,10 +24,10 @@ export const removeSideEffectsFromImport = (selections: ISelections, Army: IArmy
     units: 'Units',
   }
   Object.keys(selections).forEach(slice => {
-    const Entries: TEntry[] = Army[lookup[slice]]
-    const Names: string[] = Entries.map(x => x.name)
-    const FromEffectsVals: (boolean | undefined)[] = Entries.map(x => x.fromEffect)
-    const NameMap = mapTwoListsToDict(Names, NotFromEffectsVals)
+    const SideEffects: (boolean | undefined)[] = Army[lookup[slice]]
+      .filter(x => x.fromEffect)
+      .map(x => x.name)
+    selections[slice] = difference(selections[slice], SideEffects)
   })
 
   return selections

--- a/src/utils/import/removeSideEffectsFromImport.ts
+++ b/src/utils/import/removeSideEffectsFromImport.ts
@@ -3,7 +3,7 @@ import { IArmy } from 'types/army'
 import { ISelections } from 'types/selections'
 
 /**
- * Remove side effects (such as spells, artifacts, etc) to our imported selections
+ * Remove side effects (such as spells, artifacts, etc) from our imported selections
  * @param selections
  * @param Army
  */

--- a/src/utils/import/removeSideEffectsFromImport.ts
+++ b/src/utils/import/removeSideEffectsFromImport.ts
@@ -8,9 +8,6 @@ import { ISelections } from 'types/selections'
  * @param Army
  */
 export const removeSideEffectsFromImport = (selections: ISelections, Army: IArmy): ISelections => {
-  // console.log(selections)
-  // console.log(Army)
-
   const lookup = {
     allegiances: 'Allegiances',
     artifacts: 'Artifacts',

--- a/src/utils/import/removeSideEffectsFromImport.ts
+++ b/src/utils/import/removeSideEffectsFromImport.ts
@@ -1,0 +1,30 @@
+import { IArmy } from 'types/army'
+import { ISelections } from 'types/selections'
+import { mapListToDict } from 'utils/mapListToDict'
+
+/**
+ * Remove side effects (such as spells, artifacts, etc) to our imported selections
+ * @param selections
+ * @param Army
+ */
+export const removeSideEffectsFromImport = (selections: ISelections, Army: IArmy): ISelections => {
+  console.log(selections)
+  console.log(Army)
+
+  const lookup = {
+    allegiances: 'Allegiances',
+    artifacts: 'Artifacts',
+    battalions: 'Battalions',
+    endless_spells: 'EndlessSpells',
+    spells: 'Spells',
+    traits: 'Traits',
+    units: 'Units',
+  }
+  Object.keys(selections).forEach(slice => {
+    const Names: string[] = Army[lookup[slice]].map(({ name }) => name)
+    const NameMap = mapListToDict(Names)
+    console.log(NameMap)
+  })
+
+  return selections
+}

--- a/src/utils/import/removeSideEffectsFromImport.ts
+++ b/src/utils/import/removeSideEffectsFromImport.ts
@@ -1,13 +1,20 @@
 import { difference } from 'lodash'
 import { IArmy } from 'types/army'
+import { TImportParsers } from 'types/import'
 import { ISelections } from 'types/selections'
+import { logIgnoredImport } from 'utils/analytics'
 
 /**
  * Remove side effects (such as spells, artifacts, etc) from our imported selections
  * @param selections
  * @param Army
+ * @param parser
  */
-export const removeSideEffectsFromImport = (selections: ISelections, Army: IArmy): ISelections => {
+export const removeSideEffectsFromImport = (
+  selections: ISelections,
+  Army: IArmy,
+  parser: TImportParsers
+): ISelections => {
   const lookup = {
     allegiances: 'Allegiances',
     artifacts: 'Artifacts',
@@ -24,7 +31,10 @@ export const removeSideEffectsFromImport = (selections: ISelections, Army: IArmy
     const SideEffects: (boolean | undefined)[] = Army[lookup[slice]]
       .filter(x => x.fromEffect)
       .map(x => x.name)
-    selections[slice] = difference(selections[slice], SideEffects)
+    const previous = selections[slice]
+    selections[slice] = difference(previous, SideEffects)
+    const removed: string[] = difference(previous, selections[slice])
+    removed.forEach(s => logIgnoredImport(s, parser))
   })
 
   return selections

--- a/src/utils/import/removeSideEffectsFromImport.ts
+++ b/src/utils/import/removeSideEffectsFromImport.ts
@@ -1,6 +1,8 @@
+import { difference } from 'lodash'
 import { IArmy } from 'types/army'
 import { ISelections } from 'types/selections'
-import { mapListToDict } from 'utils/mapListToDict'
+import { mapTwoListsToDict } from 'utils/mapTwoListsToDict'
+import { TEntry } from 'types/data'
 
 /**
  * Remove side effects (such as spells, artifacts, etc) to our imported selections
@@ -8,22 +10,26 @@ import { mapListToDict } from 'utils/mapListToDict'
  * @param Army
  */
 export const removeSideEffectsFromImport = (selections: ISelections, Army: IArmy): ISelections => {
-  console.log(selections)
-  console.log(Army)
+  // console.log(selections)
+  // console.log(Army)
 
   const lookup = {
     allegiances: 'Allegiances',
     artifacts: 'Artifacts',
     battalions: 'Battalions',
+    commands: 'Commands',
     endless_spells: 'EndlessSpells',
+    scenery: 'Scenery',
     spells: 'Spells',
     traits: 'Traits',
+    triumphs: 'Triumphs',
     units: 'Units',
   }
   Object.keys(selections).forEach(slice => {
-    const Names: string[] = Army[lookup[slice]].map(({ name }) => name)
-    const NameMap = mapListToDict(Names)
-    console.log(NameMap)
+    const Entries: TEntry[] = Army[lookup[slice]]
+    const Names: string[] = Entries.map(x => x.name)
+    const FromEffectsVals: (boolean | undefined)[] = Entries.map(x => x.fromEffect)
+    const NameMap = mapTwoListsToDict(Names, NotFromEffectsVals)
   })
 
   return selections

--- a/src/utils/import/selectionLookup.ts
+++ b/src/utils/import/selectionLookup.ts
@@ -35,7 +35,7 @@ export const importSelectionLookup = (
     units: 'Units',
   }
 
-  const Names: string[] = Army[lookup[type]].filter(x => !x.fromEffect).map(({ name }) => name)
+  const Names: string[] = Army[lookup[type]].map(({ name }) => name)
   const NameMap = mapListToDict(Names)
   const validators = Validators(Names)
   const checkVal = checkImportSelection(Names, NameMap, errors, true, checkPoorSpacing, typoMap)

--- a/src/utils/import/selectionLookup.ts
+++ b/src/utils/import/selectionLookup.ts
@@ -35,7 +35,7 @@ export const importSelectionLookup = (
     units: 'Units',
   }
 
-  const Names: string[] = Army[lookup[type]].map(({ name }) => name)
+  const Names: string[] = Army[lookup[type]].filter(x => !x.fromEffect).map(({ name }) => name)
   const NameMap = mapListToDict(Names)
   const validators = Validators(Names)
   const checkVal = checkImportSelection(Names, NameMap, errors, true, checkPoorSpacing, typoMap)

--- a/src/utils/mapTwoListsToDict.ts
+++ b/src/utils/mapTwoListsToDict.ts
@@ -1,6 +1,0 @@
-export const mapTwoListsToDict = (keys: string[], vals: (boolean | undefined)[]) => {
-  return keys.reduce((a, b, i) => {
-    a[b] = vals[i]
-    return a
-  }, {})
-}

--- a/src/utils/mapTwoListsToDict.ts
+++ b/src/utils/mapTwoListsToDict.ts
@@ -1,0 +1,6 @@
+export const mapTwoListsToDict = (keys: string[], vals: (boolean | undefined)[]) => {
+  return keys.reduce((a, b, i) => {
+    a[b] = vals[i]
+    return a
+  }, {})
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1540,10 +1540,10 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/react@16.9.13":
-  version "16.9.13"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.13.tgz#b3ea5dd443f4a680599e2abba8cc66f5e1ce0059"
-  integrity sha512-LikzRslbiufJYHyzbHSW0GrAiff8QYLMBFeZmSxzCYGXKxi8m/1PHX+rsVOwhr7mJNq+VIu2Dhf7U6mjFERK6w==
+"@types/react@16.9.14":
+  version "16.9.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.14.tgz#7f1158ce450b4b5aa83b1c5e1324fa75f348bdd1"
+  integrity sha512-Q4tW4RGmR+u/CgzR8VqZcsUWjP4Pz/LcHfs9AzSG+aBnwq8As3Bid3vG1eGGsXg/xuR2k2tqNlI8pzyV8kxe0g==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -3046,7 +3046,7 @@ color@^3.0.0:
     color-convert "^1.9.1"
     color-string "^1.5.2"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -3245,10 +3245,10 @@ core-js@3.2.1:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.2.1.tgz#cd41f38534da6cc59f7db050fe67307de9868b09"
   integrity sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==
 
-core-js@3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.5.tgz#3dda65611d95699b5eb7742ea451ea052d37aa65"
-  integrity sha512-OuvejWH6vIaUo59Ndlh89purNm4DCIy/v3QoYlcGnn+PkYI8BhNHfCuAESrWX+ZPfq9JccVJ+XXgOMy77PJexg==
+core-js@3.4.7:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.7.tgz#57c35937da80fe494fbc3adcf9cf3dc00eb86b34"
+  integrity sha512-qaPVGw30J1wQ0GR3GvoPqlGf9GZfKKF4kFC7kiHlcsPTqH3txrs9crCp3ZiMAXuSenhz89Jnl4GZs/67S5VOSg==
 
 core-js@^2.4.0:
   version "2.6.10"
@@ -4562,7 +4562,7 @@ fast-levenshtein@~2.0.4:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-safe-stringify@^2.0.6:
+fast-safe-stringify@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
@@ -4789,13 +4789,13 @@ fork-ts-checker-webpack-plugin@1.5.0:
     tapable "^1.0.0"
     worker-rpc "^0.1.0"
 
-form-data@^2.3.3:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
-  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
   dependencies:
     asynckit "^0.4.0"
-    combined-stream "^1.0.6"
+    combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
 form-data@~2.3.2:
@@ -9114,15 +9114,10 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@6.9.1:
+qs@6.9.1, qs@^6.9.1:
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
   integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
-
-qs@^6.7.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.0.tgz#d1297e2a049c53119cb49cca366adbbacc80b409"
-  integrity sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA==
 
 qs@~6.5.2:
   version "6.5.2"
@@ -10111,7 +10106,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@6.3.0, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+semver@6.3.0, semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -10793,22 +10788,22 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
-superagent@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-5.1.1.tgz#f5c1336b0777e77e12a6f3962a060186342e43d0"
-  integrity sha512-bpTO/3yQsHPH5w6f7qPCWGTuhEV2w93fwFGpYODnUc5tPa3rmbHUCmwC7iuEFBQQJsyhiW1WVc/ISpfAEv6ojQ==
+superagent@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-5.1.2.tgz#b122f3a62b14c4d638612667033a7eb43c4f4d83"
+  integrity sha512-VwPCbi9H02qDtTbdY+e3+cK5XR0YHsJy9hmeCOXLQ8ezjq8+S1Bs4MdNRmpmf2QjDBetD7drG7/nEta7E3E6Sg==
   dependencies:
     component-emitter "^1.3.0"
     cookiejar "^2.1.2"
     debug "^4.1.1"
-    fast-safe-stringify "^2.0.6"
-    form-data "^2.3.3"
+    fast-safe-stringify "^2.0.7"
+    form-data "^3.0.0"
     formidable "^1.2.1"
     methods "^1.1.2"
     mime "^2.4.4"
-    qs "^6.7.0"
+    qs "^6.9.1"
     readable-stream "^3.4.0"
-    semver "^6.1.1"
+    semver "^6.3.0"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #579, and resolves the remaining failing test from #582 

Approach is:
- when constructing army collection, when an `Entry` is created from an `Effect`, store this in a variable on it
- after importing all selections from a pdf, and before adding side effects, remove _all_ side effects (as indicated by the above flag)

Notes:
- addresses the Storm Lance behaviour and tests
- identifies an erroneous Battlescribe case, with a unit with the wrong CA, so changes the test to not expect that to work
- causes a reordering of selections in some cases, so those tests have been trivially updated
- logs to Google Analytics in case this is helpful