### PR TITLE
Fix weird duplicated Infernal Flames

### DIFF
--- a/src/army/slaves_to_darkness/units.ts
+++ b/src/army/slaves_to_darkness/units.ts
@@ -279,7 +279,7 @@ export const Units: TUnits = [
       },
       {
         name: `Infernal Flames`,
-        desc: `Casting value of 7. Pick an enemy unit within 12" and visible. Roll 1 dice for each model in that unit. For each 5+ the unit suffers 1 mortal wound. If the target is a monster or war machine, roll 3 dice for each model instead.`,
+        desc: `Casting value of 7. If successfully cast, pick 1 enemy unit within 12" of the caster that is visible to them, and roll 1 dice for each model in that unit. For each 5+, that unit suffers 1 mortal wound. If that unit is a Monster or War Machine, roll 3 dice for each model instead.`,
         when: [HERO_PHASE],
         spell: true,
       },

--- a/src/army/tzeentch/units.ts
+++ b/src/army/tzeentch/units.ts
@@ -404,7 +404,7 @@ export const Units: TUnits = [
       },
       {
         name: `Infernal Flames`,
-        desc: `Casting value 7. If successfully cast, pick 1 enemy unit within 12" of the caster that is visible to them, and roll 1 dice for each model in that unit. For each 5+, that unit suffers 1 mortal wound. If that unit is an enemy Monsteror War Machine, roll 3 dice for each model instead.`,
+        desc: `Casting value of 7. If successfully cast, pick 1 enemy unit within 12" of the caster that is visible to them, and roll 1 dice for each model in that unit. For each 5+, that unit suffers 1 mortal wound. If that unit is a Monster or War Machine, roll 3 dice for each model instead.`,
         when: [HERO_PHASE],
         spell: true,
       },


### PR DESCRIPTION
Fixes #840  

Wording was different for Infernal Flames on the gaunt summoner on
foot and the gaunt summoner on disc, so they weren't de-duping
properly.

It's not ideal. These two spells have the same wording now but live in
different factions on here and we don't quite have a standardised style
guide for the wording rewrites we do (eg "Casting value 7" vs "Casting
value of 7" vs "Casting value of 7+" etc) so it's a bit of a judgement
call