### PR TITLE
Show selection counts on collapsed cards

### DIFF
--- a/src/components/info/card.tsx
+++ b/src/components/info/card.tsx
@@ -18,10 +18,11 @@ interface IBaseCardProps {
 
 interface ICardProps extends IBaseCardProps {
   isVisible: boolean
+  selectionCount?: number
 }
 
 const CardComponent: React.FC<ICardProps> = props => {
-  const { title, isVisible, isMobile, mobileTitle, children } = props
+  const { title, isVisible, isMobile, mobileTitle, children, selectionCount } = props
   const { theme } = useTheme()
 
   const bodyClass = `${theme.cardBody} ${isVisible ? `` : `d-none`} ${isMobile ? `py-3` : ``}`
@@ -32,7 +33,13 @@ const CardComponent: React.FC<ICardProps> = props => {
   return (
     <div className={colClass}>
       <div className={theme.card}>
-        <CardHeader isMobile={isMobile} isVisible={isVisible} title={title} mobileTitle={mobileTitle} />
+        <CardHeader
+          isMobile={isMobile}
+          isVisible={isVisible}
+          title={title}
+          mobileTitle={mobileTitle}
+          selectionCount={selectionCount}
+        />
         <div className={bodyClass}>{children}</div>
       </div>
     </div>
@@ -42,6 +49,7 @@ const CardComponent: React.FC<ICardProps> = props => {
 interface ICardMultiProps extends IBaseCardProps {
   hiddenSelectors: string[] // state2props
   items: TUnits | TBattalions | TArtifacts | TTraits | TAllegiances | TSpells | TEndlessSpells
+  selectionCount: number
   setValues: (selectValues: ValueType<TDropdownOption>[]) => void
   values: string[]
   enableLog?: boolean
@@ -67,7 +75,13 @@ const CardMultiComponent = (props: ICardMultiProps) => {
   if (!items.length) return null
 
   return (
-    <CardComponent isMobile={isMobile} title={title} isVisible={isVisible} mobileTitle={mobileTitle}>
+    <CardComponent
+      isMobile={isMobile}
+      title={title}
+      isVisible={isVisible}
+      mobileTitle={mobileTitle}
+      selectionCount={values.length}
+    >
       <SelectMulti values={values} items={selectItems} setValues={setValues} isClearable={true} log={log} />
     </CardComponent>
   )
@@ -77,6 +91,7 @@ interface ICardSingleSelectProps extends IBaseCardProps {
   enableLog?: boolean
   hiddenSelectors: string[] // state2props
   items: string[]
+  selectionCount: number
   setValue: TSelectOneSetValueFn
   value?: string | null
 }
@@ -97,7 +112,13 @@ const CardSingleSelectComponent: React.FC<ICardSingleSelectProps> = props => {
   const log = enableLog ? { title, label: label || title } : null
 
   return (
-    <CardComponent isMobile={isMobile} title={title} isVisible={isVisible} mobileTitle={mobileTitle}>
+    <CardComponent
+      isMobile={isMobile}
+      title={title}
+      isVisible={isVisible}
+      mobileTitle={mobileTitle}
+      selectionCount={value ? 1 : 0}
+    >
       <SelectOne setValue={setValue} items={items} value={value} isClearable={true} log={log} />
     </CardComponent>
   )
@@ -108,13 +129,23 @@ interface ICardHeaderProps extends IBaseCardProps {
   hideCard: (value: string) => void
   iconSize?: number
   isVisible: boolean
+  selectionCount?: number
   showCard: (value: string) => void
   type?: TVisibilityIconType
 }
 
 export const CardHeaderComponent = (props: ICardHeaderProps) => {
-  const { title, isMobile, mobileTitle, isVisible, hideCard, showCard, type = 'minus', iconSize = 1 } = props
-
+  const {
+    title,
+    isMobile,
+    mobileTitle,
+    isVisible,
+    hideCard,
+    showCard,
+    type = 'minus',
+    iconSize = 1,
+    selectionCount,
+  } = props
   const { theme } = useTheme()
 
   const handleVisibility = () => (isVisible ? hideCard(title) : showCard(title))
@@ -131,15 +162,20 @@ export const CardHeaderComponent = (props: ICardHeaderProps) => {
   }
 
   const titleText = isMobile && mobileTitle ? mobileTitle : title
+  const selectionCountText = selectionCount && !isVisible ? `(${selectionCount})` : ''
 
   return (
     <div className={styles.cardHeader} onClick={handleVisibility}>
       <div className={styles.flexWrapperClass}>
         <div className={styles.flexClass}>
           {isMobile ? (
-            <h5 className="CardHeaderTitle text-nowrap">{titleText}</h5>
+            <h5 className="CardHeaderTitle text-nowrap">
+              {titleText} {selectionCountText}
+            </h5>
           ) : (
-            <h4 className="CardHeaderTitle text-nowrap">{titleText}</h4>
+            <h4 className="CardHeaderTitle text-nowrap">
+              {titleText} {selectionCountText}
+            </h4>
           )}
         </div>
         <div className={styles.vizWrapper}>

--- a/src/components/info/card.tsx
+++ b/src/components/info/card.tsx
@@ -162,7 +162,7 @@ export const CardHeaderComponent = (props: ICardHeaderProps) => {
   }
 
   const titleText = isMobile && mobileTitle ? mobileTitle : title
-  const selectionCountText = selectionCount && !isVisible ? ` (${selectionCount})` : ''
+  const selectionCountText = selectionCount && !isVisible ? ` (${selectionCount})` : ``
 
   return (
     <div className={styles.cardHeader} onClick={handleVisibility}>

--- a/src/components/info/card.tsx
+++ b/src/components/info/card.tsx
@@ -155,14 +155,14 @@ export const CardHeaderComponent = (props: ICardHeaderProps) => {
   }, [hideCard, isMobile, title])
 
   const styles = {
-    cardHeader: `${theme.cardHeader} py-${isMobile ? 3 : 2}`,
+    cardHeader: `${theme.cardHeader} py-${isMobile ? 3 : 2} ${isMobile ? `px-3` : ``}`,
     flexClass: `flex-grow-1 text-center ${!isMobile ? `pl-5` : ``}`,
     flexWrapperClass: `d-flex justify-content-${isMobile ? `end` : `center`} align-items-center`,
     vizWrapper: `${isMobile ? `pr-0` : `px-3`} d-print-none`,
   }
 
   const titleText = isMobile && mobileTitle ? mobileTitle : title
-  const selectionCountText = selectionCount && !isVisible ? `(${selectionCount})` : ''
+  const selectionCountText = selectionCount && !isVisible ? ` (${selectionCount})` : ''
 
   return (
     <div className={styles.cardHeader} onClick={handleVisibility}>
@@ -170,11 +170,13 @@ export const CardHeaderComponent = (props: ICardHeaderProps) => {
         <div className={styles.flexClass}>
           {isMobile ? (
             <h5 className="CardHeaderTitle text-nowrap">
-              {titleText} {selectionCountText}
+              {titleText}
+              {selectionCountText}
             </h5>
           ) : (
             <h4 className="CardHeaderTitle text-nowrap">
-              {titleText} {selectionCountText}
+              {titleText}
+              {selectionCountText}
             </h4>
           )}
         </div>

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -164,6 +164,9 @@ small {
   }
 
 @media (max-width: 575.98px) {
+    .CardHeaderTitle {
+        font-size: 1.1rem;
+    }
     .ReminderCardBody {
         padding-top: 0.75rem;
         padding-bottom: 0.75rem;
@@ -172,7 +175,7 @@ small {
 
 @media (max-width: 395px) {
     .CardHeaderTitle {
-        font-size: 1.1rem;
+        font-size: 1rem;
     }
 }
 

--- a/src/tests/battlescribe/battlescribeHTML.test.ts
+++ b/src/tests/battlescribe/battlescribeHTML.test.ts
@@ -28,7 +28,6 @@ import {
   TOMB_KINGS,
   TZEENTCH,
   WANDERERS,
-  OGOR_MAWTRIBES,
 } from 'meta/factions'
 import { getBattlescribeArmy } from 'utils/battlescribe/getBattlescribeArmy'
 import { HYSH } from 'types/realmscapes'


### PR DESCRIPTION
Got the following messages the other day.
> this link doesn't restore fully on mobile for me BTW
> The same for anyone else?
> I only get the unit selection
> Oops, just me, I'm an idiot

Obviously, all but the units card were collapsed, but it really wasn't clear that the shared link had worked properly. This is also true with importing and loading.

So I decided to work up a solution showing the number of selected items on hidden cards.
Considered doing it only on mobile but figured it might be useful across the board. One-line change if not.

Could super do with a review, not least as I tried lots of things and I'm not sure I've removed everything extraneous: there could easily be unused props bouncing around in there. Also my code is likely to be incredibly unidiomatic, cos I'm just not used to it. Was quite far out of my comfort zone here.