### PR TITLE
Orruk Warclans - Remove Command Ability: "Go on Ladz, Get Stuck In"

### DIFF
--- a/src/factions/orruk_warclans/ironjawz/command_abilities.ts
+++ b/src/factions/orruk_warclans/ironjawz/command_abilities.ts
@@ -1,16 +1,7 @@
 import { tagAs } from 'factions/metatagger'
-import { END_OF_CHARGE_PHASE, HERO_PHASE, START_OF_COMBAT_PHASE } from 'types/phases'
+import { END_OF_CHARGE_PHASE, HERO_PHASE } from 'types/phases'
 
 const IronjawzCommandAbilities = {
-  'Go on Ladz, Get Stuck In!': {
-    effects: [
-      {
-        name: `Go on Ladz, Get Stuck In!`,
-        desc: `Pick 1 friendly IRONJAWZ unit wholly within 12" of a friendly model with this command ability, or wholly within 18" of a friendly model with this command ability that is a MONSTER. Until the end of that phase, add 1 to hit rolls for attacks made by that unit. A unit cannot benefit from this command ability more than once per phase.`,
-        when: [START_OF_COMBAT_PHASE],
-      },
-    ],
-  },
   'Mighty Destroyers': {
     effects: [
       {

--- a/src/factions/orruk_warclans/ironjawz/units.ts
+++ b/src/factions/orruk_warclans/ironjawz/units.ts
@@ -14,7 +14,6 @@ import {
   START_OF_COMBAT_PHASE,
 } from 'types/phases'
 import rule_sources from '../rule_sources'
-import command_abilities from './command_abilities'
 import spells from './spells'
 
 const StrengthFromVictoryEffect = {
@@ -62,9 +61,6 @@ const IronjawzUnits = {
     ],
   },
   'Megaboss on Maw-Krusha': {
-    mandatory: {
-      command_abilities: [keyPicker(command_abilities, ['Go on Ladz, Get Stuck In!'])],
-    },
     effects: [
       StrengthFromVictoryEffect,
       DestructiveBulkEffect,
@@ -77,9 +73,6 @@ const IronjawzUnits = {
     ],
   },
   'Orruk Megaboss': {
-    mandatory: {
-      command_abilities: [keyPicker(command_abilities, ['Go on Ladz, Get Stuck In!'])],
-    },
     effects: [
       StrengthFromVictoryEffect,
       {


### PR DESCRIPTION
Brought to my attention in the AoS subreddit: https://www.reddit.com/r/ageofsigmar/comments/s53nno/comment/htsss5v/?utm_source=share&utm_medium=web2x&context=3

"Go on Ladz, Get Stuck In" was removed from the Megaboss Warscrolls with the new tome.