### PR TITLE
perf(aos4): make beta certification coverage linear

### DIFF
--- a/src/aos4/review/certification.ts
+++ b/src/aos4/review/certification.ts
@@ -974,13 +974,17 @@ const coverageByValues = (
   values: (entry: ReviewPacketIndexEntry) => string[],
   reviewed: (entry: ReviewPacketIndexEntry) => boolean
 ): Record<string, CertificationCoverageDetail> => {
-  const keys = uniqueSorted(entries.flatMap(values))
-  return Object.fromEntries(
-    keys.map(key => {
-      const matching = entries.filter(entry => values(entry).includes(key))
-      return [key, count(matching.filter(reviewed).length, matching.length)]
+  const coverage = new Map<string, CertificationCoverageDetail>()
+  entries.forEach(entry => {
+    const keys = new Set(values(entry))
+    if (!keys.size) return
+    const entryReviewed = reviewed(entry)
+    keys.forEach(key => {
+      const current = coverage.get(key) ?? count(0, 0)
+      coverage.set(key, count(current.reviewed + Number(entryReviewed), current.expected + 1))
     })
-  )
+  })
+  return Object.fromEntries(uniqueSorted(coverage.keys()).map(key => [key, coverage.get(key)!]))
 }
 
 const categoryCoverage = (

--- a/src/tests/aos4/certification.test.ts
+++ b/src/tests/aos4/certification.test.ts
@@ -605,6 +605,20 @@ describe('AoS 4 certification evaluation', () => {
     })
   })
 
+  it('counts each review entry once per distinct coverage key', () => {
+    const input = passingInput()
+    input.index.entries[0].cohortIds = [
+      'high-risk:reaction',
+      'high-risk:reaction',
+      SAMPLING_METADATA_COHORT,
+    ]
+
+    expect(evaluateCertification(input).summary.coverageByCohort).toMatchObject({
+      'high-risk:reaction': { reviewed: 1, expected: 1 },
+      [SAMPLING_METADATA_COHORT]: { reviewed: 1, expected: 1 },
+    })
+  })
+
   it('rejects safe-index cohort relabeling that is not bound to sampling metadata', () => {
     const input = passingInput()
     input.index.entries[0].cohortIds = [


### PR DESCRIPTION
## Summary

Beta-readiness CI no longer spends several minutes repeatedly recalculating the same review coverage. Coverage is accumulated once per review entry while retaining distinct-key counting and the existing fail-closed certification result.

| Measurement | Before | After |
| --- | ---: | ---: |
| Same-machine certification benchmark | 336.693s | 11.938s |

This is a 96.45% wall-time reduction (28.2x speedup). No generated files, accepted corpus inputs, certification requirements, or command output changed.

## Validation

- `yarn lint`
- `yarn tsc --noEmit`
- `yarn test --run` — 753 tests passed
- `yarn build`
- `yarn data:aos4:verify:beta` — 79,446 pass, 0 finding, 0 cannot-verify in 9.41s after rebasing onto `origin/aos4-migration`
