### PR TITLE
fix(aos4): stabilize free import and local development

### DIFF
--- a/src/components/input/toolbar/toolbar.tsx
+++ b/src/components/input/toolbar/toolbar.tsx
@@ -61,7 +61,7 @@ const Toolbar = ({
         </ToolbarButton>
       </div>
       <div className={buttonWrapperClass}>
-        <ToolbarButton disabled={subscriberActionDisabled} onClick={onImportArmy}>
+        <ToolbarButton onClick={onImportArmy}>
           <MdFileUpload className="mr-2" />
           Import Army
         </ToolbarButton>

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -84,17 +84,17 @@ export const PlanComponent = (props: IPlanProps) => {
 
     logClick(supportPlan.title)
     const plan = isDev ? supportPlan.stripe_dev : supportPlan.stripe_prod
-    const url = isDev ? 'localhost:3000' : 'aosreminders.com'
+    const origin = window.location.origin
 
     const result = await stripe.redirectToCheckout({
       items: [{ plan, quantity: 1 }],
       customerEmail: user.email,
       clientReferenceId: user.email,
-      successUrl: `${window.location.protocol}//${url}/?${qs.stringify({
+      successUrl: `${origin}/?${qs.stringify({
         subscribed: true,
         plan: supportPlan.title,
       })}`,
-      cancelUrl: `${window.location.protocol}//${url}/?${qs.stringify({
+      cancelUrl: `${origin}/?${qs.stringify({
         canceled: true,
         plan: supportPlan.title,
       })}`,
@@ -192,7 +192,11 @@ const PayPalComponent = (props: IPlanProps) => {
         />
       )}
       {modalIsOpen && (
-        <PaypalPostSubscribeModal modalIsOpen={modalIsOpen} closeModal={closeModal} retryGrant={requestGrant} />
+        <PaypalPostSubscribeModal
+          modalIsOpen={modalIsOpen}
+          closeModal={closeModal}
+          retryGrant={requestGrant}
+        />
       )}
     </div>
   )

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -91,10 +91,6 @@ const Home = () => {
   const [shareModalIsOpen, setShareModalIsOpen] = useState(false)
   const [pendingShareId, setPendingShareId] = useState(() => consumePendingShareId())
   const [printModalIsOpen, setPrintModalIsOpen] = useState(false)
-  const importAction = useSubscriberAction({
-    onAuthorized: () => setImportModalIsOpen(true),
-    origin: 'ImportArmy',
-  })
   const savedArmiesAction = useSubscriberAction({
     onAuthorized: () => setSavedArmiesModalIsOpen(true),
     origin: 'SavedArmies',
@@ -243,14 +239,12 @@ const Home = () => {
           hiddenCount={hiddenCount}
           onClearArmy={clearArmy}
           onDownloadPdf={() => setPrintModalIsOpen(true)}
-          onImportArmy={importAction.run}
+          onImportArmy={() => setImportModalIsOpen(true)}
           onOpenSavedArmies={savedArmiesAction.run}
           onResetArmy={() => setDocument(createDefaultAos4ArmyDocument())}
           onShareArmy={shareAction.run}
           onShowAll={showAll}
-          subscriberActionDisabled={
-            importAction.disabled || savedArmiesAction.disabled || shareAction.disabled
-          }
+          subscriberActionDisabled={savedArmiesAction.disabled || shareAction.disabled}
         />
       )}
 

--- a/src/components/routes/Subscribe.tsx
+++ b/src/components/routes/Subscribe.tsx
@@ -104,7 +104,6 @@ const CurrentFeatures = () => (
       <strong>What do you get when you subscribe?</strong>
     </p>
     <ul className="lead">
-      <li>Import current army lists from the AoS app, Listbot 4.0, and New Recruit.</li>
       <li>Save, load, rename, update, and delete AoS 4 armies across your devices.</li>
       <li>Create read-only army links to share with your friends.</li>
       <li>Spare your eyes! Turn on dark mode!</li>

--- a/src/tests/aos4/accountRoutes.test.tsx
+++ b/src/tests/aos4/accountRoutes.test.tsx
@@ -127,7 +127,7 @@ describe('established account routes', () => {
     expect(container.textContent).toContain('Support AoS Reminders')
     expect(container.textContent).toContain('What do you get when you subscribe?')
     expect(container.textContent).toContain('Spare your eyes! Turn on dark mode!')
-    expect(container.textContent).toContain(
+    expect(container.textContent).not.toContain(
       'Import current army lists from the AoS app, Listbot 4.0, and New Recruit.'
     )
     expect(container.textContent).toContain(

--- a/src/tests/aos4/homePresentation.test.tsx
+++ b/src/tests/aos4/homePresentation.test.tsx
@@ -6,17 +6,47 @@ import { ThemeProvider } from 'context/useTheme'
 import { SubscriptionProvider } from 'context/useSubscription'
 import React from 'react'
 import { render, unmountComponentAtNode } from 'react-dom'
-import { act } from 'react-dom/test-utils'
+import { act, Simulate } from 'react-dom/test-utils'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const auth = vi.hoisted(() => ({
+  isAuthenticated: false,
+  isLoading: false,
+  loginWithPopup: vi.fn(),
+  logout: vi.fn(),
+  user: undefined as { email: string } | undefined,
+}))
+const getSubscription = vi.hoisted(() => vi.fn())
+const historyPush = vi.hoisted(() => vi.fn())
+
 vi.mock('@auth0/auth0-react', () => ({
-  useAuth0: () => ({
-    isAuthenticated: false,
-    isLoading: false,
-    loginWithPopup: vi.fn(),
-    logout: vi.fn(),
-  }),
+  useAuth0: () => auth,
+}))
+
+vi.mock('../../api/subscriptionApi', () => ({
+  SubscriptionApi: {
+    cancelSubscription: vi.fn(),
+    getSubscription,
+    updateTheme: vi.fn(),
+  },
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useHistory: () => ({ push: historyPush }),
+  }
+})
+
+vi.mock('components/input/importArmy/importArmyModal', () => ({
+  default: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? (
+      <div aria-label="Import Army" role="dialog">
+        Free import
+      </div>
+    ) : null,
 }))
 
 class MemoryStorage implements Storage {
@@ -50,7 +80,28 @@ class MemoryStorage implements Storage {
 describe('AoS 4 home presentation', () => {
   let container: HTMLDivElement
 
+  const renderHome = () =>
+    render(
+      <AppStatusProvider>
+        <SubscriptionProvider>
+          <ThemeProvider>
+            <MemoryRouter>
+              <Home />
+            </MemoryRouter>
+          </ThemeProvider>
+        </SubscriptionProvider>
+      </AppStatusProvider>,
+      container
+    )
+
   beforeEach(() => {
+    auth.isAuthenticated = false
+    auth.isLoading = false
+    auth.user = undefined
+    auth.loginWithPopup.mockReset()
+    getSubscription.mockReset()
+    getSubscription.mockRejectedValue({ status: 501 })
+    historyPush.mockReset()
     Object.defineProperty(window, 'localStorage', {
       configurable: true,
       value: new MemoryStorage(),
@@ -59,18 +110,7 @@ describe('AoS 4 home presentation', () => {
     document.body.appendChild(container)
 
     act(() => {
-      render(
-        <AppStatusProvider>
-          <SubscriptionProvider>
-            <ThemeProvider>
-              <MemoryRouter>
-                <Home />
-              </MemoryRouter>
-            </ThemeProvider>
-          </SubscriptionProvider>
-        </AppStatusProvider>,
-        container
-      )
+      renderHome()
     })
   })
 
@@ -100,6 +140,58 @@ describe('AoS 4 home presentation', () => {
     expect(container.textContent).toContain('Subscribe')
     expect(container.textContent).toContain('FAQ')
     expect(container.textContent).toContain('Log in')
+  })
+
+  it('opens the free import without authentication or a subscription', async () => {
+    const importButton = Array.from(container.querySelectorAll('button')).find(
+      button => button.textContent?.trim() === 'Import Army'
+    )
+    expect(importButton).not.toBeUndefined()
+    expect(importButton?.disabled).toBe(false)
+
+    await act(async () => {
+      Simulate.click(importButton!)
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    expect(auth.loginWithPopup).not.toHaveBeenCalled()
+    expect(container.querySelector('[role="dialog"][aria-label="Import Army"]')).not.toBeNull()
+  })
+
+  it('keeps import free while subscriber-only actions stay gated for an inactive account', async () => {
+    act(() => {
+      unmountComponentAtNode(container)
+    })
+    auth.isAuthenticated = true
+    auth.user = { email: 'inactive@example.com' }
+
+    await act(async () => {
+      renderHome()
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    const findButton = (label: string) =>
+      Array.from(container.querySelectorAll('button')).find(button => button.textContent?.trim() === label)
+
+    expect(getSubscription).toHaveBeenCalledWith('inactive@example.com')
+    expect(findButton('My Armies')?.disabled).toBe(false)
+    expect(findButton('Share Army')?.disabled).toBe(false)
+
+    act(() => {
+      Simulate.click(findButton('My Armies')!)
+      Simulate.click(findButton('Share Army')!)
+    })
+
+    expect(historyPush).toHaveBeenNthCalledWith(1, '/subscribe')
+    expect(historyPush).toHaveBeenNthCalledWith(2, '/subscribe')
+
+    await act(async () => {
+      Simulate.click(findButton('Import Army')!)
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    expect(auth.loginWithPopup).not.toHaveBeenCalled()
+    expect(container.querySelector('[role="dialog"][aria-label="Import Army"]')).not.toBeNull()
   })
 
   it('does not render the migration-workbench reskin', () => {

--- a/src/tests/aos4/importUi.test.tsx
+++ b/src/tests/aos4/importUi.test.tsx
@@ -105,8 +105,8 @@ const findButton = (container: HTMLElement, label: string): HTMLButtonElement =>
   return button
 }
 
-const SubscriberHarness = ({ onAuthorized }: { onAuthorized: () => void }) => {
-  const action = useSubscriberAction({ onAuthorized, origin: 'ImportArmyTest' })
+const SubscriberActionHarness = ({ onAuthorized }: { onAuthorized: () => void }) => {
+  const action = useSubscriberAction({ onAuthorized, origin: 'SubscriberActionTest' })
   return (
     <button disabled={action.disabled} onClick={action.run} type="button">
       Subscriber action
@@ -114,7 +114,7 @@ const SubscriberHarness = ({ onAuthorized }: { onAuthorized: () => void }) => {
   )
 }
 
-describe('subscriber import action', () => {
+describe('subscriber-only account action', () => {
   let container: HTMLDivElement
 
   beforeEach(() => {
@@ -134,12 +134,12 @@ describe('subscriber import action', () => {
     container.remove()
   })
 
-  it('opens login for signed-out users, Subscribe for inactive users, and the action for subscribers', () => {
+  it('opens login for signed-out users, Subscribe for inactive users, and paid actions for subscribers', () => {
     const onAuthorized = vi.fn()
     const renderHarness = () =>
       render(
         <MemoryRouter initialEntries={['/']}>
-          <SubscriberHarness onAuthorized={onAuthorized} />
+          <SubscriberActionHarness onAuthorized={onAuthorized} />
           <Route path="/subscribe">Subscribe destination</Route>
         </MemoryRouter>,
         container

--- a/src/tests/aos4/pricingPlans.test.tsx
+++ b/src/tests/aos4/pricingPlans.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+// @vitest-environment-options {"url":"https://preview.example.test/subscribe"}
 
 import { PlanComponent } from 'components/payment/pricingPlans'
 import { render, unmountComponentAtNode } from 'react-dom'
@@ -77,9 +78,11 @@ describe('subscription pricing plans', () => {
     expect(stripe.redirectToCheckout).toHaveBeenCalledTimes(1)
     expect(stripe.redirectToCheckout).toHaveBeenCalledWith(
       expect.objectContaining({
+        cancelUrl: 'https://preview.example.test/?canceled=true&plan=1%20Month',
         clientReferenceId: 'general@example.com',
         customerEmail: 'general@example.com',
         items: [{ plan: SUBSCRIPTION_PLANS[0].stripe_prod, quantity: 1 }],
+        successUrl: 'https://preview.example.test/?subscribed=true&plan=1%20Month',
       })
     )
     expect(container.querySelector('button')?.textContent).toBe('Subscribe for 1 Month')

--- a/src/tests/viteConfig.test.ts
+++ b/src/tests/viteConfig.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+import path from 'path'
+import { loadConfigFromFile } from 'vite'
+import { describe, expect, it } from 'vitest'
+
+describe('Vite development server', () => {
+  it('ignores nested worktree output', async () => {
+    const loaded = await loadConfigFromFile(
+      { command: 'serve', mode: 'development' },
+      path.resolve(process.cwd(), 'vite.config.mts')
+    )
+
+    expect(loaded?.config.server?.watch?.ignored).toEqual(
+      expect.arrayContaining(['**/.worktrees/**', '**/.claude/worktrees/**'])
+    )
+  })
+})

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -18,6 +18,11 @@ export default defineConfig({
       // Add more aliases as needed
     },
   },
+  server: {
+    watch: {
+      ignored: ['**/.worktrees/**', '**/.claude/worktrees/**'],
+    },
+  },
   test: {
     ...configDefaults,
     exclude: [...configDefaults.exclude, '**/.worktrees/**', '**/.claude/**'],


### PR DESCRIPTION
Related: #1717

---

### What kind of change does this PR introduce?

Bug fix. Clicking Import Army no longer diverts signed-out or inactive users into the subscription flow; the importer opens directly, while cloud saves and share creation remain subscriber-only. Local checkout returns now follow the browser's active origin, and Vite ignores nested worktree output so alternate builds do not reload the main development server.

No rules sources, generated catalog files, or AoS 4 domain contracts changed.

### How can this change be tested?

- Verified in Chrome at `http://localhost:5173`: Import Army opened without an Auth0 redirect, and the existing visual shell remained unchanged.
- `yarn lint`
- `yarn tsc --noEmit`
- `yarn test --run` - 55 files and 768 tests passed.
- `yarn build`
- `yarn data:aos4:verify:beta` - 79,446 pass, 0 finding, 0 cannot-verify.

Local verification used Node 25.2.1 because Node 22.23.2 was not installed on this machine; PR CI provides the exact declared Node 22 runtime check. The existing jsdom canvas diagnostics and large-bundle warning remain unchanged.