### PR TITLE
WIP Support mutually-dependent selections

### DIFF
--- a/src/army/daughters_of_khaine/units.ts
+++ b/src/army/daughters_of_khaine/units.ts
@@ -155,10 +155,41 @@ const BladedImpactEffect = {
   when: [CHARGE_PHASE],
 }
 
+const MorathiShadowQueen = {
+  name: `Morathi, the Shadow Queen`,
+  effects: [
+    ...MorathiEffects,
+    {
+      name: `Monstrous Revelation`,
+      desc: `When Morathi transforms, her High Oracle of Khaine model is removed from the battlefield and her Shadow Queen model is set up on the spot where she was standing before her transformation.
+
+               Morathi's Shadow Queen model can only be set up within 3" of an enemy unit if her High Oracle of Khaine model was within 3" of that unit before her transformation.
+
+               If there is insufficient room to place Morathi exactly where she was standing before her transformation, simply place the model as close as possible to that spot where there is room. If, after her Shadow Queen model has been set up, Morathi is more than 14" away from the spot where she was standing before her transformation, she cannot move in the following movement phase.
+
+               Any wounds allocated to Morathi in her High Oracle of Khaine form prior to her transformation are carried over to her Shadow Queen form and then doubled.
+
+               Morathi remains in this form for the remainder of the battle. If she was your general in the High Oracle form she remains your general.`,
+      when: [HERO_PHASE],
+    },
+    {
+      name: `Gaze of Morathi`,
+      desc: `If a target is hit by the Gaze of Morathi, pick a model in the target unit and roll a D6. If the result exceeds that model's Wounds characteristic, it is slain.`,
+      when: [SHOOTING_PHASE],
+    },
+    {
+      name: `Magic`,
+      desc: `This model is a wizard. Can attempt to cast 1 spell and attempt to unbind 1 spell. Knows Arcane Bolt, Mystic Shield, and Arnzipal's Black Horror.`,
+      when: [HERO_PHASE],
+    },
+  ],
+}
+
 // Unit Names
 export const Units: TUnits = [
   {
     name: `Morathi, High Oracle of Khaine`,
+    entries: [MorathiShadowQueen],
     effects: [
       ...MorathiEffects,
       {
@@ -194,35 +225,7 @@ export const Units: TUnits = [
       },
     ],
   },
-  {
-    name: `Morathi, the Shadow Queen`,
-    effects: [
-      ...MorathiEffects,
-      {
-        name: `Monstrous Revelation`,
-        desc: `When Morathi transforms, her High Oracle of Khaine model is removed from the battlefield and her Shadow Queen model is set up on the spot where she was standing before her transformation.
-
-               Morathi's Shadow Queen model can only be set up within 3" of an enemy unit if her High Oracle of Khaine model was within 3" of that unit before her transformation.
-
-               If there is insufficient room to place Morathi exactly where she was standing before her transformation, simply place the model as close as possible to that spot where there is room. If, after her Shadow Queen model has been set up, Morathi is more than 14" away from the spot where she was standing before her transformation, she cannot move in the following movement phase.
-
-               Any wounds allocated to Morathi in her High Oracle of Khaine form prior to her transformation are carried over to her Shadow Queen form and then doubled.
-
-               Morathi remains in this form for the remainder of the battle. If she was your general in the High Oracle form she remains your general.`,
-        when: [HERO_PHASE],
-      },
-      {
-        name: `Gaze of Morathi`,
-        desc: `If a target is hit by the Gaze of Morathi, pick a model in the target unit and roll a D6. If the result exceeds that model's Wounds characteristic, it is slain.`,
-        when: [SHOOTING_PHASE],
-      },
-      {
-        name: `Magic`,
-        desc: `This model is a wizard. Can attempt to cast 1 spell and attempt to unbind 1 spell. Knows Arcane Bolt, Mystic Shield, and Arnzipal's Black Horror.`,
-        when: [HERO_PHASE],
-      },
-    ],
-  },
+  MorathiShadowQueen,
   {
     name: `Hag Queen`,
     effects: [...HagQueenEffects, ...WitchbrewEffects],

--- a/src/army/daughters_of_khaine/units.ts
+++ b/src/army/daughters_of_khaine/units.ts
@@ -155,6 +155,44 @@ const BladedImpactEffect = {
   when: [CHARGE_PHASE],
 }
 
+const MorathiHighOracle = {
+  name: `Morathi, High Oracle of Khaine`,
+  effects: [
+    ...MorathiEffects,
+    {
+      name: `Monstrous Transformation`,
+      desc: `Morathi can transform into her monstrous aspect.`,
+      when: [START_OF_HERO_PHASE],
+    },
+    {
+      name: `The Truth Revealed.`,
+      desc: `Roll a D6 and if the result is equal to or less than the number of wounds currently allocated to Morathi, she transforms into Morathi, the Shadow Queen.`,
+      when: [START_OF_HERO_PHASE],
+    },
+    {
+      name: `Sorceress Supreme`,
+      desc: `Add 1 to casting and unbinding rolls made for Morathi, High Oracle of Khaine. In addition, double the range of spells she attempts to cast.`,
+      when: [HERO_PHASE],
+    },
+    {
+      name: `Enchanting Beauty`,
+      desc: `Subtract 1 from the hit rolls of attacks that target Morathi, High Oracle of Khaine.`,
+      when: [DURING_GAME],
+    },
+    {
+      name: `Magic`,
+      desc: `This model is a wizard. Can attempt to cast 3 spells and attempt to unbind 2 spells. Knows Arcane Bolt, Mystic Shield, and Arnzipal's Black Horror.`,
+      when: [HERO_PHASE],
+    },
+    {
+      name: `Worship Through Bloodshed`,
+      desc: `If Morathi, High Oracle of Khaine is your general, you can use this ability. If you do, pick up to 2 friendly Daughters of Khaine units within 14" of Morathi (you cannot choose Morathi herself ). Those units can immediately shoot as if it were the shooting phase. Alternatively, if either unit is within 3" of an enemy unit, it can instead be chosen to pile in and attack as if it were the combat phase. The same unit cannot be picked to benefit from this command ability more than once per hero phase.`,
+      when: [HERO_PHASE],
+      command_ability: true,
+    },
+  ],
+}
+
 const MorathiShadowQueen = {
   name: `Morathi, the Shadow Queen`,
   effects: [
@@ -187,45 +225,8 @@ const MorathiShadowQueen = {
 
 // Unit Names
 export const Units: TUnits = [
-  {
-    name: `Morathi, High Oracle of Khaine`,
-    entries: [MorathiShadowQueen],
-    effects: [
-      ...MorathiEffects,
-      {
-        name: `Monstrous Transformation`,
-        desc: `Morathi can transform into her monstrous aspect.`,
-        when: [START_OF_HERO_PHASE],
-      },
-      {
-        name: `The Truth Revealed.`,
-        desc: `Roll a D6 and if the result is equal to or less than the number of wounds currently allocated to Morathi, she transforms into Morathi, the Shadow Queen.`,
-        when: [START_OF_HERO_PHASE],
-      },
-      {
-        name: `Sorceress Supreme`,
-        desc: `Add 1 to casting and unbinding rolls made for Morathi, High Oracle of Khaine. In addition, double the range of spells she attempts to cast.`,
-        when: [HERO_PHASE],
-      },
-      {
-        name: `Enchanting Beauty`,
-        desc: `Subtract 1 from the hit rolls of attacks that target Morathi, High Oracle of Khaine.`,
-        when: [DURING_GAME],
-      },
-      {
-        name: `Magic`,
-        desc: `This model is a wizard. Can attempt to cast 3 spells and attempt to unbind 2 spells. Knows Arcane Bolt, Mystic Shield, and Arnzipal's Black Horror.`,
-        when: [HERO_PHASE],
-      },
-      {
-        name: `Worship Through Bloodshed`,
-        desc: `If Morathi, High Oracle of Khaine is your general, you can use this ability. If you do, pick up to 2 friendly Daughters of Khaine units within 14" of Morathi (you cannot choose Morathi herself ). Those units can immediately shoot as if it were the shooting phase. Alternatively, if either unit is within 3" of an enemy unit, it can instead be chosen to pile in and attack as if it were the combat phase. The same unit cannot be picked to benefit from this command ability more than once per hero phase.`,
-        when: [HERO_PHASE],
-        command_ability: true,
-      },
-    ],
-  },
-  MorathiShadowQueen,
+  { ...MorathiHighOracle, pairedWith: [[MorathiShadowQueen, 'units']] },
+  { ...MorathiShadowQueen, pairedWith: [[MorathiHighOracle, 'units']] },
   {
     name: `Hag Queen`,
     effects: [...HagQueenEffects, ...WitchbrewEffects],

--- a/src/components/input/toolbar/toolbar.tsx
+++ b/src/components/input/toolbar/toolbar.tsx
@@ -36,6 +36,7 @@ interface IToolbarProps {
   resetAllySelections: () => void
   resetRealmscapeStore: () => void
   resetSelections: () => void
+  resetSideEffects: () => void
   updateAllyArmy: (payload: { factionName: TSupportedFaction; Army: IArmy }) => void
   updateAllyUnits: (payload: { factionName: TSupportedFaction; units: TUnits }) => void
 }
@@ -49,6 +50,7 @@ const ToolbarComponent = (props: IToolbarProps) => {
     resetAllySelections,
     resetRealmscapeStore,
     resetSelections,
+    resetSideEffects,
     updateAllyArmy,
   } = props
   const { isGameMode, isOnline } = useAppStatus()
@@ -91,10 +93,11 @@ const ToolbarComponent = (props: IToolbarProps) => {
       resetAllySelections()
       resetRealmscapeStore()
       resetSelections()
+      resetSideEffects()
       logClick('ClearArmy')
       setLoadedArmy(null)
     },
-    [resetAllySelections, resetRealmscapeStore, resetSelections, setLoadedArmy]
+    [resetAllySelections, resetRealmscapeStore, resetSelections, resetSideEffects, setLoadedArmy]
   )
 
   if (isGameMode) return <></>
@@ -191,6 +194,7 @@ const mapDispatchToProps = {
   resetAllySelections: selections.actions.resetAllySelections,
   resetRealmscapeStore: realmscape.actions.resetRealmscapeStore,
   resetSelections: selections.actions.resetSelections,
+  resetSideEffects: selections.actions.resetSideEffects,
   updateAllyArmy: army.actions.updateAllyArmy,
   updateAllyUnits: selections.actions.updateAllyUnits,
 }

--- a/src/components/page/homeHeader.tsx
+++ b/src/components/page/homeHeader.tsx
@@ -37,6 +37,7 @@ interface IJumbotronProps {
   resetAllySelections: () => void
   resetRealmscapeStore: () => void
   resetSelections: () => void
+  resetSideEffects: () => void
   setFactionName: (value: string | null) => void
 }
 
@@ -48,6 +49,7 @@ const JumbotronComponent: React.FC<IJumbotronProps> = props => {
     resetAllySelections,
     resetRealmscapeStore,
     resetSelections,
+    resetSideEffects,
     setFactionName,
   } = props
   const { isOnline, isGameMode } = useAppStatus()
@@ -71,6 +73,7 @@ const JumbotronComponent: React.FC<IJumbotronProps> = props => {
   const setValue = withSelectOne((value: string | null) => {
     setLoadedArmy(null)
     resetSelections()
+    resetSideEffects()
     resetRealmscapeStore()
     resetAllySelections()
     resetAnalyticsStore()
@@ -132,6 +135,7 @@ const mapDispatchToProps = {
   resetAllySelections: selections.actions.resetAllySelections,
   resetRealmscapeStore: realmscape.actions.resetRealmscapeStore,
   resetSelections: selections.actions.resetSelections,
+  resetSideEffects: selections.actions.resetSideEffects,
   setFactionName: factionNames.actions.setFactionName,
 }
 

--- a/src/ducks/selections.ts
+++ b/src/ducks/selections.ts
@@ -1,4 +1,4 @@
-import { uniq, without } from 'lodash'
+import { flatten, uniq, without } from 'lodash'
 import { createSlice } from '@reduxjs/toolkit'
 import { TSupportedFaction } from 'meta/factions'
 import { TUnits, TBattalions } from 'types/army'
@@ -43,6 +43,9 @@ const resetAllySelections = (state, action) => {
 }
 const resetSelections = (state, action) => {
   state.selections = initialState.selections
+}
+const resetSideEffects = (state, action) => {
+  state.sideEffects = initialState.sideEffects
 }
 const updateAllyUnits = (state, action: { payload: { factionName: TSupportedFaction; units: TUnits } }) => {
   const { factionName, units } = action.payload
@@ -118,6 +121,7 @@ export const selections = createSlice({
     resetAllySelection,
     resetAllySelections,
     resetSelections,
+    resetSideEffects,
     updateAllegiances,
     updateAllyBattalions,
     updateAllySelections,
@@ -137,6 +141,7 @@ export const selections = createSlice({
 
 const handleSideEffects = (state: IStore['selections'], payload: string[], type: TSelectionTypes) => {
   const sideEffectNames = Object.keys(state.sideEffects)
+  const selectionNames = uniq(flatten(Object.keys(state.selections).map(x => state.selections[x])))
 
   const removedSideEffects = state.selections[type]
     .reduce((a, v) => {
@@ -150,5 +155,11 @@ const handleSideEffects = (state: IStore['selections'], payload: string[], type:
     Object.keys(sideEffect).forEach(slice => {
       state.selections[slice] = without(state.selections[slice], ...sideEffect[slice])
     })
+  })
+
+  Object.keys(state.sideEffects).forEach(s => {
+    if (!selectionNames.includes(s)) {
+      delete state.sideEffects[s]
+    }
   })
 }

--- a/src/ducks/selections.ts
+++ b/src/ducks/selections.ts
@@ -28,7 +28,7 @@ type TAddToSelectionsAction = {
   payload: {
     value: string // Hermdar Lodge
     values: string[] // ['Tyrant Slayer']
-    slice: string // e.g. artifacts, spells, etc
+    slice: TSelectionTypes // e.g. artifacts, spells, etc
   }
 }
 

--- a/src/tests/azyr/getAzyrArmy.test.ts
+++ b/src/tests/azyr/getAzyrArmy.test.ts
@@ -840,7 +840,12 @@ describe('getAzyrArmyFromPdf', () => {
       spells: ["Martyr's Sacrifice (Priest)", 'Mindrazor (Wizard)', "Arnzipal's Black Horror"],
       traits: [],
       triumphs: [],
-      units: ['Hag Queen on Cauldron of Blood', 'Morathi, High Oracle of Khaine', 'Sisters of Slaughter'],
+      units: [
+        'Hag Queen on Cauldron of Blood',
+        'Morathi, High Oracle of Khaine',
+        'Sisters of Slaughter',
+        'Morathi, the Shadow Queen',
+      ],
     })
   })
 

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -28,6 +28,7 @@ export const ENTRY_PROPERTIES: TEntryProperties[] = [
 export type TEntry = {
   name: string
   effects: TEffects[]
+  entries?: TEntry[]
   isSideEffect?: boolean
 } & {
   [prop in TEntryProperties]?: boolean

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -28,7 +28,7 @@ export const ENTRY_PROPERTIES: TEntryProperties[] = [
 export type TEntry = {
   name: string
   effects: TEffects[]
-  entries?: TEntry[]
+  pairedWith?: [TEntry, string][]
   isSideEffect?: boolean
 } & {
   [prop in TEntryProperties]?: boolean

--- a/src/utils/getSideEffects.ts
+++ b/src/utils/getSideEffects.ts
@@ -16,6 +16,11 @@ export const getSideEffects = (items: TEntry[]) => {
         addToAccum(accum, item.name, effect.name, 'commands')
       }
     })
+    if (item.entries) {
+      item.entries.forEach(entry => {
+        addToAccum(accum, item.name, entry.name, 'units')
+      })
+    }
     return accum
   }, {} as IWithSelectMultipleWithSideEffectsPayload)
 

--- a/src/utils/getSideEffects.ts
+++ b/src/utils/getSideEffects.ts
@@ -16,9 +16,9 @@ export const getSideEffects = (items: TEntry[]) => {
         addToAccum(accum, item.name, effect.name, 'commands')
       }
     })
-    if (item.entries) {
-      item.entries.forEach(entry => {
-        addToAccum(accum, item.name, entry.name, 'units')
+    if (item.pairedWith) {
+      item.pairedWith.forEach(([entry, type]) => {
+        addToAccum(accum, item.name, entry.name, type)
       })
     }
     return accum

--- a/src/utils/withSelect.ts
+++ b/src/utils/withSelect.ts
@@ -53,7 +53,7 @@ export const withSelectMultipleWithPayload: TWithSelectMultipleWithPayload = (
   method({ ...payload, [key]: values })
 }
 
-export type TSideEffectTypes = 'spells' | 'artifacts' | 'traits' | 'commands'
+export type TSideEffectTypes = 'spells' | 'artifacts' | 'traits' | 'commands' | 'units'
 
 export interface IWithSelectMultipleWithSideEffectsPayload {
   [key: string]: {

--- a/src/utils/withSelect.ts
+++ b/src/utils/withSelect.ts
@@ -78,6 +78,8 @@ export const withSelectMultiWithSideEffects: TWithSelectMultiWithSideEffects = (
 ) => selectValues => {
   const values = selectValues ? (selectValues as TDropdownOption[]).map(x => x.value) : []
 
+  method(values)
+
   Object.keys(payload).forEach(value => {
     if (values.includes(value)) {
       Object.keys(payload[value]).forEach(slice => {
@@ -95,6 +97,4 @@ export const withSelectMultiWithSideEffects: TWithSelectMultiWithSideEffects = (
       })
     }
   })
-
-  method(values)
 }


### PR DESCRIPTION
This is to make Morathi's two forms add each other, but might also be useful for Underworlds warbands with a hero and unit.

In doing this, I noticed that `state.sideEffects` only ever grew. I thought I might need it to be kept accurate for this, so decided to add a resetter for it and to handle removal of items from it

Imports worked really easily

But using the dropdowns it just wasn't working (although the side effect was being picked up, it wasn't ending up in selections). I think the issue here is the conflict between `updateUnits` and `addToSelections` when both are modifying the units slice: it isn't an issue when the side effects are in a different slice, as `state.selections.units = action.payload` doesn't wipe out the adding of side effects in `addToSelections`.

The solution in this WIP is to change the order of operations in SelectMultiple, but this then runs into probably the same problem from the other direction: when you remove one Morathi it just gets added back by the other one... So it might be just as fundamentally flawed.