### PR TITLE
Fix a couple of visual bugs on modals

### DIFF
--- a/src/components/info/confirm_dismiss_notification_modal.tsx
+++ b/src/components/info/confirm_dismiss_notification_modal.tsx
@@ -22,7 +22,7 @@ export const ConfirmDismissNotificationModal: React.FC<IModalComponentProps> = p
 
   return (
     <GenericModal isOpen={modalIsOpen} closeModal={closeModal} label="Hide Rule Modal">
-      <div className="row">
+      <div className="flex-row">
         <div className={`col ${theme.text} text-center`}>
           <h4 className="mb-3">Hide rule?</h4>
         </div>

--- a/src/components/info/confirm_dismiss_notification_modal.tsx
+++ b/src/components/info/confirm_dismiss_notification_modal.tsx
@@ -29,10 +29,10 @@ export const ConfirmDismissNotificationModal: React.FC<IModalComponentProps> = p
       </div>
 
       <div className="d-flex flex-row justify-content-center">
-        <GenericButton className={`btn btn-danger mr-2`} onClick={handleConfirm}>
+        <GenericButton className={theme.modalDangerClass} onClick={handleConfirm}>
           <FaCheck className="mr-2" /> Hide
         </GenericButton>
-        <GenericButton className={`btn btn-outline-light`} onClick={closeModal}>
+        <GenericButton className={theme.modalConfirmClass} onClick={closeModal}>
           Never mind
         </GenericButton>
       </div>

--- a/src/components/input/savedArmies/delete_army_modal.tsx
+++ b/src/components/input/savedArmies/delete_army_modal.tsx
@@ -37,14 +37,14 @@ export const DeleteArmyModal: React.FC<IModalComponentProps> = props => {
       label="Delete Army Modal"
       isProcessing={processing}
     >
-      <div className="row">
+      <div className="flex-row">
         <div className={`col ${theme.text}`}>
           <h4 className="mb-3">Delete {armyName}?</h4>
           <p>This action cannot be undone.</p>
         </div>
       </div>
 
-      <div className="row">
+      <div className="flex-row">
         <div className="col px-0">
           <GenericButton className={theme.modalDangerClass} onClick={handleDelete}>
             <FaCheck className="mr-2" /> Delete


### PR DESCRIPTION
<img width="283" alt="Screen Shot 2020-06-28 at 23 12 50" src="https://user-images.githubusercontent.com/1237986/85959546-fe3e1000-b994-11ea-946a-d009d46ba846.png">

- In Play Mode in light theme, the "Never Mind" button on the modal for hiding rules was white text and a white outline; now uses the theme 
- In both themes on mobile, the focus outline of the modals was visible as a strange shape distinct from the modal border, because the contents invisibly extended outside the modal. I've fixed this with a quick `flex-row` but there may be better approaches. The contents aren't properly centred within the modal, but that doesn't bother me as much as the outline 😁

 <img width="344" alt="Screen Shot 2020-06-28 at 23 19 11" src="https://user-images.githubusercontent.com/1237986/85959708-d7340e00-b995-11ea-8048-841ea09c32ec.png">
