### PR TITLE
ci: gate aos4-migration pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,11 @@ name: Deployment
 
 # from https://github.com/linuxacademy/content-github-actions-deep-dive-lab/blob/solution/%20.github/workflows/production.yaml
 
+# This workflow publishes to production (S3 + CloudFront). Keep the trigger list to `master` only.
+#
+# In particular, do NOT add `workflow_run` on "Lint, Test, and Build", and do NOT add
+# `aos4-migration` or any other integration branch here. Lint/test/build coverage for those
+# branches belongs in nodejs.yml, which holds no credentials and ships nothing.
 on:
   push:
     branches:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,10 +1,12 @@
 name: Lint, Test, and Build
 
+# `aos4-migration` is the long-lived integration branch for the AoS 4 migration (see AGENTS.md).
+# Without it here, migration sub-PRs merge with no lint/test/build gate at all.
 on:
   push:
-    branches: [ master ]
+    branches: [ master, aos4-migration ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, aos4-migration ]
 
 env:
   CI: true
@@ -29,8 +31,8 @@ jobs:
       - name: Lint with eslint
         run: yarn lint
 
-      - name: Test with jest
-        run: yarn test
+      - name: Test with vitest
+        run: yarn test --run
 
       - name: Build with TypeScript
         run: yarn build


### PR DESCRIPTION
Follow-up to #1722.

## Problem

`nodejs.yml` triggers only on `master`:

```yaml
on:
  push:
    branches: [ master ]
  pull_request:
    branches: [ master ]
```

Migration sub-PRs target `aos4-migration` (per AGENTS.md), so **none of them ran lint, test, or
build**. The only check reporting on them is the WIP marketplace app, which verifies the title
doesn't contain "WIP". #1722 showed a green tick having run no CI at all.

## Change

- Adds `aos4-migration` to both the `push` and `pull_request` branch filters.
- `yarn test` → `yarn test --run`. `CI: true` already made vitest exit rather than watch, but the
  explicit flag means the step cannot hang if that env var is ever dropped.
- Renames the step from "Test with jest" to "Test with vitest" — the suite moved to vitest a while
  back and the label was stale.

No change to the job itself, the Node version, or the `master` behaviour.

## Verification

This PR gates itself: it targets `aos4-migration`, and for `pull_request` events GitHub evaluates
the workflow from the PR's merge commit, so the new filter applies to this PR. A green
`Lint, Test, and Build` check here *is* the proof it works — that check has never appeared on an
`aos4-migration` PR before.

Locally on this branch: lint clean, 242 tests passing, build succeeds.

https://claude.ai/code/session_019nXN9qA3veW9ZwXPRxaUiT