### PR TITLE
Adds Cursed City Heroes

### DIFF
--- a/src/factions/cities_of_sigmar/prayers.ts
+++ b/src/factions/cities_of_sigmar/prayers.ts
@@ -54,7 +54,6 @@ const Prayers = {
       },
     ],
   },
-
 }
 
 export default tagAs(Prayers, 'prayer')

--- a/src/factions/cities_of_sigmar/prayers.ts
+++ b/src/factions/cities_of_sigmar/prayers.ts
@@ -36,6 +36,25 @@ const Prayers = {
       },
     ],
   },
+  'Celestial Prayers: Invigorating Touch': {
+    effects: [
+      {
+        name: `Invigorating Touch`,
+        desc: `4+ for this prayer to succeed. Pick 1 friendly model within 3". Heal up to D6 wounds allocated to that model.`,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+  'Celestial Prayers: Cometary Blast': {
+    effects: [
+      {
+        name: `Cometary Blast`,
+        desc: `4+ for this prayer to succeed. Pick a point on the battlefield within 18" and visible to this model. Roll a D6 for each unit within 3" of point. 1-3: Nothing. 4-5: 1 mortal wound, 6: D3 mortal wounds.`,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
+
 }
 
 export default tagAs(Prayers, 'prayer')

--- a/src/factions/cities_of_sigmar/spells.ts
+++ b/src/factions/cities_of_sigmar/spells.ts
@@ -409,6 +409,15 @@ const Spells = {
       },
     ],
   },
+  'Withering Hex': {
+    effects: [
+      {
+        name: `Withering Hex`,
+        desc: `6+ casting value. Pick 1 enemy unit within 18" and visible to the caster. Unit suffers D3 mortal wounds. In addition, for the rest of the battle, that unit is affected by Octren's Hex. Subtract 1" from Move Characteristic of units affects by Octren's Hex.`,
+        when: [HERO_PHASE],
+      },
+    ],
+  },
 }
 
 export default tagAs(Spells, 'spell')

--- a/src/factions/cities_of_sigmar/units.ts
+++ b/src/factions/cities_of_sigmar/units.ts
@@ -5,6 +5,7 @@ import {
   COMBAT_PHASE,
   DURING_GAME,
   DURING_SETUP,
+  END_OF_COMBAT_PHASE,
   END_OF_MOVEMENT_PHASE,
   HERO_PHASE,
   MOVEMENT_PHASE,
@@ -15,7 +16,6 @@ import {
   START_OF_SETUP,
   TURN_FOUR_START_OF_ROUND,
   WOUND_ALLOCATION_PHASE,
-  END_OF_COMBAT_PHASE,
 } from 'types/phases'
 import command_abilities from './command_abilities'
 import prayers from './prayers'
@@ -1264,7 +1264,7 @@ const Units = {
   },
   // Cursed City heroes
   'Brutogg Corpse-Eater': {
-    effects:[
+    effects: [
       {
         name: `Devour the Enemy`,
         desc: `If any enemy models are slain by attacks from this model during the combat phase, heal D3 wounds. If slain models include any DEATH models, heal D6 wounds.`,
@@ -1274,7 +1274,7 @@ const Units = {
     ],
   },
   'Captain Emelda Braskov': {
-    effects:[
+    effects: [
       {
         name: `Deathblow`,
         desc: `If the unmodified hit roll for an attack made with Dawnlight is 6, that attack inflicts 1 mortal wound on the target in addition to normal damage.`,
@@ -1290,14 +1290,14 @@ const Units = {
   },
   'Cleona Zeitengale': {
     mandatory: {
-      prayers: [keyPicker(prayers, ['Celestial Prayers: Invigorating Touch', 'Celestial Prayers: Cometary Blast'])],
+      prayers: [
+        keyPicker(prayers, ['Celestial Prayers: Invigorating Touch', 'Celestial Prayers: Cometary Blast']),
+      ],
     },
-    effects:[
-      DenizenOfUlfenkarnEffect,
-    ],
+    effects: [DenizenOfUlfenkarnEffect],
   },
   'Glaurio Ven Alten III': {
-    effects:[
+    effects: [
       {
         name: `Point-blank Shot`,
         desc: `If an attack made with Noblesse hits a target within 3", that attack scores 1 mortal wound and the attack sequence ends.`,
@@ -1312,7 +1312,7 @@ const Units = {
     ],
   },
   'Octren Glimscry': {
-    effects:[
+    effects: [
       {
         name: `Master of Mortality`,
         desc: `Roll a D6 each time you allocate a wound or mortal wound to this model. On a 6+, it is negated.`,

--- a/src/factions/cities_of_sigmar/units.ts
+++ b/src/factions/cities_of_sigmar/units.ts
@@ -1312,6 +1312,9 @@ const Units = {
     ],
   },
   'Octren Glimscry': {
+    mandatory: {
+      spells: [keyPicker(spells, ['Withering Hex'])],
+    },
     effects: [
       {
         name: `Master of Mortality`,

--- a/src/factions/cities_of_sigmar/units.ts
+++ b/src/factions/cities_of_sigmar/units.ts
@@ -1329,6 +1329,21 @@ const Units = {
       },
     ],
   },
+  'Jelsen Darrock': {
+    effects: [
+      {
+        name: `Firewood Stakes`,
+        desc: `Pick 1 enemy unit within 1" of this model and roll a D6, add 1 to result if target has DEATH keyword. On 3+ that unit suffers 1 mortal wound.`,
+        when: [END_OF_COMBAT_PHASE],
+      },
+      {
+        name: `Judgement`,
+        desc: `If an attack made with Judgement scores a hit. The attack sequence ends, roll a D6. If roll is double the target unit's Wounds characterstic or more, 1 model from the unit is slain after resolving this model's attacks. If the roll is less than double, the unit suffers 1 mortal wound after resolving this model's attacks.`,
+        when: [SHOOTING_PHASE],
+      },
+      DenizenOfUlfenkarnEffect,
+    ],
+  },
 }
 
 export default tagAs(Units, 'unit')

--- a/src/factions/cities_of_sigmar/units.ts
+++ b/src/factions/cities_of_sigmar/units.ts
@@ -15,6 +15,7 @@ import {
   START_OF_SETUP,
   TURN_FOUR_START_OF_ROUND,
   WOUND_ALLOCATION_PHASE,
+  END_OF_COMBAT_PHASE,
 } from 'types/phases'
 import command_abilities from './command_abilities'
 import prayers from './prayers'
@@ -212,6 +213,11 @@ const BattlemageMagicEffect = {
   name: `Magic`,
   desc: `This model knows the spell from its warscroll that includes the name of the realm it comes from.`,
   when: [HERO_PHASE],
+}
+const DenizenOfUlfenkarnEffect = {
+  name: `Denizen of Ulfenkarn`,
+  desc: `ULFENKARN is a city keyword (this means that this model cannot gain another city keyword if it is included in a Cities of Sigmar army - see the Strongholds of Order battle trait in Battletome: Cities of Sigmar).`,
+  when: [DURING_GAME],
 }
 
 const Units = {
@@ -1253,6 +1259,70 @@ const Units = {
         name: `Rune of Forging`,
         desc: `You can reroll the dice rolled to see if an Organ Gun jams if there is an ENGINEER from your army within 1" of the war machine.`,
         when: [SHOOTING_PHASE],
+      },
+    ],
+  },
+  // Cursed City heroes
+  'Brutogg Corpse-Eater': {
+    effects:[
+      {
+        name: `Devour the Enemy`,
+        desc: `If any enemy models are slain by attacks from this model during the combat phase, heal D3 wounds. If slain models include any DEATH models, heal D6 wounds.`,
+        when: [END_OF_COMBAT_PHASE],
+      },
+      DenizenOfUlfenkarnEffect,
+    ],
+  },
+  'Captain Emelda Braskov': {
+    effects:[
+      {
+        name: `Deathblow`,
+        desc: `If the unmodified hit roll for an attack made with Dawnlight is 6, that attack inflicts 1 mortal wound on the target in addition to normal damage.`,
+        when: [COMBAT_PHASE],
+      },
+      {
+        name: `Shining Exemplar`,
+        desc: `While this model is within 3" of any enemy units, do not take battleshock tests for friendly units wholly within 9" of this model.`,
+        when: [BATTLESHOCK_PHASE],
+      },
+      DenizenOfUlfenkarnEffect,
+    ],
+  },
+  'Cleona Zeitengale': {
+    mandatory: {
+      prayers: [keyPicker(prayers, ['Celestial Prayers: Invigorating Touch', 'Celestial Prayers: Cometary Blast'])],
+    },
+    effects:[
+      DenizenOfUlfenkarnEffect,
+    ],
+  },
+  'Glaurio Ven Alten III': {
+    effects:[
+      {
+        name: `Point-blank Shot`,
+        desc: `If an attack made with Noblesse hits a target within 3", that attack scores 1 mortal wound and the attack sequence ends.`,
+        when: [SHOOTING_PHASE],
+      },
+      {
+        name: `Unrivalled Duellist`,
+        desc: `Subtract 1 from melee hit rolls that target this model. If the attacker's unmodified hit roll is 1, attacking unit suffers 1 mortal wound after all of its attacks have been resolved.`,
+        when: [COMBAT_PHASE],
+      },
+      DenizenOfUlfenkarnEffect,
+    ],
+  },
+  'Octren Glimscry': {
+    effects:[
+      {
+        name: `Master of Mortality`,
+        desc: `Roll a D6 each time you allocate a wound or mortal wound to this model. On a 6+, it is negated.`,
+        when: [WOUND_ALLOCATION_PHASE],
+      },
+      DenizenOfUlfenkarnEffect,
+      {
+        name: `Magic`,
+        desc: `This model is a wizard. Can attempt to cast 1 spell and attempt to unbind 1 spell. Knows the Arcane Bolt, Mystic Shield, and Withering Hex spells.`,
+        when: [HERO_PHASE],
       },
     ],
   },

--- a/src/factions/kharadron_overlords/units.ts
+++ b/src/factions/kharadron_overlords/units.ts
@@ -342,6 +342,20 @@ const Units = {
       SkyCannonEffect,
     ],
   },
+  'Dagnai Holdenstock': {
+    effects:[
+      {
+        name: `Gold-plated Reputation`,
+        desc: `If this model is included in a Kharadron Overlords army, it starts the battle with 2 shares of aether-gold instead of 1.`,
+        when: [DURING_GAME],
+      },
+      {
+        name: `Reel 'Em In`,
+        desc: `If an attack made with this model's Harpoon Gun scores a hit on a MONSTER, if that MONSTER is not slain after that attack has been resolved, roll a dice. On a 4+, that MONSTER is skewered until the start of your next shooting phase. While that MONSTER is skewered, each time it makes a move, it must finish that move at least as close to this model as it was at the start of the move.`,
+        when: [SHOOTING_PHASE],
+      },
+    ]
+  },
 }
 
 export default tagAs(Units, 'unit')

--- a/src/factions/kharadron_overlords/units.ts
+++ b/src/factions/kharadron_overlords/units.ts
@@ -343,7 +343,7 @@ const Units = {
     ],
   },
   'Dagnai Holdenstock': {
-    effects:[
+    effects: [
       {
         name: `Gold-plated Reputation`,
         desc: `If this model is included in a Kharadron Overlords army, it starts the battle with 2 shares of aether-gold instead of 1.`,
@@ -354,7 +354,7 @@ const Units = {
         desc: `If an attack made with this model's Harpoon Gun scores a hit on a MONSTER, if that MONSTER is not slain after that attack has been resolved, roll a dice. On a 4+, that MONSTER is skewered until the start of your next shooting phase. While that MONSTER is skewered, each time it makes a move, it must finish that move at least as close to this model as it was at the start of the move.`,
         when: [SHOOTING_PHASE],
       },
-    ]
+    ],
   },
 }
 

--- a/src/factions/sylvaneth/units.ts
+++ b/src/factions/sylvaneth/units.ts
@@ -384,7 +384,7 @@ const Units = {
       },
     ],
   },
-  "Qulathis the Exile": {
+  'Qulathis the Exile': {
     effects: [
       {
         name: `Strike Unseen`,

--- a/src/factions/sylvaneth/units.ts
+++ b/src/factions/sylvaneth/units.ts
@@ -384,6 +384,25 @@ const Units = {
       },
     ],
   },
+  "Qulathis the Exile": {
+    effects: [
+      {
+        name: `Strike Unseen`,
+        desc: `The cover modifier adds 2 to save rolls vs missile weapons for this model, instead of 1.`,
+        when: [SHOOTING_PHASE],
+      },
+      {
+        name: `Oaken Arrows`,
+        desc: `If the unmodified hit roll for an attack made with Winter's Call is 6, inflict 1 mortal wound on the target in addition to normal damage.`,
+        when: [SHOOTING_PHASE],
+      },
+      {
+        name: `Guardian of the Enga'la Weald`,
+        desc: `ENGA'LA WEALD is a Glade keyword (this means that this model cannot gain another Glade keyword if it is included in a Sylvaneth army - see the Glades battle trait in Battletome: Sylvaneth).`,
+        when: [DURING_GAME],
+      },
+    ],
+  },
 }
 
 export default tagAs(Units, 'unit')

--- a/src/tests/azyr/getAzyrArmy.test.ts
+++ b/src/tests/azyr/getAzyrArmy.test.ts
@@ -1854,6 +1854,7 @@ describe('getAzyrArmyFromPdf', () => {
         'Word of Pain',
         'Bladewind',
         'Armour of Thorns',
+        'Withering Hex',
       ],
       command_traits: ['Seat on the Council (Greywater Fastness)'],
       triumphs: [],

--- a/src/tests/warscroll/warscrollPdf.test.ts
+++ b/src/tests/warscroll/warscrollPdf.test.ts
@@ -845,6 +845,7 @@ describe('getWarscrollArmyFromPdf', () => {
         'Amber Spear',
         'Word of Pain',
         'Armour of Thorns',
+        'Withering Hex',
       ],
       command_traits: [
         'Black Market Bounty (Anvilgard Battle Trait)',
@@ -1058,6 +1059,7 @@ describe('getWarscrollArmyFromPdf', () => {
       'Word of Pain',
       'Bladewind',
       'Armour of Thorns',
+      'Withering Hex',
     ])
   })
 


### PR DESCRIPTION
### Description
Adds the Cursed City Heroes to their respective lists. 

Some of the rules were quite wordy. Did my best to shorten them.

Also had to adjust some tests to cater for a new spell added to the CoS list.

### Sources
https://www.games-workshop.com/resources/PDF/AoS_Warscrolls/eng_Brutogg_Corpse_Eater_Dagnai_Holdenstock.pdf
https://www.games-workshop.com/resources/PDF/AoS_Warscrolls/eng_Captain_Emelda_Braskov_Qulathis_The_Exile.pdf
https://www.games-workshop.com/resources/PDF/AoS_Warscrolls/eng_Cleona_Zeitengale.pdf
https://www.games-workshop.com/resources/PDF/AoS_Warscrolls/eng_Glaurio_Ven_Alten_III_Octren_Glimscry.pdf
https://www.games-workshop.com/resources/PDF/AoS_Warscrolls/eng_Jelsen_Darrock.pdf
