### PR TITLE
Move reminder dropdown back onto title row on mobile

### DIFF
--- a/src/components/info/reminder.tsx
+++ b/src/components/info/reminder.tsx
@@ -14,7 +14,6 @@ import { Dropdown } from 'react-bootstrap'
 import { FaEllipsisH } from 'react-icons/fa'
 import { MdVisibilityOff } from 'react-icons/md'
 import { useDispatch, useSelector } from 'react-redux'
-import { centerContentClass } from 'theme/helperClasses'
 import { TTurnAction } from 'types/data'
 import { TTurnWhen } from 'types/phases'
 import useNote from 'utils/hooks/useNote'
@@ -161,17 +160,13 @@ const ActionText = (props: IActionTextProps) => {
   return (
     <div ref={draggableProps.innerRef} {...draggableProps.draggableProps}>
       <div className={`mb-2 ${!isVisible ? `d-print-none` : ``}`}>
-        <div className={`d-flex ${isMobile && isVisible ? 'flex-column' : ''} mb-1`}>
+        <div className={`d-flex mb-1`}>
           <div className="flex-grow-1">
             <div {...draggableProps.dragHandleProps}>
               <ActionTitle {...props} />
             </div>
           </div>
-          <div
-            className={`flex-shrink-0 ${
-              isMobile ? 'align-self-center' : 'px-2'
-            } ${centerContentClass} d-print-none`}
-          >
+          <div className={`flex-shrink-0 pl-2 mt-1 d-print-none`}>
             {isGameMode ? (
               <VisibilityToggle
                 appearance={'icon'}


### PR DESCRIPTION
I mentioned in chat that I might go to vertical ellipsis for this, but horizontal looked better to me in the end (I think if the icon were vertical aligned to the whole reminder it might have made sense, but with it just part of the title the horizontal one still looked right)