### PR TITLE
Add missing allegiance types

### DIFF
--- a/src/army/legion_of_chaos_ascendant/index.ts
+++ b/src/army/legion_of_chaos_ascendant/index.ts
@@ -8,6 +8,7 @@ import Traits from './traits'
 export default {
   Abilities,
   Allegiances,
+  AllegianceType: 'Hosts of Change',
   AlliedUnits,
   Artifacts,
   Battalions,

--- a/src/army/tzeentch/index.ts
+++ b/src/army/tzeentch/index.ts
@@ -9,6 +9,7 @@ import Traits from './traits'
 export default {
   Abilities,
   Allegiances,
+  AllegianceType: 'Change Covens',
   AlliedUnits,
   Artifacts,
   Battalions,


### PR DESCRIPTION
These can easily be shortened but the full names seemed to still fit when I had a quick play with the browser size