### PR TITLE
Update Typescript to v4.4.3 (fixes #1408)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aos-reminders",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "private": true,
   "homepage": "./",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "source-map-explorer": "2.5.2",
     "ts-node-dev": "1.1.8",
     "tsconfig-paths": "3.11.0",
-    "typescript": "4.3.5",
+    "typescript": "4.4.3",
     "workbox-core": "6.3.0",
     "workbox-expiration": "6.3.0",
     "workbox-precaching": "6.3.0",

--- a/src/factions/factionClass.ts
+++ b/src/factions/factionClass.ts
@@ -42,7 +42,7 @@ export class Faction<
     this.AggregateArmy = getAggregateArmy(SubFactions, flavorLabel)
 
     this.flavorKeys = this.AggregateArmy.Flavors.map(x => x.name)
-    
+
     this.subFactionKeys = Object.keys(SubFactions) as K[]
 
     this.subFactionKeyMap = this.subFactionKeys.reduce((a, k) => {

--- a/src/factions/seraphon/rule_sources.ts
+++ b/src/factions/seraphon/rule_sources.ts
@@ -21,7 +21,7 @@ const rule_sources = {
   WHITE_DWARF_OCTOBER_2021: {
     name: 'White Dwarf (October 2021)',
     type: 'white_dwarf',
-    },
+  },
 }
 
 export default rule_sources

--- a/src/factions/soulblight_gravelords/artifacts.ts
+++ b/src/factions/soulblight_gravelords/artifacts.ts
@@ -124,7 +124,7 @@ const Artifacts = {
     effects: [
       {
         name: `Morbheg's Claw`,
-        desc: `In your hero phase, you can say that the bearer will carve sigils into the ground using Morbheg's claw. If you do so, add 2 to casting rolls for friendly LEGION OF NIGHT WIZARDS wholly within 12" of the bearer until your next hero phase. However, the bearer cannot make a normal move, run, retreat, make a charge move, shoot or fight until your next hero phase`,
+        desc: `In your hero phase, you can say that the bearer will carve sigils into the ground using Morbheg's claw. If you do so, add 2 to casting rolls for friendly LEGION OF NIGHT WIZARDS wholly within 12" of the bearer until your next hero phase. However, the bearer cannot make a normal move, run, retreat, make a charge move, shoot or fight until your next hero phase.`,
         when: [HERO_PHASE],
         rule_sources: [
           rule_sources.BATTLETOME_SOULBLIGHT_GRAVELORDS,

--- a/src/factions/soulblight_gravelords/spells.ts
+++ b/src/factions/soulblight_gravelords/spells.ts
@@ -55,7 +55,7 @@ const Spells = {
     effects: [
       {
         name: `Vile Transference`,
-        desc: `Vile Transference is a spell that has a casting value of 7. If successfully cast, pick 1 enemy unit within 3" of the caster that is visible to them. Roll a number of dice equal to that enemy unit’s Wounds characteristic. For each 6, that unit suffers 1 mortal wound and you can heal 1 wound allocated to the caster.`,
+        desc: `Casting value of 7. If successfully cast, pick 1 enemy unit within 3" of the caster that is visible to them. Roll a number of dice equal to that enemy unit's Wounds characteristic. For each 6, that unit suffers 1 mortal wound and you can heal 1 wound allocated to the caster.`,
         when: [HERO_PHASE],
         rule_sources: [
           rule_sources.BATTLETOME_SOULBLIGHT_GRAVELORDS,

--- a/src/tests/warscroll/warscrollJson.test.ts
+++ b/src/tests/warscroll/warscrollJson.test.ts
@@ -546,7 +546,6 @@ describe('getWarscrollArmyFromJson', () => {
     const parsedText = getFile('1585867355154-Warscroll_Builder')
     const res = getWarscrollArmyFromPdf(parsedText)
     expect(res.selections.artifacts).toContain('Fusil of Conflagration')
-    
   })
 
   it('should work with Hrothgorn', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "es5",
+    "useUnknownInCatchVariables": false
   },
   "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13457,10 +13457,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
+  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- Added `"useUnknownInCatchVariables": false` to `tsconfig.json` to stop annoying compilation errors (when `catch(err)` was not explicitly defined, we got tons of errors.)