### PR TITLE
fix: preserve completion marker line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
+# Create-only completion markers are byte-exact and must retain LF endings
+.complete.json text eol=lf
+
 # Ignore fixture files when detecting languages for Github
 src/tests/fixtures/* linguist-vendored


### PR DESCRIPTION
## Summary

Fresh Windows worktrees no longer invalidate AoS 4 certification because Git rewrote the byte-exact
completion marker to CRLF. The repository now pins these markers to LF even when
`core.autocrlf=true`; no generated files or accepted inputs changed.

## Validation

- Simulated a fresh checkout with `core.autocrlf=true`: the marker remained 56 bytes with zero
  carriage returns and matched the verifier's expected content exactly.
- `yarn data:aos4:verify:beta` — 79,446 pass, 0 finding, 0 cannot-verify.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
