### PR TITLE
Remove Apprentice Runesmith from KO and Fyreslayers

### DIFF
--- a/src/factions/fyreslayers/units.ts
+++ b/src/factions/fyreslayers/units.ts
@@ -1,4 +1,3 @@
-import { OrderUnits } from 'factions/grand_alliances'
 import { keyPicker, tagAs } from 'factions/metatagger'
 import {
   BATTLESHOCK_PHASE,
@@ -70,7 +69,6 @@ const FyresteelHandaxesEffect = {
 
 //Unit names
 const Units = {
-  ...keyPicker(OrderUnits, ['Apprentice Runesmith']),
   'Auric Runefather on Magmadroth': {
     mandatory: {
       command_abilities: [keyPicker(CommandAbilities, ['Steadfast Advance'])],

--- a/src/factions/kharadron_overlords/units.ts
+++ b/src/factions/kharadron_overlords/units.ts
@@ -13,7 +13,6 @@ import {
   START_OF_MOVEMENT_PHASE,
   WOUND_ALLOCATION_PHASE,
 } from 'types/phases'
-import { OrderUnits } from '../grand_alliances'
 import command_abilities from './command_abilities'
 import rule_sources from './rule_sources'
 
@@ -24,7 +23,7 @@ const FlyingTransportEffect = {
   Halve this model's Move characteristic and it cannot Fly High if there are 11 (16 if IRONCLAD) or more models in its garrison. Units cannot join or leave this model's garrison if it has made a move or flown high in the same phase (they can join or leave before it does so). Models in the garrison are not counted towards gaining control of an objective.
 
   An attack made by a weapon that is in range of this model can target either this model or a unit in its garrison. If this model is destroyed, before it is removed from play, roll 1 dice for each model in its garrison. On a 1, that model is slain. Set up any surviving models wholly within 3" of this model and more than 3" from any enemy units.
-  
+
   If this model is in a warscroll battalion, units from the same battalion that can garrison this model can be set up as this model's garrison when this model is set up.`,
   when: [DURING_GAME],
   rule_sources: [
@@ -117,7 +116,6 @@ const EndrinmasterHealEffect = (val: '3' | 'D3') => ({
 })
 
 const Units = {
-  ...keyPicker(OrderUnits, ['Apprentice Runesmith']),
   'Endrinmaster with Dirigible Suit': {
     mandatory: {
       command_abilities: [keyPicker(command_abilities, ['By Grungni, I Have My Eye On You!'])],

--- a/src/tests/fixtures/warscroll/json/1589874682978-Warscroll_Builder.json
+++ b/src/tests/fixtures/warscroll/json/1589874682978-Warscroll_Builder.json
@@ -11,7 +11,6 @@
   "- Artefact :  Staff of Ocular Optimisation",
   "Endrinmaster with Dirigible Suit \\(220\\)",
   "- Artefact :  Phosphorite Bomblets",
-  "Apprentice Runesmith \\(70\\)",
   "UNITS",
   "10 x Arkanaut Company \\(90\\)",
   "- 1 x  Skypikes",
@@ -45,7 +44,7 @@
   "Grundstok Escort Wing \\(140\\)",
   "ENDLESS SPELLS / TERRAIN / COMMAND POINTS",
   "Warp Lightning Vortex \\(100\\)",
-  "TOTAL: 1990/2000     EXTRA COMMAND POINTS: 1     WOUNDS: 101",
-  "LEADERS: 4/6    BATTLELINES: 3 \\(3+\\)    BEHEMOTHS: 1/4    ARTILLERY: 0/4",
+  "TOTAL: 1920/2000     EXTRA COMMAND POINTS: 1     WOUNDS: 98",
+  "LEADERS: 3/6    BATTLELINES: 3 \\(3+\\)    BEHEMOTHS: 1/4    ARTILLERY: 0/4",
   "ARTEFACTS: 3/2    ALLIES: 0/400"
 ]

--- a/src/tests/warscroll/warscrollJson.test.ts
+++ b/src/tests/warscroll/warscrollJson.test.ts
@@ -591,7 +591,7 @@ describe('getWarscrollArmyFromJson', () => {
   it('should work with 1589874682978-Warscroll_Builder', () => {
     const parsedText = getFile('1589874682978-Warscroll_Builder')
     const res = getWarscrollArmyFromPdf(parsedText)
-    expect(res.selections.units).toContain('Apprentice Runesmith')
+    expect(res.selections.units).toContain('Aether-Khemist')
     expect(res.errors).toEqual([])
   })
 


### PR DESCRIPTION
I noticed KO had Apprentice Runesmith as a Hero option. Which is incorrect.

When updating this I saw Fyreslayers had him too.

I looked over the code to see why. I could find this PR:  https://github.com/daviseford/aos-reminders/pull/941 with this specific commit https://github.com/daviseford/aos-reminders/pull/941/commits/7a275b322390ee2b41deeafa265811495421b363 that addresses the Runesmith. But couldn't find a reason why this was done.

Looking at the warscroll, it seems his inclusion has been accidental. As the Runesmith isn't allied, and the Skyport isn't Barak Thryng which does allow Duardin units. But they're accessible via the ally function.