### PR TITLE
docs: correct and complete DESIGN.md from a JSX-side pass

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -260,8 +260,9 @@ optional — a new surface with no print decision is unfinished.
 
 ## Elevation & Depth
 
-**Flat by default; borders do the work.** There are no `box-shadow` values anywhere in the
-stylesheet. Separation comes from a 1px border plus a background shift: in light theme a
+**Flat by default; borders do the work.** `src/css/` declares no `box-shadow` of its own, and
+Bootstrap ships with `$enable-shadows: false`, so component surfaces are flat unless something opts
+in. Separation comes from a 1px border plus a background shift: in light theme a
 `rgba(0,0,0,0.125)` hairline against white, in dark theme an explicit `border-dark` or Pale Gray
 edge against Midnight Slate. Card headers separate from bodies by colour alone.
 
@@ -269,19 +270,34 @@ This is not minimalism for its own sake. Shadows vanish in print, so a system th
 to convey structure would lose that structure on paper — and paper is a primary output here.
 Borders survive the trip.
 
+"Flat by default" is the default, not an absolute: three things opt in, and all three are listed
+below. Reading only `src/css/` will miss two of them, because they arrive as Bootstrap utility
+classes in JSX and as a prop on a third-party control.
+
 ### Shadow Vocabulary
 
