### PR TITLE
docs: add PRODUCT.md and DESIGN.md via impeccable init and document

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,412 @@
+---
+name: AoS Reminders
+description: Phase-ordered Age of Sigmar reminders, built to be read at the table and printed on paper.
+colors:
+  deep-harbour-teal: "#063647"
+  midnight-slate: "#182633"
+  signal-teal: "#1c7595"
+  profile-wash: "rgba(28, 117, 149, 0.15)"
+  pale-gray: "#e9ecef"
+  note-blue: "#1237c7"
+  ink: "#212529"
+  paper: "#ffffff"
+typography:
+  display:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif"
+    fontSize: "2.5rem"
+    fontWeight: 500
+    lineHeight: 1.2
+  title:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 500
+    lineHeight: 1.2
+  body:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.5
+  label:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif"
+    fontSize: "0.7rem"
+    fontWeight: 700
+    lineHeight: 1.35
+    letterSpacing: "0.03em"
+rounded:
+  none: "0"
+  chip: "3px"
+  md: "0.25rem"
+spacing:
+  xs: "0.25rem"
+  sm: "0.5rem"
+  md: "1rem"
+  lg: "1.5rem"
+  xl: "3rem"
+  card-y: "0.75rem"
+  card-x: "1.25rem"
+components:
+  card:
+    backgroundColor: "{colors.paper}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.md}"
+  card-dark:
+    backgroundColor: "{colors.midnight-slate}"
+    textColor: "{colors.paper}"
+    rounded: "{rounded.md}"
+  card-header:
+    backgroundColor: "{colors.signal-teal}"
+    textColor: "{colors.paper}"
+    typography: "{typography.title}"
+    padding: "0.5rem 1.25rem"
+  card-header-mobile:
+    backgroundColor: "{colors.signal-teal}"
+    textColor: "{colors.paper}"
+    typography: "{typography.title}"
+    padding: "1rem"
+  masthead:
+    backgroundColor: "{colors.deep-harbour-teal}"
+    textColor: "{colors.paper}"
+    typography: "{typography.display}"
+  masthead-dark:
+    backgroundColor: "{colors.midnight-slate}"
+    textColor: "{colors.paper}"
+    typography: "{typography.display}"
+  button-toolbar:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.md}"
+    padding: "0.375rem 0.75rem"
+    width: "100%"
+  button-toolbar-dark:
+    backgroundColor: "transparent"
+    textColor: "{colors.paper}"
+    rounded: "{rounded.md}"
+    padding: "0.375rem 0.75rem"
+    width: "100%"
+  reminder-tag:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    typography: "{typography.label}"
+    rounded: "{rounded.chip}"
+    padding: "0.1rem 0.4rem"
+  modal:
+    backgroundColor: "{colors.paper}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.none}"
+    padding: "1.5%"
+  modal-dark:
+    backgroundColor: "{colors.midnight-slate}"
+    textColor: "{colors.paper}"
+    rounded: "{rounded.none}"
+    padding: "1.5%"
+---
+
+# Design System: AoS Reminders
+
+## Overview
+
+**Creative North Star: "The Field Manual"**
+
+This is an issued reference, not an experience. A field manual earns trust by being complete,
+densely typeset, identically organised every time you open it, and legible in bad conditions — and
+by having nothing in it that isn't needed. The visual system exists to get a rule in front of a
+player who is mid-turn with dice in one hand, and then get out of the way. Every decoration is
+weight the player has to carry.
+
+The system is deliberately built on Bootstrap 4.6 defaults with a small, specific palette laid over
+the top. That is a decision, not neglect: a manual uses standard-issue components so the *content*
+is the only thing that varies between pages. Two colours carry the entire structural language — a
+near-black teal for the masthead and a mid teal for every section header — and everything else is
+neutral. Surfaces are flat; a hairline border and a background shift do all the separating.
+
+Paper is a first-class output, not an export feature. The screen and the printed sheet are two
+renderings of the same manual, and the system is designed so that removing colour costs nothing:
+tags fall back to bordered outlines, text forces to black, and structure survives in the borders
+and the type hierarchy. If a design decision only reads in colour, it will not survive contact with
+the table.
+
+**Key Characteristics:**
+
+- Density over whitespace; the screen is a reference sheet, not a landing page
+- Two structural colours, everything else neutral
+- Flat surfaces, hairline borders, no shadows on anything that doesn't physically move
+- System fonts only — no web font is loaded, and none should be
+- Every surface has a defined print behaviour
+- Light and dark are a real contract (`ITheme`), not a class swap
+
+## Colors
+
+A cold, near-monochrome palette: two teals doing structural work against neutral paper or slate,
+with colour reserved for meaning rather than decoration.
+
+### Primary
+
+- **Deep Harbour Teal** (`#063647`): The masthead and page header in light theme. Almost black at a
+  glance, and the darkest thing on the page — it anchors the top of the document the way a manual's
+  cover band does. Also the browser `theme-color`, so installed PWA chrome matches the page.
+- **Signal Teal** (`#1c7595`): Every collapsible card header, in both themes. This is the single
+  most repeated colour in the product — roughly 24 instances on a default army — and it means one
+  thing: *a section starts here*. It also carries into the PDF as the rule colour and subtitle
+  colour, which is why it must stay legible when desaturated.
+
+### Secondary
+
+- **Midnight Slate** (`#182633`): The dark theme's surface and masthead. Cooler and lighter than
+  Deep Harbour Teal, because in dark theme it is a *background* rather than an anchor, and needs to
+  sit behind body text at length.
+- **Note Blue** (`#1237c7`): Player-authored notes in PDF export. The one place a saturated colour
+  appears, and it marks the one thing on the page the player wrote themselves.
+
+### Neutral
+
+- **Ink** (`#212529`): Body text and rule text in light theme.
+- **Paper** (`#ffffff`): Card bodies and page background in light theme; all text in dark theme.
+- **Pale Gray** (`#e9ecef`): Borders and dividers in dark theme, the mode switch handle, and
+  textarea outlines.
+- **Profile Wash** (`rgba(28, 117, 149, 0.15)`): Signal Teal at 15% behind profile card headers —
+  the same accent, quieted, on the account screens where nothing is time-critical.
+
+Muted text is expressed as opacity rather than a separate token: `text-white-75`
+(`rgba(255,255,255,0.75)`) in dark theme, Bootstrap's `text-muted` in light.
+
+### Named Rules
+
+**The Slot Rule.** No component hardcodes a colour. Every surface reads a named slot from `ITheme`
+(`theme.cardBody`, `theme.text`, `theme.reminderHeader`), and light and dark supply their own
+values. A literal hex in a component is a defect — it will be wrong in one of the two themes.
+
+**The Meaning-Only Colour Rule.** Colour marks structure (Signal Teal = section header) or
+authorship (Note Blue = the player's own words). It never decorates, and it never carries
+information alone: the reminder tags pair every tone with a distinct text label, because the tone
+disappears in print and for colour-blind players.
+
+**The Vestigial Token Rule.** `$themeDarkBlueTertiary` (`#073647`), `$themeRed` (`#a12f48`), and
+`$themeYellow` (`#e0d51f`) are declared in `theme.scss` and used nowhere. They are not part of the
+system. Do not reach for them to solve a new problem — introduce a token deliberately or reuse an
+existing one. (`$themeLightPurple` `#93a9fa` is likewise only reached as a hardcoded literal in
+`src/theme/dark.ts`, where a stale comment misattributes it to `$themeYellow`.)
+
+## Typography
+
+**Display Font:** none — the system UI stack (`-apple-system, BlinkMacSystemFont, "Segoe UI",
+"Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif`)
+**Body Font:** the same stack
+**Label/Mono Font:** `source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace` for `code`
+only
+
+**Character:** Native, invisible, and instant. No web font is loaded anywhere in the product, and
+none should be — a render-blocking font request is paid for at a game venue on bad signal, by a
+player who needs a rule now. The type does no expressive work; the hierarchy and the density do it.
+
+### Hierarchy
+
+- **Display** (500, 2.5rem, 1.2): the masthead `h1`, "Age of Sigmar Reminders". One per page.
+  Drops to 1.5rem in print.
+- **Title** (500, 1.5rem, 1.2): `.CardHeaderTitle` — every collapsible card header, and the army
+  name in Play mode. Steps down responsively to 1.1rem below 576px, 1rem below 395px, and 0.8rem
+  below 374px; 1.1rem in print.
+- **Body** (400, 1rem, 1.5): rule Trigger/Declare/Effect text, the substance of the product. Falls
+  to 0.9rem in print to fit more per page.
+- **Label** (700, 0.7rem, 1.35, `0.03em`, uppercase): the reminder timing tags. Small, wide-tracked,
+  and the only uppercase in the product.
+- **Fine print** (400, 11–12px): `small` is 12px; `.DisclaimerText` is 11px for the Games Workshop
+  disclaimer.
+
+Notes render italic (`.NoteText`), in both the screen and the PDF, so the player's own words are
+distinguishable from rules text at a glance.
+
+### Named Rules
+
+**The Level-Is-Not-Size Rule.** Heading level is document structure; font size is CSS. Card titles
+are `<h2>` at every viewport because they all sit directly under the page `<h1>`, and
+`.CardHeaderTitle` changes their size across four breakpoints. Never swap heading level to make
+something smaller — that was a real defect in this codebase and it is fixed.
+
+**The Uppercase Reservation Rule.** Uppercase is reserved for the timing tags. It is a signal that
+something is a machine-derived facet rather than rules prose, and it stops working the moment
+anything else adopts it.
+
+## Layout
+
+Bootstrap 4.6's 12-column grid, with a custom `xxl: 1900px` tier added to the default five
+(`sm: 576`, `md: 768`, `lg: 1025`, `xl: 1200`). Containers cap at 1610px at `xxl`.
+
+The page is a single centred column of stacked cards. The reminder column sits at
+`col col-sm-11 col-md-10 col-lg-10 col-xl-8` — deliberately narrower than the builder above it,
+because rule text is read in sentences and the builder is scanned in lists. The builder is a
+three-up grid on desktop (`col-md-6 col-lg-4`) and the toolbar is a seven-button responsive row
+(`col-6 col-sm-4 col-lg`).
+
+**Mobile is a different layout, not a narrower one.** Below 576px: collapsed builder cards drop to
+`col w-50` and tile two-up so the whole builder is visible without scrolling; group titles switch
+to shorter `mobileTitle` variants ("Formations", "Artefacts", "Manifestations"); card header
+padding grows from `0.5rem 1.25rem` to a uniform `1rem`; reminder cards start collapsed rather than
+expanded, so the player lands on a list of phases instead of a wall of text.
+
+Spacing is Bootstrap's `1rem`-based scale used at the low end — `0.25`/`0.5`/`1rem` do almost all
+the work. Cards use `0.75rem` vertical and `1.25rem` horizontal internal padding. The rhythm is
+tight on purpose.
+
+### Named Rules
+
+**The One Breakpoint Rule.** The mobile breakpoint is 575.98px and it is defined once, in
+`src/utils/breakpoints.ts`. The JS hooks derive from it via `matchMedia` and the stylesheet's media
+queries use the same number. Two systems disagreeing about where mobile starts was a real defect
+here; never reintroduce a second threshold.
+
+**The Print Parity Rule.** Every surface declares its paper behaviour. Chrome that must not print
+carries `d-print-none`; content that must print gets a rule in the `@media print` block. Neither is
+optional — a new surface with no print decision is unfinished.
+
+## Elevation & Depth
+
+**Flat by default; borders do the work.** There are no `box-shadow` values anywhere in the
+stylesheet. Separation comes from a 1px border plus a background shift: in light theme a
+`rgba(0,0,0,0.125)` hairline against white, in dark theme an explicit `border-dark` or Pale Gray
+edge against Midnight Slate. Card headers separate from bodies by colour alone.
+
+This is not minimalism for its own sake. Shadows vanish in print, so a system that used elevation
+to convey structure would lose that structure on paper — and paper is a primary output here.
+Borders survive the trip.
+
+### Shadow Vocabulary
+
+One exception, and it is a physical control:
+
+- **Switch handle** (`box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.6)`; active
+  `0px 0px 1px 10px rgba(0, 0, 0, 0.2)`): the Edit/Play and theme toggles. The shadow reads as a
+  handle that moves, which is exactly what it is.
+
+### Named Rules
+
+**The Flat-By-Default Rule.** Surfaces are flat at rest and flat in motion. A shadow is only
+permitted on a control that physically travels. If a new element needs to feel separated, give it a
+border and a background, not a shadow.
+
+## Shapes
+
+A quiet, near-rectilinear form language with only two radii in play.
+
+- **Cards, buttons, inputs, and badges**: Bootstrap's default gently-rounded corner (`0.25rem`).
+- **Reminder tags**: a tighter 3px, so they read as chips rather than small buttons.
+- **Modals: square** (`0`, with a 1px border). `.Modal-Light` sets a border and no radius, which
+  makes the modal the only sharp-cornered surface in the product — it sits above the page rather
+  than in it.
+- **Notes**: a dashed 1px border (2px in dark theme) around player-authored text, sized
+  `width: max-content` up to 95%, so the box hugs what was written. Dashed is doing semantic work:
+  it marks the content as provisional and personal against the solid-bordered rules cards.
+
+Icons are `react-icons` line glyphs (Font Awesome and Material) at text size, `aria-hidden` when
+decorative.
+
+### Named Rules
+
+**The Dashed-Means-Yours Rule.** A dashed border marks player-authored content — notes on screen,
+and the import dropzone awaiting a file. Rules content is never dashed.
+
+## Components
+
+The character line for all of them: **issued, not styled.** Controls look like standard-issue
+equipment — outlined, uniform, immediately legible, with no per-component expression. The content
+varies; the instruments do not.
+
+### Buttons
+
+- **Shape:** gently rounded (`0.25rem`), Bootstrap default padding (`0.375rem 0.75rem`).
+- **Toolbar (primary pattern):** full-width outline buttons, `btn-outline-dark` in light theme and
+  `btn-outline-light` in dark, laid out `col-6 col-sm-4 col-lg`. Each carries a leading icon at
+  `mr-2` and a `text-nowrap` label. Outline rather than filled because seven of them sit in one
+  row — seven filled buttons would out-shout the reminders below.
+- **Navbar:** `btn btn-outline-light btn-sm mx-2` against the teal masthead.
+- **Disabled:** used semantically, not decoratively — `Show Hidden` disables at zero hidden, and
+  the subscriber actions disable while auth or subscription state is resolving.
+- **Hover / Focus:** Bootstrap defaults, untouched. No `outline: none` appears anywhere in the
+  stylesheet and `:focus-visible` is honoured; the reminder tags add an explicit
+  `2px solid #1c7595` ring at `1px` offset.
+
+### Chips
+
+The reminder timing tags — the one genuinely bespoke component in the system.
+
+- **Style:** uppercase 0.7rem/700 at `0.03em` tracking, `0.1rem 0.4rem` padding, 3px radius, 1px
+  border, `cursor: help`.
+- **Tones:** seven semantic tones — active, reaction, passive, your-turn, enemy-turn, neutral, and
+  usage — each defined *per theme* via the `tag-tones` mixin, never by the tone class alone. Usage
+  tags are dashed to separate a constraint from a classification.
+- **State:** each tag is a real `<button>` that toggles an inline expansion, because touch devices
+  never hover and the abbreviations are not self-explanatory. `title` covers mouse, `aria-label`
+  covers assistive tech.
+- **Print:** all fills drop to transparent, text to black, border to `rgba(0,0,0,0.45)`. Weight and
+  border carry the distinction on paper.
+
+### Cards / Containers
+
+- **Corner Style:** `0.25rem`.
+- **Background:** white in light theme, Midnight Slate in dark.
+- **Shadow Strategy:** none — see Elevation.
+- **Border:** 1px hairline; dark theme adds an explicit `border border-dark`.
+- **Internal Padding:** `0.75rem` vertical / `1.25rem` horizontal, tightening to `0.75rem` vertical
+  on the reminder body below 576px and to `0.5rem` in print.
+- **Header:** Signal Teal with white text, containing a full-width `<button>` that carries the
+  padding so the entire header is the hit area, an `<h2>` title, and a Material expand/collapse
+  chevron. Collapsed headers on mobile append a selection count (`Units (3)`).
+
+### Inputs / Fields
+
+- **Selects:** `react-select`, themed through `theme.selectTheme` — light theme uses the library
+  default, dark overrides eleven neutral/primary slots to sit on Midnight Slate. Always carries an
+  `aria-label`.
+- **Note textarea:** `.NoteInput`, 95% width, `resize: vertical` only (horizontal resize let users
+  drag it past the card and scroll the page sideways), inheriting theme background and text.
+- **Dropzone:** dashed 2px, `#eeeeee` on `#fafafa` in light and Pale Gray on black in dark, with a
+  `#2196f3` border on focus and drag-over.
+
+### Navigation
+
+- **Style:** bold light links (`font-weight-bold text-light mx-2`) directly on the masthead colour,
+  inside `<header>` → `<nav aria-label="Main">`. No underline, no active-state treatment — the
+  current route's own link is simply omitted.
+- **Content:** signed out, `Subscribe` / `FAQ` / `Log in`; signed in, `Profile` / `Log out`.
+  A sale renders a `badge badge-pill badge-danger` discount chip, suppressed below 335px.
+- **Mobile:** the row narrows from 75% to 100% width; links do not collapse into a menu.
+
+### Signature Component: the Edit/Play switch
+
+The product's one true mode control, and the only place the system spends any expressive budget: an
+80×20px `react-switch` in Signal Teal with a Pale Gray handle, flanked by the words `Edit` and
+`Play`, the active one bolded. The words are click-to-toggle for the mouse but deliberately **not**
+focusable — the switch is the single keyboard control, because a focusable label that only fires in
+the opposite mode is a dead stop in the tab order.
+
+## Do's and Don'ts
+
+### Do:
+
+- **Do** read colour from an `ITheme` slot (`theme.cardBody`, `theme.text`) and verify any change
+  in both light and dark before accepting it.
+- **Do** give every new surface an explicit print behaviour — `d-print-none` for chrome, or a rule
+  in the `@media print` block for content.
+- **Do** size touch targets by the finger, not the glyph: 44×44px on touch, 24×24px absolute
+  minimum (WCAG 2.5.8). Grow the hit box with a pseudo-element overlay when the visual size must
+  stay put, as `.ReminderMenuToggle` does.
+- **Do** use a real `<button>`, `<fieldset>`/`<legend>`, `<main>`, or `<nav>` rather than ARIA on a
+  `div`. The native element is almost always the fix that also renders identically.
+- **Do** derive responsive decisions from `src/utils/breakpoints.ts` so JS and CSS agree.
+- **Do** pair every colour-coded state with a text label, because the colour is gone in print.
+- **Do** reuse the established primitives — collapsible card, outline toolbar button, timing chip —
+  when new AoS 4 data needs a new treatment.
+
+### Don't:
+
+- **Don't** introduce a web font, or any render-blocking resource on the reminders path.
+- **Don't** add a `box-shadow` to anything that doesn't physically move.
+- **Don't** hardcode a hex in a component, or reach for `$themeRed`, `$themeYellow`, or
+  `$themeDarkBlueTertiary` — they are declared but unused and are not part of the system.
+- **Don't** change heading level to change text size. Set the size in `.CardHeaderTitle`.
+- **Don't** use uppercase outside the timing tags.
+- **Don't** trade density for whitespace on the reminders screen. It is a reference sheet read
+  under time pressure, not a marketing page.
+- **Don't** restyle as a side effect of an accessibility or correctness fix. Choose the variant that
+  renders identically, state the delta, and let the user accept it.
+- **Don't** introduce a second visual language for AoS 4 data, a "migration workbench" aesthetic, or
+  a broad reskin. The live site is the baseline and a redesign requires an explicit request.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,220 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+**Primary: Warhammer: Age of Sigmar fourth-edition players**, in two distinct situations that the
+application models explicitly as Edit and Play mode.
+
+- **Preparing, at home, on a desktop or tablet — Edit mode.** The player selects a faction and
+  builds or imports an army, then curates the resulting reminders: hiding rules they already know,
+  adding notes, reordering within a phase, and exporting a PDF. Time is not scarce. The job is to
+  arrive at the table with a sheet that says only what they need.
+- **Playing, at the table, on a phone — Play mode.** Mid-game, one hand on the phone, dice in the
+  other, an opponent waiting on them. Play mode strips the builder and toolbar and filters out
+  hidden reminders. The job is to find what fires in the current phase, immediately, without
+  reading past anything they already decided was noise.
+
+**Secondary: subscribers.** The paying tier. They reach the same screens plus cloud armies,
+sharing, and dark theme, and they are the audience for whom incorrect claims on `/subscribe` are a
+refund-and-trust problem rather than a copy defect.
+
+**Secondary: players using assistive technology or with motor impairments.** The reminders screen
+renders roughly 39 reminders and 24 collapsible cards on the default army, so every repeated
+control multiplies any interaction defect by that factor.
+
+## Product Purpose
+
+AoS Reminders turns an Age of Sigmar army configuration into phase-ordered reminders, so a player
+never forgets an ability they own during the turn it applies.
+
+The product resolves a specific army's selections against a canonical rules corpus, projects the
+abilities those selections grant into discrete reminder occurrences, and orders them by the window
+in which they fire — deployment, each of the seven turn phases, round boundaries, reactions, and
+phase-independent effects.
+
+**Success for the current stretch of work is Phase 2 modernization to launch-ready**: package and
+framework upgrades, and closing the subscription-API authorization gap that blocks production
+launch, so the `aos4-migration` branch can merge to `master`. Phase 1 (data and domain correctness)
+is complete and machine-verified for beta.
+
+## Positioning
+
+**Phase-ordered projection from your own list.**
+
+Neighbouring products in this space are rules databases (Wahapedia, the official Warhammer app) or
+list builders (Listbot, New Recruit). Both answer "what does this rule say?" and require the player
+to already know which rule to look for.
+
+AoS Reminders answers a different question: *what fires now, for the army I actually brought?* It
+computes the set of abilities a specific configuration grants and orders them by when they happen
+in a turn. That makes it usable during play rather than as a lookup between turns — and it is a
+mechanism a rules database cannot truthfully copy without also modelling army composition, and a
+list builder cannot copy without also modelling rules timing.
+
+Roster imports reinforce rather than dilute this: rosters from other tools are *inputs*, never
+rules authorities.
+
+## Operating Context
+
+- **A physical tabletop game.** The usage scene is a table with terrain, models, and dice, an
+  opponent, and often a tournament round clock. Attention is contested and interruptions are
+  constant.
+- **The turn structure is the organising principle**, not the product's own information
+  architecture. Reminders are grouped by the game's windows because that is the order the player
+  encounters them.
+- **The roster is usually built elsewhere.** Players commonly arrive with a list already made in
+  the official Warhammer app, Listbot 4.0, or New Recruit, and import it rather than rebuilding it.
+- **Paper is a real output.** Many players print the reminders or export a PDF and use that at the
+  table instead of a screen — phones die, and some venues discourage them. Print is a supported
+  output path with its own layout engine, not a browser afterthought.
+- **Connectivity is unreliable.** Game venues and tournament halls have poor signal. The
+  application is a PWA with a service worker, keeps the army document in `localStorage`, and never
+  fetches rules data at runtime — the corpus is checked in and shipped with the bundle.
+
+## Capabilities and Constraints
+
+### Confirmed capabilities
+
+- Faction selection across all 28 decoded factions, and a builder covering warscrolls and content
+  groups (battle formations, artefacts of power, spell/prayer/manifestation lores, regiments of
+  renown).
+- Reminder projection grouped by timing window, with per-reminder hide/show, free-text notes, and
+  drag reordering within a group.
+- Source attribution per reminder, badged `Official` for Games Workshop records and linked where a
+  source URL exists.
+- Browser print and jsPDF export with standard and compact presets, A4 and Letter.
+- Roster import from official Warhammer app text, Listbot 4.0 text or file upload, and New Recruit
+  `.ros`/`.rosz`/`.json`.
+- Auth0 authentication; cloud armies and army sharing against an Auth0-authorized API.
+- Subscription via Stripe and PayPal, gift subscriptions, and redemption.
+- Light and dark theme, persisted per account.
+- An opt-in Legends overlay (`allowsLegends`) applied on top of the document's rules context.
+
+### The free and paid boundary is a durable product fact
+
+Preserve it; do not change it as a side effect of other work.
+
+- **Free**: faction selection, the builder, reminders, hide/show, notes, reordering, roster import,
+  browser print, and PDF export.
+- **Requires an active subscription** (`useSubscriberAction` routes an unauthenticated user to
+  login, then a non-subscriber to `/subscribe`): cloud armies (`My Armies`), army sharing, and dark
+  theme.
+
+### Durable constraints
+
+- **AoS 4 is a hard cutover.** No AoS 3 rule, timing, phase, category, alias, importer correction,
+  fixture, or data shape is evidence for an AoS 4 decision, and no AoS 3 module may be restored to
+  make a feature convenient. A temporarily incomplete AoS 4-only app is preferable to parallel live
+  rule models.
+- **The live application at `https://aosreminders.com/` is the interaction baseline.** The
+  community trusts that experience, and the data migration does not authorize a redesign. Treat any
+  interface change the user did not explicitly ask for as a code smell. Data-driven changes — phase
+  names, content-group cards, reminder text — are the expected exception.
+- **Source precedence**: Games Workshop publications are authoritative; Wahapedia exports and
+  bounded faction pages are the preferred secondary discovery source; other community sources may
+  identify gaps but never silently override official material. Preserve discrepancies rather than
+  resolving them silently.
+- **The runtime never fetches rules source data.** It loads checked-in generated artifacts only.
+  Acquisition and reconciliation stay out of React components.
+- **Generated data is never hand-edited.** Corrections go through the candidate → review → accept →
+  generate pipeline, including corrections prompted by beta feedback.
+- **Names are display text, never durable identity.** Everything resolves through stable canonical
+  IDs.
+- **A push to `master` deploys production.** Migration work targets `aos4-migration`; merging or
+  pushing `master` requires explicit authorization.
+
+### Known blocker
+
+**Production launch is blocked on subscription-API authorization.** The restored subscription API
+uses a public shared browser key and does not verify the user's Auth0 token or derive account
+ownership server-side. An Auth0-protected route is not API authorization. Launch requires
+server-side bearer-token verification, server-derived ownership, rejection of cross-account access,
+key rotation, and passing negative authorization tests. Do not describe the subscription API as
+secure. The separate army/share API (`src/api/armyApi.ts`) does send the user's Auth0 bearer token
+on every account operation.
+
+### Terminology
+
+Warscroll, battle profile, content group, ability, rules context, window, phase, reminder
+occurrence, Legends, Spearhead, General's Handbook 2026-27 (`Scourge of Aqshy`). "AoS 4" is the
+2024 game edition and is unrelated to the application version in `package.json`.
+
+## Brand Commitments
+
+- **Name**: AoS Reminders. Authored by Davis E. Ford (`daviseford.com`), credited in the masthead.
+- **Unofficial and fan-made.** The Games Workshop disclaimer appears on every page and must stay:
+  the tool is in no way endorsed or sanctioned by Games Workshop, and takes no credit for Games
+  Workshop content. The product must never adopt an official Games Workshop voice or identity.
+- **"Powered by Wahapedia" attribution** is required for published features derived from the
+  Wahapedia exports.
+- **Voice**: plain, direct, second person. Controls are named as verbs and nouns (`Clear Army`,
+  `Download PDF`, `Show Hidden`). No marketing cadence in the product surface.
+- **Provenance is a product commitment, not a footnote.** Reminders carry their source and mark
+  official records as such.
+- **Community**: Discord, and GitHub Issues on `daviseford/aos-reminders` as the sole issue
+  tracker.
+
+## Evidence on Hand
+
+- **The accepted corpus** `aos4-corpus-2026-07-28`: 28 decoded factions, 1,268 warscrolls, 1,002
+  battle profiles, 4,850 abilities, 2,247 weapons, 1,402 content groups, and 19,057 live source
+  records. Checked in under `src/aos4/generated/corpus/`.
+- **A beta certification** binding that corpus to a complete machine review — 79,446 results across
+  39,723 source/generated pairs, zero live findings, zero `cannot-verify` outcomes. Verifiable
+  offline via `yarn data:aos4:verify:beta`.
+- **An official battle-profile ledger** dispositioning all 1,350 extracted Games Workshop facts,
+  with 12 profile-only gaps left deliberately visible rather than filled by invention.
+- **A byte-pinned New Recruit import fixture corpus**
+  (`src/tests/fixtures/aos4/import/new-recruit/`), captured from opted-in accounts and
+  self-checking across all three formats.
+- **A mobile and accessibility audit**, `docs/design/2026-07-28-mobile-accessibility-audit.md`
+  (score 11/20). Most of its P0 and P1 findings have since been fixed; treat it as history and
+  re-run an audit before relying on the score.
+
+**Absences that future work must not fabricate**: there are no testimonials, no case studies, no
+press, no usage or subscriber metrics, and no benchmark data. Nothing in this repository supports a
+claim about how many people use the product or how well it performs against alternatives.
+
+## Product Principles
+
+1. **The table is the hard case.** Design and scope for a phone, one-handed, mid-turn, with an
+   opponent waiting — before designing for the desktop builder. Anything that costs time or
+   attention at the table is a real cost; anything that only reads well in a screenshot is not a
+   real benefit.
+
+2. **Continuity outranks improvement.** The live site is the baseline the community trusts. Fix
+   defects, preserve the experience, and let the user ask for change rather than inferring it.
+   When a correctness fix has a visible consequence, choose the variant that preserves current
+   behavior, state the delta, and let the user accept it.
+
+3. **Say only what is true, and show where it came from.** Every user-facing claim must match what
+   the application ships today, and every rule must be traceable to an accepted source. Stale copy
+   on a paid surface is a blocking defect. Never invent a fact to fill a gap — record the gap.
+
+4. **Correctness flows through the pipeline, never around it.** Rules mistakes are fixed by
+   acquiring, reviewing, and accepting a new candidate, not by patching generated data or
+   hard-coding an exception in the interface.
+
+5. **Reminders belong to the game's structure, not the product's.** Grouping, ordering, and naming
+   follow Age of Sigmar's phases and timing windows, because that is the order the player meets
+   them. The product does not impose an information architecture of its own.
+
+## Accessibility & Inclusion
+
+- **Target: WCAG 2.2 AA**, treated as a correctness requirement rather than an enhancement.
+- **Target size (2.5.8) is a first-class concern.** The primary usage scene is a phone held in one
+  hand while the other holds dice, so controls are sized by the finger, never by the icon.
+- **Defects multiply.** The reminders screen repeats its controls dozens of times per army, so a
+  single per-reminder interaction defect is dozens of failures for a keyboard or screen-reader
+  user.
+- **Prefer the native element** — a real `<button>`, `<fieldset>`/`<legend>`, `<main>` — over ARIA
+  applied to a `div`. The native fix is usually the one that also renders identically, which is
+  what the continuity constraint requires.
+- **Motion is minimal by design** and should stay that way; the product has no motion-heavy
+  surfaces to reduce.


### PR DESCRIPTION
## Summary

Adds the two context files the impeccable skills actually resolve and load:

- **`PRODUCT.md`** — written by `/impeccable init`. Durable product truth only.
- **`DESIGN.md`** — written by `/impeccable document`. The incumbent visual system, recorded rather
  than redesigned.

Documentation only; no application code changes.

`AGENTS.md` states the interface constraint ("the live application is the visual and interaction
baseline", "treat any UI change the user did not explicitly ask for as a code smell") but does not
describe the interface itself. These files fill that gap in the format the tooling reads.

## PRODUCT.md

Product truth only — init explicitly excludes aesthetics, which live in `DESIGN.md`.

- **Users** — the same player in the two situations the app already models as Edit and Play mode:
  building at home on a desktop, and mid-turn at the table on a phone with an opponent waiting.
- **Positioning** — phase-ordered projection from your own list. Rules databases answer "what does
  this rule say?"; this answers "what fires now, for the army I brought?"
- **Operating context** — a physical tabletop game, rosters usually built elsewhere and imported,
  paper as a real output, and unreliable venue connectivity.
- **The free/paid boundary recorded as a durable fact** — cloud armies, sharing, and dark theme
  behind the subscription; builder, reminders, import, notes, and PDF free.
- **Constraints** — the AoS 4 hard cutover, UI continuity, source precedence, the no-hand-editing
  rule for generated data, and the subscription-API authorization gap that blocks launch.
- **Accessibility** — WCAG 2.2 AA as a correctness requirement, with target size called out because
  the primary scene is one-handed phone use.

It also records what the repo does *not* have — no testimonials, metrics, or benchmarks — so future
work doesn't invent them.

## DESIGN.md

Follows the DESIGN.md format spec: YAML token frontmatter plus eight canonical sections.

Tokens were extracted from `src/css/theme.scss`, `src/css/index.scss`, the two `ITheme`
implementations, and `src/aos4/print/presets.ts` — not from memory of Bootstrap defaults.

North star: **"The Field Manual."** Named rules capture invariants the codebase already enforces,
so they're citable rather than aspirational:

- **The Slot Rule** — no component hardcodes a colour; everything reads an `ITheme` slot.
- **The One Breakpoint Rule** — 575.98px, defined once in `utils/breakpoints.ts`.
- **The Print Parity Rule** — every surface declares its paper behaviour.
- **The Flat-By-Default Rule** — no shadows except on the one control that physically moves.
- **The Level-Is-Not-Size Rule** — heading level is semantics; size is `.CardHeaderTitle`.

One finding worth surfacing: **`$themeDarkBlueTertiary`, `$themeRed`, and `$themeYellow` are
declared in `theme.scss` and used nowhere**, and `$themeLightPurple` is only reached as a hardcoded
literal in `src/theme/dark.ts` under a comment that misattributes it to `$themeYellow`. Recorded as
The Vestigial Token Rule so they aren't mistaken for part of the system.

## Notes

- `.impeccable/design.json` (the sidecar the live panel renders from) is generated alongside
  `DESIGN.md` but stays local — `.impeccable/` is gitignored at `.gitignore:98`.
- This replaces an earlier `.impeccable.md` on this branch. That file came from the standalone
  `teach-impeccable` skill, which writes a path no impeccable skill reads; `grep -rl "impeccable\.md"`
  across the plugin returns nothing. The branch was rewritten rather than stacking a revert.
- `docs/design/2026-07-28-mobile-accessibility-audit.md` (11/20) is largely stale — most of its P0
  and P1 findings are fixed on this branch. `PRODUCT.md` notes this under Evidence on Hand so the
  score isn't cited as current.

## Test plan

Documentation only — no code paths touched, nothing to run.