### PR TITLE
rename rotbringers sorcerer

### DIFF
--- a/src/factions/nurgle/units.ts
+++ b/src/factions/nurgle/units.ts
@@ -400,7 +400,7 @@ const Units = {
       },
     ],
   },
-  'Rotbringers Sorcerer': {
+  'Rotbringer Sorcerer': {
     mandatory: {
       spells: [keyPicker(Spells, ['Stream of Corruption'])],
     },


### PR DESCRIPTION
rename rotbringers sorcerer to match warscroll wording (fixes import failure)