### PR TITLE
ci: update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       CF_PATH: /*
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Configure AWS cli
         uses: aws-actions/configure-aws-credentials@v1
@@ -33,7 +33,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'yarn'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'yarn'


### PR DESCRIPTION
## Summary

CI and deployment jobs now use supported first-party action runtimes, removing the Node.js 20 deprecation warnings while preserving the project’s Node.js 22 and Yarn cache configuration.

## Validation

- PR `Lint, Test, and Build` completed successfully using `actions/checkout@v7` and `actions/setup-node@v7`
- 54 Vitest files / 765 tests passed
- AoS 4 beta certification: 79,446 pass, 0 finding, 0 cannot-verify
- Production build passed
- The completed job log contains no stale action-runtime warning

## Post-Deploy Monitoring & Validation

No additional production monitoring is required because this changes CI action runtimes only. The repository maintainer should confirm the post-merge `aos4-migration` run remains green; an action load failure or recurring Node.js 20 warning is the rollback trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
