### PR TITLE
Fix small typo in rules for Horticulus Slimux's Beast Handler ability

### DIFF
--- a/src/army/nurgle/units.ts
+++ b/src/army/nurgle/units.ts
@@ -266,7 +266,7 @@ export const Units: TUnits = [
       },
       {
         name: `Beast Handler`,
-        desc: `Re-roll failed charge rolls of 1 for friendly Beasts of Nurgle units while they are within 7" of this model.`,
+        desc: `Re-roll failed charge rolls for friendly Beasts of Nurgle units while they are within 7" of this model.`,
         when: [CHARGE_PHASE],
       },
       {


### PR DESCRIPTION
"Charge roll of 1" doesn't make sense, since they're 2d6.  Original rule is "Re-roll failed charge rolls and hit rolls of 1 for ...." but this has been split into a charge rule and a combat rule - looks like the "of 1" was mistakenly retained in the charge rule.

I haven't modified or run any tests because I don't believe this level of change affects any of them (and I don't yet have yarn installed...).