### PR TITLE
Add common Auric Runeson effects to mounted one

### DIFF
--- a/src/factions/fyreslayers/units.ts
+++ b/src/factions/fyreslayers/units.ts
@@ -103,7 +103,7 @@ const Units = {
     mandatory: {
       command_abilities: [keyPicker(CommandAbilities, ['Molten Battering Ram'])],
     },
-    effects: [...MagmadrothEffects, StareDownEffect],
+    effects: [...AuricRunesonEffects, ...MagmadrothEffects, StareDownEffect],
   },
   'Auric Runesmiter on Magmadroth': {
     mandatory: {


### PR DESCRIPTION
Magmadroth version was missing Vying for Glory and Wyrmslayer Javelin. It was all set up to be shared by both Auric Runeson warscrolls, just not used.