### PR TITLE
fix(subscribe): polish pass on layout, theming, and the demo video

### DIFF
--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -6,6 +6,7 @@ import { PaypalPostSubscribeModal } from 'components/modals/paypal_post_subscrib
 import PayPalButton from 'components/payment/paypal/paypalButton'
 import { IApprovalResponse } from 'components/payment/paypal/paypalTypes'
 import { PaypalProvider } from 'context/usePaypal'
+import { useTheme } from 'context/useTheme'
 import qs from 'qs'
 import React, { useState } from 'react'
 import { IconContext } from 'react-icons'
@@ -54,8 +55,10 @@ const PricingPlansComponent = () => {
 const PlansHeader = () => {
   const hasSale = SubscriptionPlans.some(plan => plan.sale)
 
+  // The band behind this supplies the surface colour; hardcoding bg-light here left a white strip
+  // behind the heading when the band follows the theme.
   return (
-    <div className="col-12 bg-light text-center mb-3">
+    <div className="col-12 text-center mb-3">
       <h2>
         Subscription Plans
         {hasSale && <span className="ml-2 badge badge-danger">Sale!</span>}
@@ -74,6 +77,7 @@ export const PlanComponent = (props: IPlanProps) => {
   const { supportPlan } = props
   const { user, isAuthenticated } = useAuth0()
   const { login } = useLogin({ origin: supportPlan.title })
+  const { theme } = useTheme()
   const stripe = useStripe()
 
   if (!stripe) return null
@@ -104,15 +108,20 @@ export const PlanComponent = (props: IPlanProps) => {
   }
 
   return (
-    <div className="card mb-4 shadow-sm">
+    <div className={`${theme.card} mb-4 shadow-sm`}>
       <div className="card-header bg-themeDarkBluePrimary text-light">
         <h3 className="my-0 font-weight-normal">{supportPlan.title}</h3>
       </div>
-      <div className="card-body">
+      <div className={theme.cardBody}>
         {/* A price is not a heading. The .h1 class keeps the type scale unchanged. */}
         <p className="card-title pricing-card-title h1">
           ${supportPlan.monthly_cost}
-          <small className="text-muted">/ month</small>
+          {/*
+            theme.textMuted, not text-muted: Bootstrap's #6c757d lands at 3.28:1 on the dark card
+            body, under the 4.5:1 minimum for 12px text. Dark theme's text-white-75 clears it at
+            9.24:1, and light theme resolves back to text-muted.
+          */}
+          <small className={theme.textMuted}>/ month</small>
         </p>
         <ul className="list-unstyled mt-3 mb-4">
           <li>

--- a/src/components/routes/Subscribe.tsx
+++ b/src/components/routes/Subscribe.tsx
@@ -1,6 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react'
 import AlreadySubscribed from 'components/helpers/alreadySubscribed'
-import { LinkNewTab } from 'components/helpers/link'
 import { LoadingBody, LoadingHeader } from 'components/helpers/suspenseFallbacks'
 import Contact from 'components/page/contact'
 import { PricingPlans } from 'components/payment/pricingPlans'
@@ -11,7 +10,14 @@ import { logClick, logPageView } from 'utils/analytics'
 import useWindowSize from 'utils/hooks/useWindowSize'
 
 const Navbar = lazy(() => import('components/page/navbar'))
-const headerClass = 'col-12 col-lg-8 col-xl-8 pt-5 mx-auto'
+
+/*
+ * The intro and the feature list are one text column, so they share a measure and a left edge. They
+ * previously used different widths (col-lg-8 vs col-lg-5) inside different wrappers, which left the
+ * two prose blocks starting 236px apart on a 1440px screen.
+ */
+const contentClass = 'col-12 col-lg-8 col-xl-8 mx-auto'
+const headerClass = `${contentClass} pt-5`
 
 const Subscribe = () => {
   const { isLoading } = useAuth0()
@@ -38,12 +44,14 @@ const Subscribe = () => {
         </Suspense>
       </div>
       <Intro />
-      <div className={`container ${theme.bgColor} ${theme.text}`}>
-        <div className="row align-items-start justify-content-center mt-3">
-          <CurrentFeatures />
-        </div>
+      <div className={`${theme.bgColor} ${theme.text}`}>
+        <CurrentFeatures />
       </div>
-      <div className="row py-5 bg-light justify-content-center jumbotron-fluid">
+      {/*
+        A full-bleed band, not a .row: a bare row's -15px margins overflowed the viewport by 15px and
+        scrolled the whole page sideways. PricingPlans supplies its own .container.
+      */}
+      <div className={`py-5 ${theme.sectionBand} ${theme.text}`}>
         <PricingPlans />
       </div>
       <ExamplesRow />
@@ -56,18 +64,12 @@ const Subscribe = () => {
 
 const ExamplesRow = () => {
   const { isMobile } = useWindowSize()
+  const { theme } = useTheme()
   if (!isMobile) return null
 
   return (
-    <div className="row py-5 mx-3 bg-light justify-content-center jumbotron-fluid">
-      <div className="col-12">
-        <WebmWithFallback
-          webmUrl="/img/dark_mode1.mp4"
-          gifUrl="/img/dark_mode1.gif"
-          description="Dark Mode"
-          label="Demo-DarkMode"
-        />
-      </div>
+    <div className={`py-5 px-3 ${theme.sectionBand} ${theme.text}`}>
+      <DemoVideo videoUrl="/img/dark_mode1.mp4" description="Dark Mode" label="Demo-DarkMode" />
     </div>
   )
 }
@@ -77,11 +79,13 @@ const Intro = () => {
 
   return (
     <div className={`${headerClass} ${theme.text}`}>
+      {/* height reserves the box before the image loads; the intrinsic ratio is 919x843. */}
       <img
+        alt="Subscribe to support AoS Reminders"
         className="d-block mx-auto mb-4 img-fluid rounded-circle bg-white"
+        height="110"
         src="/img/logo_medium_padding.png"
         width="120"
-        alt="Subscribe to support AoS Reminders"
       />
       {/* Rendered at h2 size so the page gains a top-level heading without a visual change. */}
       <h1 className="h2">Support AoS Reminders</h1>
@@ -96,10 +100,8 @@ const Intro = () => {
   )
 }
 
-const featuresColClass = 'col-12 col-lg-5 col-xl-5 col-xxl-5 mt-2'
-
 const CurrentFeatures = () => (
-  <div className={featuresColClass}>
+  <div className={`${contentClass} mt-3`}>
     <p className="lead">
       <strong>What do you get when you subscribe?</strong>
     </p>
@@ -112,33 +114,42 @@ const CurrentFeatures = () => (
   </div>
 )
 
-interface WebmWithFallbackProps {
-  webmUrl: string
-  gifUrl: string
+interface DemoVideoProps {
+  videoUrl: string
   description: string
   label: string
 }
 
-const WebmWithFallback = ({ webmUrl, gifUrl, description, label }: WebmWithFallbackProps) => {
-  const supportsWebm = !!document.createElement('video').canPlayType
+/**
+ * The demo loops, so it needs a way to stop it (WCAG 2.2.2). The native controls provide that, and
+ * their fullscreen button covers what the old wrapping link to the raw file was standing in for — a
+ * link around the video would have swallowed every click the controls need.
+ *
+ * There is no .webm asset in public/img; the old `video/webm` source pointed at this same .mp4, and
+ * the poster was a 1.8MB gif fronting an 862KB video. Both are gone.
+ */
+const DemoVideo = ({ videoUrl, description, label }: DemoVideoProps) => {
+  const prefersReducedMotion =
+    typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
   return (
     <figure className="figure">
-      <LinkNewTab href={supportsWebm ? webmUrl : gifUrl} onClick={() => logClick(label)} label="Video URL">
-        {/* muted + playsInline are required for autoplay on iOS Safari and Android Chrome. */}
-        <video
-          preload="metadata"
-          loop
-          muted
-          playsInline
-          poster={gifUrl}
-          autoPlay
-          className="figure-img img-fluid rounded img-thumbnail"
-        >
-          <source src={webmUrl} type="video/mp4" />
-          <source src={webmUrl} type="video/webm" />
-        </video>
-      </LinkNewTab>
+      {/* muted + playsInline are required for autoplay on iOS Safari and Android Chrome. */}
+      <video
+        aria-label={`${description} demo`}
+        autoPlay={!prefersReducedMotion}
+        className="figure-img img-fluid rounded img-thumbnail"
+        controls
+        height="550"
+        loop
+        muted
+        onClick={() => logClick(label)}
+        playsInline
+        preload="metadata"
+        width="320"
+      >
+        <source src={videoUrl} type="video/mp4" />
+      </video>
       <figcaption className="figure-caption text-center">
         <strong>{description}</strong>
       </figcaption>

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -79,6 +79,12 @@ const DarkTheme: ITheme = {
   reminderHr: `ReminderHr-Dark`,
   reminderTags: `ReminderTags-Dark`,
   secondaryButton: `btn btn-sm btn-outline-secondary`,
+  /*
+   * Light theme separates this band with a tonal shelf; dark theme separates with the card borders
+   * instead, so the band takes the page colour. $themeDarkBluePrimary was the obvious candidate but
+   * it is exactly what the plan-card headers already use — the headers would vanish into the band.
+   */
+  sectionBand: bgColor,
   selectTheme,
   text: `text-white`,
   textMuted: `text-white-75`,

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -20,6 +20,7 @@ const LightTheme: ITheme = {
   reminderHr: `ReminderHr`,
   reminderTags: `ReminderTags-Light`,
   secondaryButton: `btn btn-sm btn-outline-secondary`,
+  sectionBand: `bg-light`,
   selectTheme: {},
   text: `text-dark`,
   textMuted: `text-muted`,

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -16,6 +16,8 @@ export interface ITheme {
   reminderHr: string
   reminderTags: string
   secondaryButton: string
+  /** A recessed full-bleed band that separates a section from the page around it. */
+  sectionBand: string
   selectTheme: Record<string, string>
   text: string
   textMuted: string


### PR DESCRIPTION
## Summary

`/impeccable polish src/components/routes/Subscribe.tsx`, run against `PRODUCT.md` and `DESIGN.md`.

Light theme renders identically apart from the feature-list alignment. The visible changes are in
**dark theme** and on **mobile**.

Every finding below was measured in the browser at 386px and 1421px in both themes, not inferred
from source.

## Layout

**Horizontal page scroll at every width.** The pricing section was a bare Bootstrap `.row` outside
any container, so its −15px margins overflowed the viewport: `scrollWidth 2575` vs
`clientWidth 2560`. At 386px the entire pricing block *also* sat 15px left of the viewport, pushing
the plan cards partly off-screen. It is now a plain full-bleed band — `PricingPlans` already
supplies its own `.container`. **Measured overflow is now 0.**

**236px of raggedness.** The intro and the feature list are one text column but used different
widths (`col-lg-8` vs `col-lg-5`) in different wrappers, so at 1421px they started at x=251.8 and
x=488. They now share a measure and a left edge. **Measured gap: 0px.**

**Two dead classes.** `jumbotron-fluid` was on two bare `.row`s, where its only rule is
`padding-left/right: 0; border-radius: 0` — and `.row` has no padding. Removed.

## Theming

**The pricing section stayed a bright `#f8f9fa` slab in dark theme** — `bg-light` hardcoded on the
band and the heading, plus default white `.card`s. This is the Slot Rule violation `DESIGN.md`
warns about. All three now resolve through a new `ITheme.sectionBand` slot and the existing
`card`/`cardBody` slots.

Dark theme takes the **page colour** for the band rather than a lighter shelf: `$themeDarkBluePrimary`
was the obvious candidate, but it is exactly what the plan-card headers already use, and the headers
would have vanished into the band. Dark separates with the card borders instead, per Flat-By-Default.

**A contrast regression this exposed.** `/ month` used Bootstrap's `text-muted` (`#6c757d`), which
measures **3.28:1** on the now-dark card body — under the 4.5:1 minimum for 12px text. It passed
before only because the card was white. Now `theme.textMuted`, measured at **9.24:1** in dark and
unchanged in light.

## Demo video (mobile only)

- **Added native `controls`.** It autoplayed and looped with no way to stop it (WCAG 2.2.2). This
  replaces the wrapping link to the raw file — a link around a video swallows every click the
  controls need, and the controls' fullscreen button covers the same intent.
- **Autoplay gated on `prefers-reduced-motion`.**
- **Removed a fictional source.** The second `<source>` advertised `video/webm` while pointing at
  the same `.mp4`; there is no `.webm` asset in `public/img` at all. The `supportsWebm` flag was
  really a `<video>`-support test and only picked the link href.
- **Removed the poster** — a 1.8MB gif fronting an 862KB video, on the mobile-only surface.
- **Accessible name** was the analytics slug `"Video URL"`; now `aria-label="Dark Mode demo"`.

## Layout shift

Neither the logo nor the video reserved its box. Both now carry their intrinsic ratio (919×843 and
320×550).

## Not changed

- **Contact buttons render 48×32px icon-only below 576px.** Real finding, but `LinkButton` is shared
  with the sitewide footer — out of scope for a Subscribe polish.
- **The demo only renders on mobile**, so desktop visitors see no demo of any paid feature. Left
  alone deliberately: adding it is a content decision, not a finish pass.

## Test plan

```
yarn lint            # clean
yarn tsc --noEmit    # clean
yarn test --run      # 831/831 pass
yarn build           # succeeds
```

Plus the impeccable detector over the changed files: no findings.

Manual: load `/subscribe` at 386px and 1421px in light and dark. Confirm no horizontal scrollbar,
the intro and feature list share a left edge, the pricing section follows the theme, and the mobile
demo has working pause/fullscreen controls.

> Note for anyone verifying locally: `vite.config.mts:23` sets
> `server.watch.ignored: ['**/.claude/worktrees/**']`, so a dev server run from inside a worktree
> never picks up edits — restart it rather than relying on HMR.