### PR TITLE
Warclans rules update (fixes #759)

### DIFF
--- a/src/army/bonesplitterz/units.ts
+++ b/src/army/bonesplitterz/units.ts
@@ -186,7 +186,7 @@ export const Units: TUnits = [
       BoneTotemBearerEffect,
       {
         name: `Aim Fer Its Eyes`,
-        desc: `Improve the Rend characteristicof an attack made with a Stinga Bow by 1 if the target is a MONSTER.`,
+        desc: `Improve the Rend characteristic of an attack made with a Stinga Bow by 1 if the target is a MONSTER.`,
         when: [SHOOTING_PHASE],
       },
       {

--- a/src/army/bonesplitterz/units.ts
+++ b/src/army/bonesplitterz/units.ts
@@ -17,17 +17,17 @@ const getRogueIdol = () => filterUnits(DestructionUnits, [`Rogue Idol`])[0]
 
 const TuskerChargeEffect = {
   name: `Tusker Charge`,
-  desc: `Add 1 to hit rolls and would rolls for attacks made with this unit's Tusks and Hooves if this unit made a charge move in the same turn.`,
+  desc: `Add 1 to hit rolls and wound rolls for attacks made with this unit's Tusks and Hooves if this unit made a charge move in the same turn.`,
   when: [COMBAT_PHASE],
 }
 const SkullThumperEffect = {
   name: `Skull Thumper`,
-  desc: `Add 2 to the charge rolls of a unit with a Skull Thumper.`,
+  desc: `Add 2 to charge rolls for a unit while it includes any Skull Thumpers.`,
   when: [CHARGE_PHASE],
 }
 const BoarThumperEffect = {
   name: `Boar Thumper`,
-  desc: `Add 2 to the charge rolls of a unit with a Boar Thumper.`,
+  desc: `Add 2 to charge rolls for a unit while it includes any Boar Thumpers.`,
   when: [CHARGE_PHASE],
 }
 const BoneTotemBearerEffect = {
@@ -53,17 +53,17 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Beast Mask`,
-        desc: `The Wurrgog Prophet is -1 to be hit in melee combat.`,
+        desc: `Subtract 1 from hit rolls for attacks made with melee weapons that target this model.`,
         when: [COMBAT_PHASE],
       },
       {
         name: `Prophet of da Waaagh!`,
-        desc: `Roll a D6. On a 4+, you receive 1 Command Point.`,
+        desc: `Roll a dice. On a 4+, you receive 1 command point.`,
         when: [START_OF_HERO_PHASE],
       },
       {
         name: `Fists of Gork`,
-        desc: `Casting value 5. Pick an enemy unit within 24" and visible. Roll one dice for each model in the unit. The unit suffers 1 mortal wound for each 6+. If the casting roll was a 10+ then it does 1 mortal wound on a 4+.`,
+        desc: `Pick 1 enemy unit within 24" of the caster that is visible to them, and roll a number of dice equal to the number of models in that unit. For each 6, that unit suffers 1 mortal wound. If the casting roll was 10+, inflict 1 mortal wound for each 4+ instead of each 6.`,
         when: [HERO_PHASE],
         spell: true,
       },
@@ -75,12 +75,12 @@ export const Units: TUnits = [
       TuskerChargeEffect,
       {
         name: `Weird Squig`,
-        desc: `Once per turn, a Maniak Weirdnob can choose to reroll a casting, dispelling, or unbinding roll.`,
+        desc: `Once per turn, you can re-roll a casting, dispelling or unbinding roll for this model.`,
         when: [HERO_PHASE],
       },
       {
         name: `Bone Spirit`,
-        desc: `Casting value 7. Pick 1 friendly Bonesplitterz unit wholly within 12" of the caster and visible. Until your next hero phase, if the unmodified hit roll for an attack made by that unit is 6, that attack scores 2 hits on the target instead of 1.`,
+        desc: `Casting value 7. Pick 1 friendly BONESPLITTERZ unit wholly within 12" of the caster and visible to them. Until your next hero phase, if the unmodified hit roll for an attack made by that unit is 6, that attack scores 2 hits on the target instead of 1.`,
         when: [HERO_PHASE],
         spell: true,
       },
@@ -91,12 +91,12 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Let Me at 'Em`,
-        desc: `After this model has fought in the combat phase for the first time, you can pick a friendly Bonesplitterz unit that has not yet fought in that combat phase and which is within 3" of an enemy unit and wholly within 12" of this model. That unit fights immediately, before the opposing player picks a unit to fight in that combat phase.`,
+        desc: `After this model has fought in a combat phase for the first time, you can pick 1 friendly BONESPLITTERZ unit that has not yet fought in that combat phase, that is within 3" of an enemy unit and that is wholly within 12" of this model. That unit fights immediately, before the opposing player picks a unit to fight in that combat phase. That unit cannot fight again in that combat phase unless an ability or spell allows it to fight more than once.`,
         when: [COMBAT_PHASE],
       },
       {
         name: `Savage Attack`,
-        desc: `You can select a Bonesplitterz unit wholly within 12". Until the end of that phase, whenever you make an unmodified hit roll of 6 for a model in that unit, that attack scores 2 hits on the target instead of 1. A unit cannot benefit from this command ability more than once per phase.`,
+        desc: `Pick 1 friendly BONESPLITTERZ unit wholly within 12" of a friendly model with this command ability. Until the end of that phase, if the unmodified hit roll for an attack made by that unit is 6, that attack scores 2 hits on the target instead of 1. A unit cannot benefit from this command ability more than once per phase.`,
         when: [START_OF_COMBAT_PHASE],
         command_ability: true,
       },
@@ -107,11 +107,11 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Ritual Dance`,
-        desc: `Roll a D6, on a 3+ pick one of the following effects.
+        desc: `At the start of your hero phase, you can say that this model is performing one of the following dances:
 
-          Grimdokk Dance: Pick a Bonesplitterz model wholly within 12". That model heals D3 wounds.
-          Glyphdokk Dance: Pick a Bonesplitterz unit wholly within 12". Add 1 to save rolls for attacks that target that unit until your next hero phase. A unit cannot benefit from this ability more than once per phase.
-          Weirddokk Dance: Pick a Bonesplitterz Wizard wholly within 12". Until your next hero phase, add 1 to the casting, dispelling, and unbinding rolls for that model. A unit cannot benefit from this ability more than once per phase.`,
+        Grimdokk Dance: Pick 1 friendly BONESPLITTERZ model within 12" of this model and roll a dice. On a 3+, you can heal up to D3 wounds allocated to that model.
+        Glyphdokk Dance: Pick 1 friendly BONESPLITTERZ unit wholly within 12" of this model and roll a dice. On a 3+, add 1 to save rolls for attacks that target that unit until your next hero phase. A unit cannot benefit from this ability more than once per phase.
+        Weirddokk Dance: Pick 1 friendly BONESPLITTERZ WIZARD wholly within 12" of this model and roll a dice. On a 3+, add 1 to casting, dispelling and unbinding rolls for that WIZARD until your next hero phase. A unit cannot benefit from this ability more than once per phase.`,
         when: [START_OF_HERO_PHASE],
       },
     ],
@@ -143,7 +143,11 @@ export const Units: TUnits = [
       },
       {
         name: `Da Final Fling`,
+<<<<<<< HEAD
         desc: `If a model is slain by a melee attack, pick an enemy unit within 3" of the model before the model is removed and roll a D6. That unit suffers D3 mortal wounds on a 4+. Add 2 to this roll if the target is a MONSTER.`,
+=======
+        desc: `Each time a model from this unit is slain by an attack made with a melee weapon, before the model is removed from play, pick 1 enemy unit within 3" of the slain model and roll a dice. Add 2 to the roll if that enemy unit is a MONSTER. On a 4+, that unit suffers D3 mortal wounds.`,
+>>>>>>> updating bonesplitterz units to match book/warscrolls
         when: [COMBAT_PHASE],
       },
       {
@@ -186,12 +190,12 @@ export const Units: TUnits = [
       BoneTotemBearerEffect,
       {
         name: `Aim Fer Its Eyes`,
-        desc: `Stinga Bows have a Rend of -1 against Monsters.`,
+        desc: `Improve the Rend characteristicof an attack made with a Stinga Bow by 1 if the target is a MONSTER.`,
         when: [SHOOTING_PHASE],
       },
       {
         name: `Loads Arrows`,
-        desc: `Add 1 to the Attacks characteristic of the Stinga Bows if their unit has 15 or more models.`,
+        desc: `Add 1 to the Attacks characteristic of missile weapons used by this unit while it has 15 or more models.`,
         when: [SHOOTING_PHASE],
       },
     ],

--- a/src/army/ironjawz/units.ts
+++ b/src/army/ironjawz/units.ts
@@ -226,7 +226,7 @@ export const Battalions: TBattalions = [
     effects: [
       {
         name: `Gore-grunta Big Boss`,
-        desc: `Pick 1 Gore-grunta Boss from a unit in this battalion to be the battalion’s Big Boss. That model has a Wounds characteristic of 7 instead of 5.`,
+        desc: `Pick 1 Gore-grunta Boss from a unit in this battalion to be the battalion's Big Boss. That model has a Wounds characteristic of 7 instead of 5.`,
         when: [DURING_GAME],
       },
       {
@@ -241,7 +241,7 @@ export const Battalions: TBattalions = [
     effects: [
       {
         name: `Ironfist Big Boss`,
-        desc: `Pick 1 Brute Boss or Gore-grunta Boss from a unit in this battalion to be the battalion’s Big Boss. Add 2 to that model’s Wounds characteristic.`,
+        desc: `Pick 1 Brute Boss or Gore-grunta Boss from a unit in this battalion to be the battalion's Big Boss. Add 2 to that model's Wounds characteristic.`,
         when: [DURING_GAME],
       },
       {

--- a/src/army/ironjawz/units.ts
+++ b/src/army/ironjawz/units.ts
@@ -24,7 +24,7 @@ const MegabossEffects = [
   },
   {
     name: `Strength from Victory`,
-    desc: `If any enemy models were slain by wounds inflicted by this model's attacks in that combat phase, add 1 to this model's Wounds characteristicand add 1 to the Attacks characteristicof this model's Boss Choppa and Rip-toof Fist.`,
+    desc: `If any enemy models were slain by wounds inflicted by this model's attacks in that combat phase, add 1 to this model's Wounds characteristic and add 1 to the Attacks characteristic of this model's Boss Choppa and Rip-toof Fist.`,
     when: [END_OF_COMBAT_PHASE],
   },
   {

--- a/src/army/ironjawz/units.ts
+++ b/src/army/ironjawz/units.ts
@@ -226,7 +226,7 @@ export const Battalions: TBattalions = [
     effects: [
       {
         name: `Gore-grunta Big Boss`,
-        desc: `Pick a Gore-grunta Boss from one of the units in this battalion to be the battalion's Big Boss. The model you pick has a Wounds characteristic of 7 rather than 5.`,
+        desc: `Pick 1 Gore-grunta Boss from a unit in this battalion to be the battalion’s Big Boss. That model has a Wounds characteristic of 7 instead of 5.`,
         when: [DURING_GAME],
       },
       {
@@ -241,7 +241,7 @@ export const Battalions: TBattalions = [
     effects: [
       {
         name: `Ironfist Big Boss`,
-        desc: `Pick a Brute Boss or Gore-grunta Boss from the battalion to be its Big Boss, and add 2 to their Wounds characteristic.`,
+        desc: `Pick 1 Brute Boss or Gore-grunta Boss from a unit in this battalion to be the battalion’s Big Boss. Add 2 to that model’s Wounds characteristic.`,
         when: [DURING_GAME],
       },
       {

--- a/src/army/ironjawz/units.ts
+++ b/src/army/ironjawz/units.ts
@@ -61,7 +61,7 @@ export const Units: TUnits = [
       },
       {
         name: `Strength from Victory`,
-        desc: `At the end of the combat phase, if any enemy models were slain by wounds inflicted by this model's attacks in that combat phase, add 1 to this model's Wounds characteristic and add 1 to the Attacks characteristic of Smasha and Kunnin'.`,
+        desc: `If any enemy models were slain by wounds inflicted by this model's attacks in that combat phase, add 1 to this model's Wounds characteristic and add 1 to the Attacks characteristic of Smasha and Kunnin'.`,
         when: [END_OF_COMBAT_PHASE],
       },
       {
@@ -161,6 +161,7 @@ export const Units: TUnits = [
       {
         name: `Gore-grunta Charge`,
         desc: `Roll a dice for each enemy unit that is within 1" of a model from this unit after the model from this unit finishesa charge move. On a 4+, that enemy unit suffers 1 mortal wound. If this unit has more than 1 model, roll to determine if mortal wounds are inflicted after each model completes its charge move, but do not allocate the mortal wounds until after all of the models in the unit have moved.
+        
         In addition, add 1 to hit rolls and wound rolls for attacks made with this unit's Jagged Gore-hackas and Tusks and Hooves if this unit made a charge move in the same turn.`,
         when: [CHARGE_PHASE],
       },

--- a/src/army/ironjawz/units.ts
+++ b/src/army/ironjawz/units.ts
@@ -19,17 +19,17 @@ const getRogueIdol = () => filterUnits(DestructionUnits, [`Rogue Idol`])[0]
 const MegabossEffects = [
   {
     name: `Rip-toof Fist`,
-    desc: `If the unmodified save roll for an attack made with a melee weapon that targets a model with a Riptoof-fist is 6, the attacking unit suffers 1 mortal wound after all of its attacks have been resolved.`,
+    desc: `If the unmodified save roll for an attack that targets this model is 6, the attacking unit suffers 1 mortal wound after all of its attacks have been resolved.`,
     when: [COMBAT_PHASE],
   },
   {
     name: `Strength from Victory`,
-    desc: `If any enemy models were slain by wounds inflicted by this model's attacks in that combat phase, add +1 attack to the Megaboss's weapon and add +1 to the models Wounds characteristic.`,
+    desc: `If any enemy models were slain by wounds inflicted by this model's attacks in that combat phase, add 1 to this model's Wounds characteristicand add 1 to the Attacks characteristicof this model's Boss Choppa and Rip-toof Fist.`,
     when: [END_OF_COMBAT_PHASE],
   },
   {
     name: `Go on Ladz, Get Stuck In!`,
-    desc: `Pick 1 friendly IRONJAWZ unit wholly within 12" of a friendly model with this command ability, or wholly within 18" of a friendly model with this command ability that is a MONSTER. Until the end of the phase, add 1 to hit rolls for attacks made by that unit. A unit cannot benefit from this command ability more than once per phase.`,
+    desc: `Pick 1 friendly IRONJAWZ unit wholly within 12" of a friendly model with this command ability, or wholly within 18" of a friendly model with this command ability that is a MONSTER. Until the end of that phase, add 1 to hit rolls for attacks made by that unit. A unit cannot benefit from this command ability more than once per phase.`,
     when: [START_OF_COMBAT_PHASE],
     command_ability: true,
   },
@@ -42,12 +42,12 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Smasha`,
-        desc: `Unmodified wound rolls of 4+ inflict D3 mortal wounds if the target is a HERO and not a WIZARD and the attack sequence ends.`,
+        desc: `If the unmodified wound roll for an attack made by Smasha that targets a HERO that is not a WIZARD is 4+, that attack inflicts D3 mortal wounds on the target and the attack sequence ends (do not make a save roll or damage roll).`,
         when: [COMBAT_PHASE],
       },
       {
         name: `Kunnin'`,
-        desc: `Unmodified wound rolls of 4+ inflict D3 mortal wounds if the target is a WIZARD and the attack sequence ends.`,
+        desc: `If the unmodified wound roll for an attack made by Kunnin' that targets a WIZARD is 4+, that attack inflicts D3 mortal wounds on the target and the attack sequence ends (do not make a save roll).`,
         when: [COMBAT_PHASE],
       },
       {
@@ -61,12 +61,12 @@ export const Units: TUnits = [
       },
       {
         name: `Strength from Victory`,
-        desc: `If any enemy models were slain by wounds inflicted by this model's attacks in that combat phase, add 1 to this model's Wounds characteristic and add 1 to the Attacks characteristic of Smasha and Kunnin'.`,
+        desc: `At the end of the combat phase, if any enemy models were slain by wounds inflicted by this model's attacks in that combat phase, add 1 to this model's Wounds characteristic and add 1 to the Attacks characteristic of Smasha and Kunnin'.`,
         when: [END_OF_COMBAT_PHASE],
       },
       {
         name: `Voice of Gork`,
-        desc: `Pick up to 3 friendly DESTRUCTION units wholly within 24", until the end of the combat phase add 1 to hit rolls for attacks made by those units. A unit cannot benefit from this CA multiple times, and this CA does not stack with 'Go on Ladz, Get Stuck In!'`,
+        desc: `Pick up to 3 friendly DESTRUCTION units wholly within 24" of this model. Until the end of that phase, add 1 to hit rolls for attacks made by that unit. A unit cannot benefit from this command ability more than once per phase, and a unit cannot benefit from this ability and the Go on Ladz, Get Stuck In! ability in the same phase.`,
         when: [START_OF_COMBAT_PHASE],
         command_ability: true,
       },
@@ -78,9 +78,9 @@ export const Units: TUnits = [
       ...MegabossEffects,
       {
         name: `Destructive Bulk`,
-        desc: `After a Maw-krusha completes a charge move, pick an enemy unit within 1" and roll the number of dice shown for the Maw-krusha's Destructive Bulk on the damage table above; the enemy unit suffers 1 mortal wound for each roll of 5+.
+        desc: `After this model makes a charge move, you can pick 1 enemy unit within 1" of this model and roll a number of dice equal to the Destructive Bulk value on this model's damage table. For each 5+, that enemy unit suffers1 mortal wound.
 
-        If the wounds inflicted by a Maw-krusha's Destructive Bulk attack mean that there are no enemy models left within 3" of it, then it can immediately make another charge move (and can make another Destructive Bulk attack after the move if the charge is successfully carried out). A Maw-krusha can make any number of charge moves like this in a single turn, so long as each one results in all enemy models within 3" being slain.`,
+        If the mortal wounds inflicted by this model's Destructive Bulk mean there are no enemy models left within 3" of it, then it can attempt to make another charge move, and it can make another Destructive Bulk attack after that move if the charge is successfully carried out. This model can attempt to make any number of charge moves in a single turn, so long as each one results in all enemy models within 3" being slain.`,
         when: [CHARGE_PHASE],
       },
     ],
@@ -94,12 +94,12 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Warchanter's Beat`,
-        desc: `Each time you make a hit roll of 6 for a Warchanter's Gorkstikk and Morkstikk, you score 2 attacks instead of 1 with the weapon.`,
+        desc: `If the unmodified hit roll for an attack made with a Gorkstikk and Morkstikk is 6, that attack scores 2 hits on the target instead of 1. Make a wound and save roll for each hit.`,
         when: [COMBAT_PHASE],
       },
       {
         name: `Violent Fury`,
-        desc: `Pick one IRONJAWZ unit that is wholly within 15" of the Warchanter in your hero phase. Add 1 to the damage inflicted by attacks made with melee weapons by that unit until your next hero phase. A unit cannot benefit from this ability more than once per phase.`,
+        desc: `You can pick 1 friendly IRONJAWZ unit wholly within 15" of this model. Until your next hero phase, add 1 to the damage inflicted by attacks made with melee weapons by that unit. A unit cannot benefit from this ability more than once per phase.`,
         when: [HERO_PHASE],
       },
     ],
@@ -109,12 +109,16 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Brutal Power`,
-        desc: `If this model is wholly within 18" of a friendly IRONJAWZ unit with 10 or more models at the end of its hero phase, it can attempt to cast the Green Puke Spell in addition to any other spells it can cast, even if Green Puke was already attempted earlier in the phase.`,
+        desc: `If this model is wholly within 18" of a friendly IRONJAWZ unit with 10 or more models at the end of its hero phase, it can attempt to cast the Green Puke spell in addition to any other spells it can cast, and even if a WIZARD has already attempted to cast the Green Puke spell in that hero phase.`,
         when: [END_OF_HERO_PHASE],
       },
       {
         name: `Green Puke`,
+<<<<<<< HEAD
         desc: `Casting value 6. Pick 1 point on the battlefield within 2d6" of the caster that is visible, draw an imaginary straight line 1mm wide between that point and the closest part of the caster's base. Each unit that has models passed across by this line suffers D3 mortal wounds.`,
+=======
+        desc: `Casting value 6. Pick 1 point on the battlefield within 2D6" of the caster that is visible to them, and draw an imaginary straight line 1mm wide between that point and the closest part of the caster's base. Each unit that has models passed across by this line suffers D3 mortal wounds.`,
+>>>>>>> Updating Ironjawz to match the book/warscrolls
         when: [HERO_PHASE],
         spell: true,
       },
@@ -125,12 +129,12 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Waaagh! Drummers`,
-        desc: `Add 2 to charge rolls for a unit that includes any Waaagh! Drummers.`,
+        desc: `Add 2 to charge rolls for a unit while it includes any Waaagh! Drummers.`,
         when: [CHARGE_PHASE],
       },
       {
         name: `Gorkamorka Banner Bearer`,
-        desc: `You can add 2 to the Bravery of all models in a unit that includes any Orruk Banners.`,
+        desc: `Add 2 to the Bravery characteristic of this unit while it includes any Gorkamorka Banner Bearers.`,
         when: [BATTLESHOCK_PHASE],
       },
       {
@@ -140,7 +144,7 @@ export const Units: TUnits = [
       },
       {
         name: `Orruk-forged Shields!`,
-        desc: `Roll a D6 before allocating a wound to a model with an Orruk-forged Shield. On a roll of 6 the wound is ignored.`,
+        desc: `Roll a dice each time you allocate a wound to a model carrying an Orruk-forged Shield. On a 6, that wound is negated.`,
         when: [WOUND_ALLOCATION],
       },
     ],
@@ -150,7 +154,7 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Duff Up da Big Thing`,
-        desc: `Add 1 to hit rolls for an Orruk Brute if the target has a Wounds characteristic of 4+.`,
+        desc: `Add 1 to the hit rolls for attacks made by this unit that target a unit with a Wounds characteristic of 4+.`,
         when: [COMBAT_PHASE],
       },
     ],
@@ -160,9 +164,13 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Gore-grunta Charge`,
+<<<<<<< HEAD
         desc: `Roll a D6 for each enemy unit that is within 1" of a model from this unit after the model has finished a charge move. On a 4+, that enemy unit suffers 1 mortal wound. Allocate the mortal wounds after all models have completed their charge.
+=======
+        desc: `Roll a dice for each enemy unit that is within 1" of a model from this unit after the model from this unit finishesa charge move. On a 4+, that enemy unit suffers 1 mortal wound. If this unit has more than 1 model, roll to determine if mortal wounds are inflicted after each model completes its charge move, but do not allocate the mortal wounds until after all of the models in the unit have moved.
+>>>>>>> Updating Ironjawz to match the book/warscrolls
 
-          In addition, add 1 to hit rolls and wound rolls for attacks made with this unit's Jagged Gore-hackas and tucks and hooves if this unit made a charge move in the same turn.`,
+        In addition, add 1 to hit rolls and wound rolls for attacks made with this unit's Jagged Gore-hackas and Tusks and Hooves if this unit made a charge move in the same turn.`,
         when: [CHARGE_PHASE],
       },
     ],
@@ -172,7 +180,7 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Dead 'Ard`,
-        desc: `Roll a D6 each time you allocate a wound or mortal wound to this unit. On a 6+ the wound is negated. Wounds or mortal wounds allocated to Gurzag Ironskull are negated on a 5+ instead of a 6+.`,
+        desc: `Roll a dice each time you allocate a wound or mortal wound to this unit. On a 6, the wound or mortal wound is negated. Wounds or mortal wounds allocated to Gurzag Ironskull are negated on a 5+ instead of a 6.`,
         when: [WOUND_ALLOCATION],
       },
       {
@@ -192,23 +200,23 @@ export const Battalions: TBattalions = [
     effects: [
       {
         name: `Drawn to the Waaagh!`,
-        desc: `The Warchanter of the battalion knows this Command ability. Use this command ability when a unit from this battalion is destroyed. Roll a D6, on a 4+ a new Orruk Ardboyz unit with 10 models appears wholly within 6" of the table edge and more than 9" from enemy units.`,
+        desc: `You can use this command ability if the ORRUK WARCHANTER from this battalion is on the battlefield when a unit from this battalion is destroyed. If you do so, roll a dice. On a 4+, a new ORRUK ARDBOYS unit with 10 models is added to this battalion. Set up the new unit wholly within 6" of the edge of the battlefieldand more than 9" from any enemy units.`,
         when: [DURING_GAME],
         command_ability: true,
       },
     ],
   },
   {
-    name: `Brute Fist`,
+    name: `BruteFist`,
     effects: [
       {
         name: `Brute Big Boss`,
-        desc: `Pick a Brute Boss from one of the units in this battalion to be the battalion's Big Boss. The model you pick has a Wounds characteristic of 5 rather than 3.`,
+        desc: `Pick 1 Brute Boss from a unit in this battalion to be the battalion's Big Boss. That model has a Wounds characteristic of 5 instead of 3.`,
         when: [DURING_GAME],
       },
       {
         name: `Green-skinned Battering Ram`,
-        desc: `After a model from this battalion makes a charge move, pick 1 enemy unit within 1" of each model and roll a D6. On a 4+ that enemy unit suffers 1 mortal wound.`,
+        desc: `After a model from a unit in this battalion makes a charge move, you can pick 1 enemy unit within 1" of that model and roll a dice. On a 4+, that enemy unit suffers 1 mortal wound. If that model's unit has more than 1 model, roll to determine if a mortal wound is inflicted each time a model from that unit completes its charge move, but do not allocate the mortal wounds until all of the models in that unit have moved.`,
         when: [CHARGE_PHASE],
       },
     ],
@@ -223,7 +231,7 @@ export const Battalions: TBattalions = [
       },
       {
         name: `Da Boss's Big Idea`,
-        desc: `Each unit from this battalion that is wholly within 18" of the Big Boss can make a normal move, but cannot run, in the hero phase.`,
+        desc: `Each unit from this battalion that is wholly within 18" of the Big Boss from the same battalion at the start of that hero phase can make a normal move, but cannot run.`,
         when: [TURN_ONE_HERO_PHASE],
       },
     ],
@@ -238,7 +246,7 @@ export const Battalions: TBattalions = [
       },
       {
         name: `Up and At'Em`,
-        desc: `Once in each of your hero phases, the Big Boss from this battalion can use the Mighty Destroyers command ability (pg 55) without spending 1 command point.`,
+        desc: `Once in each of your hero phases, the Big Boss from this battalion can use the Mighty Destroyers command ability (pg 55) as if they were a MEGABOSS and without spending 1 command point.`,
         when: [HERO_PHASE],
       },
     ],
@@ -248,7 +256,7 @@ export const Battalions: TBattalions = [
     effects: [
       {
         name: `Weird Energy`,
-        desc: `If the Weirdknob Shaman from this battalion is wholly within 18" of 2 or more units from the same battalion that each have 10 or more models, it can use its Brutal Power ability twice instead of only once.`,
+        desc: `If the WEIRDNOB SHAMAN from this battalion is wholly within 18" of 2 or more units from the same battalion that each have 10 or more models, it can use its Brutal Power ability to attempt to cast Green Puke twice, in addition to any other spells it can cast, instead of only once.`,
         when: [END_OF_HERO_PHASE],
       },
     ],


### PR DESCRIPTION
Updating the bonesplitterz and ironjawz units to match the book/warscrolls