### PR TITLE
Revert bootstrap upgrade to fix mobile display bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@reduxjs/toolkit": "1.3.6",
     "@stripe/react-stripe-js": "1.1.2",
     "@stripe/stripe-js": "1.7.0",
-    "bootstrap": "4.5.0",
+    "bootstrap": "4.4.1",
     "core-js": "3.6.5",
     "jspdf": "1.5.3",
     "lodash": "4.17.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3451,10 +3451,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.0.tgz#97d9dbcb5a8972f8722c9962483543b907d9b9ec"
-  integrity sha512-Z93QoXvodoVslA+PWNdk23Hze4RBYIkpb5h8I2HY2Tu2h7A0LpAgLcyrhrSUyo2/Oxm2l1fRZPs1e5hnxnliXA==
+bootstrap@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.4.1.tgz#8582960eea0c5cd2bede84d8b0baf3789c3e8b01"
+  integrity sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
This visual bug has presumably been around on mobile since #939 was merged
I'm sure there'll be a way to fix it with the newer version of bootstrap, but reverting is straightforward in the meantime.

Before reverting:
![aosr_bug](https://user-images.githubusercontent.com/1237986/85958108-cb8f1a00-b98a-11ea-980f-750446fa1449.jpg)
![aosr_bug_2](https://user-images.githubusercontent.com/1237986/85958112-d184fb00-b98a-11ea-96e8-ad77f10a5278.jpg)

After reverting:
![aosr_bug_fix](https://user-images.githubusercontent.com/1237986/85958138-0d1fc500-b98b-11ea-9858-8ab96874b23c.jpg)

