### PR TITLE
Fix Ironclad transport rule and add OBR terrain setup

### DIFF
--- a/src/factions/kharadron_overlords/command_abilities.ts
+++ b/src/factions/kharadron_overlords/command_abilities.ts
@@ -1,8 +1,8 @@
 import { tagAs } from 'factions/metatagger'
 import {
-  HERO_PHASE,
   START_OF_CHARGE_PHASE,
   START_OF_COMBAT_PHASE,
+  START_OF_HERO_PHASE,
   START_OF_SHOOTING_PHASE,
 } from 'types/phases'
 
@@ -12,7 +12,7 @@ const CommandAbilities = {
       {
         name: `By Grungni, I Have My Eye On You!`,
         desc: `You can use this command ability in your hero phase before a friendly ENDRINRIGGERS unit wholly within 18" of a friendly model with this command ability uses its Endrincraft ability. If you do so, you can reroll any of the dice that determine how many wounds are healed by that ENDRINRIGGERS unit in that phase.`,
-        when: [HERO_PHASE],
+        when: [START_OF_HERO_PHASE],
       },
     ],
   },

--- a/src/factions/kharadron_overlords/units.ts
+++ b/src/factions/kharadron_overlords/units.ts
@@ -18,18 +18,9 @@ import command_abilities from './command_abilities'
 
 const FlyingTransportEffect = {
   name: `Flying Transport`,
-  desc: `This model can fly, and can be garrisoned by up to 15 friendly Marine models even though it is not a terrain feature. If this model is in a warscroll battalion, units from the same battalion that can garrison this model can be set up as this model's garrison when this model is set up.
+  desc: `This model can fly, and can be garrisoned by up to 15 (25 if IRONCLAD) friendly Marine models even though it is not a terrain feature. If this model is in a warscroll battalion, units from the same battalion that can garrison this model can be set up as this model's garrison when this model is set up.
 
-  Halve this model's Move characteristic and it cannot Fly High if there are 11 or more models in its garrison. Units cannot join or leave this model's garrison if it has made a move or flown high in the same phase (they can join or leave before it does so). Models in the garrison are not counted towards gaining control of an objective.
-
-  An attack made by a weapon that is in range of this model can target either this model or a unit in its garrison. If this model is destroyed, before it is removed from play, roll 1 dice for each model in its garrison. On a 1, that model is slain. Set up any surviving models wholly within 3" of this model and more than 3" from any enemy units.`,
-  when: [DURING_GAME],
-}
-const IroncladFlyingTransportEffect = {
-  name: `Flying Transport`,
-  desc: `This model can fly, and can be garrisoned by up to 25 friendly Marine models even though it is not a terrain feature. If this model is in a warscroll battalion, units from the same battalion that can garrison this model can be set up as this model's garrison when this model is set up.
-
-  Halve this model's Move characteristic and it cannot Fly High if there are 16 or more models in its garrison. Units cannot join or leave this model's garrison if it has made a move or flown high in the same phase (they can join or leave before it does so). Models in the garrison are not counted towards gaining control of an objective.
+  Halve this model's Move characteristic and it cannot Fly High if there are 11 (16 if IRONCLAD) or more models in its garrison. Units cannot join or leave this model's garrison if it has made a move or flown high in the same phase (they can join or leave before it does so). Models in the garrison are not counted towards gaining control of an objective.
 
   An attack made by a weapon that is in range of this model can target either this model or a unit in its garrison. If this model is destroyed, before it is removed from play, roll 1 dice for each model in its garrison. On a 1, that model is slain. Set up any surviving models wholly within 3" of this model and more than 3" from any enemy units.`,
   when: [DURING_GAME],
@@ -341,7 +332,7 @@ const Units = {
       BombRacksEffect,
       DisengageEffect,
       FlyHighEffect,
-      IroncladFlyingTransportEffect,
+      FlyingTransportEffect,
       getSkyhookEffect(2),
       SkyCannonEffect,
     ],

--- a/src/factions/kharadron_overlords/units.ts
+++ b/src/factions/kharadron_overlords/units.ts
@@ -25,6 +25,15 @@ const FlyingTransportEffect = {
   An attack made by a weapon that is in range of this model can target either this model or a unit in its garrison. If this model is destroyed, before it is removed from play, roll 1 dice for each model in its garrison. On a 1, that model is slain. Set up any surviving models wholly within 3" of this model and more than 3" from any enemy units.`,
   when: [DURING_GAME],
 }
