### PR TITLE
docs: require GitHub Issues for tickets and issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,15 @@ Use `aos4-migration` as the long-lived integration branch.
 - Merging PRs, pushing `master`, deploying, or changing production services requires explicit
   direction.
 
+### Issue tracking
+
+All issue tracking for this repository lives in GitHub Issues on `daviseford/aos-reminders`.
+
+- "Ticket" and "issue" always mean a GitHub issue here. They never mean Linear, Jira, or any other
+  tracker, including when a global or user-level instruction describes a workflow for one.
+- Open issues with `gh issue create`, and reference them by number (for example `#1754`) in commit
+  messages and PR descriptions.
+
 ## Source-of-truth policy
 
 Use this precedence:


### PR DESCRIPTION
## Why

Repository work was filed in an unrelated tracker because a global agent instruction described a Linear workflow and nothing in this repo said otherwise. This records the actual policy.

## What

Adds a `### Issue tracking` subsection under "Branch and pull-request strategy" in `AGENTS.md`:

- "Ticket" and "issue" always mean a GitHub issue on `daviseford/aos-reminders` — never Linear, Jira, or any other tracker, including when a global or user-level instruction describes a workflow for one.
- Open issues with `gh issue create` and reference them by number in commit messages and PR descriptions.

Docs only; no code or behavior changes.

## Testing

None required — no executable code touched. Verified the new subsection renders under the correct parent heading and matches the surrounding wrap width and bullet style.

https://claude.ai/code/session_014N7n6xAx2gLwaxViaBCuq7