### PR TITLE
Typo fixes (fixes #848)

### DIFF
--- a/src/army/tzeentch/abilities.ts
+++ b/src/army/tzeentch/abilities.ts
@@ -18,7 +18,7 @@ const Abilities: TAbilities = [
   },
   {
     name: `Masters of Destiny`,
-    desc: `Before rolling any dice for a TZEENTCH unit, you can use one or more of the remaining Destiny Dice from your pool in their stead; the result of the roll you would have made is automatically substituted with the result shown on the Destiny Dice you have chosen to use.`,
+    desc: `Before rolling any dice for a TZEENTCH unit, you can use one or more of the remaining Destiny Dice from your pool in their stead; the result of the roll you would have made is automatically substituted with the result shown on the Destiny Dice you have chosen to use. Dice used in this way cannot be rerolled or modifed in anyway.`,
     when: [DURING_GAME],
   },
   {
@@ -40,10 +40,10 @@ const Abilities: TAbilities = [
   },
   {
     name: `Agendas of Anarchy`,
-    desc: `At the start of your hero phase, you can say that your army intends to complete one of the following agendas before the start of your next hero phase. You must tell your opponent which agenda you intend to complete, and you cannot complete the same agenda more than once per battle. 
-    
-    If a friendly Tzeentch unit completes one of the following agendas during a battle, that unit gains that agenda's ability for the rest of the game. 
-    
+    desc: `At the start of your hero phase, you can say that your army intends to complete one of the following agendas before the start of your next hero phase. You must tell your opponent which agenda you intend to complete, and you cannot complete the same agenda more than once per battle.
+
+    If a friendly Tzeentch unit completes one of the following agendas during a battle, that unit gains that agenda's ability for the rest of the game.
+
     Friendly Tzeentch units that complete more than 1 agenda must choose which ability they wish to keep; any other ability gained are lost.`,
     when: [START_OF_HERO_PHASE],
   },

--- a/src/army/tzeentch/allegiances.ts
+++ b/src/army/tzeentch/allegiances.ts
@@ -152,7 +152,7 @@ const Allegiances: TAllegiances = [
     ],
   },
   {
-    name: `The Guild of SUmmoners`,
+    name: `The Guild of Summoners`,
     effects: [
       {
         name: `Scions of the Exiled`,

--- a/src/army/tzeentch/units.ts
+++ b/src/army/tzeentch/units.ts
@@ -374,8 +374,8 @@ export const Units: TUnits = [
     effects: [
       {
         name: `Book of Profane Secrets`,
-        desc: `Once per battle this model can use this ability. Summon 1 unit of the following to the battlefield: 10 Bloodletters, 10 Daemonettes, 10 Pink Horrors, 10 Plaguebearers or 6 Furies. The summoned unit must be set up wholly within 9" of a this model and more than 9" from any enemy units.`,
-        when: [HERO_PHASE],
+        desc: `Once per battle this model can use this ability at the start of your hero phase. Summon 1 unit of the following to the battlefield: 10 Bloodletters, 10 Daemonettes, 10 Pink Horrors, 10 Plaguebearers or 6 Furies. The summoned unit must be set up wholly within 9" of a this model and more than 9" from any enemy units.`,
+        when: [START_OF_HERO_PHASE],
       },
       {
         name: `Warptongue Blade`,


### PR DESCRIPTION
- Changed gaunt summoner to start of hero phase
- Changed Destiny dice to include can't be rerolled or modified
- Fixed typo in Guild of Summoners.

fixes #848 