### PR TITLE
Remove 'Shock and Awe' from shooting phase

### DIFF
--- a/src/army/stormcast_eternals/abilities.ts
+++ b/src/army/stormcast_eternals/abilities.ts
@@ -5,13 +5,13 @@ import { TAbilities } from 'types/army'
 const Abilities: TAbilities = [
   {
     name: `Scions of the Storm`,
-    desc: `Setup 1 unit in the Celestial Realm for every unit you setup on the battlefield. At the end of your movement phase you can set up one or more reserve units more than 9" from the enemy. Any units not setup before the 4th Battleround are slain.`,
+    desc: `Set up 1 unit in the Celestial Realm for every unit you set up on the battlefield. At the end of your movement phase you can set up one or more reserve units more than 9" from the enemy. Any units not set up before the 4th Battleround are slain.`,
     when: [DURING_SETUP, END_OF_MOVEMENT_PHASE],
   },
   {
     name: `Shock and Awe`,
-    desc: `Subtract 1 from hit rolls for attacks that target any unit setup this turn.`,
-    when: [COMBAT_PHASE, SHOOTING_PHASE],
+    desc: `Subtract 1 from hit rolls for attacks that target any unit set up this turn.`,
+    when: [COMBAT_PHASE],
   },
 ]
 


### PR DESCRIPTION
It's only for the same *turn* that the unit was set up. I can't think of any cases where a Stormcast unit could set up during an enemy turn, nor an enemy shoot during the Stormcast turn, so I think it's only relevant in the combat phase.

Also fixes some typos of 'set up'