### PR TITLE
feat(aos4): structured tags on rule cards

### DIFF
--- a/src/aos4/print/document.ts
+++ b/src/aos4/print/document.ts
@@ -1,4 +1,4 @@
-import type { PrintDocument, PrintParagraph, PrintRule, PrintSection } from './types'
+import type { PrintDocument, PrintParagraph, PrintRule, PrintSection, PrintTag } from './types'
 
 /**
  * Structural subset of `Aos4ReminderViewModel`. Declared here so the print model does not depend on
@@ -10,6 +10,8 @@ export interface PrintReminderInput {
   windowKey: string
   windowLabel: string
   typeLabel: string
+  /** Discrete timing facets. Absent on legacy fixtures, which fall back to `typeLabel`. */
+  tags?: PrintTag[]
   declare?: string
   reactionTrigger?: string
   effect: string
@@ -45,11 +47,22 @@ const paragraphs = (reminder: PrintReminderInput): PrintParagraph[] => [
   ...(reminder.note ? [{ role: 'ruleNote' as const, label: 'Note', text: normalize(reminder.note) }] : []),
 ]
 
-const toRule = (reminder: PrintReminderInput): PrintRule => ({
-  id: reminder.id,
-  title: reminder.typeLabel ? `${reminder.typeLabel} - ${reminder.name}` : reminder.name,
-  paragraphs: paragraphs(reminder),
-})
+/**
+ * With tags present the facets are drawn as boxes, so the title is just the name. Without them the
+ * old flattened prefix is kept, which is what lets legacy fixtures and any caller that has not
+ * adopted tags keep working unchanged.
+ */
+const toRule = (reminder: PrintReminderInput): PrintRule => {
+  const tags = reminder.tags ?? []
+  if (tags.length) {
+    return { id: reminder.id, title: reminder.name, tags, paragraphs: paragraphs(reminder) }
+  }
+  return {
+    id: reminder.id,
+    title: reminder.typeLabel ? `${reminder.typeLabel} - ${reminder.name}` : reminder.name,
+    paragraphs: paragraphs(reminder),
+  }
+}
 
 const summaryLine = (warscroll: PrintWarscrollInput): string => {
   if (!warscroll.profile) return warscroll.name

--- a/src/aos4/print/layout.ts
+++ b/src/aos4/print/layout.ts
@@ -1,9 +1,12 @@
 import type {
   PlacedLine,
+  PlacedTag,
   PrintDocument,
   PrintPlan,
   PrintPreset,
   PrintRoleStyle,
+  PrintRule,
+  PrintTag,
   PrintTextMeasurer,
   PrintTextRole,
 } from './types'
@@ -12,6 +15,8 @@ interface LineDraft {
   role: PrintTextRole
   text: string
   label?: string
+  /** `xIn` is relative to the column origin here; `emit` resolves it to an absolute page position. */
+  tags?: PlacedTag[]
   widthIn: number
   lineHeightIn: number
   spaceBeforeIn: number
@@ -145,6 +150,75 @@ const draftLines = (
   }))
 }
 
