### PR TITLE
Morathi add Morathi

### DIFF
--- a/src/components/input/select.tsx
+++ b/src/components/input/select.tsx
@@ -82,7 +82,7 @@ export const SelectOne = (props: ISelectOneProps) => {
   )
 }
 
-const convertToOptions = (items: string[] = [], toTitle: boolean = true): TDropdownOption[] => {
+export const convertToOptions = (items: string[] = [], toTitle: boolean = true): TDropdownOption[] => {
   return items.map(i => ({ value: i, label: toTitle ? titleCase(i) : i }))
 }
 

--- a/src/factions/daughters_of_khaine/units.ts
+++ b/src/factions/daughters_of_khaine/units.ts
@@ -176,7 +176,7 @@ const baseAvatarOfKhaine = {
   ],
 }
 
-const Units = {
+const Morathi = {
   'Morathi-Khaine': {
     mandatory: {
       spells: [keyPicker(Spells, ['Black Horror of Ulgu'])],
@@ -214,6 +214,22 @@ const Units = {
         when: [WOUND_ALLOCATION_PHASE],
       },
     ],
+  },
+}
+
+const Units = {
+  'Morathi-Khaine': {
+    ...Morathi['Morathi-Khaine'],
+    mandatory: {
+      ...Morathi['Morathi-Khaine'].mandatory,
+      units: [keyPicker(Morathi, ['The Shadow Queen'])],
+    },
+  },
+  'The Shadow Queen': {
+    ...Morathi['The Shadow Queen'],
+    mandatory: {
+      units: [keyPicker(Morathi, ['Morathi-Khaine'])],
+    },
   },
   'Hag Queen': {
     mandatory: {

--- a/src/tests/azyr/getAzyrArmy.test.ts
+++ b/src/tests/azyr/getAzyrArmy.test.ts
@@ -1527,7 +1527,7 @@ describe('getAzyrArmyFromPdf', () => {
       spells: ['Mindrazor', 'Black Horror of Ulgu'],
       command_traits: [],
       triumphs: [],
-      units: ['Hag Queen on Cauldron of Blood', 'Morathi-Khaine', 'Sisters of Slaughter'],
+      units: ['Hag Queen on Cauldron of Blood', 'Morathi-Khaine', 'Sisters of Slaughter', 'The Shadow Queen'],
     })
   })
 

--- a/src/tests/store/units.test.ts
+++ b/src/tests/store/units.test.ts
@@ -1,0 +1,48 @@
+import { convertToOptions, TDropdownOption } from 'components/input/select'
+import { selectionActions } from 'ducks'
+import { DAUGHTERS_OF_KHAINE } from 'meta/factions'
+import { ActionMeta } from 'react-select'
+import { store } from 'store'
+import { IArmy } from 'types/army'
+import { getArmy } from 'utils/getArmy/getArmy'
+import { getSideEffects } from 'utils/getSideEffects'
+import { withSelectMultiWithSideEffects } from 'utils/withSelect'
+
+beforeEach(() => {
+  store.dispatch(selectionActions.resetAllSelections())
+})
+
+describe('Daughters of Khaine units', () => {
+  const army = getArmy(DAUGHTERS_OF_KHAINE) as IArmy
+  const setValues = withSelectMultiWithSideEffects(
+    selectionActions.setUnits,
+    getSideEffects(army.Units),
+    DAUGHTERS_OF_KHAINE
+  )
+  const MORATHI_KHAINE = 'Morathi-Khaine'
+  // const SHADOW_QUEEN = 'Shadow Queen'
+
+  it('should handle adding Morathi-Khaine', () => {
+    const values = convertToOptions([MORATHI_KHAINE])
+    const action: ActionMeta<TDropdownOption> = { option: values[0], action: 'select-option' }
+
+    setValues(values, action)
+    const { selections } = store.getState()
+
+    const expectedSideEffects = {
+      command_abilities: ['Worship Through Bloodshed'],
+      spells: ['Black Horror of Ulgu'],
+    }
+    expect(selections.selections).toEqual(
+      expect.objectContaining({
+        ...expectedSideEffects,
+        units: [MORATHI_KHAINE],
+      })
+    )
+    expect(selections.sideEffects).toEqual({
+      'Morathi-Khaine': {
+        ...expectedSideEffects,
+      },
+    })
+  })
+})

--- a/src/tests/store/units.test.ts
+++ b/src/tests/store/units.test.ts
@@ -20,7 +20,7 @@ describe('Daughters of Khaine units', () => {
     DAUGHTERS_OF_KHAINE
   )
   const MORATHI_KHAINE = 'Morathi-Khaine'
-  // const SHADOW_QUEEN = 'Shadow Queen'
+  const SHADOW_QUEEN = 'The Shadow Queen'
 
   it('should handle adding Morathi-Khaine', () => {
     const values = convertToOptions([MORATHI_KHAINE])
@@ -32,11 +32,12 @@ describe('Daughters of Khaine units', () => {
     const expectedSideEffects = {
       command_abilities: ['Worship Through Bloodshed'],
       spells: ['Black Horror of Ulgu'],
+      units: [SHADOW_QUEEN],
     }
     expect(selections.selections).toEqual(
       expect.objectContaining({
         ...expectedSideEffects,
-        units: [MORATHI_KHAINE],
+        units: [MORATHI_KHAINE, ...expectedSideEffects.units],
       })
     )
     expect(selections.sideEffects).toEqual({
@@ -44,5 +45,49 @@ describe('Daughters of Khaine units', () => {
         ...expectedSideEffects,
       },
     })
+  })
+
+  it('should handle adding The Shadow Queen', () => {
+    const values = convertToOptions([SHADOW_QUEEN])
+    const action: ActionMeta<TDropdownOption> = { option: values[0], action: 'select-option' }
+
+    setValues(values, action)
+    const { selections } = store.getState()
+
+    const expectedSideEffects = {
+      command_abilities: ['Worship Through Bloodshed'],
+      spells: ['Black Horror of Ulgu'],
+      units: [MORATHI_KHAINE],
+    }
+    expect(selections.selections).toEqual(
+      expect.objectContaining({
+        ...expectedSideEffects,
+        units: [SHADOW_QUEEN, ...expectedSideEffects.units],
+      })
+    )
+    expect(selections.sideEffects).toEqual({
+      'The Shadow Queen': {
+        ...expectedSideEffects,
+      },
+    })
+  })
+
+  it('should handle adding and removing Morathi-Khaine', () => {
+    const values = convertToOptions([MORATHI_KHAINE])
+    const setAction: ActionMeta<TDropdownOption> = { option: values[0], action: 'select-option' }
+    const unsetAction: ActionMeta<TDropdownOption> = { option: values[0], action: 'remove-value' }
+
+    setValues(values, setAction)
+    setValues([], unsetAction)
+    const { selections } = store.getState()
+
+    expect(selections.selections).toEqual(
+      expect.objectContaining({
+        command_abilities: [],
+        spells: [],
+        units: [],
+      })
+    )
+    // expect(selections.sideEffects).toEqual({})
   })
 })


### PR DESCRIPTION
Imports test suggests this already works for imports
Tested in the browser using the dropdowns, and wrote test cases for it

Kudos to the new side effects system for handling removal of members of these pairs, which the old system couldn't do.

Once this is reviewed, I plan to do the Underworlds warbands that have Leader / Unit pairs that you always take together.