+const IroncladFlyingTransportEffect = {
+  name: `Flying Transport`,
+  desc: `This model can fly, and can be garrisoned by up to 25 friendly Marine models even though it is not a terrain feature. If this model is in a warscroll battalion, units from the same battalion that can garrison this model can be set up as this model's garrison when this model is set up.
+
+  Halve this model's Move characteristic and it cannot Fly High if there are 16 or more models in its garrison. Units cannot join or leave this model's garrison if it has made a move or flown high in the same phase (they can join or leave before it does so). Models in the garrison are not counted towards gaining control of an objective.
+
+  An attack made by a weapon that is in range of this model can target either this model or a unit in its garrison. If this model is destroyed, before it is removed from play, roll 1 dice for each model in its garrison. On a 1, that model is slain. Set up any surviving models wholly within 3" of this model and more than 3" from any enemy units.`,
+  when: [DURING_GAME],
+}
 const EndrinharnessEffect = {
   name: `Endrinharness`,
   desc: `If the unmodified hit roll for an attack made with a melee weapon by this model is 6, that attack inflicts D3 mortal wounds and the attack sequence ends (do not make a wound or save roll).`,
@@ -332,7 +341,7 @@ const Units = {
       BombRacksEffect,
       DisengageEffect,
       FlyHighEffect,
-      FlyingTransportEffect,
+      IroncladFlyingTransportEffect,
       getSkyhookEffect(2),
       SkyCannonEffect,
     ],

--- a/src/factions/ossiarch_bonereapers/scenery.ts
+++ b/src/factions/ossiarch_bonereapers/scenery.ts
@@ -1,9 +1,14 @@
 import { tagAs } from 'factions/metatagger'
-import { HERO_PHASE } from 'types/phases'
+import { HERO_PHASE, START_OF_SETUP } from 'types/phases'
 
 const Scenery = {
   'Bone-tithe Nexus': {
     effects: [
+      {
+        name: 'Bone-tithe Nexus',
+        desc: `When you choose an Ossiarch Bonereapers army, you can include 1 BONE-TITHE NEXUS. When terrain is set up for a battle, any BONE-TITHE NEXUSES must be set up by the player whose army they are a part of, before any other terrain features are set up, more than 3" from any objectives and more than 6" from the edge of the battlefield. Set up the rest of the terrain as described in the core rules. If both players can set up terrain features before any other terrain features are set up, the players must roll off, and the winner chooses who sets up their terrain features first.`,
+        when: [START_OF_SETUP],
+      },
       {
         name: `Deadly Gaze`,
         desc: `In your hero phase, you can choose for this terrain feature to unleash one of the following punishments:


### PR DESCRIPTION
Request for review:

[Output of transport change](https://imgur.com/a/kLufYXe) - would the ironclad addition be better as a tweak more like this instead:

```const FlyingTransportEffect = {
  name: `Flying Transport`,
  desc: `This model can fly, and can be garrisoned by up to 15 **(25 if Ironclad)** friendly Marine models even though it is not a terrain feature. If this model is in a warscroll battalion, units from the same battalion that can garrison this model can be set up as this model's garrison when this model is set up.

  Halve this model's Move characteristic and it cannot Fly High if there are 11 **(16 if Ironclad)** or more models in its garrison. Units cannot join or leave this model's garrison if it has made a move or flown high in the same phase (they can join or leave before it does so). Models in the garrison are not counted towards gaining control of an objective.

  An attack made by a weapon that is in range of this model can target either this model or a unit in its garrison. If this model is destroyed, before it is removed from play, roll 1 dice for each model in its garrison. On a 1, that model is slain. Set up any surviving models wholly within 3" of this model and more than 3" from any enemy units.`,
  when: [DURING_GAME],