+/** Box width for a tag: its text plus symmetric padding. */
+const tagBoxWidthIn = (context: DraftContext, tag: PrintTag): number =>
+  context.measurer.widthIn(tag.label, context.preset.roles.ruleTag) + context.preset.tagPaddingXIn * 2
+
+const TAG_GAP_IN = 0.05
+
+const totalTagWidthIn = (context: DraftContext, tags: PrintTag[]): number =>
+  tags.reduce((total, tag) => total + tagBoxWidthIn(context, tag), 0) + TAG_GAP_IN * (tags.length - 1)
+
+/** Lays tags left to right from `startXIn`, wrapping is the caller's problem. */
+const placeTagsFrom = (context: DraftContext, tags: PrintTag[], startXIn: number): PlacedTag[] => {
+  let cursor = startXIn
+  return tags.map(tag => {
+    const widthIn = tagBoxWidthIn(context, tag)
+    const placed = { ...tag, xIn: cursor, widthIn }
+    cursor += widthIn + TAG_GAP_IN
+    return placed
+  })
+}
+
+/**
+ * The rule title, with its tags either sharing the title line (right-aligned) or occupying their
+ * own line beneath it.
+ *
+ * `title-right` degrades to `below-title` whenever the title and tags would not fit on one line, so
+ * a long ability name never collides with its tags. Tag x-offsets are relative to the column origin
+ * and resolved to absolute inches during placement.
+ */
+const draftTitleWithTags = (context: DraftContext, rule: PrintRule, blockId: string): LineDraft[] => {
+  const tags = rule.tags ?? []
+  const titleDrafts = draftLines(context, 'ruleTitle', rule.title, { blockId })
+  if (!tags.length) return titleDrafts
+
+  const available = context.columnWidthIn
+  const tagsWidthIn = totalTagWidthIn(context, tags)
+  const lastTitleLine = titleDrafts[titleDrafts.length - 1]
+  const fitsBeside =
+    context.preset.tagPlacement === 'title-right' &&
+    titleDrafts.length === 1 &&
+    lastTitleLine.widthIn + TAG_GAP_IN * 2 + tagsWidthIn <= available
+
+  if (fitsBeside) {
+    return titleDrafts.map((draft, index) =>
+      index === titleDrafts.length - 1
+        ? { ...draft, tags: placeTagsFrom(context, tags, available - tagsWidthIn) }
+        : draft
+    )
+  }
+
+  const tagStyle = context.preset.roles.ruleTag
+  return [
+    ...titleDrafts,
+    {
+      role: 'ruleTag' as const,
+      text: '',
+      tags: placeTagsFrom(context, tags, 0),
+      widthIn: Math.min(tagsWidthIn, available),
+      lineHeightIn: lineHeightIn(tagStyle),
+      spaceBeforeIn: 0,
+      spaceAfterIn: tagStyle.spaceAfterIn ?? 0,
+      indentIn: 0,
+      align: 'left' as const,
+      boxed: false,
+      spansColumns: false,
+      blockId,
+    },
+  ]
+}
+
 const buildBlocks = (document: PrintDocument, context: DraftContext): FlowBlock[] => {
   const blocks: FlowBlock[] = []
 
@@ -165,7 +239,7 @@ const buildBlocks = (document: PrintDocument, context: DraftContext): FlowBlock[
         continuationTitle: `${rule.title} (continued)`,
         continuationRole: 'ruleTitle',
         lines: [
-          ...draftLines(context, 'ruleTitle', rule.title, { blockId }),
+          ...draftTitleWithTags(context, rule, blockId),
           ...rule.paragraphs.flatMap((paragraph, paragraphIndex) =>
             draftLines(context, paragraph.role, paragraph.text, {
               ...(paragraph.label ? { label: paragraph.label } : {}),
@@ -279,6 +353,14 @@ export const planPrintLayout = (
         boxed: draft.boxed,
         spansColumns: draft.spansColumns,
         ...(draft.label ? { label: draft.label } : {}),
+        ...(draft.tags
+          ? {
+              tags: draft.tags.map(tag => ({
+                ...tag,
+                xIn: columnOriginsIn[columnIndex] + tag.xIn,
+              })),
+            }
+          : {}),
         text: draft.text,
         ...(draft.blockId ? { blockId: draft.blockId } : {}),
         ...(draft.paragraphIndex === undefined ? {} : { paragraphIndex: draft.paragraphIndex }),

--- a/src/aos4/print/pdf.ts
+++ b/src/aos4/print/pdf.ts
@@ -39,6 +39,40 @@ const drawLine = (doc: jsPDF, plan: PrintPlan, line: PlacedLine) => {
   doc.text(line.text, line.xIn, line.yIn)
 }
 
+/**
+ * Draws a line's tag boxes. Every coordinate arrives resolved from the plan; this only picks ink and
+ * paints. The box is centred on the text baseline so a tag sitting beside a title reads as part of
+ * the same line.
+ */
+const drawTags = (doc: jsPDF, plan: PrintPlan, line: PlacedLine) => {
+  if (!line.tags?.length) return
+  const style = plan.preset.roles.ruleTag
+  const textHeightIn = style.sizePt / 72
+  const boxHeightIn = textHeightIn + 0.05
+  const top = line.yIn - textHeightIn - 0.012
+
+  line.tags.forEach(tag => {
+    const tone = plan.preset.tagTones[tag.tone]
+    doc.setLineWidth(0.005)
+    doc.setDrawColor(tone.border[0], tone.border[1], tone.border[2])
+
+    if (tone.fill) {
+      doc.setFillColor(tone.fill[0], tone.fill[1], tone.fill[2])
+      doc.roundedRect(tag.xIn, top, tag.widthIn, boxHeightIn, 0.02, 0.02, 'FD')
+    } else {
+      doc.roundedRect(tag.xIn, top, tag.widthIn, boxHeightIn, 0.02, 0.02, 'S')
+    }
+
+    doc.setFont('helvetica')
+    doc.setFontStyle(style.weight)
+    doc.setFontSize(style.sizePt)
+    doc.setTextColor(tone.text[0], tone.text[1], tone.text[2])
+    doc.text(tag.label, tag.xIn + plan.preset.tagPaddingXIn, line.yIn - 0.008)
+  })
+
+  doc.setTextColor(BLACK[0], BLACK[1], BLACK[2])
+}
+
 const drawSectionBox = (doc: jsPDF, plan: PrintPlan, line: PlacedLine) => {
   const style = plan.preset.roles[line.role]
   const height = (style.sizePt * style.leading) / 72
@@ -97,7 +131,8 @@ export const renderPrintPlanToPdf = (plan: PrintPlan, options: RenderPdfOptions)
       .filter(line => line.page === pageIndex)
       .forEach(line => {
         if (line.boxed) drawSectionBox(doc, plan, line)
-        drawLine(doc, plan, line)
+        drawTags(doc, plan, line)
+        if (line.text) drawLine(doc, plan, line)
       })
   }
 

--- a/src/aos4/print/presets.ts
+++ b/src/aos4/print/presets.ts
@@ -1,4 +1,11 @@
-import type { PrintPageSpec, PrintPreset, PrintRoleStyle, PrintTextRole } from './types'
+import type {
+  PrintPageSpec,
+  PrintPreset,
+  PrintRoleStyle,
+  PrintTagStyle,
+  PrintTagTone,
+  PrintTextRole,
+} from './types'
 
 export type PrintPageSize = 'a4' | 'letter'
 
@@ -42,6 +49,7 @@ const standardRoles: Record<PrintTextRole, PrintRoleStyle> = {
     spaceAfterIn: 0.1,
   },
   ruleTitle: { sizePt: 10, leading: 1.3, weight: 'bold', spaceBeforeIn: 0.1, spaceAfterIn: 0.02 },
+  ruleTag: { sizePt: 6.5, leading: 1.5, weight: 'bold', spaceAfterIn: 0.03 },
   ruleBody: { sizePt: 9.5, leading: 1.28, weight: 'normal' },
   ruleNote: { sizePt: 9.5, leading: 1.28, weight: 'italic', color: NOTE, indentIn: 0.18 },
   summaryHeading: {
@@ -76,6 +84,7 @@ const compactRoles: Record<PrintTextRole, PrintRoleStyle> = {
     spaceAfterIn: 0.06,
   },
   ruleTitle: { sizePt: 7.5, leading: 1.25, weight: 'bold', spaceBeforeIn: 0.07, spaceAfterIn: 0.015 },
+  ruleTag: { sizePt: 5.5, leading: 1.5, weight: 'bold', spaceAfterIn: 0.02 },
   ruleBody: { sizePt: 7, leading: 1.24, weight: 'normal' },
   ruleNote: { sizePt: 7, leading: 1.24, weight: 'italic', color: NOTE, indentIn: 0.12 },
   summaryHeading: {
@@ -90,12 +99,31 @@ const compactRoles: Record<PrintTextRole, PrintRoleStyle> = {
   footer: { sizePt: 7.5, leading: 1.3, weight: 'bold', align: 'center', spaceBeforeIn: 0.18 },
 }
 
+/**
+ * Tag ink. Fills stay very light so a greyscale printer renders them near-white and the dark tag
+ * text keeps its contrast; the border carries the distinction when colour is lost entirely.
+ */
+const TAG_TONES: Record<PrintTagTone, PrintTagStyle> = {
+  'kind-active': { fill: [224, 239, 245], text: [12, 74, 96], border: [180, 215, 228] },
+  'kind-reaction': { fill: [248, 236, 217], text: [121, 73, 13], border: [230, 205, 164] },
+  'kind-passive': { fill: [233, 238, 241], text: [70, 88, 95], border: [208, 218, 222] },
+  'turn-your': { fill: [230, 242, 234], text: [31, 83, 52], border: [188, 220, 199] },
+  'turn-enemy': { fill: [249, 232, 232], text: [124, 53, 53], border: [236, 201, 201] },
+  'turn-neutral': { fill: [238, 240, 242], text: [77, 90, 99], border: [216, 222, 226] },
+  priority: { fill: [248, 236, 217], text: [121, 73, 13], border: [230, 205, 164] },
+  usage: { text: [91, 107, 116], border: [185, 197, 204], dashed: true },
+}
+
 export const STANDARD_PRESET: PrintPreset = {
   id: 'standard',
   label: 'Standard',
   description: 'Larger type, one column, more whitespace',
   page: page('a4', 0.6, 1, 0),
   roles: standardRoles,
+  // 7.07in of measure leaves ample room beside the title.
+  tagPlacement: 'title-right',
+  tagTones: TAG_TONES,
+  tagPaddingXIn: 0.045,
 }
 
 export const COMPACT_PRESET: PrintPreset = {
@@ -104,6 +132,10 @@ export const COMPACT_PRESET: PrintPreset = {
   description: 'Smaller type, two columns, fewer pages',
   page: page('a4', 0.45, 2, 0.28),
   roles: compactRoles,
+  // 3.54in per column is far too narrow to share a line with the title.
+  tagPlacement: 'below-title',
+  tagTones: TAG_TONES,
+  tagPaddingXIn: 0.035,
 }
 
 export const PRINT_PRESETS = [STANDARD_PRESET, COMPACT_PRESET]

--- a/src/aos4/print/types.ts
+++ b/src/aos4/print/types.ts
@@ -11,6 +11,7 @@ export type PrintTextRole =
   | 'documentSubtitle'
   | 'sectionHeading'
   | 'ruleTitle'
+  | 'ruleTag'
   | 'ruleBody'
   | 'ruleNote'
   | 'summaryHeading'
@@ -24,10 +25,41 @@ export interface PrintParagraph {
   text: string
 }
 
+/** Names the facet, not a colour. `PrintPreset.tagTones` maps it to ink. */
+export type PrintTagTone =
+  | 'kind-active'
+  | 'kind-reaction'
+  | 'kind-passive'
+  | 'turn-your'
+  | 'turn-enemy'
+  | 'turn-neutral'
+  | 'usage'
+  | 'priority'
+
+export interface PrintTag {
+  label: string
+  tone: PrintTagTone
+}
+
+export interface PrintTagStyle {
+  fill?: readonly [number, number, number]
+  text: readonly [number, number, number]
+  border: readonly [number, number, number]
+  /** Dashed borders mark the usage limit, which is a constraint rather than a classification. */
+  dashed?: boolean
+}
+
 export interface PrintRule {
   id: string
   title: string
+  tags?: PrintTag[]
   paragraphs: PrintParagraph[]
+}
+
+/** A tag with its box resolved to absolute inches by the layout. */
+export interface PlacedTag extends PrintTag {
+  xIn: number
+  widthIn: number
 }
 
 export interface PrintSection {
@@ -85,6 +117,15 @@ export interface PrintPreset {
   description: string
   page: PrintPageSpec
   roles: Record<PrintTextRole, PrintRoleStyle>
+  /**
+   * Where a rule's tags sit. `title-right` needs a wide measure to avoid colliding with the title;
+   * `below-title` always fits. Declared per preset rather than derived from the column count, so a
+   * future preset has to make the choice deliberately.
+   */
+  tagPlacement: 'title-right' | 'below-title'
+  tagTones: Record<PrintTagTone, PrintTagStyle>
+  /** Horizontal padding inside a tag box, in inches. */
+  tagPaddingXIn: number
 }
 
 /**
@@ -115,6 +156,8 @@ export interface PlacedLine {
   spansColumns: boolean
   /** Bold run rendered before `text`, if any. Only ever set on the first line of a paragraph. */
   label?: string
+  /** Tag boxes already resolved to absolute inches, so the renderer makes no layout decisions. */
+  tags?: PlacedTag[]
   text: string
   /** Identifies the source block, so callers and tests can regroup wrapped lines. */
   blockId?: string

--- a/src/aos4/view/reminders.ts
+++ b/src/aos4/view/reminders.ts
@@ -1,4 +1,13 @@
-import { TURN_PHASES, type AbilityTiming, type Aos4Catalog } from '../domain'
+import {
+  TURN_PHASES,
+  type AbilityTiming,
+  type Aos4Catalog,
+  type CombatPriority,
+  type TimingKind,
+  type TimingPerspective,
+  type UsageLimit,
+  type UsageScope,
+} from '../domain'
 import {
   gameWindowKey,
   projectReminders,
@@ -50,12 +59,126 @@ const timingDetails = (timing: AbilityTiming): string[] => [
     : []),
 ]
 
+/**
+ * Tone drives colour and fill in both renderers. It names the *facet*, not a palette entry, so the
+ * web theme and the PDF can disagree about the exact colour while agreeing about the meaning.
+ */
+export type Aos4ReminderTagTone =
+  | 'kind-active'
+  | 'kind-reaction'
+  | 'kind-passive'
+  | 'turn-your'
+  | 'turn-enemy'
+  | 'turn-neutral'
+  | 'usage'
+  | 'priority'
+
+export interface Aos4ReminderTag {
+  label: string
+  tone: Aos4ReminderTagTone
+  /** Plain-language expansion. The abbreviated labels are not self-explanatory, least of all the
+   * usage scope, where `unit` and `army` mean very different things at the table. */
+  description: string
+}
+
+const kindDescription: Record<TimingKind, string> = {
+  active: 'Used by declaring it during the listed window.',
+  reaction: 'Used only when its trigger happens, interrupting the current sequence.',
+  passive: 'Always in effect. There is nothing to declare.',
+}
+
+const perspectiveDescription: Record<TimingPerspective, string> = {
+  your: 'Only during your own turn.',
+  enemy: "Only during your opponent's turn.",
+  any: "During either player's turn.",
+  neutral: "Not tied to either player's turn.",
+}
+
+const usageScopeDescription: Record<UsageScope, string> = {
+  unit: 'to each unit separately',
+  army: 'across your whole army',
+  player: 'to you as a player',
+}
+
+const usageDescription = (usage: UsageLimit): string =>
+  `Can be used ${usage.limit} time${usage.limit === 1 ? '' : 's'} per ${usage.period.replace('-', ' ')}. ` +
+  `That limit applies ${usageScopeDescription[usage.scope]}.`
+
+const priorityDescription: Record<CombatPriority, string> = {
+  'strike-first': 'Fights before units that do not strike first.',
+  normal: 'Fights in the normal sequence.',
+  'strike-last': 'Fights after units that do not strike last.',
+}
+
+const kindTone: Record<TimingKind, Aos4ReminderTagTone> = {
+  active: 'kind-active',
+  reaction: 'kind-reaction',
+  passive: 'kind-passive',
+}
+
+const perspectiveTone = (perspective: TimingPerspective): Aos4ReminderTagTone => {
+  switch (perspective) {
+    case 'your':
+      return 'turn-your'
+    case 'enemy':
+      return 'turn-enemy'
+    default:
+      return 'turn-neutral'
+  }
+}
+
+/**
+ * The same four facets `timingDetails` flattens into a string, kept discrete so each can be styled
+ * and scanned on its own.
+ *
+ * Two deliberate differences from `typeLabel`: a `normal` combat priority is dropped because it is
+ * the default and carries no information, and the usage limit is compressed to `1 / turn · army`,
+ * which survives a narrow print column where `1 per turn (army)` does not.
+ */
+const timingTags = (timing: AbilityTiming): Aos4ReminderTag[] => [
+  {
+    label: titleCase(timing.kind),
+    tone: kindTone[timing.kind],
+    description: kindDescription[timing.kind],
+  },
+  ...(timing.perspective
+    ? [
+        {
+          label: `${titleCase(timing.perspective)} turn`,
+          tone: perspectiveTone(timing.perspective),
+          description: perspectiveDescription[timing.perspective],
+        },
+      ]
+    : []),
+  ...(timing.priority && timing.priority !== 'normal'
+    ? [
+        {
+          label: titleCase(timing.priority),
+          tone: 'priority' as const,
+          description: priorityDescription[timing.priority],
+        },
+      ]
+    : []),
+  ...(timing.usage
+    ? [
+        {
+          label: `${timing.usage.limit} / ${timing.usage.period.replace('-', ' ')} · ${timing.usage.scope}`,
+          tone: 'usage' as const,
+          description: usageDescription(timing.usage),
+        },
+      ]
+    : []),
+]
+
 export interface Aos4ReminderViewModel {
   id: ReminderOccurrenceId
   name: string
   windowKey: string
   windowLabel: string
+  /** Flattened facets, retained for the accessible label and any text-only consumer. */
   typeLabel: string
+  /** The same facets, discrete, for tag rendering on screen and in print. */
+  tags: Aos4ReminderTag[]
   accessibleLabel: string
   declare?: string
   reactionTrigger?: string
@@ -77,6 +200,7 @@ const withPreferences = (reminder: ProjectedReminder, document: Aos4ArmyDocument
     windowKey: gameWindowKey(reminder.timing.window),
     windowLabel: label,
     typeLabel: details.join(' · '),
+    tags: timingTags(reminder.timing),
     accessibleLabel: [
       reminder.name,
       label,

--- a/src/components/info/reminders.tsx
+++ b/src/components/info/reminders.tsx
@@ -135,7 +135,7 @@ const ReminderEntry = ({
           </span>
           {isMobile && <ReminderTags tags={reminder.tags} />}
         </div>
-        <div className="flex-shrink-0 pl-2 mt-1 d-print-none">
+        <div className="flex-shrink-0 ReminderOptions d-print-none">
           <Dropdown>
             <Dropdown.Toggle
               as="button"

--- a/src/components/info/reminders.tsx
+++ b/src/components/info/reminders.tsx
@@ -53,6 +53,53 @@ const RuleText = ({ label, text, muted = false }: { label?: string; text: string
   )
 }
 
+/**
+ * The timing facets as discrete tags. Tag text is real text rather than decoration, so a screen
+ * reader announces the same words the flattened prefix used to supply.
+ *
+ * The abbreviated labels are not self-explanatory, so each tag carries its expansion. `title` covers
+ * mouse hover, `aria-label` covers assistive tech, and tapping toggles the expansion inline because
+ * a touch device never fires hover.
+ */
+const ReminderTags = ({ tags }: { tags: Aos4ReminderViewModel['tags'] }) => {
+  const { theme } = useTheme()
+  const [explained, setExplained] = useState<string | null>(null)
+
+  if (!tags.length) return null
+
+  const handleToggle = (key: string) => setExplained(current => (current === key ? null : key))
+
+  // The explainer is a sibling of the tag row, not a child: nesting it inside the row widens the
+  // flex container and drags the right-aligned tags out of alignment when it opens.
+  return (
+    <>
+      <span className={`ReminderTags ${theme.reminderTags}`}>
+        {tags.map(tag => {
+          const key = `${tag.tone}:${tag.label}`
+          return (
+            <button
+              key={key}
+              type="button"
+              className={`ReminderTag ReminderTag--${tag.tone}`}
+              title={tag.description}
+              aria-label={`${tag.label}. ${tag.description}`}
+              aria-expanded={explained === key}
+              onClick={() => handleToggle(key)}
+            >
+              {tag.label}
+            </button>
+          )
+        })}
+      </span>
+      {explained && (
+        <span className={`ReminderTagExplainer ${theme.reminderTags}`} role="note">
+          {tags.find(tag => `${tag.tone}:${tag.label}` === explained)?.description}
+        </span>
+      )}
+    </>
+  )
+}
+
 const ReminderEntry = ({
   getSources,
   isGameMode,
@@ -69,6 +116,7 @@ const ReminderEntry = ({
   reminder: Aos4ReminderViewModel
 }) => {
   const { theme } = useTheme()
+  const isMobile = useIsMobile()
   const [editingNote, setEditingNote] = useState(false)
   const sources = getSources(reminder)
 
@@ -79,10 +127,13 @@ const ReminderEntry = ({
       className={`mb-2 ${reminder.hidden ? 'd-print-none' : ''}`}
     >
       <div className="d-flex mb-1">
-        <div className="flex-grow-1" {...provided.dragHandleProps}>
-          <span className={`${theme.textMuted} font-weight-bold`}>{reminder.typeLabel} - </span>
-          <strong className={theme.text}>{reminder.name}</strong>
-          {reminder.hidden && <MdVisibilityOff className={`${theme.text} ml-2`} />}
+        <div className="flex-grow-1 ReminderHeading" {...provided.dragHandleProps}>
+          <span className="ReminderHeadingRow">
+            <strong className={theme.text}>{reminder.name}</strong>
+            {reminder.hidden && <MdVisibilityOff className={`${theme.text} ml-2`} />}
+            {!isMobile && <ReminderTags tags={reminder.tags} />}
+          </span>
+          {isMobile && <ReminderTags tags={reminder.tags} />}
         </div>
         <div className="flex-shrink-0 pl-2 mt-1 d-print-none">
           <Dropdown>

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -103,6 +103,19 @@ small {
     align-items: baseline;
 }
 
+/**
+ * The options button centres against the heading's first line box rather than the whole heading, so
+ * it stays put whether the tags sit beside the name or wrap beneath it. `min-height` matches the
+ * name's line box; without it the button chases the tallest element on the row.
+ */
+.ReminderOptions {
+    display: flex;
+    align-items: center;
+    align-self: flex-start;
+    min-height: 1.5rem;
+    margin-inline-start: 0.85rem;
+}
+
 .ReminderHeadingRow > .ReminderTags {
     margin-inline-start: auto;
 }

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -82,6 +82,147 @@ small {
     }
 }
 
+/**
+ * Timing facet tags.
+ *
+ * Above the mobile breakpoint the heading is a single row with the name on the left and the tags
+ * pushed to the right; at or below it the tags wrap onto their own line beneath the name. Tone
+ * colours are set per theme below, never by the tone class alone, so light and dark can differ.
+ */
+.ReminderHeadingRow {
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+}
+
+.ReminderTags {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    align-items: baseline;
+}
+
+.ReminderHeadingRow > .ReminderTags {
+    margin-inline-start: auto;
+}
+
+.ReminderHeading > .ReminderTags {
+    margin-block-start: 0.25rem;
+}
+
+.ReminderTag {
+    appearance: none;
+    font-family: inherit;
+    font-size: 0.7rem;
+    font-weight: 700;
+    line-height: 1.35;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    border: 1px solid transparent;
+    cursor: help;
+
+    &:focus-visible {
+        outline: 2px solid $themeLightBlue;
+        outline-offset: 1px;
+    }
+}
+
+/**
+ * Touch devices never hover, so the tapped tag's expansion lands on its own full-width line. As a
+ * flex sibling of the tag row it wraps below without disturbing the row's right alignment.
+ */
+.ReminderTagExplainer {
+    display: block;
+    flex-basis: 100%;
+    width: 100%;
+    margin-block-start: 0.2rem;
+    font-size: 0.78rem;
+    font-style: italic;
+    line-height: 1.35;
+    text-align: start;
+
+    &.ReminderTags-Light {
+        color: #4d5a63;
+    }
+
+    &.ReminderTags-Dark {
+        color: rgba(255, 255, 255, 0.78);
+    }
+}
+
+@mixin tag-tones($active, $reaction, $passive, $your, $enemy, $neutral, $usage) {
+    .ReminderTag {
+        &--kind-active {
+            @include tag-tone($active...);
+        }
+        &--kind-reaction {
+            @include tag-tone($reaction...);
+        }
+        &--kind-passive {
+            @include tag-tone($passive...);
+        }
+        &--turn-your {
+            @include tag-tone($your...);
+        }
+        &--turn-enemy {
+            @include tag-tone($enemy...);
+        }
+        &--turn-neutral {
+            @include tag-tone($neutral...);
+        }
+        &--priority {
+            @include tag-tone($reaction...);
+        }
+        &--usage {
+            @include tag-tone($usage...);
+            border-style: dashed;
+        }
+    }
+}
+
+@mixin tag-tone($bg, $fg, $border) {
+    background-color: $bg;
+    color: $fg;
+    border-color: $border;
+}
+
+.ReminderTags-Light {
+    @include tag-tones(
+        (#e0eff5, #0c4a60, #b4d7e4),
+        (#f8ecd9, #79490d, #e6cda4),
+        (#e9eef1, #46585f, #d0dade),
+        (#e6f2ea, #1f5334, #bcdcc7),
+        (#f9e8e8, #7c3535, #ecc9c9),
+        (#eef0f2, #4d5a63, #d8dee2),
+        (transparent, #5b6b74, #b9c5cc)
+    );
+}
+
+.ReminderTags-Dark {
+    @include tag-tones(
+        (rgba(28, 117, 149, 0.34), #86d3ea, rgba(28, 117, 149, 0.62)),
+        (rgba(198, 144, 58, 0.26), #f2c982, rgba(198, 144, 58, 0.5)),
+        (rgba(255, 255, 255, 0.1), #bccad2, rgba(255, 255, 255, 0.2)),
+        (rgba(72, 160, 105, 0.24), #92d8ac, rgba(72, 160, 105, 0.45)),
+        (rgba(190, 90, 90, 0.24), #f0a6a6, rgba(190, 90, 90, 0.45)),
+        (rgba(255, 255, 255, 0.08), #b3c1ca, rgba(255, 255, 255, 0.18)),
+        (transparent, #a9bac3, rgba(255, 255, 255, 0.3))
+    );
+}
+
+/** Browser print drops the fills; the border and weight carry the distinction on paper. */
+@media print {
+    .ReminderTag {
+        background-color: transparent !important;
+        color: black !important;
+        border-color: rgba(0, 0, 0, 0.45) !important;
+    }
+}
+
 .SelectArmy {
     margin-block-start: 2rem;
     margin-inline-end: 5%;

--- a/src/tests/aos4/printTags.test.ts
+++ b/src/tests/aos4/printTags.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COMPACT_PRESET,
+  STANDARD_PRESET,
+  createAos4PrintDocument,
+  createJsPdfMeasurer,
+  planPrintLayout,
+  type PlacedLine,
+  type PrintReminderInput,
+  type PrintTag,
+} from '../../aos4/print'
+
+const EPSILON = 0.001
+
+const tags: PrintTag[] = [
+  { label: 'Active', tone: 'kind-active' },
+  { label: 'Your turn', tone: 'turn-your' },
+  { label: '1 / turn · army', tone: 'usage' },
+]
+
+const reminder = (overrides: Partial<PrintReminderInput> & { id: string }): PrintReminderInput => ({
+  name: `Rule ${overrides.id}`,
+  windowKey: 'hero-phase',
+  windowLabel: 'Hero Phase',
+  typeLabel: 'Active · Your turn · 1 per turn (army)',
+  effect: 'Short effect text.',
+  hidden: false,
+  ...overrides,
+})
+
+const planFor = (preset: typeof STANDARD_PRESET, input: PrintReminderInput) =>
+  planPrintLayout(
+    createAos4PrintDocument([input], { armyName: 'Army', factionName: 'Faction' }),
+    preset,
+    createJsPdfMeasurer()
+  )
+
+const titleLine = (lines: PlacedLine[]) => lines.find(line => line.role === 'ruleTitle')
+const tagLine = (lines: PlacedLine[]) => lines.find(line => line.role === 'ruleTag')
+
+describe('print tags', () => {
+  it('drops the flattened prefix from the title once tags are supplied', () => {
+    const document = createAos4PrintDocument([reminder({ id: 'a', tags })], {
+      armyName: 'Army',
+      factionName: 'Faction',
+    })
+    expect(document.sections[0].rules[0].title).toBe('Rule a')
+    expect(document.sections[0].rules[0].tags).toEqual(tags)
+  })
+
+  it('keeps the legacy prefixed title when a caller supplies no tags', () => {
+    const document = createAos4PrintDocument([reminder({ id: 'a' })], {
+      armyName: 'Army',
+      factionName: 'Faction',
+    })
+    expect(document.sections[0].rules[0].title).toBe('Active · Your turn · 1 per turn (army) - Rule a')
+    expect(document.sections[0].rules[0].tags).toBeUndefined()
+  })
+
+  it('right-aligns tags on the title line in the standard preset', () => {
+    const plan = planFor(STANDARD_PRESET, reminder({ id: 'a', tags }))
+    const title = titleLine(plan.lines)
+
+    expect(title?.tags).toHaveLength(3)
+    expect(tagLine(plan.lines)).toBeUndefined()
+
+    const placed = title!.tags!
+    const rightEdge = placed[placed.length - 1].xIn + placed[placed.length - 1].widthIn
+    const columnRight = plan.columnOriginsIn[0] + plan.columnWidthIn
+    expect(rightEdge).toBeCloseTo(columnRight, 2)
+
+    // Tags start after the title text ends, so the two never overlap.
+    expect(placed[0].xIn).toBeGreaterThan(title!.xIn + title!.widthIn)
+  })
+
+  it('puts tags on their own line below the title in the compact preset', () => {
+    const plan = planFor(COMPACT_PRESET, reminder({ id: 'a', tags }))
+    const title = titleLine(plan.lines)
+    const below = tagLine(plan.lines)
+
+    expect(title?.tags).toBeUndefined()
+    expect(below?.tags).toHaveLength(3)
+    expect(below!.yIn).toBeGreaterThan(title!.yIn)
+    expect(below!.tags![0].xIn).toBeCloseTo(plan.columnOriginsIn[below!.column], 2)
+  })
+
+  it('falls back to a tag line when a long title leaves no room beside it', () => {
+    const longName = 'A Preposterously Overlong Ability Name That Consumes The Entire Measure Alone'
+    const plan = planFor(STANDARD_PRESET, reminder({ id: 'a', name: longName, tags }))
+
+    expect(titleLine(plan.lines)?.tags).toBeUndefined()
+    expect(tagLine(plan.lines)?.tags).toHaveLength(3)
+  })
+
+  it('keeps every tag box inside the column in both presets', () => {
+    ;[STANDARD_PRESET, COMPACT_PRESET].forEach(preset => {
+      const plan = planFor(preset, reminder({ id: 'a', tags }))
+      plan.lines
+        .filter(line => line.tags?.length)
+        .forEach(line => {
+          const columnLeft = plan.columnOriginsIn[line.column]
+          const columnRight = columnLeft + plan.columnWidthIn
+          line.tags!.forEach(tag => {
+            expect(tag.xIn).toBeGreaterThanOrEqual(columnLeft - EPSILON)
+            expect(tag.xIn + tag.widthIn).toBeLessThanOrEqual(columnRight + EPSILON)
+          })
+        })
+    })
+  })
+
+  it('never overlaps adjacent tag boxes', () => {
+    const plan = planFor(COMPACT_PRESET, reminder({ id: 'a', tags }))
+    const placed = tagLine(plan.lines)!.tags!
+    placed.slice(1).forEach((tag, index) => {
+      const previous = placed[index]
+      expect(tag.xIn).toBeGreaterThanOrEqual(previous.xIn + previous.widthIn - EPSILON)
+    })
+  })
+
+  it('resolves a tone for every tag in both presets', () => {
+    const tones: PrintTag['tone'][] = [
+      'kind-active',
+      'kind-reaction',
+      'kind-passive',
+      'turn-your',
+      'turn-enemy',
+      'turn-neutral',
+      'usage',
+      'priority',
+    ]
+    ;[STANDARD_PRESET, COMPACT_PRESET].forEach(preset => {
+      tones.forEach(tone => {
+        const style = preset.tagTones[tone]
+        expect(style, `${preset.id} is missing a tone for ${tone}`).toBeDefined()
+        expect(style.text).toHaveLength(3)
+        expect(style.border).toHaveLength(3)
+      })
+    })
+  })
+})

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -77,6 +77,7 @@ const DarkTheme: ITheme = {
   profileCardHeader: `card-header bg-profileHeader text-dark mb-0 pb-1`,
   reminderHeader: `bg-themeLightBlue`,
   reminderHr: `ReminderHr-Dark`,
+  reminderTags: `ReminderTags-Dark`,
   secondaryButton: `btn btn-sm btn-outline-secondary`,
   selectTheme,
   text: `text-white`,

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -18,6 +18,7 @@ const LightTheme: ITheme = {
   profileCardHeader: `card-header bg-profileHeader text-dark mb-0 pb-1`,
   reminderHeader: `bg-themeDarkBluePrimary`,
   reminderHr: `ReminderHr`,
+  reminderTags: `ReminderTags-Light`,
   secondaryButton: `btn btn-sm btn-outline-secondary`,
   selectTheme: {},
   text: `text-dark`,

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -14,6 +14,7 @@ export interface ITheme {
   profileCardHeader: string
   reminderHeader: string
   reminderHr: string
+  reminderTags: string
   secondaryButton: string
   selectTheme: Record<string, string>
   text: string


### PR DESCRIPTION
Replaces the free-form timing prefix on rule cards with structured, subtly-coloured tags — on screen and in both print presets.

**Before:** `Active · Your turn · 1 per turn (army) - ORACULAR VISIONS`
**After:** the name as the heading, with `ACTIVE` `YOUR TURN` `1 / TURN · ARMY` as discrete tags.

## Layouts, chosen from mockups

Two layouts, split by available measure — the reviewed choice was made per-surface, and it maps onto real column widths:

| Surface | Measure | Layout |
|---|---|---|
| Web > 480px | — | name left, tags right-aligned |
| Standard print | 7.07in, 1 col | name left, tags right-aligned |
| Web ≤ 480px | — | name first, tags beneath |
| Compact print | 3.54in, 2 cols | name first, tags beneath |

`title-right` degrades to `below-title` automatically whenever a long ability name would collide with its tags, so the narrow case is handled even in the wide preset.

## No new data

`AbilityTiming` already carried `kind`, `perspective`, `priority`, and `usage` as discrete typed fields; the view model was flattening them at the last moment. This only changes presentation. `typeLabel` is retained for the accessible label and any text-only consumer.

Two deliberate refinements: a `normal` combat priority is dropped (it's the default and carries no information), and the usage limit compresses to `1 / turn · army` so it fits a narrow column.

## Tooltips

The abbreviated labels aren't self-explanatory — the usage *scope* least of all, since `unit`, `army`, and `player` mean very different things at the table. Each tag carries a plain-language expansion surfaced three ways: `title` for hover, `aria-label` for assistive tech, and tap-to-expand for touch, which never fires hover. Tags are `<button>` elements, which react-beautiful-dnd already excludes from drag initiation.

## Print architecture

`PrintRule` gains optional `tags`; `PrintPreset` declares its own `tagPlacement` rather than inferring it from column count, so a future preset has to choose deliberately. The layout resolves every tag box to absolute inches, keeping `pdf.ts` a pure renderer with no layout decisions — the property that makes the layout testable without parsing a PDF.

Fills are light enough to greyscale legibly on a mono printer, and the browser print stylesheet drops them to bordered outlines.

## Verification

- **8 new layout tests** covering right-alignment, the below-title case, long-title fallback, column containment, tag-box non-overlap, and tone coverage for all 8 facets in both presets.
- **All 37 existing print tests pass untouched** — callers supplying no tags keep the old prefixed title, so fixtures are unaffected.
- **Real PDFs generated and inspected** for both presets: 39 tagged lines each, rendering correctly.
- **Page counts unchanged** — 4 standard / 2 compact for the default army, measured against the same document built without tags.
- Verified on screen at desktop and mobile widths, light and dark themes.
- `yarn lint` clean; `yarn test` 337 passing.

**Pre-existing failure, not from this branch:** `reviewPackets.test.ts > parses the staged human review workflow` and a `humanReviewCommand.ts` type error both reproduce on a pristine `aos4-migration` head with these changes stashed. That's in-flight certification work.

https://claude.ai/code/session_019nXN9qA3veW9ZwXPRxaUiT