### PR TITLE
Redux persist and a Clear Army button

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-stripe-elements": "6.0.1",
     "react-switch": "5.0.1",
     "redux": "4.0.4",
-    "redux-persist": "^6.0.0",
+    "redux-persist": "6.0.0",
     "string.prototype.matchall": "4.0.1",
     "superagent": "5.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/jspdf": "1.3.3",
     "@types/lodash": "4.14.149",
     "@types/luxon": "1.21.0",
-    "@types/node": "12.12.18",
+    "@types/node": "12.12.19",
     "@types/parse5": "5.0.2",
     "@types/pdfjs-dist": "2.1.3",
     "@types/qs": "6.9.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-stripe-elements": "6.0.1",
     "react-switch": "5.0.1",
     "redux": "4.0.4",
+    "redux-persist": "^6.0.0",
     "string.prototype.matchall": "4.0.1",
     "superagent": "5.1.2"
   },

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6,7 +6,6 @@ import { ROUTES } from 'utils/env'
 import { BrowserRouter, Route, Switch } from 'react-router-dom'
 import { PrivateRoute } from 'components/page/privateRoute'
 import { handleCheckout, handleArmyLink } from 'utils/handleQueryParams'
-import { loadArmyFromLocalStore } from 'utils/loadArmy/loadArmyHelpers'
 
 // Lazy loading routes (takes advantage of code splitting)
 const Home = lazy(() => import('components/routes/Home'))
