### PR TITLE
fix: retry the PayPal grant with payment proof while the post-subscribe modal polls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
 
       - name: Install dependencies with yarn

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
 
       - name: Install dependencies with yarn

--- a/src/api/subscriptionApi.ts
+++ b/src/api/subscriptionApi.ts
@@ -29,6 +29,12 @@ interface IRedeemGift {
   userName: string // userName receiving the gift
 }
 
+interface IRequestGrant {
+  userName: string
+  subscriptionId?: string // PayPal subscription id from the onApprove response
+  planId?: string // PayPal plan id the user subscribed to
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const withAuth = (data: Record<string, any>) => ({ ...data, authKey: SUBSCRIPTION_AUTH_KEY })
 
@@ -36,7 +42,9 @@ const cancelSubscription = (data: ICancel) => request.post(`${api}/cancel`).send
 const getSubscription = (userName: string) => request.get(`${api}/user/${userName}`)
 const redeemCoupon = (data: IRedeemCoupon) => request.post(`${api}/redeem_coupon`).send(withAuth(data))
 const redeemGift = (data: IRedeemGift) => request.post(`${api}/redeem`).send(withAuth(data))
-const requestGrant = (userName: string) => request.post(`${api}/paypal_grant`).send(withAuth({ userName }))
+// subscriptionId + planId let the API create a provisional row when the
+// CREATED webhook hasn't arrived yet (the grant-vs-webhook race)
+const requestGrant = (data: IRequestGrant) => request.post(`${api}/paypal_grant`).send(withAuth(data))
 const updateTheme = (data: IUpdateTheme) => request.post(`${api}/theme`).send(withAuth(data))
 
 export const SubscriptionApi = {

--- a/src/components/modals/paypal_post_subscribe_modal.tsx
+++ b/src/components/modals/paypal_post_subscribe_modal.tsx
@@ -10,9 +10,10 @@ import { useSetInterval } from 'utils/hooks/useInterval'
 interface IModalComponentProps {
   modalIsOpen: boolean
   closeModal: () => void
+  retryGrant?: () => Promise<unknown>
 }
 
-export const PaypalPostSubscribeModal = ({ closeModal, modalIsOpen }: IModalComponentProps) => {
+export const PaypalPostSubscribeModal = ({ closeModal, modalIsOpen, retryGrant }: IModalComponentProps) => {
   const { isActive, subscriptionLoading, getSubscription } = useSubscription()
   const { theme } = useTheme()
 
@@ -29,6 +30,9 @@ export const PaypalPostSubscribeModal = ({ closeModal, modalIsOpen }: IModalComp
 
     if (!isActive && !subscriptionLoading) {
       console.log('Checking for subscription update from Paypal...')
+      // Re-send the grant each tick: the first attempt races PayPal's CREATED
+      // webhook (median 12s behind the approval) and may have found no row yet
+      retryGrant?.().catch(() => undefined)
       getSubscription()
     }
   }, interval)

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -209,7 +209,7 @@ const PayPalComponent = (props: IPlanProps) => {
         <PayPalButton
           onCancel={handleCancel}
           onSuccess={handleSuccess}
-          planId={isDev ? paypal_dev : paypal_prod}
+          planId={planId}
           planTitle={title}
         />
       )}

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -5,6 +5,7 @@ import { SubscriptionApi } from 'api/subscriptionApi'
 import GenericButton from 'components/input/generic_button'
 import { PaypalPostSubscribeModal } from 'components/modals/paypal_post_subscribe_modal'
 import PayPalButton from 'components/payment/paypal/paypalButton'
+import { IApprovalResponse } from 'components/payment/paypal/paypalTypes'
 import { PaypalProvider } from 'context/usePaypal'
 import qs from 'qs'
 import React, { useState } from 'react'
@@ -163,20 +164,33 @@ const PlanComponent = (props: IPlanProps) => {
 const PayPalComponent = (props: IPlanProps) => {
   const { user } = useAuth0()
   const [modalIsOpen, setModalIsOpen] = useState(false)
+  const [approval, setApproval] = useState<IApprovalResponse | null>(null)
 
   const { paypal_dev, paypal_prod, title } = props.supportPlan
+  const planId = isDev ? paypal_dev : paypal_prod
 
-  const handleSuccess = async () => {
+  // The approval response is proof of payment — passing its subscriptionID
+  // lets the API grant access even before PayPal's webhooks arrive. The modal
+  // retries this every poll tick, so a lost first attempt is not fatal.
+  const requestGrant = async (data: IApprovalResponse | null = approval) => {
+    if (!user?.email) return null
+    return SubscriptionApi.requestGrant({
+      userName: user.email,
+      subscriptionId: data?.subscriptionID,
+      planId: data?.subscriptionID ? planId : undefined,
+    })
+  }
+
+  const handleSuccess = async (data: IApprovalResponse) => {
+    setApproval(data)
     setModalIsOpen(true)
     props.setPaypalModalIsOpen(true)
     logEvent(`Checkout-Subscribed-${title}`)
     logSubscription(title, 'paypal')
     try {
-      if (!user?.email) return null
-      // Request a ten-minute temporary grant while Paypal approvals happen in the background
-      await SubscriptionApi.requestGrant(user.email)
+      await requestGrant(data)
     } catch (err) {
-      // pass
+      // The post-subscribe modal keeps retrying the grant while it polls
     }
   }
 
@@ -199,7 +213,9 @@ const PayPalComponent = (props: IPlanProps) => {
           planTitle={title}
         />
       )}
-      {modalIsOpen && <PaypalPostSubscribeModal modalIsOpen={modalIsOpen} closeModal={closeModal} />}
+      {modalIsOpen && (
+        <PaypalPostSubscribeModal modalIsOpen={modalIsOpen} closeModal={closeModal} retryGrant={requestGrant} />
+      )}
     </div>
   )
 }

--- a/src/tests/subscriptionApi.test.ts
+++ b/src/tests/subscriptionApi.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const send = vi.fn().mockResolvedValue({ ok: true })
+const post = vi.fn((url: string) => ({ send, url }))
+const get = vi.fn((url: string) => Promise.resolve({ body: {}, url }))
+
+vi.mock('superagent', () => ({
+  default: {
+    post: (url: string) => post(url),
+    get: (url: string) => get(url),
+  },
+}))
+
+import { SubscriptionApi } from 'api/subscriptionApi'
+
+describe('SubscriptionApi.requestGrant', () => {
+  beforeEach(() => {
+    post.mockClear()
+    send.mockClear()
+  })
+
+  it('sends the payment proof (subscriptionId + planId) with the grant request', async () => {
+    await SubscriptionApi.requestGrant({
+      userName: 'user@example.com',
+      subscriptionId: 'I-ABC123XYZ',
+      planId: 'P-54G67667NT497912UL5TBTBQ',
+    })
+
+    expect(post).toHaveBeenCalledWith(expect.stringContaining('/paypal_grant'))
+    const payload = send.mock.calls[0][0]
+    expect(payload.userName).toEqual('user@example.com')
+    expect(payload.subscriptionId).toEqual('I-ABC123XYZ')
+    expect(payload.planId).toEqual('P-54G67667NT497912UL5TBTBQ')
+    expect(typeof payload.authKey).toEqual('string')
+  })
+
+  it('degrades to a userName-only grant when no approval data is available', async () => {
+    await SubscriptionApi.requestGrant({ userName: 'user@example.com' })
+
+    const payload = send.mock.calls[0][0]
+    expect(payload.userName).toEqual('user@example.com')
+    expect(payload.subscriptionId).toBeUndefined()
+    expect(payload.planId).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Context

Companion to daviseford/aos-reminders-subscription-api#15. The frontend's single fire-and-forget `paypal_grant` call raced PayPal's CREATED webhook (median 12s behind approval) and lost 168 times over five years, with the error silently swallowed — customers stared at the "verifying your transaction" modal with no retry.

## Changes

- `requestGrant` carries the approval response's `subscriptionID` + the plan's PayPal `planId` so the API can create a provisional row before any webhook arrives (degrades to userName-only when approval data is missing).
- The post-subscribe modal re-sends the grant on every poll tick until the subscription is active or the modal closes — a lost first attempt is no longer fatal.
- `ci:` Node bumped 20 → 22 in `nodejs.yml` and `deploy.yml` (matches the API services' runtime).

**Deploy order:** safe in either order — the current prod API ignores the extra grant fields; the new API keeps the legacy userName-only path.

## Testing

- New vitest contract tests for the grant payload (full payload + degraded userName-only), lint + `tsc --noEmit` clean.
- Full suite: 363 pass; the 5 failures in `warhammerApp.test.ts` are pre-existing on master (reproduced on the untouched base) and unrelated to this diff.
- Live dev verification (with the API branch deployed): grant-before-webhooks produced immediate access and converged to `active` with no status demotion (V3 in the API PR's replay matrix).

## Post-Deploy Monitoring & Validation

Frontend-only change; server-side monitoring lives with the API PR. Watch `grant-created-provisional-row` in CloudWatch after real purchases and the #1731 live checklist. Failure signal: post-subscribe modal spinning >1 min for fresh purchases despite active PayPal payment. Rollback: revert this PR; the old single-shot behavior returns.

Produced by the Compound Engineering workflow.

https://claude.ai/code/session_01N4W8BV5jjQPH1gCzhkxrkk
