### PR TITLE
feat(aos4): generate exhaustive Listbot import corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,5 +91,9 @@ src/tests/fixtures/intake/*
 
 # Don't ignore the placeholder file
 !src/tests/fixtures/intake/placeholder.txt
+
+# Private/source-derived full import corpora
+/data/aos4/import-corpus/
+
 .impeccable/
 /.claude/worktrees

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "scripts": {
     "build": "tsc && vite build",
+    "corpus:listbot": "vite-node --script src/tests/support/listbotCorpusCommand.ts",
     "data:aos4:candidate": "vite-node --script src/aos4/data/candidateCommand.ts",
     "data:aos4:discover-official": "vite-node --script src/aos4/data/gamesWorkshop/catalogCommand.ts",
     "data:aos4:certify": "vite-node --script src/aos4/review/certificationCommand.ts",

--- a/src/tests/aos4/listbotCorpus.test.ts
+++ b/src/tests/aos4/listbotCorpus.test.ts
@@ -1,0 +1,406 @@
+import {
+  LISTBOT_MISSING_FORMATION_LABEL,
+  createListbotCoverageCorpus,
+  mergeListbotGameData,
+  parseListbotCurrentPage,
+  parseListbotGameData,
+  parseListbotVersionMarker,
+  type ListbotArmyBinding,
+  type ListbotGameData,
+  type ListbotUnscopedUnitBinding,
+} from '../support/listbotCorpus'
+import { decodeAos4TextRoster } from '../../importers/aos4'
+
+const snapshot: ListbotGameData = {
+  version: '2026-07-29T00:00:00Z',
+  factions: [
+    { id: 'faction:alpha', name: 'Alpha Hosts' },
+    { id: 'faction:archive', name: 'Archive Hosts' },
+    { id: 'faction:beta', name: 'Beta Hosts' },
+  ],
+  units: [
+    {
+      id: 'unit:guard',
+      name: 'Alpha Guard',
+      factionId: 'faction:alpha',
+      pointsCost: 100,
+      isHero: false,
+      isRor: false,
+      isTerrain: false,
+      minModels: 10,
+      abilities: [{ name: 'Ignored', effect: 'RULE TEXT MUST NOT BE COPIED' }],
+    },
+    {
+      id: 'unit:captain',
+      name: 'Alpha Captain',
+      factionId: 'faction:alpha',
+      pointsCost: 140,
+      isHero: true,
+      isRor: false,
+      isTerrain: false,
+      minModels: 1,
+    },
+    {
+      id: 'unit:archive',
+      name: 'Archive Guard',
+      factionId: 'faction:archive',
+      pointsCost: 80,
+      isHero: false,
+      isRor: true,
+      isTerrain: false,
+      minModels: 5,
+    },
+  ],
+  battleFormations: [
+    {
+      id: 'formation:zeta',
+      name: 'Zeta Formation',
+      factionId: 'faction:alpha',
+      isAor: false,
+    },
+    {
+      id: 'formation:alpha',
+      name: 'Alpha Formation',
+      factionId: 'faction:alpha',
+      isAor: false,
+    },
+  ],
+}
+
+const armyBindings = [
+  {
+    catalogFactionId: 'catalog-faction:alpha',
+    apiFactionId: 'faction:alpha',
+    currentPageFactionId: 'page-faction:101',
+    expectedName: 'Alpha Hosts',
+  },
+  {
+    catalogFactionId: 'catalog-faction:beta',
+    apiFactionId: 'faction:beta',
+    expectedName: 'Beta Hosts',
+  },
+] as const satisfies readonly ListbotArmyBinding[]
+
+const unscopedUnitBindings = [
+  {
+    currentUnitId: 'page-unit:202',
+    sourceFactionId: '999',
+    apiUnitId: 'unit:guard',
+  },
+] as const satisfies readonly ListbotUnscopedUnitBinding[]
+
+describe('Listbot all-units coverage corpus', () => {
+  it('validates the live version marker contract', () => {
+    expect(
+      parseListbotVersionMarker({
+        version: '2026-07-29T00:00:00Z',
+        factionCount: 3,
+        unitCount: 3,
+      })
+    ).toEqual({
+      version: '2026-07-29T00:00:00Z',
+      factionCount: 3,
+      unitCount: 3,
+    })
+    expect(() => parseListbotVersionMarker({ version: 'current', unitCount: 3 })).toThrow(
+      'versionMarker.factionCount'
+    )
+  })
+
+  it('projects provider data to composition fields and fails on unsafe references', () => {
+    const parsed = parseListbotGameData(snapshot)
+
+    expect(parsed.units[0]).toEqual({
+      id: 'unit:guard',
+      name: 'Alpha Guard',
+      factionId: 'faction:alpha',
+      pointsCost: 100,
+      isHero: false,
+      isRor: false,
+      isTerrain: false,
+      minModels: 10,
+    })
+    expect(parsed.units[0]).not.toHaveProperty('abilities')
+    expect(
+      parseListbotGameData({
+        ...snapshot,
+        units: [
+          ...snapshot.units,
+          {
+            ...snapshot.units[0],
+            factionId: 'faction:archive',
+            name: 'Shared Alpha Guard',
+          },
+        ],
+      }).units
+    ).toHaveLength(4)
+    expect(() =>
+      parseListbotGameData({
+        ...snapshot,
+        units: [{ ...snapshot.units[0], factionId: 'faction:missing' }],
+      })
+    ).toThrow('unit:guard refers to unknown faction faction:missing')
+    expect(() =>
+      parseListbotGameData({
+        ...snapshot,
+        units: [...snapshot.units, { ...snapshot.units[0] }],
+      })
+    ).toThrow('Duplicate Listbot unit identity in faction faction:alpha: unit:guard')
+  })
+
+  it('decodes the current desktop inventory without evaluating provider JavaScript', () => {
+    const current = parseListbotCurrentPage(`
+      <select class="faction-select">
+        <option value="">Select Faction</option>
+        <optgroup label="Order">
+          <option value="101">Alpha Hosts</option>
+        </optgroup>
+      </select>
+      <script>
+        const globalHeroData = {};
+        globalHeroData[201] = {
+          'id': 201,
+          'name': 'Captain&#x27;s Guard',
+          'pointsCost': 150,
+          'factionId': 101,
+          'isHero': true,
+          'isRor': false
+        }
+        const globalUnitData = {};
+        globalUnitData[202] = {
+          'id': 202,
+          'name': 'Current Guard',
+          'pointsCost': 110,
+          'factionId': 101,
+          'numberOfModels': 10,
+          'isHero': false
+        }
+        globalUnitData[203] = {
+          'id': 203,
+          'name': 'Detached Guard',
+          'pointsCost': 120,
+          'factionId': 999,
+          'numberOfModels': 5,
+          'isHero': false
+        }
+      </script>
+    `)
+
+    expect(current.factions).toEqual([{ id: 'page-faction:101', name: 'Alpha Hosts' }])
+    expect(current.units).toEqual([
+      {
+        id: 'page-unit:201',
+        name: "Captain's Guard",
+        factionId: 'page-faction:101',
+        pointsCost: 150,
+        isHero: true,
+        isRor: false,
+        isTerrain: false,
+        minModels: 1,
+      },
+      {
+        id: 'page-unit:202',
+        name: 'Current Guard',
+        factionId: 'page-faction:101',
+        pointsCost: 110,
+        isHero: false,
+        isRor: false,
+        isTerrain: false,
+        minModels: 10,
+      },
+    ])
+    expect(current.unscopedUnits).toEqual([
+      {
+        id: 'page-unit:203',
+        name: 'Detached Guard',
+        sourceFactionId: '999',
+        pointsCost: 120,
+        isHero: false,
+        isRor: false,
+        isTerrain: false,
+        minModels: 5,
+      },
+    ])
+
+    expect(() =>
+      parseListbotCurrentPage(`
+        <select class="faction-select"><option value="101">Alpha Hosts</option></select>
+        <script>
+          globalUnitData[202] = {
+            'id': 202,
+            'name': 'Current Guard',
+            'pointsCost': 110,
+            'factionId': 101,
+            'numberOfModels': 10,
+            'isHero': 'false'
+          }
+        </script>
+      `)
+    ).toThrow('globalUnitData[202].isHero must be a boolean when present')
+
+    expect(() =>
+      parseListbotCurrentPage(`
+        <select class="faction-select"><option value="101">Alpha Hosts</option></select>
+        <script>
+          globalUnitData[202] = {
+            'id': 202,
+            'name': 'First Guard',
+            'pointsCost': 110,
+            'factionId': 101,
+            'numberOfModels': 10
+          }
+          globalUnitData[202] = {
+            'id': 202,
+            'name': 'Second Guard',
+            'pointsCost': 120,
+            'factionId': 101,
+            'numberOfModels': 10
+          }
+        </script>
+      `)
+    ).toThrow('Duplicate Listbot current data assignment: globalUnitData[202]')
+  })
+
+  it('prefers current desktop units while retaining API-only armies and supplemental catalogs', () => {
+    const current = parseListbotCurrentPage(`
+      <select class="faction-select">
+        <option value="">Select Faction</option>
+        <option value="101">Alpha Hosts</option>
+      </select>
+      <script>
+        const globalHeroData = {};
+        globalHeroData[201] = {
+          'id': 201,
+          'name': 'Current Captain',
+          'pointsCost': 150,
+          'factionId': 101,
+          'isHero': true,
+          'isRor': false
+        }
+        const globalUnitData = {};
+        globalUnitData[202] = {
+          'id': 202,
+          'name': 'Alpha Guard',
+          'pointsCost': 100,
+          'factionId': 999,
+          'numberOfModels': 10,
+          'isHero': false
+        }
+      </script>
+    `)
+    const merged = mergeListbotGameData(snapshot, current, armyBindings, unscopedUnitBindings)
+
+    expect(merged.gameData.factions.map(faction => faction.name)).toEqual([
+      'Alpha Hosts',
+      'Archive Hosts',
+      'Beta Hosts',
+    ])
+    expect(merged.gameData.units.map(unit => `${unit.factionId}:${unit.name}`).sort()).toEqual([
+      'faction:archive:Archive Guard',
+      'page-faction:101:Alpha Guard',
+      'page-faction:101:Current Captain',
+    ])
+    expect(merged.reconciledUnscopedUnits).toEqual([
+      {
+        currentUnitId: 'page-unit:202',
+        sourceFactionId: '999',
+        factionName: 'Alpha Hosts',
+        apiUnitId: 'unit:guard',
+      },
+    ])
+    expect(merged.drift).toEqual([
+      {
+        factionName: 'Alpha Hosts',
+        apiUnitEntries: 2,
+        currentUnitEntries: 2,
+        onlyInApi: ['Alpha Captain'],
+        onlyInCurrent: ['Current Captain'],
+      },
+    ])
+
+    expect(() =>
+      mergeListbotGameData(
+        snapshot,
+        {
+          ...current,
+          factions: [{ id: 'page-faction:101', name: 'Renamed Alpha Hosts' }],
+        },
+        armyBindings,
+        unscopedUnitBindings
+      )
+    ).toThrow('Listbot current faction page-faction:101 name changed')
+  })
+
+  it('builds deterministic army and supplemental rosters without copying rule text', () => {
+    const corpus = createListbotCoverageCorpus(snapshot, ['faction:alpha', 'faction:beta'])
+
+    expect(corpus.missingArmyFactionIds).toEqual([])
+    expect(corpus.coverage).toEqual({
+      sourceFactions: 3,
+      emptySourceFactions: 1,
+      sourceUnitEntries: 3,
+      armyFactions: 1,
+      armyUnitEntries: 2,
+      supplementalFactions: 1,
+      supplementalUnitEntries: 1,
+      uncoveredUnitEntries: 0,
+    })
+    expect(corpus.emptyFactions).toEqual([{ id: 'faction:beta', name: 'Beta Hosts' }])
+
+    const army = corpus.rosters.find(roster => roster.category === 'army')
+    expect(army).toMatchObject({
+      factionId: 'faction:alpha',
+      factionName: 'Alpha Hosts',
+      formation: { id: 'formation:alpha', name: 'Alpha Formation' },
+      file: 'armies/alpha-hosts.txt',
+      unitCount: 2,
+      totalPoints: 240,
+    })
+    expect(army?.text).toBe(
+      [
+        'Alpha Hosts',
+        'Alpha Formation',
+        '',
+        '- 1 x Alpha Captain (140)',
+        '- 10 x Alpha Guard (100)',
+        '',
+        '240/2000pts',
+        '2 drops',
+        '',
+        'Generated by Listbot 4.0',
+        '',
+      ].join('\n')
+    )
+    expect(army?.text).not.toContain('RULE TEXT MUST NOT BE COPIED')
+
+    const supplemental = corpus.rosters.find(roster => roster.category === 'supplemental')
+    expect(supplemental).toMatchObject({
+      factionName: 'Archive Hosts',
+      formation: null,
+      file: 'supplemental/archive-hosts.txt',
+      unitCount: 1,
+    })
+    expect(supplemental?.text).toContain(LISTBOT_MISSING_FORMATION_LABEL)
+  })
+
+  it('round-trips every source unit entry through the real Listbot decoder exactly once', () => {
+    const corpus = createListbotCoverageCorpus(snapshot, ['faction:alpha', 'faction:beta'])
+
+    corpus.rosters.forEach(roster => {
+      const decoded = decodeAos4TextRoster(roster.text)
+
+      expect(decoded.diagnostics).toEqual([])
+      expect(decoded.parsedRoster?.declaredFaction).toBe(roster.factionName)
+      expect(
+        decoded.parsedRoster?.selections.filter(selection => selection.kindHint === 'warscroll')
+      ).toHaveLength(roster.unitCount)
+    })
+    expect(corpus.rosters.reduce((total, roster) => total + roster.unitCount, 0)).toBe(snapshot.units.length)
+  })
+
+  it('reports catalog armies that the provider snapshot does not contain', () => {
+    expect(
+      createListbotCoverageCorpus(snapshot, ['faction:alpha', 'faction:missing']).missingArmyFactionIds
+    ).toEqual(['faction:missing'])
+  })
+})

--- a/src/tests/aos4/listbotCorpusCommand.test.ts
+++ b/src/tests/aos4/listbotCorpusCommand.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, mkdir, readFile, readdir, rename, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { writeListbotCorpus } from '../support/listbotCorpusCommand'
+
+describe('Listbot corpus publication', () => {
+  let workspaceRoot: string
+  let outputRoot: string
+  let output: string
+
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(path.join(tmpdir(), 'aos-listbot-corpus-'))
+    outputRoot = path.join(workspaceRoot, 'data', 'aos4', 'import-corpus')
+    output = path.join(outputRoot, 'listbot')
+  })
+
+  afterEach(async () => {
+    await rm(workspaceRoot, { recursive: true, force: true })
+  })
+
+  const writeCorpus = (force: boolean, text = 'new roster') =>
+    writeListbotCorpus({
+      workspaceRoot,
+      outputRoot,
+      output,
+      force,
+      files: [{ file: 'armies/alpha.txt', text }],
+      manifest: { schemaVersion: 1 },
+    })
+
+  it('publishes atomically and requires force before replacing a corpus', async () => {
+    await writeCorpus(false)
+
+    await expect(readFile(path.join(output, 'armies', 'alpha.txt'), 'utf8')).resolves.toBe('new roster')
+    await expect(writeCorpus(false, 'replacement')).rejects.toThrow('pass --force')
+
+    await writeCorpus(true, 'replacement')
+    await expect(readFile(path.join(output, 'armies', 'alpha.txt'), 'utf8')).resolves.toBe('replacement')
+    expect((await readdir(outputRoot)).filter(name => name.includes('.backup'))).toEqual([])
+  })
+
+  it('refuses to traverse a junction outside the configured output root', async () => {
+    const outside = path.join(workspaceRoot, 'outside')
+    await mkdir(outputRoot, { recursive: true })
+    await mkdir(outside)
+    await writeFile(path.join(outside, 'sentinel.txt'), 'keep me')
+    const junction = path.join(outputRoot, 'escape')
+    await symlink(outside, junction, process.platform === 'win32' ? 'junction' : 'dir')
+
+    await expect(
+      writeListbotCorpus({
+        workspaceRoot,
+        outputRoot,
+        output: path.join(junction, 'listbot'),
+        force: true,
+        files: [{ file: 'armies/alpha.txt', text: 'new roster' }],
+        manifest: {},
+      })
+    ).rejects.toThrow('Refusing to traverse symbolic link or junction')
+    await expect(readFile(path.join(outside, 'sentinel.txt'), 'utf8')).resolves.toBe('keep me')
+  })
+
+  it('restores the previous corpus when publishing the replacement fails', async () => {
+    await mkdir(output, { recursive: true })
+    await writeFile(path.join(output, 'old.txt'), 'old roster')
+    let publicationFailed = false
+
+    await expect(
+      writeListbotCorpus({
+        workspaceRoot,
+        outputRoot,
+        output,
+        force: true,
+        files: [{ file: 'armies/alpha.txt', text: 'new roster' }],
+        manifest: {},
+        renamePath: async (from, to) => {
+          if (
+            !publicationFailed &&
+            String(from).endsWith('.tmp') &&
+            path.resolve(String(to)) === path.resolve(output)
+          ) {
+            publicationFailed = true
+            throw new Error('simulated publication failure')
+          }
+          await rename(from, to)
+        },
+      })
+    ).rejects.toThrow('simulated publication failure')
+
+    await expect(readFile(path.join(output, 'old.txt'), 'utf8')).resolves.toBe('old roster')
+    await expect(readFile(path.join(output, 'armies', 'alpha.txt'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
+  })
+})

--- a/src/tests/fixtures/aos4/import/listbot/README.md
+++ b/src/tests/fixtures/aos4/import/listbot/README.md
@@ -1,0 +1,52 @@
+# Listbot import fixtures
+
+The two checked-in text files are small format fixtures for the Listbot 4.0 decoder. For exhaustive
+name-resolution coverage, generate the private all-units corpus:
+
+```sh
+yarn corpus:listbot
+```
+
+This writes one synthetic roster for every AoS 4 army, plus separate supplemental Listbot
+catalogues, under `data/aos4/import-corpus/listbot/`. That directory is gitignored. Pass `--force`
+to replace an existing generated corpus, or `--output <path>` to choose another location below
+`data/aos4/import-corpus/`.
+
+## Why this is programmatic
+
+Listbot publishes its current desktop inventory in the read-only `/listbot/` page and a versioned
+JSON snapshot at `/api/gamedata/`. The JSON snapshot includes Legends and supplemental catalogues
+that are not selectable in the current desktop builder, but it can lag the desktop inventory.
+The command therefore prefers the desktop data for live armies and uses the API only for those
+additional catalogues. It:
+
+1. retrieves the current page, API snapshot, and bracketing API version markers through the
+   repository's HTTPS-only, public-IP-pinned acquisition layer;
+2. checks the API version and faction/unit counts agree before and after retrieval;
+3. decodes current inline data as bounded fields without evaluating provider JavaScript;
+4. validates source-scoped identities and faction references against an explicit bridge of
+   canonical faction IDs, Listbot API IDs, and current-page IDs; names are drift assertions only;
+5. reconciles the one currently known page record attached to an unselectable faction through an
+   explicit current-unit/API-unit ID binding and verifies that its composition has not changed;
+6. records label drift between the current builder and versioned API;
+7. matches every army in the checked-in AoS 4 catalog, including Legends armies;
+8. emits every selected source unit entry exactly once and round-trips each roster through the real
+   Listbot decoder;
+9. runs each army roster through canonical resolution and records unresolved labels in
+   `manifest.json`.
+
+The generated rosters are intentionally illegal, over-points coverage inputs. They are not claimed
+to be playable army lists.
+
+## Content boundary
+
+The raw provider response is cached only below `.cache/aos4/`. The roster projection retains the
+composition fields needed to test imports: faction, battle formation, unit name, model count, and
+points. Weapons, characteristics, abilities, and rule text are dropped before roster generation.
+
+The manifest records source URLs, immutable SHA-256 checksums, byte lengths, the Listbot API
+version, current/API drift, per-faction counts, generated-file checksums, and
+canonical-resolution results. If Listbot drops a catalog army, changes either response contract,
+returns an unexpected media type, or changes the API marker during retrieval, generation fails
+closed. Additional provider catalogs are preserved as supplemental coverage. Output publication
+rejects symlink/junction escapes and restores the previous corpus if an atomic replacement fails.

--- a/src/tests/support/listbotCorpus.ts
+++ b/src/tests/support/listbotCorpus.ts
@@ -1,0 +1,835 @@
+import { parse, parseFragment } from 'parse5'
+
+export const LISTBOT_GAME_DATA_URL = 'https://www.listbot.co.uk/api/gamedata/'
+export const LISTBOT_GAME_DATA_VERSION_URL = 'https://www.listbot.co.uk/api/gamedata/version/'
+export const LISTBOT_CURRENT_PAGE_URL = 'https://www.listbot.co.uk/listbot/'
+export const LISTBOT_MISSING_FORMATION_LABEL = 'No Listbot battle formation available'
+
+export interface ListbotArmyBinding {
+  catalogFactionId: string
+  apiFactionId: string
+  currentPageFactionId?: string
+  expectedName: string
+}
+
+export interface ListbotUnscopedUnitBinding {
+  currentUnitId: string
+  sourceFactionId: string
+  apiUnitId: string
+}
+
+export const LISTBOT_ARMY_BINDINGS: readonly ListbotArmyBinding[] = [
+  {
+    catalogFactionId: 'faction:33167839-7fb5-5074-8e3e-d0d012a00398',
+    apiFactionId: '5549-bece-2339-36e9',
+    expectedName: 'Beasts of Chaos',
+  },
+  {
+    catalogFactionId: 'faction:dfec0a1a-2f9c-5247-8755-a4a378b53cd6',
+    apiFactionId: 'd545-cdca-9e60-ad27',
+    currentPageFactionId: 'page-faction:3066',
+    expectedName: 'Blades of Khorne',
+  },
+  {
+    catalogFactionId: 'faction:a263f36c-1c76-5ded-b3af-f4c3fa9bf00b',
+    apiFactionId: '9a23-9c43-868d-528e',
+    expectedName: 'Bonesplitterz',
+  },
+  {
+    catalogFactionId: 'faction:bd4c3ac6-6450-52a1-a82f-c987cfa361f0',
+    apiFactionId: '42ad-8ca7-4b48-7df1',
+    currentPageFactionId: 'page-faction:3057',
+    expectedName: 'Cities of Sigmar',
+  },
+  {
+    catalogFactionId: 'faction:a7ea09c4-af98-5c10-b517-cb1509879206',
+    apiFactionId: '5232-3bab-5562-3172',
+    currentPageFactionId: 'page-faction:3058',
+    expectedName: 'Daughters of Khaine',
+  },
+  {
+    catalogFactionId: 'faction:b6a863d4-7e16-5748-a7ab-d47627ef3e1e',
+    apiFactionId: 'd731-9058-b0e5-6ff5',
+    currentPageFactionId: 'page-faction:3067',
+    expectedName: 'Disciples of Tzeentch',
+  },
+  {
+    catalogFactionId: 'faction:151c54f6-a281-5cea-b5ff-3dacd3afec43',
+    apiFactionId: 'b53b-1217-df2e-66d2',
+    currentPageFactionId: 'page-faction:3078',
+    expectedName: 'Flesh-eater Courts',
+  },
+  {
+    catalogFactionId: 'faction:16248666-7b1f-549c-9d76-14ff340da6b8',
+    apiFactionId: 'b3f9-6c96-b99a-1e71',
+    currentPageFactionId: 'page-faction:3064',
+    expectedName: 'Fyreslayers',
+  },
+  {
+    catalogFactionId: 'faction:7ac1f55f-9fc1-5473-8514-ba8de2589cb0',
+    apiFactionId: '9baf-c109-f621-e60',
+    currentPageFactionId: 'page-faction:3076',
+    expectedName: 'Gloomspite Gitz',
+  },
+  {
+    catalogFactionId: 'faction:4df09a85-c7ef-5cba-89db-5ff0f4a0b8ed',
+    apiFactionId: 'afdb-68a1-283e-3bf2',
+    currentPageFactionId: 'page-faction:3068',
+    expectedName: 'Hedonites of Slaanesh',
+  },
+  {
+    catalogFactionId: 'faction:1ad30c95-35a2-5373-b003-b91d6c4e350c',
+    apiFactionId: 'b7b7-cf58-4189-56ec',
+    currentPageFactionId: 'page-faction:3169',
+    expectedName: 'Helsmiths of Hashut',
+  },
+  {
+    catalogFactionId: 'faction:336daaf4-fa12-57ff-9ddc-b99a6a0382f7',
+    apiFactionId: '40a4-1c1c-8a00-bb65',
+    currentPageFactionId: 'page-faction:3059',
+    expectedName: 'Idoneth Deepkin',
+  },
+  {
+    catalogFactionId: 'faction:a87fbd85-38ce-5199-97ad-ff8bf3262471',
+    apiFactionId: '832c-fd6-a535-ffae',
+    currentPageFactionId: 'page-faction:3072',
+    expectedName: 'Ironjawz',
+  },
+  {
+    catalogFactionId: 'faction:685674e4-5dc7-5a42-a92e-d0719ca2a58d',
+    apiFactionId: '1100-a22f-15c6-bdea',
+    currentPageFactionId: 'page-faction:3062',
+    expectedName: 'Kharadron Overlords',
+  },
+  {
+    catalogFactionId: 'faction:26c5ea0d-7e4c-5440-b7c5-ffb2bae39c42',
+    apiFactionId: '8aef-b85d-b63a-ef05',
+    currentPageFactionId: 'page-faction:3073',
+    expectedName: 'Kruleboyz',
+  },
+  {
+    catalogFactionId: 'faction:d9758824-d17d-5c67-b153-1efc58d7670c',
+    apiFactionId: 'efc5-b8d-894c-67c6',
+    currentPageFactionId: 'page-faction:3063',
+    expectedName: 'Lumineth Realm-lords',
+  },
+  {
+    catalogFactionId: 'faction:a5f0c597-152e-59a2-8505-22bae7656788',
+    apiFactionId: '5079-92b5-4879-69f8',
+    currentPageFactionId: 'page-faction:3069',
+    expectedName: 'Maggotkin of Nurgle',
+  },
+  {
+    catalogFactionId: 'faction:89f27eab-fd1d-5b80-9ac4-bd784f07b9e2',
+    apiFactionId: '640e-6bc1-c83d-13c',
+    currentPageFactionId: 'page-faction:3079',
+    expectedName: 'Nighthaunt',
+  },
+  {
+    catalogFactionId: 'faction:6e6eb059-7938-5cef-b6db-9b694bad9e15',
+    apiFactionId: '6353-cb84-ac7f-9a15',
+    currentPageFactionId: 'page-faction:3075',
+    expectedName: 'Ogor Mawtribes',
+  },
+  {
+    catalogFactionId: 'faction:1a7ec2eb-9a00-5589-963a-53a986197fb9',
+    apiFactionId: '8e0e-5e8c-5824-89c9',
+    currentPageFactionId: 'page-faction:3081',
+    expectedName: 'Ossiarch Bonereapers',
+  },
+  {
+    catalogFactionId: 'faction:2ed6da96-b5ea-5a74-a417-fe41ab0c49a8',
+    apiFactionId: '4e3-e1a7-a8d4-8719',
+    currentPageFactionId: 'page-faction:3060',
+    expectedName: 'Seraphon',
+  },
+  {
+    catalogFactionId: 'faction:898f1d47-6f98-59f2-b5b7-e6865b2dfb79',
+    apiFactionId: '231a-2a83-26f0-a718',
+    currentPageFactionId: 'page-faction:3070',
+    expectedName: 'Skaven',
+  },
+  {
+    catalogFactionId: 'faction:9d9f8a78-e619-5b8c-a4b9-51274734c50b',
+    apiFactionId: '2c23-a678-196b-ad69',
+    currentPageFactionId: 'page-faction:3071',
+    expectedName: 'Slaves to Darkness',
+  },
+  {
+    catalogFactionId: 'faction:c079fb1a-6436-5673-b96d-50d6eec79ac3',
+    apiFactionId: 'de5f-588b-ea57-d6b5',
+    currentPageFactionId: 'page-faction:3077',
+    expectedName: 'Sons of Behemat',
+  },
+  {
+    catalogFactionId: 'faction:8658a21b-51d6-5dca-b06c-b3796c00aee6',
+    apiFactionId: '405e-c5f4-8579-b05c',
+    currentPageFactionId: 'page-faction:3080',
+    expectedName: 'Soulblight Gravelords',
+  },
+  {
+    catalogFactionId: 'faction:5b9d7142-ce11-515b-a1bd-37bddfad592a',
+    apiFactionId: '1bd9-ad7d-68ee-3b53',
+    currentPageFactionId: 'page-faction:3056',
+    expectedName: 'Stormcast Eternals',
+  },
+  {
+    catalogFactionId: 'faction:1c32f94e-f417-567d-885f-e256c60a634d',
+    apiFactionId: 'bb7e-b0da-5c2-a980',
+    currentPageFactionId: 'page-faction:3061',
+    expectedName: 'Sylvaneth',
+  },
+]
+
+export const LISTBOT_UNSCOPED_UNIT_BINDINGS: readonly ListbotUnscopedUnitBinding[] = [
+  {
+    currentUnitId: 'page-unit:5968',
+    sourceFactionId: '3103',
+    apiUnitId: 'b7be-ddee-783e-9048',
+  },
+]
+
+export interface ListbotFaction {
+  id: string
+  name: string
+}
+
+export interface ListbotUnit {
+  id: string
+  name: string
+  factionId: string
+  pointsCost: number
+  isHero: boolean
+  isRor: boolean
+  isTerrain: boolean
+  minModels: number
+  abilities?: unknown
+}
+
+export interface ListbotBattleFormation {
+  id: string
+  name: string
+  factionId: string
+  isAor: boolean
+}
+
+export interface ListbotGameData {
+  version: string
+  factions: ListbotFaction[]
+  units: ListbotUnit[]
+  battleFormations: ListbotBattleFormation[]
+}
+
+export interface ListbotCurrentPageData {
+  factions: ListbotFaction[]
+  units: ListbotUnit[]
+  unscopedUnits: ListbotUnscopedUnit[]
+}
+
+export interface ListbotUnscopedUnit extends Omit<ListbotUnit, 'factionId'> {
+  sourceFactionId: string
+}
+
+export interface ListbotReconciledUnscopedUnit {
+  currentUnitId: string
+  sourceFactionId: string
+  factionName: string
+  apiUnitId: string
+}
+
+export interface ListbotSourceDrift {
+  factionName: string
+  apiUnitEntries: number
+  currentUnitEntries: number
+  onlyInApi: string[]
+  onlyInCurrent: string[]
+}
+
+export interface ListbotVersionMarker {
+  version: string
+  factionCount: number
+  unitCount: number
+}
+
+export interface ListbotCoverageRoster {
+  category: 'army' | 'supplemental'
+  factionId: string
+  factionName: string
+  formation: { id: string; name: string } | null
+  file: string
+  unitCount: number
+  totalPoints: number
+  heroCount: number
+  regimentOfRenownCount: number
+  terrainCount: number
+  text: string
+}
+
+export interface ListbotCoverageCorpus {
+  version: string
+  coverage: {
+    sourceFactions: number
+    emptySourceFactions: number
+    sourceUnitEntries: number
+    armyFactions: number
+    armyUnitEntries: number
+    supplementalFactions: number
+    supplementalUnitEntries: number
+    uncoveredUnitEntries: number
+  }
+  emptyFactions: Array<{ id: string; name: string }>
+  missingArmyFactionIds: string[]
+  emptyArmyFactionIds: string[]
+  rosters: ListbotCoverageRoster[]
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const requiredString = (record: Record<string, unknown>, field: string, owner: string): string => {
+  const value = record[field]
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${owner}.${field} must be a non-empty string`)
+  }
+  if (/[\r\n]/.test(value)) throw new Error(`${owner}.${field} must fit on one line`)
+  return value.trim()
+}
+
+const requiredBoolean = (record: Record<string, unknown>, field: string, owner: string): boolean => {
+  const value = record[field]
+  if (typeof value !== 'boolean') throw new Error(`${owner}.${field} must be a boolean`)
+  return value
+}
+
+const requiredInteger = (
+  record: Record<string, unknown>,
+  field: string,
+  owner: string,
+  minimum: number
+): number => {
+  const value = record[field]
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < minimum) {
+    throw new Error(`${owner}.${field} must be an integer greater than or equal to ${minimum}`)
+  }
+  return value
+}
+
+const requiredArray = (record: Record<string, unknown>, field: string): unknown[] => {
+  const value = record[field]
+  if (!Array.isArray(value)) throw new Error(`Listbot game data ${field} must be an array`)
+  return value
+}
+
+export const parseListbotVersionMarker = (value: unknown): ListbotVersionMarker => {
+  if (!isRecord(value)) throw new Error('Listbot game-data version marker must be an object')
+  return {
+    version: requiredString(value, 'version', 'versionMarker'),
+    factionCount: requiredInteger(value, 'factionCount', 'versionMarker', 0),
+    unitCount: requiredInteger(value, 'unitCount', 'versionMarker', 0),
+  }
+}
+
+const parseFaction = (value: unknown, index: number): ListbotFaction => {
+  if (!isRecord(value)) throw new Error(`Listbot faction ${index} must be an object`)
+  return {
+    id: requiredString(value, 'id', `factions[${index}]`),
+    name: requiredString(value, 'name', `factions[${index}]`),
+  }
+}
+
+const parseUnit = (value: unknown, index: number): ListbotUnit => {
+  if (!isRecord(value)) throw new Error(`Listbot unit ${index} must be an object`)
+  return {
+    id: requiredString(value, 'id', `units[${index}]`),
+    name: requiredString(value, 'name', `units[${index}]`),
+    factionId: requiredString(value, 'factionId', `units[${index}]`),
+    pointsCost: requiredInteger(value, 'pointsCost', `units[${index}]`, 0),
+    isHero: requiredBoolean(value, 'isHero', `units[${index}]`),
+    isRor: requiredBoolean(value, 'isRor', `units[${index}]`),
+    isTerrain: requiredBoolean(value, 'isTerrain', `units[${index}]`),
+    minModels: requiredInteger(value, 'minModels', `units[${index}]`, 1),
+  }
+}
+
+const parseBattleFormation = (value: unknown, index: number): ListbotBattleFormation => {
+  if (!isRecord(value)) throw new Error(`Listbot battle formation ${index} must be an object`)
+  return {
+    id: requiredString(value, 'id', `battleFormations[${index}]`),
+    name: requiredString(value, 'name', `battleFormations[${index}]`),
+    factionId: requiredString(value, 'factionId', `battleFormations[${index}]`),
+    isAor: requiredBoolean(value, 'isAor', `battleFormations[${index}]`),
+  }
+}
+
+const assertUnique = <T>(values: readonly T[], identity: (value: T) => string, label: string): void => {
+  const seen = new Set<string>()
+  values.forEach(value => {
+    const id = identity(value)
+    if (seen.has(id)) throw new Error(`Duplicate Listbot ${label}: ${id}`)
+    seen.add(id)
+  })
+}
+
+const assertSnapshotIntegrity = (snapshot: ListbotGameData): void => {
+  assertUnique(snapshot.factions, faction => faction.id, 'faction identity')
+  assertUnique(snapshot.factions, faction => faction.name, 'faction name')
+  assertUnique(snapshot.battleFormations, formation => formation.id, 'battle formation identity')
+
+  const factionIds = new Set(snapshot.factions.map(faction => faction.id))
+  const unitIdentities = new Set<string>()
+  snapshot.units.forEach(unit => {
+    const identity = `${unit.factionId}\u0000${unit.id}`
+    if (unitIdentities.has(identity)) {
+      throw new Error(`Duplicate Listbot unit identity in faction ${unit.factionId}: ${unit.id}`)
+    }
+    unitIdentities.add(identity)
+    if (!factionIds.has(unit.factionId)) {
+      throw new Error(`Listbot unit ${unit.id} refers to unknown faction ${unit.factionId}`)
+    }
+  })
+  snapshot.battleFormations.forEach(formation => {
+    if (!factionIds.has(formation.factionId)) {
+      throw new Error(
+        `Listbot battle formation ${formation.id} refers to unknown faction ${formation.factionId}`
+      )
+    }
+  })
+}
+
+export const parseListbotGameData = (value: unknown): ListbotGameData => {
+  if (!isRecord(value)) throw new Error('Listbot game data must be an object')
+  const snapshot = {
+    version: requiredString(value, 'version', 'gameData'),
+    factions: requiredArray(value, 'factions').map(parseFaction),
+    units: requiredArray(value, 'units').map(parseUnit),
+    battleFormations: requiredArray(value, 'battleFormations').map(parseBattleFormation),
+  }
+  assertSnapshotIntegrity(snapshot)
+  return snapshot
+}
+
+interface HtmlNode {
+  nodeName?: string
+  attrs?: Array<{ name: string; value: string }>
+  childNodes?: HtmlNode[]
+  value?: string
+}
+
+const descendants = (node: HtmlNode): HtmlNode[] => [node, ...(node.childNodes ?? []).flatMap(descendants)]
+
+const attribute = (node: HtmlNode, name: string): string | undefined =>
+  node.attrs?.find(item => item.name === name)?.value
+
+const htmlText = (node: HtmlNode): string => node.value ?? (node.childNodes ?? []).map(htmlText).join('')
+
+const decodeHtmlText = (value: string): string => htmlText(parseFragment(value) as unknown as HtmlNode).trim()
+
+const requiredScriptString = (block: string, property: string, owner: string): string => {
+  const value = block.match(new RegExp(`^\\s*'${property}':\\s*'([^']*)',?\\s*$`, 'm'))?.[1]
+  if (value === undefined) throw new Error(`${owner}.${property} must be a quoted string`)
+  const decoded = decodeHtmlText(value)
+  if (!decoded || /[\r\n]/.test(decoded)) {
+    throw new Error(`${owner}.${property} must be a non-empty single-line string`)
+  }
+  return decoded
+}
+
+const requiredScriptInteger = (block: string, property: string, owner: string, minimum: number): number => {
+  const value = block.match(new RegExp(`^\\s*'${property}':\\s*(\\d+),?\\s*$`, 'm'))?.[1]
+  const parsed = value === undefined ? Number.NaN : Number(value)
+  if (!Number.isInteger(parsed) || parsed < minimum) {
+    throw new Error(`${owner}.${property} must be an integer greater than or equal to ${minimum}`)
+  }
+  return parsed
+}
+
+const optionalScriptBoolean = (
+  block: string,
+  property: string,
+  owner: string,
+  fallback: boolean
+): boolean => {
+  const value = block.match(new RegExp(`^\\s*'${property}':\\s*([^,\\r\\n]+),?\\s*$`, 'm'))?.[1]
+  if (value === undefined) return fallback
+  if (value !== 'true' && value !== 'false') {
+    throw new Error(`${owner}.${property} must be a boolean when present`)
+  }
+  return value === 'true'
+}
+
+export const parseListbotCurrentPage = (html: string): ListbotCurrentPageData => {
+  const document = parse(html) as unknown as HtmlNode
+  const nodes = descendants(document)
+  const factionSelect = nodes.find(
+    node =>
+      node.nodeName === 'select' &&
+      (attribute(node, 'class') ?? '').split(/\s+/).filter(Boolean).includes('faction-select')
+  )
+  if (!factionSelect) throw new Error('Listbot current page is missing its faction selector')
+
+  const factions = descendants(factionSelect)
+    .filter(node => node.nodeName === 'option' && Boolean(attribute(node, 'value')))
+    .map(node => {
+      const rawId = attribute(node, 'value') as string
+      if (!/^\d+$/.test(rawId)) throw new Error(`Listbot current faction id is not numeric: ${rawId}`)
+      const name = htmlText(node).trim()
+      if (!name || /[\r\n]/.test(name)) {
+        throw new Error(`Listbot current faction ${rawId} must have a single-line name`)
+      }
+      return { id: `page-faction:${rawId}`, name }
+    })
+  assertUnique(factions, faction => faction.id, 'current faction identity')
+  assertUnique(factions, faction => faction.name, 'current faction name')
+
+  const factionIds = new Map(factions.map(faction => [faction.id.slice('page-faction:'.length), faction.id]))
+  const script = nodes
+    .filter(node => node.nodeName === 'script')
+    .map(htmlText)
+    .join('\n')
+  const assignmentPattern = /global(Hero|Unit)Data\[(\d+)\]\s*=\s*\{([\s\S]*?)^\s*\}/gm
+  const assignmentKeys = new Set<string>()
+  const units: ListbotUnit[] = []
+  const unscopedUnits: ListbotUnscopedUnit[] = []
+  for (const match of Array.from(script.matchAll(assignmentPattern))) {
+    const kind = match[1]
+    const rawId = match[2]
+    const assignmentKey = `${kind}:${rawId}`
+    if (assignmentKeys.has(assignmentKey)) {
+      throw new Error(`Duplicate Listbot current data assignment: global${kind}Data[${rawId}]`)
+    }
+    assignmentKeys.add(assignmentKey)
+    const block = match[3]
+    const owner = `global${kind}Data[${rawId}]`
+    const declaredId = requiredScriptInteger(block, 'id', owner, 1)
+    if (String(declaredId) !== rawId) {
+      throw new Error(`${owner}.id does not match its assignment key`)
+    }
+    const rawFactionId = String(requiredScriptInteger(block, 'factionId', owner, 1))
+    const factionId = factionIds.get(rawFactionId)
+    const isHero = optionalScriptBoolean(block, 'isHero', owner, kind === 'Hero')
+    if (isHero !== (kind === 'Hero')) {
+      throw new Error(`${owner}.isHero conflicts with its Listbot data collection`)
+    }
+    const unit = {
+      id: `page-unit:${rawId}`,
+      name: requiredScriptString(block, 'name', owner),
+      pointsCost: requiredScriptInteger(block, 'pointsCost', owner, 0),
+      isHero,
+      isRor: optionalScriptBoolean(block, 'isRor', owner, false),
+      isTerrain: false,
+      minModels: kind === 'Hero' ? 1 : requiredScriptInteger(block, 'numberOfModels', owner, 1),
+    }
+    if (factionId) {
+      units.push({ ...unit, factionId })
+    } else {
+      unscopedUnits.push({ ...unit, sourceFactionId: rawFactionId })
+    }
+  }
+  if (!units.length && !unscopedUnits.length) {
+    throw new Error('Listbot current page did not contain any unit data')
+  }
+  assertSnapshotIntegrity({
+    version: 'current-page',
+    factions,
+    units,
+    battleFormations: [],
+  })
+  assertUnique(unscopedUnits, unit => unit.id, 'unscoped current unit identity')
+  return { factions, units, unscopedUnits }
+}
+
+const sortedNames = (values: readonly ListbotUnit[]): string[] =>
+  Array.from(new Set(values.map(value => value.name))).sort(compareText)
+
+const scopeUnit = (unit: ListbotUnscopedUnit, factionId: string): ListbotUnit => ({
+  id: unit.id,
+  name: unit.name,
+  factionId,
+  pointsCost: unit.pointsCost,
+  isHero: unit.isHero,
+  isRor: unit.isRor,
+  isTerrain: unit.isTerrain,
+  minModels: unit.minModels,
+})
+
+export const mergeListbotGameData = (
+  api: ListbotGameData,
+  current: ListbotCurrentPageData,
+  armyBindings: readonly ListbotArmyBinding[],
+  unscopedUnitBindings: readonly ListbotUnscopedUnitBinding[] = []
+): {
+  gameData: ListbotGameData
+  drift: ListbotSourceDrift[]
+  reconciledUnscopedUnits: ListbotReconciledUnscopedUnit[]
+} => {
+  assertSnapshotIntegrity(api)
+  const apiFactionById = new Map(api.factions.map(faction => [faction.id, faction]))
+  const currentFactionById = new Map(current.factions.map(faction => [faction.id, faction]))
+  assertUnique(armyBindings, binding => binding.catalogFactionId, 'catalog faction binding')
+  assertUnique(armyBindings, binding => binding.apiFactionId, 'API faction binding')
+  assertUnique(
+    armyBindings.filter(binding => binding.currentPageFactionId),
+    binding => binding.currentPageFactionId as string,
+    'current-page faction binding'
+  )
+  assertUnique(unscopedUnitBindings, binding => binding.currentUnitId, 'unscoped current unit binding')
+  assertUnique(unscopedUnitBindings, binding => binding.apiUnitId, 'unscoped API unit binding')
+
+  const bindingByApiFactionId = new Map(armyBindings.map(binding => [binding.apiFactionId, binding]))
+  const bindingByCurrentFactionId = new Map(
+    armyBindings.flatMap(binding =>
+      binding.currentPageFactionId ? [[binding.currentPageFactionId, binding] as const] : []
+    )
+  )
+  armyBindings.forEach(binding => {
+    const apiFaction = apiFactionById.get(binding.apiFactionId)
+    if (!apiFaction) {
+      throw new Error(`Listbot API is missing bound faction ${binding.apiFactionId}`)
+    }
+    if (apiFaction.name !== binding.expectedName) {
+      throw new Error(
+        `Listbot API faction ${binding.apiFactionId} name changed: ` +
+          `${apiFaction.name} != ${binding.expectedName}`
+      )
+    }
+    if (!binding.currentPageFactionId) return
+    const currentFaction = currentFactionById.get(binding.currentPageFactionId)
+    if (!currentFaction) {
+      throw new Error(`Listbot current page is missing bound faction ${binding.currentPageFactionId}`)
+    }
+    if (currentFaction.name !== binding.expectedName) {
+      throw new Error(
+        `Listbot current faction ${binding.currentPageFactionId} name changed: ` +
+          `${currentFaction.name} != ${binding.expectedName}`
+      )
+    }
+  })
+  current.factions.forEach(faction => {
+    if (!bindingByCurrentFactionId.has(faction.id)) {
+      throw new Error(`Listbot current faction ${faction.id} has no stable binding`)
+    }
+  })
+
+  const apiUnitById = new Map(api.units.map(unit => [unit.id, unit]))
+  const unscopedUnitById = new Map(current.unscopedUnits.map(unit => [unit.id, unit]))
+  const reconciledUnscopedUnits: ListbotReconciledUnscopedUnit[] = []
+  current.unscopedUnits.forEach(unit => {
+    if (!unscopedUnitBindings.some(binding => binding.currentUnitId === unit.id)) {
+      throw new Error(
+        `Listbot current unit ${unit.id} from unselectable faction ${unit.sourceFactionId} ` +
+          'has no stable binding'
+      )
+    }
+  })
+  const reconciledUnits = unscopedUnitBindings.map(binding => {
+    const unit = unscopedUnitById.get(binding.currentUnitId)
+    if (!unit || unit.sourceFactionId !== binding.sourceFactionId) {
+      throw new Error(`Listbot unscoped unit binding ${binding.currentUnitId} no longer matches the page`)
+    }
+    const apiUnit = apiUnitById.get(binding.apiUnitId)
+    if (!apiUnit) throw new Error(`Listbot API is missing bound unit ${binding.apiUnitId}`)
+    const factionBinding = bindingByApiFactionId.get(apiUnit.factionId)
+    if (!factionBinding?.currentPageFactionId) {
+      throw new Error(`Listbot API unit ${apiUnit.id} does not map to a current-page army`)
+    }
+    const compositionMatches =
+      apiUnit.name === unit.name &&
+      apiUnit.pointsCost === unit.pointsCost &&
+      apiUnit.minModels === unit.minModels &&
+      apiUnit.isHero === unit.isHero &&
+      apiUnit.isRor === unit.isRor &&
+      apiUnit.isTerrain === unit.isTerrain
+    if (!compositionMatches) {
+      throw new Error(`Listbot unscoped unit binding ${binding.currentUnitId} changed composition`)
+    }
+    reconciledUnscopedUnits.push({
+      currentUnitId: unit.id,
+      sourceFactionId: unit.sourceFactionId,
+      factionName: factionBinding.expectedName,
+      apiUnitId: apiUnit.id,
+    })
+    return scopeUnit(unit, factionBinding.currentPageFactionId)
+  })
+  const currentUnits = [...current.units, ...reconciledUnits]
+  const mergedFactions = api.factions.map(
+    faction =>
+      currentFactionById.get(bindingByApiFactionId.get(faction.id)?.currentPageFactionId ?? '') ?? faction
+  )
+
+  const apiFallbackUnits = api.units.filter(
+    unit => !bindingByApiFactionId.get(unit.factionId)?.currentPageFactionId
+  )
+  const mergedFormations = api.battleFormations.map(formation => {
+    const currentFactionId = bindingByApiFactionId.get(formation.factionId)?.currentPageFactionId
+    return currentFactionId
+      ? {
+          ...formation,
+          id: `api-formation:${formation.id}`,
+          factionId: currentFactionId,
+        }
+      : formation
+  })
+  const gameData = {
+    version: api.version,
+    factions: mergedFactions,
+    units: [...apiFallbackUnits, ...currentUnits],
+    battleFormations: mergedFormations,
+  }
+  assertSnapshotIntegrity(gameData)
+
+  const drift = armyBindings.flatMap(binding => {
+    if (!binding.currentPageFactionId) return []
+    const faction = currentFactionById.get(binding.currentPageFactionId) as ListbotFaction
+    const apiUnits = api.units.filter(unit => unit.factionId === binding.apiFactionId)
+    const factionCurrentUnits = currentUnits.filter(unit => unit.factionId === faction.id)
+    const apiNames = sortedNames(apiUnits)
+    const currentUnitNames = sortedNames(factionCurrentUnits)
+    const apiNameSet = new Set(apiNames)
+    const currentNameSet = new Set(currentUnitNames)
+    return [
+      {
+        factionName: faction.name,
+        apiUnitEntries: apiUnits.length,
+        currentUnitEntries: factionCurrentUnits.length,
+        onlyInApi: apiNames.filter(name => !currentNameSet.has(name)),
+        onlyInCurrent: currentUnitNames.filter(name => !apiNameSet.has(name)),
+      },
+    ]
+  })
+
+  return { gameData, drift, reconciledUnscopedUnits }
+}
+
+const compareText = (left: string, right: string): number =>
+  left.localeCompare(right, 'en', { sensitivity: 'base' }) || left.localeCompare(right, 'en')
+
+const slugify = (value: string): string => {
+  const slug = value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+  if (!slug) throw new Error(`Cannot create a file name for Listbot faction: ${value}`)
+  return slug
+}
+
+const rosterText = (
+  faction: ListbotFaction,
+  formation: ListbotBattleFormation | undefined,
+  units: ListbotUnit[]
+): string => {
+  const totalPoints = units.reduce((total, unit) => total + unit.pointsCost, 0)
+  const dropSuffix = units.length === 1 ? 'drop' : 'drops'
+  return [
+    faction.name,
+    formation?.name ?? LISTBOT_MISSING_FORMATION_LABEL,
+    '',
+    ...units.map(unit => `- ${unit.minModels} x ${unit.name} (${unit.pointsCost})`),
+    '',
+    `${totalPoints}/2000pts`,
+    `${units.length} ${dropSuffix}`,
+    '',
+    'Generated by Listbot 4.0',
+    '',
+  ].join('\n')
+}
+
+export const createListbotCoverageCorpus = (
+  snapshot: ListbotGameData,
+  armyFactionIds: readonly string[]
+): ListbotCoverageCorpus => {
+  assertSnapshotIntegrity(snapshot)
+  const acceptedArmies = new Set(armyFactionIds)
+  if (acceptedArmies.size !== armyFactionIds.length) {
+    throw new Error('The accepted Listbot army-faction ID list contains duplicates')
+  }
+
+  const unitsByFaction = new Map<string, ListbotUnit[]>()
+  const formationsByFaction = new Map<string, ListbotBattleFormation[]>()
+  const rosters: ListbotCoverageRoster[] = []
+  const emptyFactions: Array<{ id: string; name: string }> = []
+  const usedFiles = new Set<string>()
+
+  snapshot.units.forEach(unit => {
+    unitsByFaction.set(unit.factionId, [...(unitsByFaction.get(unit.factionId) ?? []), unit])
+  })
+  snapshot.battleFormations.forEach(formation => {
+    formationsByFaction.set(formation.factionId, [
+      ...(formationsByFaction.get(formation.factionId) ?? []),
+      formation,
+    ])
+  })
+
+  snapshot.factions
+    .slice()
+    .sort((left, right) => compareText(left.name, right.name) || compareText(left.id, right.id))
+    .forEach(faction => {
+      const units = (unitsByFaction.get(faction.id) ?? [])
+        .slice()
+        .sort((left, right) => compareText(left.name, right.name) || compareText(left.id, right.id))
+      if (!units.length) {
+        emptyFactions.push({ id: faction.id, name: faction.name })
+        return
+      }
+
+      const category = acceptedArmies.has(faction.id) ? 'army' : 'supplemental'
+      const file = `${category === 'army' ? 'armies' : 'supplemental'}/${slugify(faction.name)}.txt`
+      if (usedFiles.has(file)) throw new Error(`Duplicate Listbot corpus file name: ${file}`)
+      usedFiles.add(file)
+
+      const formation = (formationsByFaction.get(faction.id) ?? [])
+        .slice()
+        .sort(
+          (left, right) =>
+            Number(left.isAor) - Number(right.isAor) ||
+            compareText(left.name, right.name) ||
+            compareText(left.id, right.id)
+        )[0]
+      rosters.push({
+        category,
+        factionId: faction.id,
+        factionName: faction.name,
+        formation: formation ? { id: formation.id, name: formation.name } : null,
+        file,
+        unitCount: units.length,
+        totalPoints: units.reduce((total, unit) => total + unit.pointsCost, 0),
+        heroCount: units.filter(unit => unit.isHero).length,
+        regimentOfRenownCount: units.filter(unit => unit.isRor).length,
+        terrainCount: units.filter(unit => unit.isTerrain).length,
+        text: rosterText(faction, formation, units),
+      })
+    })
+
+  const sourceFactionIds = new Set(snapshot.factions.map(faction => faction.id))
+  const missingArmyFactionIds = Array.from(acceptedArmies)
+    .filter(id => !sourceFactionIds.has(id))
+    .sort(compareText)
+  const emptyFactionIds = new Set(emptyFactions.map(faction => faction.id))
+  const emptyArmyFactionIds = Array.from(acceptedArmies)
+    .filter(id => emptyFactionIds.has(id))
+    .sort(compareText)
+  const armyRosters = rosters.filter(roster => roster.category === 'army')
+  const supplementalRosters = rosters.filter(roster => roster.category === 'supplemental')
+  const armyUnitEntries = armyRosters.reduce((total, roster) => total + roster.unitCount, 0)
+  const supplementalUnitEntries = supplementalRosters.reduce((total, roster) => total + roster.unitCount, 0)
+  const coveredUnitEntries = armyUnitEntries + supplementalUnitEntries
+
+  return {
+    version: snapshot.version,
+    coverage: {
+      sourceFactions: snapshot.factions.length,
+      emptySourceFactions: emptyFactions.length,
+      sourceUnitEntries: snapshot.units.length,
+      armyFactions: armyRosters.length,
+      armyUnitEntries,
+      supplementalFactions: supplementalRosters.length,
+      supplementalUnitEntries,
+      uncoveredUnitEntries: snapshot.units.length - coveredUnitEntries,
+    },
+    emptyFactions,
+    missingArmyFactionIds,
+    emptyArmyFactionIds,
+    rosters,
+  }
+}

--- a/src/tests/support/listbotCorpusCommand.ts
+++ b/src/tests/support/listbotCorpusCommand.ts
@@ -1,0 +1,560 @@
+import { randomUUID } from 'node:crypto'
+import { lstat, mkdir, realpath, rename, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  FileArtifactCache,
+  acquireArtifact,
+  artifactChecksum,
+  createArtifactManifest,
+  createPinnedHttpsTransport,
+  resolveDnsAddresses,
+} from '../../aos4/data'
+import type { RulesContextId } from '../../aos4/domain'
+import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID } from '../../aos4/generated'
+import { stableJson } from '../../aos4/generate/serialization'
+import { resolveParsedRoster } from '../../aos4/import'
+import { decodeAos4TextRoster } from '../../importers/aos4'
+import {
+  LISTBOT_CURRENT_PAGE_URL,
+  LISTBOT_ARMY_BINDINGS,
+  LISTBOT_GAME_DATA_URL,
+  LISTBOT_GAME_DATA_VERSION_URL,
+  LISTBOT_UNSCOPED_UNIT_BINDINGS,
+  createListbotCoverageCorpus,
+  mergeListbotGameData,
+  parseListbotCurrentPage,
+  parseListbotGameData,
+  parseListbotVersionMarker,
+  type ListbotCoverageRoster,
+} from './listbotCorpus'
+
+const ADAPTER_VERSION = 'listbot-game-data/1'
+const MAX_GAME_DATA_BYTES = 5 * 1024 * 1024
+const MAX_CURRENT_PAGE_BYTES = 5 * 1024 * 1024
+const MAX_VERSION_BYTES = 64 * 1024
+const OUTPUT_ROOT = path.resolve('data', 'aos4', 'import-corpus')
+const DEFAULT_OUTPUT = path.join(OUTPUT_ROOT, 'listbot')
+const CACHE_ROOT = path.resolve('.cache', 'aos4', 'import', 'listbot')
+const NON_ARMY_FACTION_IDS = new Set(['faction:e668f75e-fd2f-513d-8ebb-e24696ceacb6'])
+const IMPORTABLE_CONTEXT_STATUSES = new Set(['current', 'seasonal', 'legends'])
+
+interface CommandOptions {
+  force: boolean
+  output: string
+}
+
+interface ArmyContext {
+  catalogFactionId: string
+  listbotFactionId: string
+  apiFactionId: string
+  currentPageFactionId?: string
+  name: string
+  rulesContextId: RulesContextId
+}
+
+const usage = (): never => {
+  console.error('Usage: yarn corpus:listbot [--output <path>] [--force]')
+  console.error(`  output must be below ${OUTPUT_ROOT}`)
+  process.exit(2)
+}
+
+export const validateOutputPath = (value: string): string => {
+  const output = path.resolve(value)
+  const relative = path.relative(OUTPUT_ROOT, output)
+  if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`Output must be below ${OUTPUT_ROOT}`)
+  }
+  return output
+}
+
+const parseArgs = (values: string[]): CommandOptions => {
+  let force = false
+  let output = DEFAULT_OUTPUT
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index]
+    if (value === '--force') {
+      if (force) throw new Error('--force may only be supplied once')
+      force = true
+      continue
+    }
+    if (value !== '--output') usage()
+    const next = values[index + 1]
+    if (!next || next.startsWith('--')) usage()
+    output = next
+    index += 1
+  }
+  return { force, output: validateOutputPath(output) }
+}
+
+const decodeJson = (bytes: Uint8Array, source: string): unknown => {
+  try {
+    return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) as unknown
+  } catch (error) {
+    throw new Error(`${source} did not return valid UTF-8 JSON: ${String(error)}`)
+  }
+}
+
+const decodeText = (bytes: Uint8Array, source: string): string => {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+  } catch (error) {
+    throw new Error(`${source} did not return valid UTF-8: ${String(error)}`)
+  }
+}
+
+const catalogArmyContexts = (): ArmyContext[] => {
+  const contextById = new Map(AOS4_CATALOG.rulesContexts.map(context => [context.id, context]))
+  const bindingsByCatalogFactionId = new Map(
+    LISTBOT_ARMY_BINDINGS.map(binding => [binding.catalogFactionId, binding])
+  )
+  const factions = AOS4_CATALOG.entities.flatMap(entity =>
+    entity.kind === 'faction' && !NON_ARMY_FACTION_IDS.has(entity.id) ? [entity] : []
+  )
+  const factionIds = new Set(factions.map(faction => faction.id))
+  LISTBOT_ARMY_BINDINGS.forEach(binding => {
+    if (!factionIds.has(binding.catalogFactionId as (typeof factions)[number]['id'])) {
+      throw new Error(`Listbot binding refers to missing catalog faction ${binding.catalogFactionId}`)
+    }
+  })
+  return factions
+    .map(faction => {
+      const binding = bindingsByCatalogFactionId.get(faction.id)
+      if (!binding) throw new Error(`No stable Listbot binding exists for army ${faction.id}`)
+      if (binding.expectedName !== faction.name) {
+        throw new Error(
+          `AoS 4 catalog faction ${faction.id} name changed: ${faction.name} != ${binding.expectedName}`
+        )
+      }
+      const preferredContext = faction.rulesContextIds.includes(AOS4_DEFAULT_RULES_CONTEXT_ID)
+        ? AOS4_DEFAULT_RULES_CONTEXT_ID
+        : faction.rulesContextIds.find(contextId => {
+            const context = contextById.get(contextId)
+            return context && IMPORTABLE_CONTEXT_STATUSES.has(context.status)
+          })
+      if (!preferredContext) {
+        throw new Error(`No importable AoS 4 rules context exists for army ${faction.name}`)
+      }
+      return {
+        catalogFactionId: faction.id,
+        listbotFactionId: binding.currentPageFactionId ?? binding.apiFactionId,
+        apiFactionId: binding.apiFactionId,
+        currentPageFactionId: binding.currentPageFactionId,
+        name: faction.name,
+        rulesContextId: preferredContext,
+      }
+    })
+    .sort((left, right) => left.name.localeCompare(right.name))
+}
+
+const verifyRoster = (roster: ListbotCoverageRoster, rulesContextId: RulesContextId | undefined) => {
+  const decoded = decodeAos4TextRoster(roster.text)
+  if (decoded.diagnostics.length || !decoded.parsedRoster) {
+    throw new Error(`Generated Listbot roster did not decode: ${roster.file}`)
+  }
+  const unitSelections = decoded.parsedRoster.selections.filter(
+    selection => selection.kindHint === 'warscroll'
+  )
+  if (
+    decoded.parsedRoster.declaredFaction !== roster.factionName ||
+    unitSelections.length !== roster.unitCount
+  ) {
+    throw new Error(`Generated Listbot roster did not round-trip all unit entries: ${roster.file}`)
+  }
+  if (!rulesContextId) return null
+
+  const preview = resolveParsedRoster(AOS4_CATALOG, decoded.parsedRoster, {
+    defaultRulesContextId: rulesContextId,
+    createDocumentId: () => 'listbot-all-units-coverage',
+  })
+  const matchedLines = new Set(preview.matches.map(match => match.line))
+  const diagnosticsByLine = new Map<number, Set<string>>()
+  preview.diagnostics.forEach(diagnostic => {
+    if (diagnostic.line === undefined) return
+    const codes = diagnosticsByLine.get(diagnostic.line) ?? new Set<string>()
+    codes.add(diagnostic.code)
+    diagnosticsByLine.set(diagnostic.line, codes)
+  })
+  const unresolved = unitSelections
+    .filter(selection => !matchedLines.has(selection.line))
+    .map(selection => ({
+      line: selection.line,
+      label: selection.label,
+      diagnosticCodes: Array.from(diagnosticsByLine.get(selection.line) ?? []).sort(),
+    }))
+
+  return {
+    rulesContextId,
+    resolvedUnitEntries: unitSelections.length - unresolved.length,
+    unresolvedUnitEntries: unresolved.length,
+    unresolved,
+  }
+}
+
+const pathExists = async (target: string): Promise<boolean> => {
+  try {
+    await lstat(target)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw error
+  }
+}
+
+const isContainedPath = (root: string, target: string): boolean => {
+  const relative = path.relative(root, target)
+  return (
+    relative === '' ||
+    (!path.isAbsolute(relative) && relative !== '..' && !relative.startsWith(`..${path.sep}`))
+  )
+}
+
+const ensureDirectoryInside = async (root: string, target: string): Promise<string> => {
+  const absoluteRoot = path.resolve(root)
+  const absoluteTarget = path.resolve(target)
+  if (!isContainedPath(absoluteRoot, absoluteTarget)) {
+    throw new Error(`${absoluteTarget} must stay below ${absoluteRoot}`)
+  }
+  const canonicalRoot = await realpath(absoluteRoot)
+  const relative = path.relative(absoluteRoot, absoluteTarget)
+  let cursor = absoluteRoot
+  for (const segment of relative.split(path.sep).filter(Boolean)) {
+    cursor = path.join(cursor, segment)
+    if (!(await pathExists(cursor))) await mkdir(cursor)
+    const stats = await lstat(cursor)
+    if (stats.isSymbolicLink()) {
+      throw new Error(`Refusing to traverse symbolic link or junction: ${cursor}`)
+    }
+    if (!stats.isDirectory()) throw new Error(`Expected a directory: ${cursor}`)
+    const canonicalCursor = await realpath(cursor)
+    if (!isContainedPath(canonicalRoot, canonicalCursor)) {
+      throw new Error(`Resolved output path escapes ${canonicalRoot}: ${cursor}`)
+    }
+  }
+  return realpath(absoluteTarget)
+}
+
+interface WriteListbotCorpusOptions {
+  workspaceRoot: string
+  outputRoot: string
+  output: string
+  force: boolean
+  files: Array<{ file: string; text: string }>
+  manifest: unknown
+  renamePath?: typeof rename
+}
+
+export const writeListbotCorpus = async (options: WriteListbotCorpusOptions): Promise<void> => {
+  const { files, force, manifest } = options
+  const outputRoot = path.resolve(options.outputRoot)
+  const output = path.resolve(options.output)
+  const renamePath = options.renamePath ?? rename
+  const lexicalRelative = path.relative(outputRoot, output)
+  if (
+    !lexicalRelative ||
+    path.isAbsolute(lexicalRelative) ||
+    lexicalRelative === '..' ||
+    lexicalRelative.startsWith(`..${path.sep}`)
+  ) {
+    throw new Error(`Output must be below ${outputRoot}`)
+  }
+
+  const canonicalOutputRoot = await ensureDirectoryInside(options.workspaceRoot, outputRoot)
+  const outputParent = await ensureDirectoryInside(canonicalOutputRoot, path.dirname(output))
+  const safeOutput = path.join(outputParent, path.basename(output))
+  const outputExists = await pathExists(safeOutput)
+  if (outputExists) {
+    const stats = await lstat(safeOutput)
+    if (stats.isSymbolicLink()) {
+      throw new Error(`Refusing to replace symbolic link or junction: ${safeOutput}`)
+    }
+    const canonicalOutput = await realpath(safeOutput)
+    if (!isContainedPath(canonicalOutputRoot, canonicalOutput)) {
+      throw new Error(`Resolved output path escapes ${canonicalOutputRoot}: ${safeOutput}`)
+    }
+  }
+  if (outputExists && !force) {
+    throw new Error(`${safeOutput} already exists; pass --force to replace this generated corpus`)
+  }
+
+  const operationId = randomUUID()
+  const temporary = path.join(canonicalOutputRoot, `.listbot-${operationId}.tmp`)
+  const backup = path.join(canonicalOutputRoot, `.listbot-${operationId}.backup`)
+  let backupCreated = false
+  await mkdir(temporary, { recursive: false })
+  try {
+    for (const file of files) {
+      const relative = path.normalize(file.file)
+      if (
+        !relative ||
+        path.isAbsolute(relative) ||
+        relative === '..' ||
+        relative.startsWith(`..${path.sep}`)
+      ) {
+        throw new Error(`Generated Listbot file escapes its corpus: ${file.file}`)
+      }
+      const target = path.join(temporary, file.file)
+      await mkdir(path.dirname(target), { recursive: true })
+      await writeFile(target, file.text, { encoding: 'utf8', flag: 'wx' })
+    }
+    await writeFile(path.join(temporary, 'manifest.json'), stableJson(manifest), {
+      encoding: 'utf8',
+      flag: 'wx',
+    })
+    if (outputExists) {
+      await renamePath(safeOutput, backup)
+      backupCreated = true
+    }
+    try {
+      await renamePath(temporary, safeOutput)
+    } catch (publicationError) {
+      if (backupCreated) {
+        try {
+          await renamePath(backup, safeOutput)
+          backupCreated = false
+        } catch (restorationError) {
+          throw new AggregateError(
+            [publicationError, restorationError],
+            `Failed to publish and restore Listbot corpus at ${safeOutput}`
+          )
+        }
+      }
+      throw publicationError
+    }
+    if (backupCreated) {
+      await rm(backup, { recursive: true })
+      backupCreated = false
+    }
+  } catch (error) {
+    await rm(temporary, { recursive: true, force: true })
+    throw error
+  }
+}
+
+const run = async (): Promise<void> => {
+  const options = parseArgs(process.argv.slice(2))
+  const retrievedAt = new Date().toISOString()
+  const dependencies = {
+    transport: createPinnedHttpsTransport(),
+    cache: new FileArtifactCache(CACHE_ROOT),
+    now: () => retrievedAt,
+    policy: {
+      allowedHosts: ['www.listbot.co.uk'],
+      resolveAddresses: resolveDnsAddresses,
+    },
+  }
+
+  const versionBeforeResult = await acquireArtifact(
+    {
+      url: LISTBOT_GAME_DATA_VERSION_URL,
+      adapterVersion: ADAPTER_VERSION,
+      allowedMediaTypes: ['application/json'],
+      maxBytes: MAX_VERSION_BYTES,
+      timeoutMs: 30_000,
+      maxRedirects: 0,
+      candidateManifest: createArtifactManifest(),
+    },
+    dependencies
+  )
+  const gameDataResult = await acquireArtifact(
+    {
+      url: LISTBOT_GAME_DATA_URL,
+      adapterVersion: ADAPTER_VERSION,
+      allowedMediaTypes: ['application/json'],
+      maxBytes: MAX_GAME_DATA_BYTES,
+      timeoutMs: 30_000,
+      maxRedirects: 0,
+      candidateManifest: versionBeforeResult.candidateManifest,
+    },
+    dependencies
+  )
+  const currentPageResult = await acquireArtifact(
+    {
+      url: LISTBOT_CURRENT_PAGE_URL,
+      adapterVersion: ADAPTER_VERSION,
+      allowedMediaTypes: ['text/html'],
+      maxBytes: MAX_CURRENT_PAGE_BYTES,
+      timeoutMs: 30_000,
+      maxRedirects: 0,
+      candidateManifest: gameDataResult.candidateManifest,
+    },
+    dependencies
+  )
+  const versionAfterResult = await acquireArtifact(
+    {
+      url: LISTBOT_GAME_DATA_VERSION_URL,
+      adapterVersion: ADAPTER_VERSION,
+      allowedMediaTypes: ['application/json'],
+      maxBytes: MAX_VERSION_BYTES,
+      timeoutMs: 30_000,
+      maxRedirects: 0,
+      candidateManifest: currentPageResult.candidateManifest,
+    },
+    dependencies
+  )
+
+  const versionBefore = parseListbotVersionMarker(
+    decodeJson(versionBeforeResult.bytes, LISTBOT_GAME_DATA_VERSION_URL)
+  )
+  const versionAfter = parseListbotVersionMarker(
+    decodeJson(versionAfterResult.bytes, LISTBOT_GAME_DATA_VERSION_URL)
+  )
+  const apiGameData = parseListbotGameData(decodeJson(gameDataResult.bytes, LISTBOT_GAME_DATA_URL))
+  if (JSON.stringify(versionBefore) !== JSON.stringify(versionAfter)) {
+    throw new Error('Listbot game-data version marker changed during retrieval')
+  }
+  if (versionAfter.version !== apiGameData.version) {
+    throw new Error(
+      `Listbot version changed during retrieval: ${versionAfter.version} != ${apiGameData.version}`
+    )
+  }
+  if (
+    versionAfter.factionCount !== apiGameData.factions.length ||
+    versionAfter.unitCount !== apiGameData.units.length
+  ) {
+    throw new Error('Listbot version counts do not match the downloaded game-data snapshot')
+  }
+  const currentPage = parseListbotCurrentPage(decodeText(currentPageResult.bytes, LISTBOT_CURRENT_PAGE_URL))
+  const { gameData, drift, reconciledUnscopedUnits } = mergeListbotGameData(
+    apiGameData,
+    currentPage,
+    LISTBOT_ARMY_BINDINGS,
+    LISTBOT_UNSCOPED_UNIT_BINDINGS
+  )
+  const currentFactionIds = new Set<string>(
+    LISTBOT_ARMY_BINDINGS.flatMap(binding => (binding.currentPageFactionId ? [binding.apiFactionId] : []))
+  )
+  const apiOnlyFactionCount = apiGameData.factions.filter(
+    faction => !currentFactionIds.has(faction.id)
+  ).length
+
+  const armyContexts = catalogArmyContexts()
+  const armyContextByListbotId = new Map(armyContexts.map(army => [army.listbotFactionId, army]))
+  const corpus = createListbotCoverageCorpus(
+    gameData,
+    armyContexts.map(army => army.listbotFactionId)
+  )
+  if (corpus.missingArmyFactionIds.length) {
+    throw new Error(`Listbot game data is missing AoS 4 army IDs: ${corpus.missingArmyFactionIds.join(', ')}`)
+  }
+  if (corpus.emptyArmyFactionIds.length) {
+    throw new Error(
+      `Listbot game data contains empty AoS 4 army IDs: ${corpus.emptyArmyFactionIds.join(', ')}`
+    )
+  }
+  if (corpus.coverage.uncoveredUnitEntries !== 0) {
+    throw new Error(`${corpus.coverage.uncoveredUnitEntries} Listbot unit entries were not collected`)
+  }
+
+  const rosterResults = corpus.rosters.map(roster => ({
+    roster,
+    resolution: verifyRoster(roster, armyContextByListbotId.get(roster.factionId)?.rulesContextId),
+  }))
+  const resolvedUnitEntries = rosterResults.reduce(
+    (total, result) => total + (result.resolution?.resolvedUnitEntries ?? 0),
+    0
+  )
+  const unresolvedUnitEntries = rosterResults.reduce(
+    (total, result) => total + (result.resolution?.unresolvedUnitEntries ?? 0),
+    0
+  )
+  const gameDataEntry = gameDataResult.entry
+  const currentPageEntry = currentPageResult.entry
+  const versionEntry = versionAfterResult.entry
+  const manifest = {
+    schemaVersion: 1,
+    kind: 'listbot-all-units-coverage',
+    generatedAt: retrievedAt,
+    source: {
+      adapterVersion: ADAPTER_VERSION,
+      version: gameData.version,
+      currentPage: {
+        url: currentPageEntry.finalUrl,
+        byteLength: currentPageEntry.byteLength,
+        sha256: currentPageEntry.checksum,
+        mediaType: currentPageEntry.mediaType,
+        factionCount: currentPage.factions.length,
+        unitCount: currentPage.units.length + currentPage.unscopedUnits.length,
+        unscopedUnitCount: currentPage.unscopedUnits.length,
+        reconciledUnscopedUnits,
+      },
+      gameData: {
+        url: gameDataEntry.finalUrl,
+        byteLength: gameDataEntry.byteLength,
+        sha256: gameDataEntry.checksum,
+        mediaType: gameDataEntry.mediaType,
+        factionCount: apiGameData.factions.length,
+        unitCount: apiGameData.units.length,
+      },
+      versionMarker: {
+        url: versionEntry.finalUrl,
+        byteLength: versionEntry.byteLength,
+        sha256: versionEntry.checksum,
+        mediaType: versionEntry.mediaType,
+      },
+    },
+    contract: {
+      purpose: 'Importer label coverage; these exhaustive, over-points rosters are not legal lists.',
+      ruleTextRetained: false,
+      remoteWritesPerformed: false,
+      currentPagePreferred: true,
+      catalogArmyCount: armyContexts.length,
+      matchedCatalogArmies: armyContexts.map(army => ({
+        catalogFactionId: army.catalogFactionId,
+        listbotFactionId: army.listbotFactionId,
+        name: army.name,
+      })),
+      missingCatalogArmies: corpus.missingArmyFactionIds,
+      emptyCatalogArmies: corpus.emptyArmyFactionIds,
+    },
+    coverage: corpus.coverage,
+    sourceDrift: drift,
+    resolution: {
+      attemptedArmyUnitEntries: resolvedUnitEntries + unresolvedUnitEntries,
+      resolvedUnitEntries,
+      unresolvedUnitEntries,
+    },
+    emptySourceFactions: corpus.emptyFactions,
+    rosters: rosterResults.map(({ roster, resolution }) => {
+      const { text, ...metadata } = roster
+      return {
+        ...metadata,
+        sourceKind: currentPage.factions.some(faction => faction.id === roster.factionId)
+          ? 'current-page'
+          : 'game-data-api',
+        sha256: artifactChecksum(new TextEncoder().encode(text)),
+        resolution,
+      }
+    }),
+  }
+
+  await writeListbotCorpus({
+    workspaceRoot: path.resolve('.'),
+    outputRoot: OUTPUT_ROOT,
+    output: options.output,
+    force: options.force,
+    files: corpus.rosters.map(roster => ({ file: roster.file, text: roster.text })),
+    manifest,
+  })
+  console.log(
+    `Collected ${currentPage.factions.length} current Listbot factions and ` +
+      `${apiOnlyFactionCount} API-only catalogs`
+  )
+  console.log(`Listbot game-data fallback version ${gameData.version}`)
+  console.log(`Wrote ${corpus.coverage.armyFactions} army rosters (${corpus.coverage.armyUnitEntries} units)`)
+  console.log(
+    `Wrote ${corpus.coverage.supplementalFactions} supplemental rosters ` +
+      `(${corpus.coverage.supplementalUnitEntries} units)`
+  )
+  console.log(
+    `Resolved ${resolvedUnitEntries}/${resolvedUnitEntries + unresolvedUnitEntries} AoS 4 army unit entries`
+  )
+  console.log(`Manifest: ${path.join(options.output, 'manifest.json')}`)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  run().catch(error => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## Summary

AoS 4 importer work can now generate a private Listbot-format coverage roster for every catalog
army, including the two Legends armies absent from Listbot's current builder. A live run on
2026-07-29 produced 27 army rosters with 1,421 unit entries and four supplemental rosters with 55
entries; every exposed source entry was emitted exactly once.

The acquisition prefers Listbot's current `/listbot/` inventory and uses the versioned game-data
API (`2026-01-11T12:00:22.131617Z`) only for unavailable catalogs. Canonical faction IDs, API IDs,
and current-page IDs are bridged explicitly, so provider names are drift checks rather than
identity. The one current page record attached to an unselectable faction is likewise reconciled
through reviewed provider IDs and verified composition fields.

Raw responses remain in `.cache/aos4/`, generated rosters remain gitignored, and rule text is
dropped before projection. No accepted catalog or runtime-generated file changes. This tooling
does not establish game-rule facts or effective dates.

Canonical import resolution currently matches 700 of the 1,421 army entries. The manifest retains
all 721 unresolved labels and their diagnostics so later importer work can close those gaps without
losing provider coverage.

## Validation

- `yarn corpus:listbot --force` — generated 27/27 army rosters, 1,421 army entries, 55
  supplemental entries, and zero uncovered entries
- `yarn vitest run src/tests/aos4/listbotCorpus.test.ts src/tests/aos4/listbotCorpusCommand.test.ts`
  — 10 tests passed, including malformed source data, duplicate assignments, junction rejection,
  and failed-publication restoration
- `yarn lint`
- `yarn tsc --noEmit`
- `yarn build`
- `yarn data:aos4:verify:beta` — 79,446 passed, zero findings, zero unverifiable
- `yarn test --run` — 392/393 passed; the unchanged baseline
  `importOfficialApp.test.ts` CRLF line-number assertion remains the sole failure

## Post-deploy Monitoring & Validation

This adds developer-only acquisition and test tooling; it does not alter the browser runtime or
production deployment. After merge, rerun `yarn corpus:listbot --force` when Listbot changes.
Healthy output reports all 27 catalog armies and zero uncovered entries. Any missing stable binding,
contract drift, version change during retrieval, unsafe path, or uncovered entry fails closed before
the previous corpus is replaced.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