@@ -17,8 +16,7 @@ const Redeem = lazy(() => import('components/routes/Redeem'))
 const App = () => {
   useEffect(() => {
     handleCheckout() // Post-checkout handling
-    const loadedLink = handleArmyLink() // Load army from link
-    if (!loadedLink) loadArmyFromLocalStore() // Load an army from the localStore (after redirect)
+    handleArmyLink() // Load army from link
   }, [])
 
   return (

--- a/src/components/info/banners/update_banner.tsx
+++ b/src/components/info/banners/update_banner.tsx
@@ -3,7 +3,6 @@ import { useAppStatus } from 'context/useAppStatus'
 import { useTheme } from 'context/useTheme'
 import { MdRefresh } from 'react-icons/md'
 import { componentWithSize } from 'utils/mapSizesToProps'
-import { LocalStoredArmy } from 'utils/localStore'
 import { logClick } from 'utils/analytics'
 import { NotificationBanner } from 'components/info/banners/notification_banner'
 import GenericButton from 'components/input/generic_button'
@@ -21,22 +20,7 @@ const UpdateBanner = componentWithSize(({ isTinyMobile = false, isMobile = false
 
   const handleAccept = async () => {
     logClick('ReloadContentButton')
-    LocalStoredArmy.set() // Save anything we're working on
     window.location.reload()
-    // try {
-    //   if (navigator && navigator.serviceWorker) {
-    //     const waitingServiceWorker = await navigator.serviceWorker.ready
-
-    //     if (waitingServiceWorker.waiting) {
-    //       logClick('ReloadContentButton')
-    //       LocalStoredArmy.set() // Save anything we're working on
-    //       window.location.reload()
-    //       // waitingServiceWorker.waiting.postMessage({ type: 'SKIP_WAITING' })
-    //     }
-    //   }
-    // } catch (e) {
-    //   console.error(e)
-    // }
   }
 
   if (!hasNewContent) return <></>

--- a/src/components/input/savedArmies/save_army_btn.tsx
+++ b/src/components/input/savedArmies/save_army_btn.tsx
@@ -5,7 +5,6 @@ import { useAuth0 } from 'react-auth0-wrapper'
 import { FaSave } from 'react-icons/fa'
 import { useAppStatus } from 'context/useAppStatus'
 import { useSubscription } from 'context/useSubscription'
-import { useSavedArmies } from 'context/useSavedArmies'
 import { useTheme } from 'context/useTheme'
 import { centerContentClass } from 'theme/helperClasses'
 import { selectors } from 'ducks'
@@ -29,9 +28,8 @@ const SaveArmyBtnComponent: React.FC<ISaveArmyProps> = ({
   hiddenReminders,
 }) => {
   const { isOffline } = useAppStatus()
-  const { isAuthenticated } = useAuth0()
+  const { isAuthenticated, loginWithRedirect } = useAuth0()
   const { isActive } = useSubscription()
-  const { handleLogin } = useSavedArmies()
 
   const [modalIsOpen, setModalIsOpen] = useState(false)
 
@@ -42,7 +40,7 @@ const SaveArmyBtnComponent: React.FC<ISaveArmyProps> = ({
 
   return (
     <>
-      {!isAuthenticated && <SaveButton handleClick={handleLogin} />}
+      {!isAuthenticated && <SaveButton handleClick={loginWithRedirect} />}
 
       {isAuthenticated && !isActive && <SubscribeBtn />}
 

--- a/src/components/input/shareArmy/share_army_btn.tsx
+++ b/src/components/input/shareArmy/share_army_btn.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { FaLink } from 'react-icons/fa'
 import { useAppStatus } from 'context/useAppStatus'
-import { useSavedArmies } from 'context/useSavedArmies'
 import { useSubscription } from 'context/useSubscription'
 import { useTheme } from 'context/useTheme'
 import { centerContentClass } from 'theme/helperClasses'
@@ -27,9 +26,8 @@ const ShareArmyBtnComponent: React.FC<IShareArmyProps> = ({
   showSavedArmies,
   hiddenReminders,
 }) => {
-  const { isAuthenticated } = useAuth0()
+  const { isAuthenticated, loginWithRedirect } = useAuth0()
   const { isOffline } = useAppStatus()
-  const { handleLogin } = useSavedArmies()
   const { isActive } = useSubscription()
 
   const [modalIsOpen, setModalIsOpen] = useState(false)
@@ -41,7 +39,7 @@ const ShareArmyBtnComponent: React.FC<IShareArmyProps> = ({
 
   return (
     <>
-      {!isAuthenticated && <ShareButton handleClick={handleLogin} />}
+      {!isAuthenticated && <ShareButton handleClick={loginWithRedirect} />}
 
       {isAuthenticated && !isActive && <SubscribeBtn />}
 

--- a/src/components/input/toolbar/clear_army_btn.tsx
+++ b/src/components/input/toolbar/clear_army_btn.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FaTrash } from 'react-icons/fa'
+import { FaTrashAlt } from 'react-icons/fa'
 import GenericButton from 'components/input/generic_button'
 
 interface IClearArmyButton {
@@ -11,7 +11,7 @@ const ClearArmyButton: React.FC<IClearArmyButton> = props => {
 
   return (
     <GenericButton onClick={clearArmyClick}>
-      <FaTrash className="mr-2" /> Clear Army
+      <FaTrashAlt className="mr-2" /> Clear Army
     </GenericButton>
   )
 }

--- a/src/components/input/toolbar/clear_army_btn.tsx
+++ b/src/components/input/toolbar/clear_army_btn.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { FaTrash } from 'react-icons/fa'
+import GenericButton from 'components/input/generic_button'
+
+interface IClearArmyButton {
+  clearArmyClick: (e: any) => void
+}
+
+const ClearArmyButton: React.FC<IClearArmyButton> = props => {
+  const { clearArmyClick } = props
+
+  return (
+    <GenericButton onClick={clearArmyClick}>
+      <FaTrash className="mr-2" /> Clear Army
+    </GenericButton>
+  )
+}
+
+export default ClearArmyButton

--- a/src/components/input/toolbar/toolbar.tsx
+++ b/src/components/input/toolbar/toolbar.tsx
@@ -7,6 +7,7 @@ import { useSubscription } from 'context/useSubscription'
 import { selections, army, selectors, realmscape } from 'ducks'
 import { getArmy } from 'utils/getArmy/getArmy'
 import { armyHasEntries } from 'utils/armyUtils'
+import { logClick } from 'utils/analytics'
 import { LoadingBtn } from 'components/helpers/suspenseFallbacks'
 import { SUPPORTED_FACTIONS, TSupportedFaction } from 'meta/factions'
 import { TUnits, IArmy } from 'types/army'
@@ -85,6 +86,7 @@ const ToolbarComponent = (props: IToolbarProps) => {
       resetAllySelections()
       resetRealmscapeStore()
       resetSelections()
+      logClick('ClearArmy')
       setLoadedArmy(null)
     },
     [resetAllySelections, resetRealmscapeStore, resetSelections, setLoadedArmy]

--- a/src/components/page/homeHeader.tsx
+++ b/src/components/page/homeHeader.tsx
@@ -8,7 +8,6 @@ import { withSelectOne } from 'utils/withSelect'
 import { logFactionSwitch } from 'utils/analytics'
 import { componentWithSize } from 'utils/mapSizesToProps'
 import { titleCase } from 'utils/textUtils'
-import { LocalStoredArmy } from 'utils/localStore'
 import { getArmyLink } from 'utils/handleQueryParams'
 import { LoadingHeader } from 'components/helpers/suspenseFallbacks'
 import { SelectOne } from 'components/input/select'
@@ -60,7 +59,7 @@ const JumbotronComponent: React.FC<IJumbotronProps> = props => {
 
   // Set our favorite faction
   useEffect(() => {
-    if (favoriteFaction && !LocalStoredArmy.exists() && !hasSelections && getArmyLink() === null) {
+    if (favoriteFaction && !hasSelections && getArmyLink() === null) {
       setFactionName(favoriteFaction)
     }
     // Don't want to refresh this on hasSelections, so we need to ignore that piece of state

--- a/src/components/page/navbar.tsx
+++ b/src/components/page/navbar.tsx
@@ -5,17 +5,10 @@ import { max } from 'lodash'
 import config from 'auth_config.json'
 import { useAppStatus } from 'context/useAppStatus'
 import { useSubscription } from 'context/useSubscription'
-import { useSavedArmies } from 'context/useSavedArmies'
 import { navbarStyles } from 'theme/helperClasses'
 import { BASE_URL, ROUTES } from 'utils/env'
 import { logClick } from 'utils/analytics'
-import {
-  LocalFavoriteFaction,
-  LocalSavedArmies,
-  LocalStoredArmy,
-  LocalTheme,
-  LocalUserName,
-} from 'utils/localStore'
+import { LocalFavoriteFaction, LocalSavedArmies, LocalTheme, LocalUserName } from 'utils/localStore'
 import { componentWithSize } from 'utils/mapSizesToProps'
 import { LoadingHeader, OfflineHeader } from 'components/helpers/suspenseFallbacks'
 import { SubscriptionPlans } from 'utils/plans'
@@ -23,9 +16,8 @@ import NavbarWrapper from 'components/page/navbar_wrapper'
 
 const Navbar: React.FC = componentWithSize(({ isTinyMobile = false }) => {
   const { isOffline } = useAppStatus()
-  const { isAuthenticated, logout, loading } = useAuth0()
+  const { isAuthenticated, logout, loading, loginWithRedirect } = useAuth0()
   const { isActive, subscriptionLoading } = useSubscription()
-  const { handleLogin } = useSavedArmies()
   const { pathname } = window.location
   const loginBtnText = !isAuthenticated ? `Log in` : `Log out`
 
@@ -34,13 +26,12 @@ const Navbar: React.FC = componentWithSize(({ isTinyMobile = false }) => {
       logClick('Navbar-Logout')
       LocalFavoriteFaction.clear() // Get rid of any existing local favoriteFaction value
       LocalUserName.clear() // Get rid of stored user info
-      LocalStoredArmy.clear() // Remove stored army (saved for post-login redirect) if it exists
       LocalSavedArmies.clear() // Remove any saved armies that we've fetched from the API
       LocalTheme.clear() // Revert back to default theme settings
       return logout({ client_id: config.clientId, returnTo: BASE_URL })
     } else {
       logClick('Navbar-Login')
-      return handleLogin()
+      return loginWithRedirect()
     }
   }
 

--- a/src/components/payment/giftSubscriptions.tsx
+++ b/src/components/payment/giftSubscriptions.tsx
@@ -5,19 +5,17 @@ import qs from 'qs'
 import { capitalize } from 'lodash'
 import CopyToClipboard from 'react-copy-to-clipboard'
 import { FaGift, FaCheck, FaRegSmileBeam } from 'react-icons/fa'
-import { useSavedArmies } from 'context/useSavedArmies'
 import { useSubscription } from 'context/useSubscription'
 import { useTheme } from 'context/useTheme'
 import { logClick } from 'utils/analytics'
 import { isDev, STRIPE_KEY } from 'utils/env'
-import { LocalStoredArmy } from 'utils/localStore'
 import { componentWithSize } from 'utils/mapSizesToProps'
 import AsyncStripeProvider from 'components/payment/asyncStripeProvider'
 import { GiftedSubscriptionPlans, IGiftedSubscriptionPlans } from 'utils/plans'
+import { centerContentClass } from 'theme/helperClasses'
 import GenericButton from 'components/input/generic_button'
 import { IGiftSubscription } from 'types/subscription'
 import { IUser } from 'types/user'
-import { centerContentClass } from 'theme/helperClasses'
 
 const COL_SIZE = `col-12 col-sm-12 col-md-10 col-xl-8 col-xxl-6`
 
@@ -196,8 +194,7 @@ interface IPlanProps {
 
 const PlanComponent: React.FC<IPlanProps> = props => {
   const { stripe, user, supportPlan, isMobile } = props
-  const { isAuthenticated } = useAuth0()
-  const { handleLogin } = useSavedArmies()
+  const { isAuthenticated, loginWithRedirect } = useAuth0()
   const [quantity, setQuantity] = useState(1)
 
   // When the customer clicks on the button, redirect them to Checkout.
@@ -207,8 +204,6 @@ const PlanComponent: React.FC<IPlanProps> = props => {
     if (quantity === 0) return // Can't do anything with zero quantity
 
     logClick(`${supportPlan.title}-GiftedSubscription`)
-
-    LocalStoredArmy.set() // Store our current army in local storage so we don't lose it
 
     const sku = isDev ? supportPlan.dev : supportPlan.prod
     const url = isDev ? 'localhost:3000' : 'aosreminders.com'
@@ -271,7 +266,7 @@ const PlanComponent: React.FC<IPlanProps> = props => {
         <button
           type="button"
           className={`btn btn ${isMobile ? `btn-sm` : ``} btn-block btn-primary`}
-          onClick={isAuthenticated ? handleCheckout : handleLogin}
+          onClick={isAuthenticated ? handleCheckout : loginWithRedirect}
         >
           {isMobile ? `Buy` : `Purchase`}
         </button>

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -2,12 +2,10 @@ import React from 'react'
 import { injectStripe, Elements } from 'react-stripe-elements'
 import qs from 'qs'
 import { useAuth0 } from 'react-auth0-wrapper'
-import { useSavedArmies } from 'context/useSavedArmies'
 import { logClick } from 'utils/analytics'
 import { isDev, STRIPE_KEY } from 'utils/env'
-import { LocalStoredArmy } from 'utils/localStore'
-import AsyncStripeProvider from 'components/payment/asyncStripeProvider'
 import { SubscriptionPlans, ISubscriptionPlan } from 'utils/plans'
+import AsyncStripeProvider from 'components/payment/asyncStripeProvider'
 import { IUser } from 'types/user'
 
 interface ICheckoutProps {
@@ -65,16 +63,13 @@ interface IPlanProps {
 
 const PlanComponent: React.FC<IPlanProps> = props => {
   const { stripe, user, supportPlan } = props
-  const { isAuthenticated } = useAuth0()
-  const { handleLogin } = useSavedArmies()
+  const { isAuthenticated, loginWithRedirect } = useAuth0()
 
   // When the customer clicks on the button, redirect them to Checkout.
   const handleCheckout = async e => {
     e.preventDefault()
 
     logClick(supportPlan.title)
-
-    LocalStoredArmy.set() // Store our current army in local storage so we don't lose it
 
     const plan = isDev ? supportPlan.dev : supportPlan.prod
     const url = isDev ? 'localhost:3000' : 'aosreminders.com'
@@ -135,7 +130,7 @@ const PlanComponent: React.FC<IPlanProps> = props => {
           type="button"
           className="btn btn btn-block btn-primary"
           onClick={
-            isAuthenticated ? handleCheckout : () => handleLogin({ redirect_uri: window.location.href })
+            isAuthenticated ? handleCheckout : () => loginWithRedirect({ redirect_uri: window.location.href })
           }
         >
           Subscribe for {supportPlan.title}

--- a/src/components/routes/Redeem.tsx
+++ b/src/components/routes/Redeem.tsx
@@ -5,7 +5,6 @@ import qs from 'qs'
 import { SubscriptionApi } from 'api/subscriptionApi'
 import { useSubscription } from 'context/useSubscription'
 import { useTheme } from 'context/useTheme'
-import { useSavedArmies } from 'context/useSavedArmies'
 import { logPageView, logClick, logEvent } from 'utils/analytics'
 import { ROUTES } from 'utils/env'
 import { LocalRedemptionKey } from 'utils/localStore'
@@ -180,13 +179,13 @@ const setLocalRedemptionKey = () => {
   }
 }
 const LoginSection = () => {
-  const { handleLogin } = useSavedArmies()
+  const { loginWithRedirect } = useAuth0()
 
   const handleClick = e => {
     e.preventDefault()
     setLocalRedemptionKey()
     logClick('Login-Before-Redeem')
-    return handleLogin({ redirect_uri: window.location.href })
+    return loginWithRedirect({ redirect_uri: window.location.href })
   }
 
   return (

--- a/src/context/useSavedArmies.tsx
+++ b/src/context/useSavedArmies.tsx
@@ -7,7 +7,7 @@ import { PreferenceApi } from 'api/preferenceApi'
 import { SubscriptionApi } from 'api/subscriptionApi'
 import { logEvent } from 'utils/analytics'
 import { isValidFactionName, prepareArmyForS3 } from 'utils/armyUtils'
-import { LocalUserName, LocalStoredArmy, LocalFavoriteFaction, LocalSavedArmies } from 'utils/localStore'
+import { LocalUserName, LocalFavoriteFaction, LocalSavedArmies } from 'utils/localStore'
 import { unTitleCase } from 'utils/textUtils'
 import { isDev } from 'utils/env'
 import { TSupportedFaction } from 'meta/factions'
@@ -23,7 +23,6 @@ interface ISavedArmiesContext {
   deleteSavedArmy: (id: string) => Promise<void>
   favoriteFaction: TSupportedFaction | null
   getFavoriteFaction: () => Promise<void>
-  handleLogin: (args?: { [key: string]: any }) => void
   loadedArmy: { id: string; armyName: string } | null
   loadSavedArmies: () => Promise<void>
   saveArmy: (army: ISavedArmy) => Promise<void>
@@ -49,7 +48,7 @@ const SavedArmiesContext = React.createContext<ISavedArmiesContext | void>(undef
 
 const SavedArmiesProvider: React.FC = ({ children }) => {
   const { isOffline } = useAppStatus()
-  const { user, loginWithRedirect } = useAuth0()
+  const { user } = useAuth0()
   const { subscription, isActive } = useSubscription()
   const [savedArmies, setSavedArmies] = useState<ISavedArmyFromApi[]>([])
   const [loadedArmy, setLoadedArmy] = useState<TLoadedArmy>(null)
@@ -211,14 +210,6 @@ const SavedArmiesProvider: React.FC = ({ children }) => {
     [subscription, isActive]
   )
 
-  const handleLogin = useCallback(
-    (args = {}) => {
-      LocalStoredArmy.set()
-      loginWithRedirect(args)
-    },
-    [loginWithRedirect]
-  )
-
   useEffect(() => {
     if (user && isActive) LocalUserName.set(user.email)
   }, [user, isActive])
@@ -230,7 +221,6 @@ const SavedArmiesProvider: React.FC = ({ children }) => {
         deleteSavedArmy,
         favoriteFaction,
         getFavoriteFaction,
-        handleLogin,
         loadedArmy,
         loadSavedArmies,
         saveArmy,

--- a/src/utils/loadArmy/loadArmyHelpers.ts
+++ b/src/utils/loadArmy/loadArmyHelpers.ts
@@ -3,7 +3,6 @@ import { PreferenceApi } from 'api/preferenceApi'
 import { factionNames, army, selections, realmscape, visibility } from 'ducks'
 import { logEvent, logLoadedArmy } from 'utils/analytics'
 import { getArmy } from 'utils/getArmy/getArmy'
-import { LocalStoredArmy } from 'utils/localStore'
 import { IArmy } from 'types/army'
 import { TLoadedArmy } from 'types/import'
 import { ILinkedArmy } from 'types/savedArmy'
@@ -22,18 +21,6 @@ export const loadArmyFromLink = async (id: string) => {
   } catch (err) {
     console.error(err)
   }
-}
-
-export const loadArmyFromLocalStore = () => {
-  const storedArmy = LocalStoredArmy.get()
-
-  if (!storedArmy) return
-
-  addArmyToStore(storedArmy)
-
-  LocalStoredArmy.clear()
-
-  logEvent(`LoadArmyFromStore-${storedArmy.factionName}`)
 }
 
 export const addArmyToStore = (loadedArmy: TLoadedArmy) => {

--- a/src/utils/localStore.ts
+++ b/src/utils/localStore.ts
@@ -1,14 +1,9 @@
-import { store } from 'index'
-import { selectors } from 'ducks'
 import { TSupportedFaction } from 'meta/factions'
-import { ICurrentArmy } from 'types/army'
 import { ISavedArmyFromApi } from 'types/savedArmy'
-import { IVisibilityStore } from 'types/store'
 import { TThemeType } from 'types/theme'
 
 const LOCAL_FAVORITE_KEY = 'favoriteFaction'
 const LOCAL_SAVED_ARMIES_KEY = 'savedArmies'
-const LOCAL_STORED_ARMY_KEY = 'storedArmy'
 const LOCAL_THEME_KEY = 'theme'
 const LOCAL_USERNAME_KEY = 'userName'
 const LOCAL_REDEMPTION_KEY = 'redeem'
@@ -33,27 +28,6 @@ export const LocalFavoriteFaction = {
   clear: () => localStorage.removeItem(LOCAL_FAVORITE_KEY),
   get: () => localStorage.getItem(LOCAL_FAVORITE_KEY) as TSupportedFaction | null,
   set: (factionName: TSupportedFaction) => localStorage.setItem(LOCAL_FAVORITE_KEY, factionName),
-}
-
-export const LocalStoredArmy = {
-  clear: () => localStorage.removeItem(LOCAL_STORED_ARMY_KEY),
-  get: () => {
-    const storedArmy = localStorage.getItem(LOCAL_STORED_ARMY_KEY)
-    if (!storedArmy) return null
-    return JSON.parse(storedArmy) as ICurrentArmy & { hiddenReminders: IVisibilityStore['reminders'] }
-  },
-  exists: () => {
-    const storedArmy = LocalStoredArmy.get()
-    return !!(storedArmy && Object.values(storedArmy.selections).some(x => x.length > 0))
-  },
-  set: () => {
-    const state = store.getState()
-    const currentArmy = selectors.getCurrentArmy(state)
-    const hiddenReminders = selectors.getReminders(state)
-    if (currentArmy) {
-      localStorage.setItem(LOCAL_STORED_ARMY_KEY, JSON.stringify({ ...currentArmy, hiddenReminders }))
-    }
-  },
 }
 
 export const LocalTheme = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,10 +2083,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.7.tgz#57682a9771a3f7b09c2497f28129a0462966524a"
   integrity sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==
 
-"@types/node@12.12.18":
-  version "12.12.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.18.tgz#8d16634797d63c2af5bc647ce879f8de20b56469"
-  integrity sha512-DBkZuIMFuAfjJHiunyRc+aNvmXYNwV1IPMgGKGlwCp6zh6MKrVtmvjSWK/axWcD25KJffkXgkfvFra8ndenXAw==
+"@types/node@12.12.19":
+  version "12.12.19"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.19.tgz#6133aa2a765accdec89ad7792b651a0830f7a34e"
+  integrity sha512-OXw80IpKyLeuZ5a8r2XCxVNnRAtS3lRDHBleSUQmbgu3C6eKqRsz7/5XNBU0EvK0RTVfotvYFgvRwwe2jeoiKw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10454,7 +10454,7 @@ redux-immutable-state-invariant@^2.1.0:
     invariant "^2.1.0"
     json-stringify-safe "^5.0.1"
 
-redux-persist@^6.0.0:
+redux-persist@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
   integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10454,6 +10454,11 @@ redux-immutable-state-invariant@^2.1.0:
     invariant "^2.1.0"
     json-stringify-safe "^5.0.1"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"


### PR DESCRIPTION
There's a very real extent to which
![](http://m.quickmeme.com/img/73/7368bba925cab9dd176e32f7ce8c4d1fbf9917c0870d39ecfe8254874e42b907.jpg)

But this seems to work and I've not found any issues with the persistence. It does make the Favorite Faction feature a lot less relevant. The Clear Army button very much came out of no longer being able to just refresh the page to clear it, and switching back and forth between factions is a faff (and not even obvious to everyone as a way of achieving that)

I think I've caught everything I need to in the reset button.

Very happy for UI improvements to be made and any technical stuff that needs doing too!