### PR TITLE
docs(aos4): hand off completed Phase 1

### DIFF
--- a/docs/handoffs/2026-07-28-aos4-phase-1.md
+++ b/docs/handoffs/2026-07-28-aos4-phase-1.md
@@ -1,0 +1,191 @@
+# AoS 4 Phase 1 handoff
+
+## Status
+
+Phase 1 is complete on `aos4-migration` as of 2026-07-28.
+
+- Phase 1a established the AoS 4-only domain, selection, reminder, state, storage, and runtime
+  boundaries.
+- Phase 1b accepted a reviewed full-faction corpus, authoritative Games Workshop evidence, current
+  Wahapedia HTML, stable identities, reconciliation, and deterministic generation.
+- The familiar AoS Reminders presentation, account shell, Auth0 flow, subscriptions, themes,
+  printing, footer, and responsive behavior remain intact.
+- AoS 3 runtime data and compatibility paths remain retired.
+- Phase 2 package and framework modernization has not started.
+
+The completed corpus landed through
+[PR #1723](https://github.com/daviseford/aos-reminders/pull/1723) at integration commit
+`fe607e03`. The long-lived
+[draft integration PR #1717](https://github.com/daviseford/aos-reminders/pull/1717) still targets
+`master`. It must remain draft and unmerged until the user explicitly authorizes launch.
+
+## Accepted snapshot
+
+The accepted manifest contains 104 immutable source artifacts:
+
+| Source | Artifacts |
+|---|---:|
+| Wahapedia pipe-delimited exports | 13 |
+| Current Wahapedia HTML | 55 |
+| Games Workshop PDFs | 36 |
+
+The strict-pass generated catalog contains:
+
+| Entity | Count |
+|---|---:|
+| Factions | 28 |
+| Warscrolls | 1,268 |
+| Battle profiles | 1,002 |
+| Abilities | 4,260 |
+| Weapons | 2,247 |
+| Content groups | 1,172 |
+| Relationships | 10,331 |
+| Current source records | 17,443 |
+| Superseded source records retained for audit | 18,897 |
+
+There are five explicit rules contexts:
+
+- current standard AoS 4
+- current Spearhead
+- historical standard content through 2026-07-05
+- Legends
+- seasonal General's Handbook 2026-27, Scourge of Aqshy
+
+The runtime defaults to Stormcast Eternals in the 2026-27 seasonal context.
+
+Key snapshot files:
+
+- `data/aos4/manifests/accepted-2026-07-27.json`
+- `data/aos4/reviews/corpus-2026-07-27.json`
+- `data/aos4/identities/corpus.json`
+- `data/aos4/catalog/catalog.json`
+- `data/aos4/catalog/official-battle-profiles.json`
+- `data/aos4/reports/corpus-2026-07-27-reconciliation.json`
+- `data/aos4/reports/corpus-2026-07-27-summary.json`
+- `src/aos4/generated/corpus/runtime.json`
+
+Do not hand-edit generated products. Change reviewed inputs or pipeline code, regenerate, inspect the
+diff, and update the review gate deliberately.
+
+## Source and reconciliation state
+
+Games Workshop remains authoritative. Wahapedia is the coherent discovery and coverage source.
+The pipeline keeps acquisition bytes, provider records, normalized facts, accepted entities, and
+runtime projections separate.
+
+The official Battle Profiles ledger contains 1,350 facts:
+
+- 1,303 effective and 47 superseded
+- 967 unit profiles
+- 307 roster options
+- 76 Regiments of Renown
+- 928 applied to runtime
+- 12 retained as explicit profile-only gaps
+- 363 structured reference facts
+
+Reconciliation is locked to:
+
+- 1,268 Wahapedia warscroll pages
+- 928 matched official unit facts
+- 12 unmatched official unit facts
+- 669 preserved field disagreements
+- checksum `c8dfaaa6cac77218ef42ec3a10197602a62d31aeef5090471726ab6be245aee4`
+
+The 12 profile-only gaps are not silently invented as warscrolls. They are ten new Ogor Mawtribes
+profiles (`Cleavers`, `Gluttons`, `Grell Firefist`, `Gutseers`, `Hunters with Sabrefangs`,
+`Maulbeast Cavalry`, `Maulbeast Raiders`, `Morga the Mighty, Overtyrant`,
+`Redd the Maw, High Slaughtermaster`, and `Tyrant on Glutthorn`), Stormcast Eternals'
+`Lorai, Child of the Abyss`, and the Legends profile `The Emberwatch`. Revisit them only when a
+current warscroll source becomes available.
+
+The 669 disagreements are audit evidence, not unresolved runtime ambiguity: official values win
+where the reviewed pipeline has an applicable official fact. The reconciliation gate detects any
+future change in matches, gaps, or disagreements.
+
+The final review also fixed four source-boundary defects:
+
+- Legends facts can match only a warscroll with a Legends identity, preventing a retired profile
+  from leaking into same-named current warscrolls.
+- Offline candidate replay derives the complete accepted adapter URL set and no longer reports
+  unused accepted artifacts as replayed output.
+- the acquisition timeout remains active through response-body consumption
+- Wahapedia profile parsing no longer creates a new JSDOM document for every profile
+
+## Runtime and UI boundary
+
+The browser imports only checked-in products under `src/aos4/generated/`. It never fetches source
+data.
+
+The UI is intentionally evolutionary rather than redesigned:
+
+- dark-blue masthead, typography, spacing, edit/play control, teal selection cards, reminder cards,
+  notes, hide/show behavior, footer, and responsive layout match the live application
+- signed-out navigation remains `Subscribe`, `FAQ`, and `Log in`
+- authenticated navigation remains `Profile` and `Log out`
+- Auth0, subscription status/cancellation, subscriber themes, and account routes remain connected
+- printing and PDF export use the AoS 4 view model without restoring AoS 3 data
+
+Desktop and 390-pixel mobile browser comparisons against `https://aosreminders.com/` were completed
+after the final corpus merge. Treat broad UI changes, navigation changes, or account-flow changes
+as a code smell unless the user explicitly requests them.
+
+## Verification at handoff
+
+The integrated state passed:
+
+```powershell
+yarn lint
+yarn tsc --noEmit
+yarn test --run
+yarn build
+yarn data:aos4:generate
+```
+
+Results:
+
+- ESLint clean
+- TypeScript clean
+- 29 test files and 242 tests passed
+- production Vite build passed
+- deterministic generation verified every checked-in product byte-for-byte
+- GitHub's `Lint, Test, and Build` check passed on draft PR #1717
+
+Known non-blocking signals:
+
+- jsdom prints `HTMLCanvasElement.getContext` warnings while the print tests still pass
+- the generated Home chunk is about 11.5 MB before gzip; bundle/package work belongs to Phase 2
+
+## How to refresh data
+
+Read `AGENTS.md` and `docs/data/aos4-maintenance.md` before refreshing sources.
+
+For deterministic validation of the accepted snapshot:
+
+```powershell
+yarn data:aos4:candidate `
+  --accepted-manifest data/aos4/manifests/accepted-2026-07-27.json `
+  --offline `
+  --output .cache/aos4/replay-<new-name>
+
+yarn data:aos4:generate
+```
+
+For a live refresh, write to a new candidate directory, retain the immutable source artifacts in
+the ignored cache, review source and reconciliation diagnostics, then update the accepted manifest
+and review file. Never overwrite a candidate directory or promote a blocked candidate wholesale.
+
+## Next agent
+
+Start from the latest `origin/aos4-migration`. Preserve the draft integration PR and branch
+strategy in `AGENTS.md`.
+
+The next program of work is Phase 2 planning and modernization:
+
+1. measure and plan dependency/framework upgrades before changing packages
+2. preserve the current AoS 4 domain and generated-data contracts while modernizing the shell
+3. address bundle loading and print-test environment warnings as part of that plan
+4. keep UI/account continuity tests and live-site comparisons as release gates
+5. target every work PR at `aos4-migration`, never `master`
+
+Do not reintroduce AoS 3 compatibility, provider-shaped runtime models, browser source fetching, or
+name-based identities to make modernization easier.


### PR DESCRIPTION
### What kind of change does this PR introduce?

Documentation update. The next agent can now resume from the completed Phase 1 integration with the
accepted corpus shape, reconciliation state, verification evidence, source-refresh workflow, UI
constraints, PR topology, known non-blocking signals, and Phase 2 starting point in one durable
handoff.

Related: #1723

### How can this change be tested?

- Verified every count and checksum against the checked-in strict-pass reports.
- Confirmed PR #1723 is merged into `aos4-migration` and draft launch PR #1717 remains unmerged.
- Ran `git diff --check`.
