### PR TITLE
Make reordering and hiding play nicely together

### DIFF
--- a/src/components/info/reminders.tsx
+++ b/src/components/info/reminders.tsx
@@ -6,6 +6,7 @@ import { visibility, selectors } from 'ducks'
 import { componentWithSize } from 'utils/mapSizesToProps'
 import { processReminders } from 'utils/processReminders'
 import { getVisibleReminders } from 'utils/reminderUtils'
+import { reorderReminders } from 'utils/reorder'
 import { titleCase } from 'utils/textUtils'
 import { Reminder } from 'components/info/reminder'
 import { IArmy, TAllyArmies, ICurrentArmy } from 'types/army'
@@ -47,7 +48,7 @@ const RemindersComponent = (props: IRemindersProps) => {
     )
   }, [army, allyArmies, currentArmy])
 
-  if (isGameMode) reminders = getVisibleReminders(reminders, hiddenReminders)
+  if (isGameMode) reminders = reorderReminders(getVisibleReminders(reminders, hiddenReminders))
 
   const whens = useMemo(() => Object.keys(reminders), [reminders])
   const titles = useMemo(() => whens.map(titleCase), [whens])

--- a/src/utils/reorder.ts
+++ b/src/utils/reorder.ts
@@ -1,4 +1,4 @@
-import { sortBy, isEqual } from 'lodash'
+import { sortBy, isEqual, difference } from 'lodash'
 import { LocalReminderOrder } from 'utils/localStore'
 import { IReminder } from 'types/data'
 import { TTurnWhen } from 'types/phases'
@@ -30,7 +30,7 @@ export const reorderReminders = (reminders: IReminder): IReminder => {
     const currentIds = sortBy(actions.map(x => x.id))
     const storedIds = LocalReminderOrder.getWhen(when as TTurnWhen) || []
 
-    if (storedIds.length > 0 && isEqual(currentIds, sortBy(storedIds))) {
+    if (storedIds.length > 0 && difference(currentIds, sortBy(storedIds)).length === 0) {
       const reordered = reorderViaIndex(actions, storedIds)
       accum[when] = reordered
     } else {

--- a/src/utils/reorder.ts
+++ b/src/utils/reorder.ts
@@ -15,7 +15,7 @@ export const reorderViaIndex = <T extends WithId>(list: T[], ids: string[]) => {
   }, [] as T[])
 }
 
-// Used for drag and drop by react-beautful-dnd
+// Used for drag and drop by react-beautiful-dnd
 export const reorder = <T>(list: T[], startIndex: number, endIndex: number) => {
   const result = Array.from(list)
   const [removed] = result.splice(startIndex, 1)

--- a/src/utils/reorder.ts
+++ b/src/utils/reorder.ts
@@ -1,4 +1,4 @@
-import { sortBy, isEqual, difference } from 'lodash'
+import { sortBy, difference } from 'lodash'
 import { LocalReminderOrder } from 'utils/localStore'
 import { IReminder } from 'types/data'
 import { TTurnWhen } from 'types/phases'


### PR DESCRIPTION
Fixes #956 

Given that this works, I think it might be the right solution 😁 

There's still some inconsistency when reordering in Play mode, but I think we're agreed on removing that case anyway so I didn't worry about making it work. I did take a quick look at removing it myself but I wasn't sure how to do the conditional stuff I needed around the `Draggable` object.