### PR TITLE
fix: return Stripe checkout to the current origin

### DIFF
--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -84,17 +84,17 @@ export const PlanComponent = (props: IPlanProps) => {
 
     logClick(supportPlan.title)
     const plan = isDev ? supportPlan.stripe_dev : supportPlan.stripe_prod
-    const url = isDev ? 'localhost:3000' : 'aosreminders.com'
+    const origin = window.location.origin
 
     const result = await stripe.redirectToCheckout({
       items: [{ plan, quantity: 1 }],
       customerEmail: user.email,
       clientReferenceId: user.email,
-      successUrl: `${window.location.protocol}//${url}/?${qs.stringify({
+      successUrl: `${origin}/?${qs.stringify({
         subscribed: true,
         plan: supportPlan.title,
       })}`,
-      cancelUrl: `${window.location.protocol}//${url}/?${qs.stringify({
+      cancelUrl: `${origin}/?${qs.stringify({
         canceled: true,
         plan: supportPlan.title,
       })}`,

--- a/src/tests/aos4/pricingPlans.test.tsx
+++ b/src/tests/aos4/pricingPlans.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+// @vitest-environment-options {"url":"http://localhost:5173/subscribe"}
 
 import { PlanComponent } from 'components/payment/pricingPlans'
 import { render, unmountComponentAtNode } from 'react-dom'
@@ -77,9 +78,11 @@ describe('subscription pricing plans', () => {
     expect(stripe.redirectToCheckout).toHaveBeenCalledTimes(1)
     expect(stripe.redirectToCheckout).toHaveBeenCalledWith(
       expect.objectContaining({
+        cancelUrl: 'http://localhost:5173/?canceled=true&plan=1%20Month',
         clientReferenceId: 'general@example.com',
         customerEmail: 'general@example.com',
         items: [{ plan: SUBSCRIPTION_PLANS[0].stripe_prod, quantity: 1 }],
+        successUrl: 'http://localhost:5173/?subscribed=true&plan=1%20Month',
       })
     )
     expect(container.querySelector('button')?.textContent).toBe('Subscribe for 1 Month')


### PR DESCRIPTION
## Summary

Stripe subscribers now return to the same origin that launched Checkout, so Vite development returns to `localhost:5173` instead of the retired CRA port and deployed environments preserve their actual host and protocol. Regression coverage pins both success and cancellation URLs to the current origin. No rules, source inputs, or generated corpus files changed.

## Validation

- `eslint src --max-warnings 0`
- `tsc --noEmit`
- `vitest run` — 765 tests passed on the latest `origin/aos4-migration`
- `tsc && vite build`
- `yarn data:aos4:verify:beta` — 79,446 passed with zero findings against the same patch before isolation; a fresh Windows worktree cannot repeat the check because Git rewrites the byte-exact completion sentinel to CRLF

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
