### PR TITLE
WIP: Potential prototype for equality checking

### DIFF
--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -121,6 +121,12 @@ export type TEffects = {
   desc: string
   when: TTurnWhen[]
   rule_sources?: TRuleSource[]
+  /**
+   * Is this effect shared between different units?
+   *
+   * Only used for data de-duplication purposes
+   */
+  shared?: boolean
 } & {
   [prop in TEntryProperties]?: boolean
 }


### PR DESCRIPTION
Outputs:

```
{
    "Magic": {
        "count": 2,
        "occurrences": [
            "Spellweaver",
            "Sisters of the Thorn"
        ],
        "effect": {
            "name": "Magic",
            "desc": "A Spellweaver is a wizard. A Spellweaver can attempt to cast one spell in each of your own hero phases, and attempt to unbind one spell in each enemy hero phase. A Spellweaver knows the Arcane Bolt, Mystic Shield and Blessing of Life spells.",
            "when": [
                "DURING_HERO_PHASE"
            ]
        }
    },
    "Standard Bearer": {
        "count": 4,
        "occurrences": [
            "Sisters of the Thorn",
            "Eternal Guard",
            "Wild Riders",
            "Wildwood Rangers"
        ],
        "effect": {
            "name": "Standard Bearer",
            "desc": "If the unit includes any Standard Bearers, add 1 to the Bravery of its models. Add 2 their Bravery instead if the unit is in cover.",
            "when": [
                "DURING_BATTLESHOCK_PHASE"
            ]
        }
    },
    "Hornblower": {
        "count": 3,
        "occurrences": [
            "Sisters of the Thorn",
            "Wild Riders",
            "Wildwood Rangers"
        ],
        "effect": {
            "name": "Hornblower",
            "desc": "You can reroll the dice when determining how far this unit can run if it includes any Hornblowers.",
            "when": [
                "DURING_MOVEMENT_PHASE"
            ],
            "shared": true
        }
    }
}
```