### PR TITLE
Fix: Harbinger of Decay - Morbid Vigour

### DIFF
--- a/src/factions/nurgle/command_abilities.ts
+++ b/src/factions/nurgle/command_abilities.ts
@@ -64,7 +64,7 @@ const CommandAbilities = {
       },
       {
         name: `Morbid Vigour`,
-        desc: `If active, roll a D6 each time you allocate a wound or mortal wound to a friendly Nurgle unit within 7" of this model. On a 5+ the wound is negated. The same unit cannot benefit from this ability more than once in the same phase.`,
+        desc: `If active, roll a D6 each time you allocate a wound or mortal wound to a friendly Nurgle mortal unit within 7" of this model. On a 5+ the wound is negated. The same unit cannot benefit from this ability more than once in the same phase.`,
         when: [WOUND_ALLOCATION_PHASE],
       },
     ],

--- a/src/factions/tzeentch/command_abilities.ts
+++ b/src/factions/tzeentch/command_abilities.ts
@@ -66,7 +66,7 @@ const CommandAbilities = {
       },
       {
         name: `Entourage of Sky-Sharks`,
-        desc: `If active, until your next hero phase, improve the Rend characteristic of that unit's Lamprey Bite by 1. `,
+        desc: `If active, until your next hero phase, improve the Rend characteristic of that unit's Lamprey Bite by 1.`,
         when: [COMBAT_PHASE],
       },
     ],


### PR DESCRIPTION
Added clarification that only mortal units are affected by the ability, not all Nurgle units.

The linter (husky?) also caught a stray space in a Tzeentch file.