-One exception, and it is a physical control:
+Three, in descending order of how deliberate they look:
 
 - **Switch handle** (`box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.6)`; active
-  `0px 0px 1px 10px rgba(0, 0, 0, 0.2)`): the Edit/Play and theme toggles. The shadow reads as a
-  handle that moves, which is exactly what it is.
+  `0px 0px 1px 10px rgba(0, 0, 0, 0.2)`): the Edit/Play toggle (`src/components/page/homeHeader.tsx`)
+  and the theme toggle (`src/components/routes/Profile.tsx`), both passed as props to `react-switch`.
+  The shadow reads as a handle that moves, which is exactly what it is.
+- **Focus ring** (`box-shadow: 0 0 0 0.2rem <tinted>`, Bootstrap's `$input-btn-focus-box-shadow`):
+  how Bootstrap draws focus on buttons and inputs. Not decorative and not optional — it is the
+  visible keyboard-focus indicator, and nothing may suppress it.
+- **Card lift** (`shadow-sm`, `0 .125rem .25rem rgba(0,0,0,.075)`): exactly two places — the
+  subscription plan cards (`src/components/payment/pricingPlans.tsx`) and the FAQ entry cards
+  (`src/components/routes/Faq.tsx`). Both are standalone marketing/reference cards on secondary
+  routes, not part of the reminders surface, and neither is reproduced by the reminder or builder
+  cards. Treat it as incumbent, not as licence to spread `shadow-sm` onto the game screen.
 
 ### Named Rules
 
-**The Flat-By-Default Rule.** Surfaces are flat at rest and flat in motion. A shadow is only
-permitted on a control that physically travels. If a new element needs to feel separated, give it a
-border and a background, not a shadow.
+**The Flat-By-Default Rule.** Surfaces are flat unless they earn otherwise, and the reminders and
+builder surfaces are flat without exception. Two things earn it: a control that physically travels
+(the switch handles) and the focus ring, which is an accessibility requirement rather than a
+depth choice. `shadow-sm` on the plan and FAQ cards predates this record and is preserved as
+incumbent. If a new element needs to feel separated, give it a border and a background.
 
 ## Shapes
 
@@ -343,7 +359,8 @@ The reminder timing tags — the one genuinely bespoke component in the system.
 
 - **Corner Style:** `0.25rem`.
 - **Background:** white in light theme, Midnight Slate in dark.
-- **Shadow Strategy:** none — see Elevation.
+- **Shadow Strategy:** none. The reminder and builder cards carry no `shadow-sm`; the plan and FAQ
+  cards do — see Elevation.
 - **Border:** 1px hairline; dark theme adds an explicit `border border-dark`.
 - **Internal Padding:** `0.75rem` vertical / `1.25rem` horizontal, tightening to `0.75rem` vertical
   on the reminder body below 576px and to `0.5rem` in print.
@@ -399,7 +416,11 @@ the opposite mode is a dead stop in the tab order.
 ### Don't:
 
 - **Don't** introduce a web font, or any render-blocking resource on the reminders path.
-- **Don't** add a `box-shadow` to anything that doesn't physically move.
+- **Don't** add a `box-shadow` to a new element. The switch handles, Bootstrap's focus ring, and the
+  incumbent `shadow-sm` on the plan and FAQ cards are the whole vocabulary; never put one on the
+  reminders or builder surface.
+- **Don't** suppress Bootstrap's focus ring — it is a `box-shadow`, and removing it removes the
+  visible keyboard-focus indicator.
 - **Don't** hardcode a hex in a component, or reach for `$themeRed`, `$themeYellow`, or
   `$themeDarkBlueTertiary` — they are declared but unused and are not part of the system.
 - **Don't** change heading level to change text size. Set the size in `.CardHeaderTitle`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,6 +10,11 @@ colors:
   note-blue: "#1237c7"
   ink: "#212529"
   paper: "#ffffff"
+  action-blue: "#007bff"
+  success-green: "#28a745"
+  danger-red: "#dc3545"
+  warning-amber: "#ffc107"
+  info-cyan: "#17a2b8"
 typography:
   display:
     fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif"
@@ -26,6 +31,11 @@ typography:
     fontSize: "1rem"
     fontWeight: 400
     lineHeight: 1.5
+  lead:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif"
+    fontSize: "1.25rem"
+    fontWeight: 300
+    lineHeight: 1.5
   label:
     fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif"
     fontSize: "0.7rem"
@@ -36,6 +46,7 @@ rounded:
   none: "0"
   chip: "3px"
   md: "0.25rem"
+  pill: "10rem"
 spacing:
   xs: "0.25rem"
   sm: "0.5rem"
@@ -83,12 +94,23 @@ components:
     rounded: "{rounded.md}"
     padding: "0.375rem 0.75rem"
     width: "100%"
+  button-cta:
+    backgroundColor: "{colors.action-blue}"
+    textColor: "{colors.paper}"
+    rounded: "{rounded.md}"
+    padding: "0.5rem 0.75rem"
+    width: "100%"
   reminder-tag:
     backgroundColor: "transparent"
     textColor: "{colors.ink}"
     typography: "{typography.label}"
     rounded: "{rounded.chip}"
     padding: "0.1rem 0.4rem"
+  badge-official:
+    backgroundColor: "{colors.action-blue}"
+    textColor: "{colors.paper}"
+    rounded: "{rounded.pill}"
+    padding: "0.25em 0.6em"
   modal:
     backgroundColor: "{colors.paper}"
     textColor: "{colors.ink}"
@@ -128,7 +150,7 @@ the table.
 **Key Characteristics:**
 
 - Density over whitespace; the screen is a reference sheet, not a landing page
-- Two structural colours, everything else neutral
+- Two structural colours plus Bootstrap's semantic set; nothing decorative
 - Flat surfaces, hairline borders, no shadows on anything that doesn't physically move
 - System fonts only — no web font is loaded, and none should be
 - Every surface has a defined print behaviour
@@ -136,8 +158,13 @@ the table.
 
 ## Colors
 
-A cold, near-monochrome palette: two teals doing structural work against neutral paper or slate,
-with colour reserved for meaning rather than decoration.
+Two teals doing structural work against neutral paper or slate, plus Bootstrap's semantic set for
+actions and status. Colour is reserved for meaning; nothing here is decorative.
+
+The teals are the project's own and carry the identity. The semantic colours are Bootstrap 4.6
+defaults, used unmodified — a deliberate consequence of the Field Manual thesis, since standard
+signal colours are the ones a reader already knows. They are listed below because they are real,
+frequent, and user-facing, not because they were designed.
 
 ### Primary
 
@@ -165,6 +192,28 @@ with colour reserved for meaning rather than decoration.
   textarea outlines.
 - **Profile Wash** (`rgba(28, 117, 149, 0.15)`): Signal Teal at 15% behind profile card headers —
   the same accent, quieted, on the account screens where nothing is time-critical.
+
+### Semantic
+
+Bootstrap 4.6's defaults, reached through utility classes in JSX rather than through `theme.scss`.
+They do not appear on the reminders surface, which is the point: seeing one means something
+happened.
+
+- **Action Blue** (`#007bff`, `$primary`): `btn-primary` on every commitment control — the three
+  Subscribe CTAs, gift purchase, redemption. Also `badge-primary` on the `Official` marker beside a
+  Games Workshop source link, which is the one place it appears on the reminders screen. It is the
+  most saturated colour in the product and it means *this is the action* or *this is authoritative*.
+- **Danger Red** (`#dc3545`): destructive confirmation buttons, `alert-danger` on failed saves,
+  shares, and imports, and the `badge-danger` sale flash in the navbar and on plan cards.
+- **Success Green** (`#28a745`): confirmed saves and completed subscription state.
+- **Warning Amber** (`#ffc107`) and **Info Cyan** (`#17a2b8`): subscription status text on
+  `/profile`, and `alert-info` guidance in the saved-armies and profile flows.
+
+### Named Rules
+
+**The Signal-Colour Rule.** The semantic colours are for state, action, and authority — never for
+emphasis or decoration. A saturated colour on the reminders surface should be so rare it reads as
+information: today the only one is the `Official` badge.
 
 Muted text is expressed as opacity rather than a separate token: `text-white-75`
 (`rgba(255,255,255,0.75)`) in dark theme, Bootstrap's `text-muted` in light.
@@ -205,6 +254,11 @@ player who needs a rule now. The type does no expressive work; the hierarchy and
 - **Title** (500, 1.5rem, 1.2): `.CardHeaderTitle` — every collapsible card header, and the army
   name in Play mode. Steps down responsively to 1.1rem below 576px, 1rem below 395px, and 0.8rem
   below 374px; 1.1rem in print.
+- **Lead** (300, 1.25rem, 1.5): Bootstrap's `.lead`, the standing-prose role — Subscribe's intro and
+  feature list, modal explanations, the loading message, and account-flow guidance. It is the voice
+  the product uses when it is *talking to* the player rather than quoting a rule, so it appears on
+  every surface except the reminders themselves. The light 300 weight is what distinguishes it from
+  Body at a glance.
 - **Body** (400, 1rem, 1.5): rule Trigger/Declare/Effect text, the substance of the product. Falls
   to 0.9rem in print to fit more per page.
 - **Label** (700, 0.7rem, 1.35, `0.03em`, uppercase): the reminder timing tags. Small, wide-tracked,
@@ -334,6 +388,12 @@ varies; the instruments do not.
   `mr-2` and a `text-nowrap` label. Outline rather than filled because seven of them sit in one
   row — seven filled buttons would out-shout the reminders below.
 - **Navbar:** `btn btn-outline-light btn-sm mx-2` against the teal masthead.
+- **Commitment (`btn-primary`, Action Blue):** the only *filled* buttons in the product, reserved
+  for the moment money or an account changes — the three Subscribe CTAs, gift purchase, redemption.
+  Filled-vs-outline is the hierarchy: outline for everything reversible, filled for the one control
+  that commits. `btn-success` and `btn-danger` fill likewise for confirm and destroy in modals.
+- **Width:** `btn-block` is the dominant shape (14 uses). Buttons in this product are full-width in
+  their column far more often than they are inline.
 - **Disabled:** used semantically, not decoratively — `Show Hidden` disables at zero hidden, and
   the subscriber actions disable while auth or subscription state is resolving.
 - **Hover / Focus:** Bootstrap defaults, untouched. No `outline: none` appears anywhere in the
@@ -355,6 +415,47 @@ The reminder timing tags — the one genuinely bespoke component in the system.
 - **Print:** all fills drop to transparent, text to black, border to `rgba(0,0,0,0.45)`. Weight and
   border carry the distinction on paper.
 
+### Badges
+
+Bootstrap badges, always `badge-pill` (`10rem` radius) — the product has no square badge.
+
+- **`Official`** (`badge-primary`, Action Blue): beside a Games Workshop source in the reminder
+  overflow menu. Marks authority, and is the only saturated colour on the reminders surface.
+- **Sale flash** (`badge-danger`): the discount percentage in the navbar and on plan cards.
+  Suppressed below 335px, where the navbar has no room for it.
+- **Selection count**: rendered as plain text in the card title (`Units (3)`), not a badge —
+  deliberate, since it is a state readout rather than an attention marker.
+
+### Alerts
+
+Bootstrap alerts — ten typed instances across the account flows — are the standard way this product
+reports the outcome of an account operation. Never a toast, never a modal. `alert-danger` for a failed save, share, or import;
+`alert-warning` for a recoverable problem; `alert-success` for a confirmed write; `alert-info` for
+standing guidance. They render inline in the modal or panel that owns the action, so the message
+sits where the failure happened. They carry `role="alert"` where the content is not present at
+first render.
+
+### Inputs / Fields
+
+- **Text inputs:** Bootstrap `form-control` (12 uses), `form-control-sm` in dense modal rows. Always
+  paired with a real `<label>` — several are `sr-only` where the surrounding copy already names the
+  field.
+- **Selects:** `react-select`, themed through `theme.selectTheme` — light theme uses the library
+  default, dark overrides eleven neutral/primary slots to sit on Midnight Slate. Always carries an
+  `aria-label`.
+- **Note textarea:** `.NoteInput`, 95% width, `resize: vertical` only (horizontal resize let users
+  drag it past the card and scroll the page sideways), inheriting theme background and text.
+- **Dropzone:** dashed 2px, `#eeeeee` on `#fafafa` in light and Pale Gray on black in dark, with a
+  `#2196f3` border on focus and drag-over.
+
+### Loading and empty states
+
+- **Spinner:** Bootstrap `spinner-border`, with `spinner-border-sm` inline in buttons. Always
+  accompanied by `sr-only` "Loading..." text under `role="status"`, so the state is announced and
+  not merely animated.
+- **Suspense fallbacks:** `LoadingHeader` and `LoadingBody` stand in for the navbar and routed
+  content, so the masthead does not collapse while a lazy route resolves.
+
 ### Cards / Containers
 
 - **Corner Style:** `0.25rem`.
@@ -367,16 +468,6 @@ The reminder timing tags — the one genuinely bespoke component in the system.
 - **Header:** Signal Teal with white text, containing a full-width `<button>` that carries the
   padding so the entire header is the hit area, an `<h2>` title, and a Material expand/collapse
   chevron. Collapsed headers on mobile append a selection count (`Units (3)`).
-
-### Inputs / Fields
-
-- **Selects:** `react-select`, themed through `theme.selectTheme` — light theme uses the library
-  default, dark overrides eleven neutral/primary slots to sit on Midnight Slate. Always carries an
-  `aria-label`.
-- **Note textarea:** `.NoteInput`, 95% width, `resize: vertical` only (horizontal resize let users
-  drag it past the card and scroll the page sideways), inheriting theme background and text.
-- **Dropzone:** dashed 2px, `#eeeeee` on `#fafafa` in light and Pale Gray on black in dark, with a
-  `#2196f3` border on focus and drag-over.
 
 ### Navigation
 
@@ -394,6 +485,30 @@ The product's one true mode control, and the only place the system spends any ex
 `Play`, the active one bolded. The words are click-to-toggle for the mouse but deliberately **not**
 focusable — the switch is the single keyboard control, because a focusable label that only fires in
 the opposite mode is a dead stop in the tab order.
+
+### Named Rules
+
+**The Dead Class Rule.** A class in JSX that no rule defines is a design intention that silently
+never happened, and this codebase has a habit of them. Checked against the compiled bundle, seven
+are live in `src/components/` today:
+
+| Class | Where | What was intended |
+| --- | --- | --- |
+| `pulsate-fwd` | `helpers/suspenseFallbacks.tsx:56` | A pulse on the loading heading |
+| `fade-out` | `helpers/suspenseFallbacks.tsx:57` | A fade on "Loading…" |
+| `btn-pill` | `payment/pricingPlans.tsx:132` | A rounded Subscribe CTA (`rounded-pill` is the real class) |
+| `btn-md` | `routes/Profile.tsx:318` | A medium button; Bootstrap only ships `btn-sm`/`btn-lg` |
+| `h-md-250` | `routes/Faq.tsx:61` | A fixed FAQ card height |
+| `g-0` | `routes/Faq.tsx:61` | Zero gutters — Bootstrap **5** syntax; 4.6 wants `no-gutters` |
+| `pricing-card-title` | `payment/pricingPlans.tsx:113` | Carried over from a Bootstrap example |
+
+The first two matter most to this record. The product has essentially no motion — the only
+transition in the stylesheet is the dropzone's border on drag-over — and that reads as a deliberate
+choice fitting the use scene. But the loading screen *asked* for a pulse and a fade and got neither,
+so the absence of motion there is an accident, not a decision. Treat it as open rather than settled.
+
+Verify a new utility class exists before relying on it — `grep` the compiled CSS, not your memory of
+which Bootstrap version this is.
 
 ## Do's and Don'ts
 
@@ -425,6 +540,10 @@ the opposite mode is a dead stop in the tab order.
   `$themeDarkBlueTertiary` — they are declared but unused and are not part of the system.
 - **Don't** change heading level to change text size. Set the size in `.CardHeaderTitle`.
 - **Don't** use uppercase outside the timing tags.
+- **Don't** use a filled button for a reversible action. Filled (`btn-primary`) is reserved for the
+  control that commits; everything else is outline.
+- **Don't** reach for a Bootstrap 5 utility. This is Bootstrap 4.6 — `g-0`, `btn-md`, and
+  `display-5` are all in that trap, and two of them are live in the codebase today.
 - **Don't** trade density for whitespace on the reminders screen. It is a reference sheet read
   under time pressure, not a marketing page.
 - **Don't** restyle as a side effect of an accessibility or correctness fix. Choose the variant that


### PR DESCRIPTION
## Summary

`DESIGN.md` was extracted from `theme.scss`, `index.scss`, and the `ITheme` implementations. That
method misses everything this codebase expresses as **Bootstrap utility classes in JSX** — which
turns out to be a lot. Two commits:

1. **Correct the elevation section** — the specific error that exposed the problem.
2. **Complete the record from a JSX pass** — inventory all **223 distinct classes** used across
   `src/components` and reconcile.

Documentation only. No code changes.

---

## 1. Elevation

Claimed *"no `box-shadow` values anywhere in the stylesheet"* and listed the switch handle as
**"One exception."** Actual vocabulary:

| Source | Where | Was documented? |
|---|---|---|
| Switch handles | `homeHeader.tsx:77`, `Profile.tsx:289` | Yes |
| Bootstrap focus ring | `$input-btn-focus-box-shadow` | **No** |
| `shadow-sm` | `pricingPlans.tsx:107`, `Faq.tsx:61` | **No** |

The focus ring is the one that could have caused harm — it *is* a `box-shadow`, so the old blanket
Don't could have justified suppressing the visible keyboard-focus indicator. There's now an explicit
Don't against it.

`src/css/` really does declare no `box-shadow` and Bootstrap ships `$enable-shadows: false`, so
"flat by default" survives — as a default with three named exceptions rather than an absolute.

## 2. Colors — the largest gap

Bootstrap's semantic set is in active, user-facing use and was **entirely absent** from a document
that called the palette *"cold, near-monochrome."*

- **Action Blue** (`#007bff`) — `btn-primary` is the **only filled button style in the product**,
  carrying every Subscribe CTA, gift purchase, and redemption. `badge-primary` is also the
  `Official` marker beside Games Workshop sources, which makes it the one saturated colour on the
  reminders surface.
- **Danger Red / Success Green / Warning Amber / Info Cyan** — destructive confirmation, alert
  state, and subscription status.

Added as a `### Semantic` group with a **Signal-Colour Rule**: these are for state, action, and
authority, never emphasis or decoration.

## 3. Typography

Added the **Lead** role (Bootstrap `.lead`, 1.25rem/300, 12 uses) — the standing-prose voice on
every surface except the reminders. Its light 300 weight is what distinguishes it from Body, and
missing it meant the doc had no role covering most of the product's prose.

## 4. Components

Four documented that previously existed only in JSX: **badges** (always pill), **alerts** as the
standard account-operation result surface, **form controls**, and the **spinner / suspense** loading
states. Buttons gain the filled-vs-outline hierarchy `btn-primary` establishes.

## 5. The Dead Class Rule

Checked every JSX class against the compiled bundle. **Seven resolve to no rule at all:**

| Class | Where | Intended |
|---|---|---|
| `pulsate-fwd` | `suspenseFallbacks.tsx:56` | Pulse on the loading heading |
| `fade-out` | `suspenseFallbacks.tsx:57` | Fade on "Loading…" |
| `btn-pill` | `pricingPlans.tsx:132` | Rounded CTA (`rounded-pill` is real) |
| `btn-md` | `Profile.tsx:318` | Bootstrap only ships `btn-sm`/`btn-lg` |
| `h-md-250` | `Faq.tsx:61` | Fixed FAQ card height |
| `g-0` | `Faq.tsx:61` | Zero gutters — **Bootstrap 5** syntax; 4.6 wants `no-gutters` |
| `pricing-card-title` | `pricingPlans.tsx:113` | Carried from a Bootstrap example |

The first two are the interesting ones: **the loading screen is the only place the product ever
asked for motion, and it doesn't move.** The absence of motion there is an accident, not a decision,
so the record now treats it as open.

**Recorded, not fixed** — these are code changes and belong in their own PR.

## Verification

```
node scripts/… 223 distinct classes checked against dist/assets/index-*.css
bootstrap 4.6.0 confirmed; .no-gutters defined, .g-0 not
all frontmatter keys present; 8 canonical sections still in spec order
sidecar .impeccable/design.json revalidated (13 colours, 5 type roles, 11 rules)
```

Usage counts in the doc were re-checked by grep and corrected where my first tally was off
(`form-control` 9→12, alerts stated as ten typed instances).

`.impeccable/design.json` is regenerated to match but isn't in this diff — `.impeccable/` is
gitignored at `.gitignore:98`.

## Note on remaining risk

This pass covered `className` strings in `src/components`. Inline `style` props, `react-select`'s
`selectTheme` overrides, and third-party component defaults (react-bootstrap `Dropdown`,
react-modal, react-switch) are still only partially represented in `DESIGN.md`. Lower risk — they're
localised rather than systemic — but not zero.