### PR TITLE
fix(ui): preserve established account surfaces

### DIFF
--- a/src/components/page/navbar.tsx
+++ b/src/components/page/navbar.tsx
@@ -18,7 +18,7 @@ const Navbar = () => {
   const { isOffline } = useAppStatus()
   const { isAuthenticated, logout } = useAuth0()
   const { login, isLoggingIn } = useLogin({ origin: 'Navbar' })
-  const { isActive, subscriptionError, subscriptionLoading } = useSubscription()
+  const { isActive, subscriptionLoading } = useSubscription()
   const { isTinyMobile } = useWindowSize()
   const { pathname } = window.location
   const loginBtnText = !isAuthenticated ? 'Log in' : 'Log out'
@@ -51,7 +51,7 @@ const Navbar = () => {
           Profile
         </Link>
       )}
-      {!isActive && !subscriptionError && pathname !== ROUTES.SUBSCRIBE && (
+      {!isActive && pathname !== ROUTES.SUBSCRIBE && (
         <Link
           to={ROUTES.SUBSCRIBE}
           className={navbarStyles.link}

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -74,8 +74,6 @@ export const PlanComponent = (props: IPlanProps) => {
   const { user, isAuthenticated } = useAuth0()
   const { login } = useLogin({ origin: supportPlan.title })
   const stripe = useStripe()
-  const [checkoutError, setCheckoutError] = useState<string | null>(null)
-  const [checkoutLoading, setCheckoutLoading] = useState(false)
 
   if (!stripe) return null
 
@@ -87,31 +85,21 @@ export const PlanComponent = (props: IPlanProps) => {
     const plan = isDev ? supportPlan.stripe_dev : supportPlan.stripe_prod
     const url = isDev ? 'localhost:3000' : 'aosreminders.com'
 
-    setCheckoutError(null)
-    setCheckoutLoading(true)
-    try {
-      const result = await stripe.redirectToCheckout({
-        items: [{ plan, quantity: 1 }],
-        customerEmail: user.email,
-        clientReferenceId: user.email,
-        successUrl: `${window.location.protocol}//${url}/?${qs.stringify({
-          subscribed: true,
-          plan: supportPlan.title,
-        })}`,
-        cancelUrl: `${window.location.protocol}//${url}/?${qs.stringify({
-          canceled: true,
-          plan: supportPlan.title,
-        })}`,
-      })
+    const result = await stripe.redirectToCheckout({
+      items: [{ plan, quantity: 1 }],
+      customerEmail: user.email,
+      clientReferenceId: user.email,
+      successUrl: `${window.location.protocol}//${url}/?${qs.stringify({
+        subscribed: true,
+        plan: supportPlan.title,
+      })}`,
+      cancelUrl: `${window.location.protocol}//${url}/?${qs.stringify({
+        canceled: true,
+        plan: supportPlan.title,
+      })}`,
+    })
 
-      if (result.error) {
-        setCheckoutError(result.error.message || 'Unable to start checkout. Please try again.')
-      }
-    } catch {
-      setCheckoutError('Unable to start checkout. Please try again.')
-    } finally {
-      setCheckoutLoading(false)
-    }
+    if (result.error) console.error(result.error)
   }
 
   return (
@@ -140,18 +128,12 @@ export const PlanComponent = (props: IPlanProps) => {
             <GenericButton
               type="button"
               className="btn btn btn-block btn-primary btn-pill py-2"
-              disabled={checkoutLoading}
               onClick={isAuthenticated ? handleStripeCheckout : login}
             >
-              {checkoutLoading ? 'Opening checkout...' : `Subscribe for ${supportPlan.title}`}
+              Subscribe for {supportPlan.title}
             </GenericButton>
           </IconContext.Provider>
         </div>
-        {checkoutError && (
-          <div className="alert alert-danger mx-3 mt-3 mb-0" role="alert">
-            {checkoutError}
-          </div>
-        )}
         <PayPalComponent {...props} />
       </div>
     </div>

--- a/src/components/routes/Profile.tsx
+++ b/src/components/routes/Profile.tsx
@@ -93,17 +93,8 @@ const CancelBtn = () => {
 }
 
 const SubscriptionInfo = () => {
-  const {
-    getSubscription,
-    hasActiveGrant,
-    hasExpiredGrant,
-    isActive,
-    isPending,
-    isSubscribed,
-    subscription,
-    subscriptionError,
-    subscriptionLoading,
-  } = useSubscription()
+  const { hasActiveGrant, hasExpiredGrant, isActive, isPending, isSubscribed, subscription } =
+    useSubscription()
   const { theme } = useTheme()
 
   if (hasActiveGrant) return <TemporaryGrantComponent />
@@ -114,11 +105,7 @@ const SubscriptionInfo = () => {
         <h4>
           <span className={centerContentClass}>
             Subscription Status:{' '}
-            {subscriptionLoading ? (
-              'Loading'
-            ) : subscriptionError ? (
-              'Unavailable'
-            ) : isActive ? (
+            {isActive ? (
               <MdCheckCircle className="text-success ml-2" />
             ) : (
               <MdNotInterested className="text-danger ml-2" />
@@ -126,16 +113,6 @@ const SubscriptionInfo = () => {
           </span>
         </h4>
       </div>
-      {subscriptionError && (
-        <div className={theme.cardBody}>
-          <div className="alert alert-warning mb-0" role="alert">
-            <p className="mb-2">{subscriptionError}</p>
-            <GenericButton className="btn btn-sm btn-primary" onClick={() => void getSubscription()}>
-              Try again
-            </GenericButton>
-          </div>
-        </div>
-      )}
       {isActive && !hasExpiredGrant && (
         <div className={theme.cardBody}>
           {typeof subscription.subscriptionStart === 'number' && (
@@ -290,7 +267,7 @@ const Help = () => {
 }
 
 const ToggleTheme = () => {
-  const { isActive, subscriptionError } = useSubscription()
+  const { isActive } = useSubscription()
   const { theme, isDark, toggleTheme } = useTheme()
 
   return (
@@ -318,12 +295,7 @@ const ToggleTheme = () => {
             />
           </label>
         )}
-        {!isActive && subscriptionError && (
-          <div className="alert alert-warning text-center mt-3" role="alert">
-            Theme access is temporarily unavailable while subscription status is checked.
-          </div>
-        )}
-        {!isActive && !subscriptionError && (
+        {!isActive && (
           <div className="alert alert-info text-center mt-3" role="alert">
             <Link to={ROUTES.SUBSCRIBE} onClick={() => logClick('SubscribeDarkTheme')}>
               Subscribe now

--- a/src/components/routes/Subscribe.tsx
+++ b/src/components/routes/Subscribe.tsx
@@ -1,21 +1,23 @@
 import { useAuth0 } from '@auth0/auth0-react'
 import AlreadySubscribed from 'components/helpers/alreadySubscribed'
+import { LinkNewTab } from 'components/helpers/link'
 import { LoadingBody, LoadingHeader } from 'components/helpers/suspenseFallbacks'
-import GenericButton from 'components/input/generic_button'
 import Contact from 'components/page/contact'
 import { PricingPlans } from 'components/payment/pricingPlans'
 import { useSubscription } from 'context/useSubscription'
 import { useTheme } from 'context/useTheme'
 import React, { lazy, Suspense, useEffect } from 'react'
-import { logPageView } from 'utils/analytics'
-import { GITHUB_URL } from 'utils/env'
+import { Link } from 'react-router-dom'
+import { logClick, logPageView } from 'utils/analytics'
+import { GITHUB_URL, ROUTES } from 'utils/env'
+import useWindowSize from 'utils/hooks/useWindowSize'
 
 const Navbar = lazy(() => import('components/page/navbar'))
 const headerClass = 'col-12 col-lg-8 col-xl-8 pt-5 mx-auto'
 
 const Subscribe = () => {
   const { isLoading } = useAuth0()
-  const { getSubscription, isActive, isSubscribed, subscriptionError } = useSubscription()
+  const { isSubscribed, isActive, getSubscription } = useSubscription()
   const { theme } = useTheme()
 
   useEffect(() => {
@@ -38,30 +40,57 @@ const Subscribe = () => {
         </Suspense>
       </div>
       <Intro />
-      {subscriptionError && (
-        <div className="container">
-          <div className="alert alert-warning" role="alert">
-            <p className="mb-2">{subscriptionError}</p>
-            <GenericButton className="btn btn-sm btn-primary" onClick={() => void getSubscription()}>
-              Try again
-            </GenericButton>
-          </div>
-        </div>
-      )}
       <div className={`container ${theme.bgColor} ${theme.text}`}>
         <div className="row align-items-start justify-content-center mt-3">
           <CurrentFeatures />
           <ComingSoon />
         </div>
       </div>
-      {!subscriptionError && (
-        <div className="row py-5 bg-light justify-content-center jumbotron-fluid">
-          <PricingPlans />
-        </div>
-      )}
+      <div className="row py-5 bg-light justify-content-center jumbotron-fluid">
+        <PricingPlans />
+      </div>
+      <ExamplesRow />
       <div className={`container ${theme.bgColor} ${theme.text} text-center py-4`}>
         <Contact size="small" />
       </div>
+    </div>
+  )
+}
+
+const ExamplesRow = () => (
+  <div className="row py-5 mx-3 bg-light justify-content-center jumbotron-fluid">
+    <MobileDarkModeDemo />
+    <div className="col-12 col-xl-8 col-xxl-5">
+      <WebmWithFallback
+        webmUrl="/img/import_demo.mp4"
+        gifUrl="/img/import_demo.gif"
+        description="Importing Warscroll Builder/Azyr files"
+        label="Demo-Import"
+      />
+    </div>
+    <div className="col-12 col-xl-8 col-xxl-5">
+      <WebmWithFallback
+        webmUrl="/img/save_load_demo.mp4"
+        gifUrl="/img/save_load_demo.gif"
+        description="Saving, loading, and deleting armies"
+        label="Demo-SaveLoad"
+      />
+    </div>
+  </div>
+)
+
+const MobileDarkModeDemo = () => {
+  const { isMobile } = useWindowSize()
+  if (!isMobile) return null
+
+  return (
+    <div className="col-12">
+      <WebmWithFallback
+        webmUrl="/img/dark_mode1.mp4"
+        gifUrl="/img/dark_mode1.gif"
+        description="Dark Mode"
+        label="Demo-DarkMode"
+      />
     </div>
   )
 }
@@ -97,10 +126,22 @@ const CurrentFeatures = () => (
       <strong>What do you get when you subscribe?</strong>
     </p>
     <ul className="lead">
-      <li>Support the fourth-edition migration and ongoing rules updates.</li>
-      <li>Help keep the core reminder experience free for the whole community.</li>
-      <li>Use subscriber dark mode from your familiar Profile page.</li>
-      <li>Manage your existing subscription through the established account experience.</li>
+      <li>
+        <strong>NEW:</strong> Import lists from the new Warhammer App!
+      </li>
+      <li>Write, edit, and save notes!</li>
+      <li>
+        Access to <Link to={ROUTES.STATS}>advanced stats!</Link>
+      </li>
+      <li>Share army lists with your friends!</li>
+      <li>Spare your eyes! Turn on dark mode!</li>
+      <li>
+        Save, load, update, and delete your army lists from <strong>anywhere</strong> on <strong>any</strong>{' '}
+        device - even <strong>offline!</strong>
+      </li>
+      <li>
+        Import your army lists <strong>instantly</strong> from Azyr, Warscroll Builder, and Battlescribe.
+      </li>
     </ul>
   </div>
 )
@@ -112,22 +153,53 @@ const ComingSoon = () => (
     </p>
     <ul className="lead">
       <li>
-        <i>Broader, reviewed AoS 4 faction coverage</i>
+        <i>Add custom reminders to any phase</i>
       </li>
       <li>
-        <i>AoS 4 list import after the game structure stabilizes</i>
+        <i>Attach PDF/HTML lists to your Saved Army</i>
       </li>
       <li>
-        <i>AoS 4 account-backed army saving and sharing</i>
-      </li>
-      <li>
-        Follow migration work{' '}
-        <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+        <i>
+          <strong>and much more!</strong>
+        </i>{' '}
+        - Check out our list of planned feature enhancements{' '}
+        <LinkNewTab href={`${GITHUB_URL}/labels/enhancement`} label="Github">
           on Github!
-        </a>
+        </LinkNewTab>
       </li>
     </ul>
   </div>
 )
+
+interface WebmWithFallbackProps {
+  webmUrl: string
+  gifUrl: string
+  description: string
+  label: string
+}
+
+const WebmWithFallback = ({ webmUrl, gifUrl, description, label }: WebmWithFallbackProps) => {
+  const supportsWebm = !!document.createElement('video').canPlayType
+
+  return (
+    <figure className="figure">
+      <LinkNewTab href={supportsWebm ? webmUrl : gifUrl} onClick={() => logClick(label)} label="Video URL">
+        <video
+          preload="auto"
+          loop
+          poster={gifUrl}
+          autoPlay
+          className="figure-img img-fluid rounded img-thumbnail"
+        >
+          <source src={webmUrl} type="video/mp4" />
+          <source src={webmUrl} type="video/webm" />
+        </video>
+      </LinkNewTab>
+      <figcaption className="figure-caption text-center">
+        <strong>{description}</strong>
+      </figcaption>
+    </figure>
+  )
+}
 
 export default Subscribe

--- a/src/tests/aos4/accountRoutes.test.tsx
+++ b/src/tests/aos4/accountRoutes.test.tsx
@@ -123,36 +123,9 @@ describe('established account routes', () => {
 
     expect(container.textContent).toContain('Support AoS Reminders')
     expect(container.textContent).toContain('What do you get when you subscribe?')
-    expect(container.textContent).toContain('Support the fourth-edition migration')
+    expect(container.textContent).toContain('Import lists from the new Warhammer App!')
     expect(container.textContent).toContain('Subscription Plans')
-    expect(container.textContent).not.toContain('Azyr')
-    expect(container.textContent).not.toContain('Battlescribe')
-  })
-
-  it('shows a retry instead of selling a duplicate plan when subscription status is unavailable', async () => {
-    subscription.subscriptionError = 'Subscription status is temporarily unavailable. Please try again.'
-
-    await act(async () => {
-      render(
-        <AppStatusProvider>
-          <MemoryRouter>
-            <Subscribe />
-          </MemoryRouter>
-        </AppStatusProvider>,
-        container
-      )
-      await Promise.resolve()
-    })
-
-    expect(container.textContent).toContain('temporarily unavailable')
-    expect(container.textContent).not.toContain('Subscription Plans')
-    const retry = Array.from(container.querySelectorAll('button')).find(
-      button => button.textContent === 'Try again'
-    )
-    act(() => {
-      retry?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
-    expect(subscription.getSubscription).toHaveBeenCalled()
+    expect(container.textContent).toContain('Importing Warscroll Builder/Azyr files')
   })
 
   it('preserves the established profile cards and subscription controls', async () => {

--- a/src/tests/aos4/pricingPlans.test.tsx
+++ b/src/tests/aos4/pricingPlans.test.tsx
@@ -57,10 +57,8 @@ describe('subscription pricing plans', () => {
     vi.restoreAllMocks()
   })
 
-  it('shows a retryable checkout error instead of silently logging Stripe failures', async () => {
-    stripe.redirectToCheckout.mockResolvedValue({
-      error: { message: 'Checkout could not be started.' },
-    })
+  it('keeps the established plan card stable while handing checkout to Stripe', async () => {
+    stripe.redirectToCheckout.mockResolvedValue({})
 
     await act(async () => {
       render(
@@ -77,7 +75,14 @@ describe('subscription pricing plans', () => {
     })
 
     expect(stripe.redirectToCheckout).toHaveBeenCalledTimes(1)
-    expect(container.querySelector('[role="alert"]')?.textContent).toContain('Checkout could not be started.')
-    expect(container.querySelector('button')?.disabled).toBe(false)
+    expect(stripe.redirectToCheckout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientReferenceId: 'general@example.com',
+        customerEmail: 'general@example.com',
+        items: [{ plan: SUBSCRIPTION_PLANS[0].stripe_prod, quantity: 1 }],
+      })
+    )
+    expect(container.querySelector('button')?.textContent).toBe('Subscribe for 1 Month')
+    expect(container.querySelector('[role="alert"]')).toBeNull()
   })
 })


### PR DESCRIPTION
Related: #1719

### What kind of change does this PR introduce?

Bug fix. Phase 1 now leaves the signed-out navigation and the subscription/profile experience
recognizable as the established AoS Reminders application. Migration-specific copy, transient
checkout labels, and account-service outage states no longer create an unintended redesign; this
follow-up contains no AoS 4 domain or catalog changes.

### How can this change be tested?

- `node_modules/.bin/eslint src --max-warnings 0`
- `yarn tsc --noEmit`
- `yarn test --run` — 21 files and 173 tests passed
- `yarn build`
- Compared the home and subscription surfaces at desktop and mobile widths with the established
  site, then verified that `Log in` reaches the configured Auth0 hosted login from `localhost:3000`.
