### PR TITLE
chore(deps): migrate from Bootstrap 4.6 to Bootstrap 5.3 (#1176)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,9 +137,12 @@ a package blocks correct data work, the build, or safe operation.
 
 Phase 2 is underway. Its capability-restoration track (plan `2026-07-29-001`) has delivered
 printing and PDF export (`src/aos4/print/`, documented in `docs/printing.md`) and importing, cloud
-armies, and sharing; its planned package and framework upgrades remain pending. Checked-in plans
-live under `docs/plans/`. Preserve the completed AoS 4 domain, generated-data contracts, beta
-gate, and familiar interface while working through:
+armies, and sharing. Its package track has begun: Bootstrap is on 5.3 and react-bootstrap on 2.x
+(issue #1176), migrated for visual parity — `src/css/theme.scss` pins the Bootstrap 4.6 defaults the
+interface was built against, and those pins are part of the design system (see DESIGN.md, "The
+Parity Pin Rule"). The remaining framework upgrades are pending. Checked-in plans live under
+`docs/plans/`. Preserve the completed AoS 4 domain, generated-data contracts, beta gate, and
+familiar interface while working through:
 
 - upgrade React, Vite, TypeScript, Sass, PWA tooling, and supporting packages
 - remove packages made unused by the AoS 3 retirement

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -135,7 +135,7 @@ by having nothing in it that isn't needed. The visual system exists to get a rul
 player who is mid-turn with dice in one hand, and then get out of the way. Every decoration is
 weight the player has to carry.
 
-The system is deliberately built on Bootstrap 4.6 defaults with a small, specific palette laid over
+The system is deliberately built on Bootstrap defaults with a small, specific palette laid over
 the top. That is a decision, not neglect: a manual uses standard-issue components so the *content*
 is the only thing that varies between pages. Two colours carry the entire structural language — a
 near-black teal for the masthead and a mid teal for every section header — and everything else is
@@ -161,10 +161,15 @@ the table.
 Two teals doing structural work against neutral paper or slate, plus Bootstrap's semantic set for
 actions and status. Colour is reserved for meaning; nothing here is decorative.
 
-The teals are the project's own and carry the identity. The semantic colours are Bootstrap 4.6
-defaults, used unmodified — a deliberate consequence of the Field Manual thesis, since standard
-signal colours are the ones a reader already knows. They are listed below because they are real,
-frequent, and user-facing, not because they were designed.
+The teals are the project's own and carry the identity. The semantic colours are Bootstrap's stock
+signal set — a deliberate consequence of the Field Manual thesis, since standard signal colours are
+the ones a reader already knows. They are listed below because they are real, frequent, and
+user-facing, not because they were designed.
+
+Three of them are no longer Bootstrap's *current* defaults. Bootstrap 5 re-picked `$blue`, `$green`,
+and `$cyan`, and `$dark` moved a step darker; `src/css/theme.scss` pins all four back to the 4.6
+values the product was built on. See "Parity pins" under Layout — the hexes below are the truth, and
+the framework's own defaults are not.
 
 ### Primary
 
@@ -195,16 +200,16 @@ frequent, and user-facing, not because they were designed.
 
 ### Semantic
 
-Bootstrap 4.6's defaults, reached through utility classes in JSX rather than through `theme.scss`.
+Bootstrap's signal set, reached through utility classes in JSX rather than through `theme.scss`.
 They do not appear on the reminders surface, which is the point: seeing one means something
 happened.
 
 - **Action Blue** (`#007bff`, `$primary`): `btn-primary` on every commitment control — the three
-  Subscribe CTAs, gift purchase, redemption. Also `badge-primary` on the `Official` marker beside a
+  Subscribe CTAs, gift purchase, redemption. Also `badge bg-primary` on the `Official` marker beside a
   Games Workshop source link, which is the one place it appears on the reminders screen. It is the
   most saturated colour in the product and it means *this is the action* or *this is authoritative*.
 - **Danger Red** (`#dc3545`): destructive confirmation buttons, `alert-danger` on failed saves,
-  shares, and imports, and the `badge-danger` sale flash in the navbar and on plan cards.
+  shares, and imports, and the `bg-danger` sale flash in the navbar and on plan cards.
 - **Success Green** (`#28a745`): confirmed saves and completed subscription state.
 - **Warning Amber** (`#ffc107`) and **Info Cyan** (`#17a2b8`): subscription status text on
   `/profile`, and `alert-info` guidance in the saved-armies and profile flows.
@@ -282,8 +287,28 @@ anything else adopts it.
 
 ## Layout
 
-Bootstrap 4.6's 12-column grid, with a custom `xxl: 1900px` tier added to the default five
-(`sm: 576`, `md: 768`, `lg: 1025`, `xl: 1200`). Containers cap at 1610px at `xxl`.
+Bootstrap 5.3's 12-column grid, with `lg` moved to 1025px and `xxl` to 1900px (`sm: 576`,
+`md: 768`, `lg: 1025`, `xl: 1200`, `xxl: 1900`). Containers cap at 1610px at `xxl`. The gutter is
+30px, not Bootstrap 5's 1.5rem — see below.
+
+### Named Rules
+
+**The Parity Pin Rule.** The product moved from Bootstrap 4.6 to 5.3 for technical reasons only, and
+`src/css/theme.scss` carries a block of overrides that hold the 4.6 defaults in place: the gutter,
+the border radii, the card spacers, the badge metrics, link decoration, the focus-ring width, the
+signal colours, and RFS (off). Each one is a value this record describes, and each is annotated in
+the stylesheet with the 5.3 default it replaces.
+
+Those pins are the system, not legacy debris. Changing one is a design decision with a visible
+consequence, so it needs the same deliberation as any other change here — do not "modernise" them
+to the framework defaults as tidy-up. Equally, do not assume an unpinned Bootstrap 5 default matches
+what this document says: if a value matters, check `theme.scss` first.
+
+Three compatibility rules sit below the Bootstrap import for behaviour that no variable controls:
+`.card`/`.card-body` colour and padding, the bare `<label>` bottom margin (with the radio-label
+exception), and gutters for the handful of `col-*` elements that live outside a `.row`. Bootstrap 5
+also applies gutters to *every* direct child of a `.row`, where 4.6 only styled `col`-classed
+children; five non-column row children opt out with `px-0` and carry a comment saying so.
 
 The page is a single centred column of stacked cards. The reminder column sits at
 `col col-sm-11 col-md-10 col-lg-10 col-xl-8` — deliberately narrower than the builder above it,
@@ -298,8 +323,8 @@ padding grows from `0.5rem 1.25rem` to a uniform `1rem`; reminder cards start co
 expanded, so the player lands on a list of phases instead of a wall of text.
 
 Spacing is Bootstrap's `1rem`-based scale used at the low end — `0.25`/`0.5`/`1rem` do almost all
-the work. Cards use `0.75rem` vertical and `1.25rem` horizontal internal padding. The rhythm is
-tight on purpose.
+the work. Card bodies use `1.25rem` all round and card headers `0.75rem` vertical / `1.25rem`
+horizontal. The rhythm is tight on purpose.
 
 **Section bands.** A full-bleed horizontal band marks a major section break on the account routes —
 today the pricing block and the mobile demo on `/subscribe`. It is a theme slot,
@@ -391,14 +416,15 @@ varies; the instruments do not.
 - **Shape:** gently rounded (`0.25rem`), Bootstrap default padding (`0.375rem 0.75rem`).
 - **Toolbar (primary pattern):** full-width outline buttons, `btn-outline-dark` in light theme and
   `btn-outline-light` in dark, laid out `col-6 col-sm-4 col-lg`. Each carries a leading icon at
-  `mr-2` and a `text-nowrap` label. Outline rather than filled because seven of them sit in one
+  `me-2` and a `text-nowrap` label. Outline rather than filled because seven of them sit in one
   row — seven filled buttons would out-shout the reminders below.
 - **Navbar:** `btn btn-outline-light btn-sm mx-2` against the teal masthead.
 - **Commitment (`btn-primary`, Action Blue):** the only *filled* buttons in the product, reserved
   for the moment money or an account changes — the three Subscribe CTAs, gift purchase, redemption.
   Filled-vs-outline is the hierarchy: outline for everything reversible, filled for the one control
   that commits. `btn-success` and `btn-danger` fill likewise for confirm and destroy in modals.
-- **Width:** `btn-block` is the dominant shape (14 uses). Buttons in this product are full-width in
+- **Width:** full-width is the dominant shape — `d-block w-100`, 14 uses (Bootstrap 5 dropped
+  `.btn-block`). Buttons in this product are full-width in
   their column far more often than they are inline.
 - **Disabled:** used semantically, not decoratively — `Show Hidden` disables at zero hidden, and
   the subscriber actions disable while auth or subscription state is resolving.
@@ -423,11 +449,14 @@ The reminder timing tags — the one genuinely bespoke component in the system.
 
 ### Badges
 
-Bootstrap badges, always `badge-pill` (`10rem` radius) — the product has no square badge.
+Bootstrap badges, almost always pill-shaped: `badge rounded-pill`, kept at 4.6's `10rem` radius and
+`.6em` horizontal padding by a rule in `theme.scss` (Bootstrap 5's `.rounded-pill` sets the radius
+and nothing else). The one exception is the inline `Sale!` flash beside a plan title, which is a
+plain `badge`.
 
-- **`Official`** (`badge-primary`, Action Blue): beside a Games Workshop source in the reminder
+- **`Official`** (`badge bg-primary`, Action Blue): beside a Games Workshop source in the reminder
   overflow menu. Marks authority, and is the only saturated colour on the reminders surface.
-- **Sale flash** (`badge-danger`): the discount percentage in the navbar and on plan cards.
+- **Sale flash** (`bg-danger`): the discount percentage in the navbar and on plan cards.
   Suppressed below 335px, where the navbar has no room for it.
 - **Selection count**: rendered as plain text in the card title (`Units (3)`), not a badge —
   deliberate, since it is a state readout rather than an attention marker.
@@ -444,7 +473,7 @@ first render.
 ### Inputs / Fields
 
 - **Text inputs:** Bootstrap `form-control` (12 uses), `form-control-sm` in dense modal rows. Always
-  paired with a real `<label>` — several are `sr-only` where the surrounding copy already names the
+  paired with a real `<label>` — several are `visually-hidden` where the surrounding copy already names the
   field.
 - **Selects:** `react-select`, themed through `theme.selectTheme` — light theme uses the library
   default, dark overrides eleven neutral/primary slots to sit on Midnight Slate. Always carries an
@@ -457,7 +486,7 @@ first render.
 ### Loading and empty states
 
 - **Spinner:** Bootstrap `spinner-border`, with `spinner-border-sm` inline in buttons. Always
-  accompanied by `sr-only` "Loading..." text under `role="status"`, so the state is announced and
+  accompanied by `visually-hidden` "Loading..." text under `role="status"`, so the state is announced and
   not merely animated.
 - **Suspense fallbacks:** `LoadingHeader` and `LoadingBody` stand in for the navbar and routed
   content, so the masthead does not collapse while a lazy route resolves.
@@ -469,19 +498,22 @@ first render.
 - **Shadow Strategy:** none. The reminder and builder cards carry no `shadow-sm`; the plan and FAQ
   cards do — see Elevation.
 - **Border:** 1px hairline; dark theme adds an explicit `border border-dark`.
-- **Internal Padding:** `0.75rem` vertical / `1.25rem` horizontal, tightening to `0.75rem` vertical
-  on the reminder body below 576px and to `0.5rem` in print.
+- **Internal Padding:** `1.25rem` on all four sides of `.card-body`, tightening to `0.75rem`
+  vertical on the reminder body below 576px and to `0.5rem` in print. (Bootstrap 4.6's `.card-body`
+  took `$card-spacer-x` as a single value, so its vertical padding was 1.25rem and `$card-spacer-y`
+  never reached it; 5.x corrected that to `0.75rem 1.25rem`, and `theme.scss` pins the old
+  behaviour. `$card-spacer-y` still drives the header, below.)
 - **Header:** Signal Teal with white text, containing a full-width `<button>` that carries the
   padding so the entire header is the hit area, an `<h2>` title, and a Material expand/collapse
   chevron. Collapsed headers on mobile append a selection count (`Units (3)`).
 
 ### Navigation
 
-- **Style:** bold light links (`font-weight-bold text-light mx-2`) directly on the masthead colour,
+- **Style:** bold light links (`fw-bold text-light mx-2`) directly on the masthead colour,
   inside `<header>` → `<nav aria-label="Main">`. No underline, no active-state treatment — the
   current route's own link is simply omitted.
 - **Content:** signed out, `Subscribe` / `FAQ` / `Log in`; signed in, `Profile` / `Log out`.
-  A sale renders a `badge badge-pill badge-danger` discount chip, suppressed below 335px.
+  A sale renders a `badge rounded-pill bg-danger` discount chip, suppressed below 335px.
 - **Mobile:** the row narrows from 75% to 100% width; links do not collapse into a menu.
 
 ### Signature Component: the Edit/Play switch
@@ -495,7 +527,7 @@ the opposite mode is a dead stop in the tab order.
 ### Named Rules
 
 **The Dead Class Rule.** A class in JSX that no rule defines is a design intention that silently
-never happened, and this codebase has a habit of them. Checked against the compiled bundle, seven
+never happened, and this codebase has a habit of them. Checked against the compiled bundle, six
 are live in `src/components/` today:
 
 | Class | Where | What was intended |
@@ -505,7 +537,6 @@ are live in `src/components/` today:
 | `btn-pill` | `payment/pricingPlans.tsx` | A rounded Subscribe CTA (`rounded-pill` is the real class) |
 | `btn-md` | `routes/Profile.tsx` | A medium button; Bootstrap only ships `btn-sm`/`btn-lg` |
 | `h-md-250` | `routes/Faq.tsx` | A fixed FAQ card height |
-| `g-0` | `routes/Faq.tsx` | Zero gutters — Bootstrap **5** syntax; 4.6 wants `no-gutters` |
 | `pricing-card-title` | `payment/pricingPlans.tsx` | Carried over from a Bootstrap example |
 
 The first two matter most to this record. The product has essentially no motion — the only
@@ -514,7 +545,12 @@ choice fitting the use scene. But the loading screen *asked* for a pulse and a f
 so the absence of motion there is an accident, not a decision. Treat it as open rather than settled.
 
 Verify a new utility class exists before relying on it — `grep` the compiled CSS, not your memory of
-which Bootstrap version this is.
+which Bootstrap version this is. A seventh entry, `g-0` on the FAQ row, left this table in the 5.3
+upgrade: it was Bootstrap 5 syntax written while the project was still on 4.6, so it had never done
+anything, and the upgrade would have brought it to life and narrowed every FAQ card. It was deleted
+rather than honoured, because reviving a style that has never shipped is a design change. That is
+the general remedy for this table: a dead class is removed or implemented deliberately, never left
+to switch itself on during an upgrade.
 
 ## Do's and Don'ts
 
@@ -550,8 +586,13 @@ which Bootstrap version this is.
 - **Don't** use uppercase outside the timing tags.
 - **Don't** use a filled button for a reversible action. Filled (`btn-primary`) is reserved for the
   control that commits; everything else is outline.
-- **Don't** reach for a Bootstrap 5 utility. This is Bootstrap 4.6 — `g-0`, `btn-md`, and
-  `display-5` are all in that trap, and two of them are live in the codebase today.
+- **Don't** reach for a Bootstrap 4 utility. This is Bootstrap 5.3 — `ml-*`/`mr-*`, `sr-only`,
+  `badge-primary`, `badge-pill`, `btn-block`, `no-gutters`, `font-weight-bold`, and the
+  `custom-control` form family are all gone. `btn-md` is in the trap in both versions and is still
+  live in the codebase today.
+- **Don't** replace a parity pin in `theme.scss` with the Bootstrap 5 default without deciding to
+  change the design. Each pin holds a value this document specifies, and each is annotated with the
+  default it overrides.
 - **Don't** trade density for whitespace on the reminders screen. It is a reference sheet read
   under time pressure, not a marketing page.
 - **Don't** restyle as a side effect of an accessibility or correctness fix. Choose the variant that

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@reduxjs/toolkit": "1.9.7",
     "@stripe/react-stripe-js": "2.4.0",
     "@stripe/stripe-js": "1.54.1",
-    "bootstrap": "4.6.0",
+    "bootstrap": "5.3.8",
     "core-js": "3.35.0",
     "deepmerge": "4.3.1",
     "eslint-plugin-import": "^2.29.1",
@@ -22,7 +22,7 @@
     "qs": "6.11.2",
     "react": "17.0.2",
     "react-beautiful-dnd": "13.1.1",
-    "react-bootstrap": "1.6.4",
+    "react-bootstrap": "2.10.10",
     "react-copy-to-clipboard": "5.1.0",
     "react-dom": "17.0.2",
     "react-dropzone": "11.5.1",
@@ -141,6 +141,7 @@
   "resolutions": {
     "typescript": "5.3.3",
     "@typescript-eslint/parser": "^7.16.0",
-    "autoprefixer": "10.4.5"
+    "autoprefixer": "10.4.5",
+    "@types/react": "17.0.43"
   }
 }

--- a/src/components/aos4/collapsibleCardHeader.tsx
+++ b/src/components/aos4/collapsibleCardHeader.tsx
@@ -37,10 +37,10 @@ export const CollapsibleCardHeader = ({
         type="button"
       >
         <div className={`d-flex justify-content-${isMobile ? 'end' : 'center'} align-items-center`}>
-          <div className={`flex-grow-1 text-center ${isMobile ? '' : 'pl-5'}`}>
+          <div className={`flex-grow-1 text-center ${isMobile ? '' : 'ps-5'}`}>
             <h2 className="CardHeaderTitle">{title}</h2>
           </div>
-          <div className={`${isMobile ? 'pr-0' : 'px-3'} d-print-none`}>
+          <div className={`${isMobile ? 'pe-0' : 'px-3'} d-print-none`}>
             {isExpanded ? <MdRemove aria-hidden /> : <MdExpandMore aria-hidden />}
           </div>
         </div>

--- a/src/components/helpers/link.tsx
+++ b/src/components/helpers/link.tsx
@@ -34,7 +34,7 @@ export const LinkButton = ({ Icon, href, btnClass, text }: LinkButtonProps) => {
       label={text}
     >
       <div className={centerContentClass}>
-        <Icon className={isMobile ? 'mx-2 my-1' : 'mr-2'} />
+        <Icon className={isMobile ? 'mx-2 my-1' : 'me-2'} />
         {isMobile ? '' : ` ${text}`}
       </div>
     </LinkNewTab>

--- a/src/components/helpers/spinner.tsx
+++ b/src/components/helpers/spinner.tsx
@@ -17,7 +17,7 @@ const Spinner = ({ variant = 'dark', size = 'normal', className = '' }: SpinnerP
   return (
     <div className={`d-flex justify-content-center ${className}`}>
       <div className={`spinner-border ${colorClass} ${sizeClass}`} style={style} role="status">
-        <span className="sr-only">Loading...</span>
+        <span className="visually-hidden">Loading...</span>
       </div>
     </div>
   )

--- a/src/components/helpers/suspenseFallbacks.tsx
+++ b/src/components/helpers/suspenseFallbacks.tsx
@@ -9,13 +9,13 @@ import { ROUTES } from 'utils/env'
 
 export const LoadingBtn = ({ text = 'Loading' }: { text?: string }) => (
   <GenericButton disabled type="button">
-    <span className="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true" /> {text}
+    <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" /> {text}
   </GenericButton>
 )
 
 export const OfflineBtn = ({ text = 'Offline' }: { text?: string }) => (
   <GenericButton disabled type="button">
-    <FiWifiOff className="mr-2 text-danger" /> {text}
+    <FiWifiOff className="me-2 text-danger" /> {text}
   </GenericButton>
 )
 
@@ -25,7 +25,7 @@ export const LoadingHeader = () => {
   return (
     <div className={`${theme.headerColor} py-2`}>
       <NavbarWrapper>
-        <div className="py-1 mr-3 mr-sm-5 align-items-center">
+        <div className="py-1 me-3 me-sm-5 align-items-center">
           <Spinner variant="light" size="small" />
         </div>
       </NavbarWrapper>
@@ -41,7 +41,7 @@ export const OfflineHeader = () => (
       </Link>
     )}
     <GenericButton className={navbarStyles.btn} disabled type="button">
-      <FiWifiOff className="mr-2" /> Offline
+      <FiWifiOff className="me-2" /> Offline
     </GenericButton>
   </NavbarWrapper>
 )

--- a/src/components/info/donate.tsx
+++ b/src/components/info/donate.tsx
@@ -23,8 +23,13 @@ export const DonateComponent = () => {
           className={`col-10 col-sm-8 col-md-6 col-lg-4 col-xl-4 card ${theme.bgColor} ${theme.text} py-3`}
         >
           <div className="row d-flex justify-content-center d-print-none">
-            <div className="btn-group btn-group-lg" role="group" aria-label="Donate">
-              <div className="btn-group mr-2" role="group" aria-label="Donate options">
+            {/* px-0 w-auto flex-shrink-1: opt out of Bootstrap 5's `.row > *` gutters — see navbar_wrapper. */}
+            <div
+              className="btn-group btn-group-lg px-0 w-auto flex-shrink-1"
+              role="group"
+              aria-label="Donate"
+            >
+              <div className="btn-group me-2" role="group" aria-label="Donate options">
                 <IconContext.Provider value={{ size: '2.2em' }}>
                   <FaCcPaypal onClick={handlePaypalClick} className="mx-2" style={{ cursor: 'pointer' }} />
                 </IconContext.Provider>

--- a/src/components/info/offline.tsx
+++ b/src/components/info/offline.tsx
@@ -17,9 +17,9 @@ const OfflineComponent = () => {
           className={`col-12 col-sm-8 col-md-6 col-lg-6 col-xl-6 col-xxl-4 ${theme.card} ${theme.bgColor} ${theme.text} py-3 text-center`}
         >
           <p className="text-danger">
-            <FiWifiOff className="mr-2" />
+            <FiWifiOff className="me-2" />
             You are in <strong>Offline</strong> mode.
-            <FiWifiOff className="ml-2" />
+            <FiWifiOff className="ms-2" />
           </p>
           <p>Your capabilites are limited in this mode.</p>
           You cannot save a new army.

--- a/src/components/info/reminders.tsx
+++ b/src/components/info/reminders.tsx
@@ -131,7 +131,7 @@ const ReminderEntry = ({
         <div className="flex-grow-1 ReminderHeading" {...provided.dragHandleProps}>
           <span className="ReminderHeadingRow">
             <strong className={theme.text}>{reminder.name}</strong>
-            {reminder.hidden && <MdVisibilityOff className={`${theme.text} ml-2`} />}
+            {reminder.hidden && <MdVisibilityOff className={`${theme.text} ms-2`} />}
             {!isMobile && <ReminderTags tags={reminder.tags} />}
           </span>
           {isMobile && <ReminderTags tags={reminder.tags} />}
@@ -145,7 +145,7 @@ const ReminderEntry = ({
             >
               <FaEllipsisH />
             </Dropdown.Toggle>
-            <Dropdown.Menu alignRight>
+            <Dropdown.Menu align="end">
               <Dropdown.Item onClick={() => onHide(reminder)}>
                 {reminder.hidden ? 'Show rule' : 'Hide rule'}
               </Dropdown.Item>
@@ -165,12 +165,12 @@ const ReminderEntry = ({
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    {source.official && <span className="badge badge-primary badge-pill mr-2">Official</span>}
+                    {source.official && <span className="badge bg-primary rounded-pill me-2">Official</span>}
                     {source.label}
                   </a>
                 ) : (
                   <Dropdown.ItemText key={source.id}>
-                    {source.official && <span className="badge badge-primary badge-pill mr-2">Official</span>}
+                    {source.official && <span className="badge bg-primary rounded-pill me-2">Official</span>}
                     {source.label}
                   </Dropdown.ItemText>
                 )
@@ -242,7 +242,12 @@ const ReminderCard = ({
             {...provided.droppableProps}
             className={`row d-block PageBreak ${printable ? '' : 'd-print-none'}`}
           >
-            <div className="card border-dark my-2 mx-1">
+            {/*
+              px-0 w-auto: opt out of Bootstrap 5's `.row > *` rule — see navbar_wrapper. Here the
+              row is `d-block`, so the card is a block box: the injected `width: 100%` would fight
+              its own `mx-1` margins and push the card past the row.
+            */}
+            <div className="card border-dark my-2 mx-1 px-0 w-auto">
               <CollapsibleCardHeader
                 bodyId={bodyId}
                 isExpanded={isExpanded}

--- a/src/components/input/armySharing/shareArmyModal.tsx
+++ b/src/components/input/armySharing/shareArmyModal.tsx
@@ -67,7 +67,7 @@ const ShareArmyModal = ({ closeModal, document, isOpen }: ShareArmyModalProps) =
 
         {shareUrl ? (
           <>
-            <label className="font-weight-bold" htmlFor="share-army-url">
+            <label className="fw-bold" htmlFor="share-army-url">
               Share link
             </label>
             <input
@@ -76,13 +76,13 @@ const ShareArmyModal = ({ closeModal, document, isOpen }: ShareArmyModalProps) =
               readOnly
               value={shareUrl}
             />
-            <button className={`${theme.modalConfirmClass} btn-block mt-3`} onClick={() => void copy()}>
+            <button className={`${theme.modalConfirmClass} d-block w-100 mt-3`} onClick={() => void copy()}>
               {copied ? 'Copied' : 'Copy link'}
             </button>
           </>
         ) : (
           <button
-            className={`${theme.modalSuccessClass} btn-block`}
+            className={`${theme.modalSuccessClass} d-block w-100`}
             disabled={!configured}
             onClick={() => void create()}
             type="button"

--- a/src/components/input/armySharing/sharedArmyModal.tsx
+++ b/src/components/input/armySharing/sharedArmyModal.tsx
@@ -90,13 +90,13 @@ const SharedArmyModal = ({
         )}
         <div className="row mt-3">
           <div className="col-6">
-            <button className={`${theme.modalDangerClass} btn-block`} onClick={closeModal} type="button">
+            <button className={`${theme.modalDangerClass} d-block w-100`} onClick={closeModal} type="button">
               Keep current army
             </button>
           </div>
           <div className="col-6">
             <button
-              className={`${theme.modalSuccessClass} btn-block`}
+              className={`${theme.modalSuccessClass} d-block w-100`}
               disabled={!share}
               onClick={apply}
               type="button"

--- a/src/components/input/cloudArmies/savedArmiesModal.tsx
+++ b/src/components/input/cloudArmies/savedArmiesModal.tsx
@@ -116,7 +116,7 @@ const SavedArmiesModal = ({ closeModal, currentDocument, isOpen, onApply }: Save
 
         <div className="card mb-3">
           <div className={`card-body ${theme.cardBody}`}>
-            <label className="font-weight-bold" htmlFor="saved-army-name">
+            <label className="fw-bold" htmlFor="saved-army-name">
               Save current army
             </label>
             <div className="input-group">
@@ -127,16 +127,19 @@ const SavedArmiesModal = ({ closeModal, currentDocument, isOpen, onApply }: Save
                 onChange={event => setSaveName(event.target.value)}
                 value={saveName}
               />
-              <div className="input-group-append">
-                <button
-                  className={theme.modalSuccessClass}
-                  disabled={!configured || !saveName.trim()}
-                  onClick={() => void saveNew()}
-                  type="button"
-                >
-                  Save new
-                </button>
-              </div>
+              {/*
+                Bootstrap 5 removed the .input-group-append wrapper: an input group's children are
+                now direct flex items, and the trailing control's square inner corners come from
+                `.input-group > :not(:first-child)`. The button is unchanged.
+              */}
+              <button
+                className={theme.modalSuccessClass}
+                disabled={!configured || !saveName.trim()}
+                onClick={() => void saveNew()}
+                type="button"
+              >
+                Save new
+              </button>
             </div>
           </div>
         </div>
@@ -149,7 +152,7 @@ const SavedArmiesModal = ({ closeModal, currentDocument, isOpen, onApply }: Save
           <div aria-label="Saved armies" className="list-group">
             {armies.map(army => (
               <div className={`list-group-item ${theme.cardBody} ${theme.text}`} key={army.id}>
-                <label className="sr-only" htmlFor={`army-name-${army.id}`}>
+                <label className="visually-hidden" htmlFor={`army-name-${army.id}`}>
                   Saved army name
                 </label>
                 <input
@@ -167,21 +170,21 @@ const SavedArmiesModal = ({ closeModal, currentDocument, isOpen, onApply }: Save
                 </p>
                 <div className="d-flex flex-wrap">
                   <button
-                    className={`${theme.genericButton} btn-sm mr-2 mb-2`}
+                    className={`${theme.genericButton} btn-sm me-2 mb-2`}
                     onClick={() => setPendingLoad(army)}
                     type="button"
                   >
                     Load
                   </button>
                   <button
-                    className={`${theme.genericButton} btn-sm mr-2 mb-2`}
+                    className={`${theme.genericButton} btn-sm me-2 mb-2`}
                     onClick={() => void rename(army)}
                     type="button"
                   >
                     Rename
                   </button>
                   <button
-                    className={`${theme.genericButton} btn-sm mr-2 mb-2`}
+                    className={`${theme.genericButton} btn-sm me-2 mb-2`}
                     onClick={() => void updateFromCurrent(army)}
                     type="button"
                   >
@@ -190,7 +193,7 @@ const SavedArmiesModal = ({ closeModal, currentDocument, isOpen, onApply }: Save
                   {pendingDeleteId === army.id ? (
                     <>
                       <button
-                        className={`${theme.modalDangerClass} btn-sm mr-2 mb-2`}
+                        className={`${theme.modalDangerClass} btn-sm me-2 mb-2`}
                         onClick={() => void confirmDelete(army)}
                         type="button"
                       >
@@ -226,7 +229,7 @@ const SavedArmiesModal = ({ closeModal, currentDocument, isOpen, onApply }: Save
               {selectedCount} selections in {pendingLoad.document.rulesContextId}
             </p>
             <button
-              className={`${theme.modalConfirmClass} btn-sm mr-2`}
+              className={`${theme.modalConfirmClass} btn-sm me-2`}
               onClick={() => {
                 onApply(pendingLoad.document)
                 closeModal()

--- a/src/components/input/importArmy/importArmyModal.tsx
+++ b/src/components/input/importArmy/importArmyModal.tsx
@@ -150,7 +150,7 @@ const ImportArmyModal = ({
           </button>
         </div>
 
-        <div aria-label="Import source" className="btn-group btn-block mb-3" role="group">
+        <div aria-label="Import source" className="btn-group w-100 mb-3" role="group">
           <button
             aria-pressed={mode === 'paste'}
             className={mode === 'paste' ? 'btn btn-info' : theme.genericButton}
@@ -171,7 +171,7 @@ const ImportArmyModal = ({
 
         {mode === 'paste' ? (
           <>
-            <label className="font-weight-bold" htmlFor="import-roster-text">
+            <label className="fw-bold" htmlFor="import-roster-text">
               Paste roster text
             </label>
             <textarea
@@ -185,7 +185,7 @@ const ImportArmyModal = ({
               value={text}
             />
             <button
-              className={`${theme.modalConfirmClass} btn-block mt-3`}
+              className={`${theme.modalConfirmClass} d-block w-100 mt-3`}
               disabled={!text.trim()}
               onClick={previewText}
               type="button"
@@ -201,7 +201,7 @@ const ImportArmyModal = ({
             onDragOver={handleDragOver}
             onDrop={handleDrop}
           >
-            <label className="font-weight-bold text-center" htmlFor="import-roster-file">
+            <label className="fw-bold text-center" htmlFor="import-roster-file">
               Drag and drop your roster here
             </label>
             <p className="small text-center mb-2">
@@ -217,7 +217,7 @@ const ImportArmyModal = ({
             {!!droppedFileName && <p className="small mt-2 mb-0">{droppedFileName}</p>}
             <input
               accept=".txt,.ros,.rosz,text/plain,application/xml,application/zip"
-              className="sr-only"
+              className="visually-hidden"
               id="import-roster-file"
               onChange={event => void previewFile(event.target.files?.[0])}
               ref={fileInputRef}
@@ -237,13 +237,13 @@ const ImportArmyModal = ({
 
         <div className="row mt-4">
           <div className="col-6">
-            <button className={`${theme.modalDangerClass} btn-block`} onClick={closeModal} type="button">
+            <button className={`${theme.modalDangerClass} d-block w-100`} onClick={closeModal} type="button">
               Cancel
             </button>
           </div>
           <div className="col-6">
             <button
-              className={`${theme.modalSuccessClass} btn-block`}
+              className={`${theme.modalSuccessClass} d-block w-100`}
               disabled={!canApply}
               onClick={apply}
               type="button"

--- a/src/components/input/importArmy/importPreview.tsx
+++ b/src/components/input/importArmy/importPreview.tsx
@@ -78,7 +78,7 @@ const ImportPreview = ({
 
       {!declaredContext && (
         <>
-          <label className="font-weight-bold" htmlFor="import-rules-context">
+          <label className="fw-bold" htmlFor="import-rules-context">
             Which ruleset do you want to use?
           </label>
           <select

--- a/src/components/input/toolbar/toolbar.tsx
+++ b/src/components/input/toolbar/toolbar.tsx
@@ -44,43 +44,43 @@ const Toolbar = ({
     <div className="row justify-content-center pt-3">
       <div className={buttonWrapperClass}>
         <ToolbarButton onClick={onClearArmy}>
-          <FaTrash className="mr-2" />
+          <FaTrash className="me-2" />
           Clear Army
         </ToolbarButton>
       </div>
       <div className={buttonWrapperClass}>
         <ToolbarButton onClick={onResetArmy}>
-          <MdRefresh className="mr-2" />
+          <MdRefresh className="me-2" />
           Reset Army
         </ToolbarButton>
       </div>
       <div className={buttonWrapperClass}>
         <ToolbarButton onClick={onDownloadPdf}>
-          <MdFileDownload className="mr-2" />
+          <MdFileDownload className="me-2" />
           Download PDF
         </ToolbarButton>
       </div>
       <div className={buttonWrapperClass}>
         <ToolbarButton onClick={onImportArmy}>
-          <MdFileUpload className="mr-2" />
+          <MdFileUpload className="me-2" />
           Import Army
         </ToolbarButton>
       </div>
       <div className={buttonWrapperClass}>
         <ToolbarButton disabled={subscriberActionDisabled} onClick={onOpenSavedArmies}>
-          <MdSave className="mr-2" />
+          <MdSave className="me-2" />
           My Armies
         </ToolbarButton>
       </div>
       <div className={buttonWrapperClass}>
         <ToolbarButton disabled={subscriberActionDisabled} onClick={onShareArmy}>
-          <MdShare className="mr-2" />
+          <MdShare className="me-2" />
           Share Army
         </ToolbarButton>
       </div>
       <div className={buttonWrapperClass}>
         <ToolbarButton disabled={!hiddenCount} onClick={onShowAll}>
-          <MdVisibility className="mr-2" />
+          <MdVisibility className="me-2" />
           Show Hidden{hiddenCount ? ` (${hiddenCount})` : ''}
         </ToolbarButton>
       </div>

--- a/src/components/modals/generic/generic_destructive_modal.tsx
+++ b/src/components/modals/generic/generic_destructive_modal.tsx
@@ -78,7 +78,7 @@ const GenericDestructiveModal = ({
       </div>
       <div className="d-flex flex-row justify-content-around">
         <GenericButton className={`${theme.modalDangerClass} ${btnResponsiveClass}`} onClick={handleConfirm}>
-          <FaCheck className="mr-2" /> {confirmText}
+          <FaCheck className="me-2" /> {confirmText}
         </GenericButton>
         <GenericButton className={`${theme.modalConfirmClass} ${btnResponsiveClass}`} onClick={handleDeny}>
           {denyText}

--- a/src/components/page/homeHeader.tsx
+++ b/src/components/page/homeHeader.tsx
@@ -28,7 +28,13 @@ export const Header = ({
   const { theme } = useTheme()
   const isMobile = useIsMobile()
   const option = factions.find(faction => faction.value === factionId) ?? null
-  const jumboClass = `jumbotron jumbotron-fluid text-center ${theme.headerColor} d-print-none mb-0 pt-4 ${
+  /*
+   * Bootstrap 5 dropped .jumbotron/.jumbotron-fluid. Nothing is lost here: after the utilities on
+   * this same element (mb-0, pt-4, pb-2/pb-3, and theme.headerColor) the pair contributed only
+   * padding-inline: 0 and border-radius: 0, which a bare <div> already has. Measured before and
+   * after the upgrade, the element's box is unchanged.
+   */
+  const mastheadClass = `text-center ${theme.headerColor} d-print-none mb-0 pt-4 ${
     isMobile ? 'pb-2' : 'pb-3'
   }`
 
@@ -36,7 +42,7 @@ export const Header = ({
     <div className={theme.headerColor}>
       <Navbar />
 
-      <div className={jumboClass}>
+      <div className={mastheadClass}>
         <div className="container">
           <h1 className="text-white">Age of Sigmar Reminders</h1>
           <p className="mt-3 mb-1 d-none d-sm-block text-white">
@@ -60,7 +66,7 @@ export const Header = ({
                 in the opposite mode is a dead stop in the tab order.
               */}
               <span
-                className={`align-self-center pb-2 mr-2 ${isGameMode ? '' : 'font-weight-bold'}`}
+                className={`align-self-center pb-2 me-2 ${isGameMode ? '' : 'fw-bold'}`}
                 onClick={() => isGameMode && onToggleGameMode()}
               >
                 Edit
@@ -84,7 +90,7 @@ export const Header = ({
                 />
               </label>
               <span
-                className={`align-self-center pb-2 ml-2 ${isGameMode ? 'font-weight-bold' : ''}`}
+                className={`align-self-center pb-2 ms-2 ${isGameMode ? 'fw-bold' : ''}`}
                 onClick={() => !isGameMode && onToggleGameMode()}
               >
                 Play
@@ -100,7 +106,7 @@ export const Header = ({
             <>
               <span className="text-white">Select your faction to get started:</span>
               <div className="d-flex pt-3 pb-2 justify-content-center">
-                <div className="col-12 col-sm-9 col-md-6 col-lg-4 text-left">
+                <div className="col-12 col-sm-9 col-md-6 col-lg-4 text-start">
                   <Select
                     aria-label="Faction"
                     value={option}

--- a/src/components/page/navbar.tsx
+++ b/src/components/page/navbar.tsx
@@ -59,7 +59,7 @@ const Navbar = () => {
         >
           Subscribe
           {!!discount && !isTinyMobile && (
-            <span className="ml-1 badge badge-pill badge-danger">{discount}% off!</span>
+            <span className="ms-1 badge rounded-pill bg-danger">{discount}% off!</span>
           )}
         </Link>
       )}

--- a/src/components/page/navbar_wrapper.tsx
+++ b/src/components/page/navbar_wrapper.tsx
@@ -8,9 +8,18 @@ const NavbarWrapper = ({ children }: React.PropsWithChildren<object>) => {
 
   return (
     <header className={`${navbarStyles.headerClass} ${theme.headerColor}`}>
+      {/*
+        `px-0 w-auto flex-shrink-1` neutralises Bootstrap 5's `.row > *` rule, which applies gutter
+        padding, `width: 100%`, and `flex-shrink: 0` to *every* direct child of a row. Bootstrap 4
+        only styled children that carried a `col` class, so these two were plain flex items: the
+        spacer grew, and the nav sized to its links. Without this the nav stretches to the full row
+        and wraps onto its own line. See the same fix in reminders, donate, and pricingPlans.
+      */}
       <div className={`row d-flex w-${isMobile ? 100 : 75}`}>
-        <div className="flex-grow-1"> </div>
-        <nav aria-label="Main">{children}</nav>
+        <div className="flex-grow-1 px-0 w-auto flex-shrink-1"> </div>
+        <nav aria-label="Main" className="px-0 w-auto flex-shrink-1">
+          {children}
+        </nav>
       </div>
     </header>
   )

--- a/src/components/page/redemption.tsx
+++ b/src/components/page/redemption.tsx
@@ -37,7 +37,7 @@ export const RedemptionError = ({ error, showButton }: { error: string; showButt
     {showButton && (
       <GenericButton className="btn btn-danger btn-lg" disabled>
         Error!
-        <FaRegFrown className="ml-2" />
+        <FaRegFrown className="ms-2" />
       </GenericButton>
     )}
     <p className="pt-3">We&apos;re sorry. There was an error redeeming your subscription.</p>

--- a/src/components/payment/giftSubscriptions.tsx
+++ b/src/components/payment/giftSubscriptions.tsx
@@ -70,7 +70,7 @@ const GiftTable = () => {
             <div className={rowClass}>
               <p className={`mb-1 ${theme.text} ${centerContentClass}`}>
                 These gifts were given to you by the AoS Reminders team. Spread them around!
-                {!isMobile && <FaRegSmileBeam className="ml-2" />}
+                {!isMobile && <FaRegSmileBeam className="ms-2" />}
               </p>
             </div>
             <div className={rowClass}>
@@ -102,10 +102,10 @@ const GiftButton = (props: IGiftSubscription) => {
   return (
     <CopyToClipboard onCopy={handleCopy} text={props.url}>
       <GenericButton className={`${theme.genericButton} mx-2 my-2`}>
-        <FaGift className="mr-2" />
-        <strong className="mr-1">{label}</strong>
+        <FaGift className="me-2" />
+        <strong className="me-1">{label}</strong>
         {!isMobile && ' Gift'}
-        {copied && <FaCheck className="text-success ml-2" />}
+        {copied && <FaCheck className="text-success ms-2" />}
       </GenericButton>
     </CopyToClipboard>
   )
@@ -213,7 +213,7 @@ const PlanComponent = ({ supportPlan }: { supportPlan: IGiftedSubscriptionPlans 
       <td>${(parseFloat(supportPlan.cost) * quantity).toFixed(2)}</td>
       <td>
         <GenericButton
-          className={`btn ${isMobile ? 'btn-sm' : ''} btn-block btn-primary`}
+          className={`btn ${isMobile ? 'btn-sm' : ''} d-block w-100 btn-primary`}
           onClick={isAuthenticated ? handleCheckout : login}
         >
           {isMobile ? 'Buy' : 'Purchase'}

--- a/src/components/payment/giftSubscriptions.tsx
+++ b/src/components/payment/giftSubscriptions.tsx
@@ -57,7 +57,8 @@ const GiftTable = () => {
         </div>
         {purchasedSubs.length > 0 && (
           <div className={rowClass}>
-            <div className={theme.text}>
+            {/* px-0 w-auto flex-shrink-1: non-column child of a .row — see navbar_wrapper. */}
+            <div className={`${theme.text} px-0 w-auto flex-shrink-1`}>
               {purchasedSubs.map(gift => (
                 <GiftButton {...gift} key={gift.id} />
               ))}
@@ -68,7 +69,8 @@ const GiftTable = () => {
         {adminCreatedSubs.length > 0 && (
           <>
             <div className={rowClass}>
-              <p className={`mb-1 ${theme.text} ${centerContentClass}`}>
+              {/* px-0 w-auto flex-shrink-1: non-column child of a .row — see navbar_wrapper. */}
+              <p className={`mb-1 ${theme.text} ${centerContentClass} px-0 w-auto flex-shrink-1`}>
                 These gifts were given to you by the AoS Reminders team. Spread them around!
                 {!isMobile && <FaRegSmileBeam className="ms-2" />}
               </p>
@@ -101,7 +103,13 @@ const GiftButton = (props: IGiftSubscription) => {
 
   return (
     <CopyToClipboard onCopy={handleCopy} text={props.url}>
-      <GenericButton className={`${theme.genericButton} mx-2 my-2`}>
+      {/*
+        w-auto flex-shrink-1 (but not px-0): these buttons are rendered straight into a .row in the
+        admin-gift list, and Bootstrap 5's `.row > *` would stretch each one to full width. The
+        padding needs no fix — `.btn` is declared after `.row > *` in Bootstrap's own source, so the
+        button's padding already wins.
+      */}
+      <GenericButton className={`${theme.genericButton} mx-2 my-2 w-auto flex-shrink-1`}>
         <FaGift className="me-2" />
         <strong className="me-1">{label}</strong>
         {!isMobile && ' Gift'}

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -61,7 +61,7 @@ const PlansHeader = () => {
     <div className="col-12 text-center mb-3">
       <h2>
         Subscription Plans
-        {hasSale && <span className="ml-2 badge badge-danger">Sale!</span>}
+        {hasSale && <span className="ms-2 badge bg-danger">Sale!</span>}
       </h2>
     </div>
   )
@@ -107,10 +107,15 @@ export const PlanComponent = (props: IPlanProps) => {
     if (result.error) console.error(result.error)
   }
 
+  /*
+   * px-0 only: this card is a direct child of a `row-cols-*` row, so Bootstrap 5's `.row > *` would
+   * inset the header and body 15px inside the card's own border. Its width still comes from
+   * `.row-cols-*`, so unlike the other opt-outs (see navbar_wrapper) this one must not touch it.
+   */
   return (
-    <div className={`${theme.card} mb-4 shadow-sm`}>
+    <div className={`${theme.card} mb-4 shadow-sm px-0`}>
       <div className="card-header bg-themeDarkBluePrimary text-light">
-        <h3 className="my-0 font-weight-normal">{supportPlan.title}</h3>
+        <h3 className="my-0 fw-normal">{supportPlan.title}</h3>
       </div>
       <div className={theme.cardBody}>
         {/* A price is not a heading. The .h1 class keeps the type scale unchanged. */}
@@ -127,7 +132,7 @@ export const PlanComponent = (props: IPlanProps) => {
           <li>
             {!!supportPlan.discount_pct && (
               <>
-                <span className="badge badge-pill badge-danger mb-2">{supportPlan.discount_pct}% off!</span>
+                <span className="badge rounded-pill bg-danger mb-2">{supportPlan.discount_pct}% off!</span>
                 <br />
               </>
             )}
@@ -138,7 +143,7 @@ export const PlanComponent = (props: IPlanProps) => {
           <IconContext.Provider value={{ size: '1.2em' }}>
             <GenericButton
               type="button"
-              className="btn btn btn-block btn-primary btn-pill py-2"
+              className="btn btn d-block w-100 btn-primary btn-pill py-2"
               onClick={isAuthenticated ? handleStripeCheckout : login}
             >
               Subscribe for {supportPlan.title}

--- a/src/components/print/printModal.tsx
+++ b/src/components/print/printModal.tsx
@@ -40,16 +40,21 @@ const RadioGroup = <T extends string>({
     </legend>
     <div className="d-flex justify-content-center">
       {options.map(option => (
-        <div className="custom-control custom-radio custom-control-inline" key={option.id}>
+        /*
+          Bootstrap 5 folded .custom-control/.custom-radio into the single .form-check family; the
+          bespoke-styled radio is now the only radio there is. Geometry is the same (1.5em of left
+          padding, 1rem inline gap, a 1em control).
+        */
+        <div className="form-check form-check-inline" key={option.id}>
           <input
             checked={value === option.id}
-            className="custom-control-input"
+            className="form-check-input"
             id={`${name}-${option.id}`}
             name={name}
             onChange={() => onChange(option.id)}
             type="radio"
           />
-          <label className="custom-control-label" htmlFor={`${name}-${option.id}`}>
+          <label className="form-check-label" htmlFor={`${name}-${option.id}`}>
             {option.label}
           </label>
         </div>
@@ -129,13 +134,17 @@ const PrintModal = ({ closeModal, defaultFileName, isOpen, onDownloadPdf }: Prin
       */}
       <div className="row mx-3 mt-4 pb-3">
         <div className="col-12 pb-2">
-          <button className={`${theme.modalDangerClass} btn-block`} onClick={closeModal} type="button">
+          <button className={`${theme.modalDangerClass} d-block w-100`} onClick={closeModal} type="button">
             Cancel
           </button>
         </div>
         <div className="col-12 pb-2">
-          <button className={`${theme.modalConfirmClass} btn-block`} onClick={handleDownload} type="button">
-            <MdFileDownload className="mr-2" />
+          <button
+            className={`${theme.modalConfirmClass} d-block w-100`}
+            onClick={handleDownload}
+            type="button"
+          >
+            <MdFileDownload className="me-2" />
             Download PDF
           </button>
         </div>

--- a/src/components/routes/Faq.tsx
+++ b/src/components/routes/Faq.tsx
@@ -58,7 +58,15 @@ interface FaqEntryProps {
 
 const FaqEntry = ({ title, text, imgUrl = '', imgAlt = '' }: FaqEntryProps) => (
   <div className="col-12 col-md-8 col-lg-6 col-xl-5 mx-xl-1">
-    <div className="row g-0 border rounded overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative">
+    {/*
+      `g-0` was removed rather than migrated. It is Bootstrap 5 syntax that did nothing under 4.6
+      (which spelled it `no-gutters`), so this row has always rendered *with* gutters: the bordered
+      box is pulled 15px wider than its column and the image column carries 15px of padding. The
+      upgrade would have brought the class to life and quietly narrowed every FAQ card, which is a
+      visual change this migration is not authorised to make. Restoring the zero-gutter intent is a
+      design decision for another day.
+    */}
+    <div className="row border rounded overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative">
       <div className="col p-4 d-flex flex-column position-static">
         {/* Sits directly under the page h1, so it is an h2. .h3 keeps the existing type scale. */}
         <h2 className="mb-0 h3">{title}</h2>

--- a/src/components/routes/Profile.tsx
+++ b/src/components/routes/Profile.tsx
@@ -106,9 +106,9 @@ const SubscriptionInfo = () => {
           <span className={centerContentClass}>
             Subscription Status:{' '}
             {isActive ? (
-              <MdCheckCircle className="text-success ml-2" />
+              <MdCheckCircle className="text-success ms-2" />
             ) : (
-              <MdNotInterested className="text-danger ml-2" />
+              <MdNotInterested className="text-danger ms-2" />
             )}
           </span>
         </h4>
@@ -157,7 +157,7 @@ const TemporaryGrantComponent = () => {
       <div className={theme.profileCardHeader}>
         <h4>
           <span className={centerContentClass}>
-            Subscription Status: <FaSearchDollar className="text-warning ml-2" />
+            Subscription Status: <FaSearchDollar className="text-warning ms-2" />
           </span>
         </h4>
       </div>
@@ -165,7 +165,7 @@ const TemporaryGrantComponent = () => {
         <div className={`${centerContentClass} row`}>
           <div className="col-12">
             <h1>
-              <FaPaypal className="text-info ml-2 align-self-center" />
+              <FaPaypal className="text-info ms-2 align-self-center" />
             </h1>
           </div>
           <div className="col-12">
@@ -207,9 +207,9 @@ const RecurringPaymentInfo = () => {
           <span className={centerContentClass}>
             Recurring Payment:{' '}
             {isActive && !isCanceled ? (
-              <MdCheckCircle className="text-success ml-2" />
+              <MdCheckCircle className="text-success ms-2" />
             ) : (
-              <MdNotInterested className="text-danger ml-2" />
+              <MdNotInterested className="text-danger ms-2" />
             )}
           </span>
         </h4>
@@ -221,9 +221,9 @@ const RecurringPaymentInfo = () => {
       )}
       {isGifted && (
         <div className={theme.cardBody}>
-          <FaGift className="mr-2" />
+          <FaGift className="me-2" />
           You were gifted this subscription!
-          <FaGift className="ml-2" />
+          <FaGift className="ms-2" />
           <br />
           You may purchase a recurring subscription at the end of this period.
         </div>

--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -40,6 +40,13 @@ $container-max-widths: (
  */
 
 /*
+ * Bootstrap's functions only, so the alert pins below can express 4.6's tint/shade formulas rather
+ * than hardcoding the resulting hexes. This defines no rules and emits no CSS; the full framework
+ * is imported further down, and re-importing functions there is a no-op.
+ */
+@import "bootstrap/scss/functions";
+
+/*
  * Responsive font sizes. 4.6 shipped RFS switched off ($enable-responsive-font-sizes: false); 5.x
  * turns it on by default, which makes the masthead h1 and <legend> fluid (calc(... + vw)) instead of
  * the fixed sizes DESIGN.md specifies (Display 2.5rem, and .CardHeaderTitle's four explicit
@@ -124,6 +131,55 @@ $badge-padding-y: 0.25em; // 5.3 default: .35em
 $badge-padding-x: 0.4em; // 5.3 default: .65em
 $alert-padding-y: 0.75rem; // 5.3 default: $spacer
 $alert-padding-x: 1.25rem; // 5.3 default: $spacer
+
+/*
+ * Alert text and border colours. 4.6 derived an alert variant with theme-color-level(): text at
+ * level 6 (a 48% shade) and border at level -9 (a 72% tint). 5.3 replaced that with the
+ * *-text-emphasis / *-border-subtle scale at 60% both ways, so alert text got darker and borders
+ * got lighter — e.g. alert-danger text #721c24 -> #58151c, border #f5c6cb -> #f1aeb5. Backgrounds
+ * are unaffected: 5.3's *-bg-subtle is an 80% tint, which is what level -10 already was.
+ *
+ * DESIGN.md calls alerts "the standard way this product reports the outcome of an account
+ * operation", so these are user-facing on every account flow. Colours are written as the 4.6
+ * formula rather than as literals so the relationship to the theme colour stays visible.
+ */
+$primary-text-emphasis: shade-color(#007bff, 48%);
+$secondary-text-emphasis: shade-color(#6c757d, 48%);
+$success-text-emphasis: shade-color(#28a745, 48%);
+$info-text-emphasis: shade-color(#17a2b8, 48%);
+$warning-text-emphasis: shade-color(#ffc107, 48%);
+$danger-text-emphasis: shade-color(#dc3545, 48%);
+$light-text-emphasis: shade-color(#f8f9fa, 48%);
+$dark-text-emphasis: shade-color(#343a40, 48%);
+
+$primary-border-subtle: tint-color(#007bff, 72%);
+$secondary-border-subtle: tint-color(#6c757d, 72%);
+$success-border-subtle: tint-color(#28a745, 72%);
+$info-border-subtle: tint-color(#17a2b8, 72%);
+$warning-border-subtle: tint-color(#ffc107, 72%);
+$danger-border-subtle: tint-color(#dc3545, 72%);
+$light-border-subtle: tint-color(#f8f9fa, 72%);
+$dark-border-subtle: tint-color(#343a40, 72%);
+
+/*
+ * Text inputs. 5.x repointed all three of these at CSS variables that resolve differently from
+ * 4.6's greys: the text got darker ($gray-700 -> body colour), the border lighter ($gray-400 ->
+ * $gray-300), and the placeholder changed from a flat grey to 75% of the body colour.
+ */
+$input-color: #495057; // 5.3 default: var(--bs-body-color) (#212529)
+$input-border-color: #ced4da; // 5.3 default: var(--bs-border-color) (#dee2e6)
+$input-placeholder-color: #6c757d; // 5.3 default: var(--bs-secondary-color)
+
+/*
+ * The saved-armies list and the gift purchase table. Both live behind authentication, so neither is
+ * reachable from a signed-out render; both had their spacing retightened by 5.x.
+ */
+$list-group-item-padding-y: 0.75rem; // 5.3 default: $spacer * .5 (8px)
+$list-group-item-padding-x: 1.25rem; // 5.3 default: $spacer (16px)
+$table-cell-padding-y: 0.75rem; // 5.3 default: .5rem
+$table-cell-padding-x: 0.75rem; // 5.3 default: .5rem
+$table-cell-padding-y-sm: 0.3rem; // 5.3 default: .25rem
+$table-cell-padding-x-sm: 0.3rem; // 5.3 default: .25rem
 $dropdown-item-padding-x: 1.5rem; // 5.3 default: $spacer
 $dropdown-border-color: rgba(0, 0, 0, 0.15); // 5.3 default: var(--bs-border-color-translucent) (.175)
 $input-btn-focus-width: 0.2rem; // 5.3 default: $focus-ring-width (.25rem)
@@ -212,9 +268,50 @@ small,
     color: inherit;
 }
 
-.card-body {
+/*
+ * `:not(.list-group-item)` preserves a Bootstrap 4.6 cascade accident that the saved-armies list
+ * depends on. Those rows carry both classes (`list-group-item` + theme.cardBody), and in 4.6
+ * _list-group.scss is imported after _card.scss, so at equal specificity the list-group padding
+ * (.75rem 1.25rem) won. This rule sits after the whole framework, so without the exclusion it would
+ * win instead and pad those rows 1.25rem all round.
+ */
+.card-body:not(.list-group-item) {
     padding: $card-spacer-x;
+}
+
+.card-body {
     color: inherit;
+}
+
+/*
+ * 5.x added `appearance: none` to .form-control (to normalise date inputs in Safari). 4.6 did not,
+ * and the import preview's ruleset picker is a <select class="form-control"> — under 5.x it loses
+ * its native dropdown arrow and stops looking like a control at all. Bootstrap 5's answer is
+ * .form-select, but that is a different look; this keeps the 4.6 rendering.
+ */
+/*
+ * Tables (the gift purchase table on /profile, the only one in the product).
+ *
+ * 4.6 drew a *leading* rule — `border-top` on every cell, so a line sits above the header and none
+ * below the last row — plus a 2px rule under the header. 5.x inverted that to a trailing
+ * `border-bottom` per cell and made the thicker header rule opt-in (.table-group-divider). Cell
+ * padding is pinned above; this restores where the lines land.
+ */
+.table > :not(caption) > * > * {
+    border-top: var(--bs-border-width) solid var(--bs-table-border-color);
+    border-bottom-width: 0;
+}
+
+.table > thead > tr > th {
+    vertical-align: bottom;
+    border-bottom: calc(var(--bs-border-width) * 2) solid var(--bs-table-border-color);
+}
+
+select.form-control {
+    appearance: auto;
+    /* 4.6 gave .form-control an explicit height; 5.x lets content size it, and a native select
+       lands a pixel short of the text inputs beside it. */
+    height: calc(1.5em + 0.75rem + 2px);
 }
 
 /*

--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -88,6 +88,7 @@ $font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto"
     "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 $small-font-size: 80%; // 5.3 default: .875em
 $code-font-size: 87.5%; // 5.3 default: $small-font-size
+$figure-caption-font-size: 90%; // 5.3 default: $small-font-size — the /subscribe demo-video caption
 $line-height-sm: 1.5; // 5.3 default: 1.25 — reaches btn-sm / form-control-sm
 $line-height-lg: 1.5; // 5.3 default: 2
 
@@ -124,7 +125,18 @@ $badge-padding-x: 0.4em; // 5.3 default: .65em
 $alert-padding-y: 0.75rem; // 5.3 default: $spacer
 $alert-padding-x: 1.25rem; // 5.3 default: $spacer
 $dropdown-item-padding-x: 1.5rem; // 5.3 default: $spacer
+$dropdown-border-color: rgba(0, 0, 0, 0.15); // 5.3 default: var(--bs-border-color-translucent) (.175)
 $input-btn-focus-width: 0.2rem; // 5.3 default: $focus-ring-width (.25rem)
+
+/*
+ * Radios/checkboxes. The print modal's radios were .custom-control/.custom-radio under 4.6, which
+ * 5.x folded into .form-check. Two of the new defaults differ from the custom-control ones they
+ * replace: the control's outline is lighter ($gray-300 rather than 4.6's
+ * $custom-control-indicator-border-color: $gray-500), and .form-check gained a 2px bottom margin
+ * that .custom-control never had.
+ */
+$form-check-input-border: 1px solid #adb5bd; // 5.3 default: 1px solid var(--bs-border-color)
+$form-check-margin-bottom: 0; // 5.3 default: .125rem
 
 /*
  * <hr>. 4.6 drew a solid rgba(0,0,0,.1) rule; 5.x draws currentColor at opacity .25, which changes
@@ -147,6 +159,16 @@ $hr-opacity: 1;
 label {
     display: inline-block;
     margin-bottom: 0.5rem;
+}
+
+/*
+ * ...but not a radio/checkbox label. 4.6 carried this exact exception (`margin-bottom: 0; //
+ * Override default <label> bottom margin` on both .form-check-label and .custom-control-label);
+ * 5.x has no such rule only because its Reboot no longer adds the margin in the first place.
+ * Without this the shim above pushes the print modal's radio rows 8px apart.
+ */
+.form-check-label {
+    margin-bottom: 0;
 }
 
 /*

--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -27,5 +27,210 @@ $container-max-widths: (
     xxl: 1610px,
 );
 
+/*
+ * Bootstrap 4.6 -> 5.3 parity pins.
+ *
+ * The move to Bootstrap 5 was made for technical reasons only; it is not a redesign. Bootstrap 5
+ * changed a number of default variable values, and left unpinned each one would have shifted the
+ * rendered page. Every override below restores the 4.6 default the product was actually built
+ * against, so the compiled CSS keeps painting what DESIGN.md documents.
+ *
+ * Do not "modernise" these to the Bootstrap 5 defaults without an explicit design decision — each
+ * one is a visible change, and several are named in DESIGN.md as part of the system.
+ */
+
+/*
+ * Responsive font sizes. 4.6 shipped RFS switched off ($enable-responsive-font-sizes: false); 5.x
+ * turns it on by default, which makes the masthead h1 and <legend> fluid (calc(... + vw)) instead of
+ * the fixed sizes DESIGN.md specifies (Display 2.5rem, and .CardHeaderTitle's four explicit
+ * breakpoints). Leaving this on would silently take over the type scale.
+ */
+$enable-rfs: false;
+
+/*
+ * Brand/semantic palette. 5.x re-picked three of Bootstrap's signal colours; DESIGN.md documents the
+ * 4.6 values as part of the product's palette (Action Blue, Success Green, Info Cyan), and $dark is
+ * the toolbar's btn-outline-dark, the most repeated control on the game screen.
+ */
+$blue: #007bff; // 5.3 default: #0d6efd
+$green: #28a745; // 5.3 default: #198754
+$cyan: #17a2b8; // 5.3 default: #0dcaf0
+$dark: #343a40; // 5.3 default: $gray-900 (#212529)
+
+/*
+ * Filled-button text colour. 4.6 picked it with color-yiq() (a brightness threshold); 5.x picks it
+ * with color-contrast(), which demands a 4.5:1 WCAG ratio and therefore chooses BLACK text on
+ * primary, success, danger, and info — including the three Subscribe CTAs, which DESIGN.md calls
+ * out as the only filled buttons in the product. 2.5 is the threshold at which color-contrast()
+ * reproduces every one of 4.6's eight decisions exactly: white on primary/secondary/success/
+ * danger/info/dark, black on warning/light.
+ *
+ * This lowers a contrast floor, so it is worth being explicit: it does not make anything less
+ * legible than it is on the live site today — it keeps the existing rendering rather than changing
+ * it. Raising the real contrast of these buttons is a design change, and a separate decision.
+ */
+$min-contrast-ratio: 2.5; // 5.3 default: 4.5
+
+/*
+ * Muted text. 5.3 repointed .text-muted at --bs-secondary-color (rgba(body-color, .75)) and marked
+ * it deprecated in favour of .text-body-secondary. DESIGN.md names "Bootstrap's text-muted" as the
+ * light-theme muted tone, which is $gray-600.
+ */
+$text-muted: #6c757d; // 5.3 default: var(--bs-secondary-color)
+
+/*
+ * Typography. 5.x points $font-family-base at its own system stack, which would land on .form-control
+ * (4.6 left $input-font-family unset, so inputs inherited from body). Pinning it to the stack
+ * src/css/index.scss already paints on <body> keeps Bootstrap and the app in agreement, and keeps
+ * every input rendering the font it renders today.
+ */
+$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+$small-font-size: 80%; // 5.3 default: .875em
+$code-font-size: 87.5%; // 5.3 default: $small-font-size
+$line-height-sm: 1.5; // 5.3 default: 1.25 — reaches btn-sm / form-control-sm
+$line-height-lg: 1.5; // 5.3 default: 2
+
+/*
+ * Geometry. DESIGN.md ("Shapes") names 0.25rem as the product's one rounded corner, and the 12-column
+ * grid is sized off $grid-gutter-width — 5.x narrowed it from 30px to 1.5rem (24px), which would have
+ * retightened every row and container on every page.
+ */
+$border-radius: 0.25rem; // 5.3 default: .375rem
+$border-radius-lg: 0.3rem; // 5.3 default: .5rem
+$border-radius-sm: 0.2rem; // 5.3 default: .25rem
+$grid-gutter-width: 30px; // 5.3 default: 1.5rem
+
+/*
+ * Links. 4.6 left body links undecorated and underlined them on hover; 5.x underlines them at rest.
+ * DESIGN.md's Navigation section specifies "No underline".
+ */
+$link-decoration: none;
+$link-hover-decoration: underline;
+
+/*
+ * Components. Card padding and badge metrics are both quoted in DESIGN.md (cards 0.75rem/1.25rem,
+ * the Official badge 0.25em 0.6em); the focus ring is documented as 0 0 0 0.2rem and is the visible
+ * keyboard-focus indicator, so its width is not a free parameter.
+ */
+$card-border-color: rgba(0, 0, 0, 0.125); // 5.3 default: rgba($black, .175) — DESIGN.md's hairline
+$card-spacer-y: 0.75rem; // 5.3 default: $spacer (1rem)
+$card-spacer-x: 1.25rem; // 5.3 default: $spacer (1rem)
+$card-cap-padding-y: $card-spacer-y; // 5.3 default: $card-spacer-y * .5
+$card-cap-bg: rgba(0, 0, 0, 0.03); // 5.3 default: rgba(var(--bs-body-color-rgb), .03)
+$badge-font-size: 75%; // 5.3 default: .75em
+$badge-padding-y: 0.25em; // 5.3 default: .35em
+$badge-padding-x: 0.4em; // 5.3 default: .65em
+$alert-padding-y: 0.75rem; // 5.3 default: $spacer
+$alert-padding-x: 1.25rem; // 5.3 default: $spacer
+$dropdown-item-padding-x: 1.5rem; // 5.3 default: $spacer
+$input-btn-focus-width: 0.2rem; // 5.3 default: $focus-ring-width (.25rem)
+
+/*
+ * <hr>. 4.6 drew a solid rgba(0,0,0,.1) rule; 5.x draws currentColor at opacity .25, which changes
+ * the divider's colour in both themes.
+ */
+$hr-border-color: rgba(0, 0, 0, 0.1);
+$hr-opacity: 1;
+
 /* Import Bootstrap source */
 @import "bootstrap/scss/bootstrap";
+
+/*
+ * Reboot parity.
+ *
+ * 4.6 styled the bare <label> element ($label-margin-bottom: .5rem plus display: inline-block); 5.x
+ * moved that onto the opt-in .form-label class and leaves <label> an unstyled inline. Every <label>
+ * in this codebase is a bare element, so without this rule they all lose their bottom spacing. This
+ * is a compatibility shim, not a new style — it reproduces 4.6's Reboot exactly.
+ */
+label {
+    display: inline-block;
+    margin-bottom: 0.5rem;
+}
+
+/*
+ * 4.6's .badge-pill widened a pill badge's horizontal padding to .6em; 5.x replaced .badge-pill with
+ * the geometry-only .rounded-pill, which sets the radius and nothing else. This restores the padding
+ * so the Official marker and the sale flash keep their current shape.
+ */
+.badge.rounded-pill {
+    padding-right: 0.6em;
+    padding-left: 0.6em;
+}
+
+/*
+ * 4.6's `small, .small` rule set `font-weight: 400` as well as the font size; 5.x sets only the
+ * size. The difference shows wherever a <small> sits inside a heading — the "/ month" suffix on the
+ * subscription plan prices inherits the heading's 500 instead of being reset to normal.
+ */
+small,
+.small {
+    font-weight: 400;
+}
+
+/*
+ * Cards.
+ *
+ * Two separate 5.x changes, both of which alter every card in the product:
+ *
+ * 1. Padding. 4.6's .card-body was `padding: $card-spacer-x` — a *single* value, so the vertical
+ *    padding was 1.25rem too and $card-spacer-y never reached it (it fed .card-title and the header
+ *    only). 5.x corrected that to `$card-spacer-y $card-spacer-x`, which tightens every card body
+ *    from 20px to 12px top and bottom. The 4.6 behaviour is what the live site renders, so it is
+ *    what we keep. Note this makes DESIGN.md's "0.75rem vertical / 1.25rem horizontal" true of the
+ *    card *header* but not the body; the body is 1.25rem all round.
+ *
+ * 2. Colour. 4.6's .card set no colour, so cards inherited the theme's text colour from an
+ *    ancestor. 5.3 hardcodes `color: var(--bs-body-color)` on .card and .card-body, which is not
+ *    routed through a Sass variable and cannot be switched off. Left alone it paints dark body text
+ *    inside dark-theme cards. `inherit` restores the 4.6 contract that ITheme relies on.
+ */
+.card {
+    color: inherit;
+}
+
+.card-body {
+    padding: $card-spacer-x;
+    color: inherit;
+}
+
+/*
+ * Columns used outside a .row.
+ *
+ * 4.6 put the gutter padding (and `width: 100%`) on the column classes themselves; 5.x moved both
+ * onto `.row > *`. Seven `col-*` elements in this codebase sit outside a row — a long-standing
+ * misuse that 4.6 rendered without complaint — and the upgrade stripped their padding and width
+ * basis, widening their contents by 30px and collapsing two of them to shrink-to-fit. This restores
+ * 4.6's base column rule for exactly those elements; real row children still take their gutters
+ * from `.row > *` and are untouched.
+ */
+:not(.row) > .col,
+:not(.row) > [class^="col-"],
+:not(.row) > [class*=" col-"] {
+    position: relative;
+    padding-right: $grid-gutter-width * 0.5;
+    padding-left: $grid-gutter-width * 0.5;
+}
+
+/*
+ * Width is restored only for the *unsized* `.col`. 4.6 gave every column `width: 100%` and then
+ * sized it with flex-basis and max-width, so the 100% was a floor the sized classes overrode; 5.x
+ * sizes columns with `width` directly, so re-declaring `width: 100%` here would beat `col-lg-8` and
+ * stretch it to full bleed. Unsized `.col` is the one case that genuinely loses its width: 5.x
+ * gives it `flex: 1 0 0%`, which in the column-direction flex parents on /join and /redeem sizes
+ * the height, leaving the width to shrink to fit.
+ */
+:not(.row) > .col {
+    width: 100%;
+}
+
+/*
+ * .text-muted is the light theme's muted tone (theme.textMuted; dark uses .text-white-75). 5.3
+ * repointed the utility at --bs-secondary-color — rgba(33,37,41,.75) rather than $gray-600 — and
+ * hardcodes that in its utilities map, so the $text-muted variable above does not reach it (it
+ * still reaches .form-text). This restores 4.6's colour.
+ */
+.text-muted {
+    color: $text-muted !important;
+}

--- a/src/tests/aos4/homePresentation.test.tsx
+++ b/src/tests/aos4/homePresentation.test.tsx
@@ -122,7 +122,9 @@ describe('AoS 4 home presentation', () => {
   })
 
   it('preserves the established header, builder-card, toolbar, and reminder-card presentation', () => {
-    expect(container.querySelector('.jumbotron.jumbotron-fluid')).not.toBeNull()
+    // The masthead band: Bootstrap 5 removed .jumbotron, so the landmark is the themed,
+    // print-suppressed header block that carried those classes.
+    expect(container.querySelector('.bg-themeDarkBluePrimary.d-print-none')).not.toBeNull()
     expect(container.querySelector('.bg-themeDarkBluePrimary')).not.toBeNull()
     expect(container.querySelector('[role="switch"]')).not.toBeNull()
     expect(container.querySelector('.card-header.bg-themeLightBlue')).not.toBeNull()

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -68,7 +68,7 @@ const DarkTheme: ITheme = {
   cardHeader: `card-header bg-themeLightBlue text-white`,
   dropzone: `dropzone-dark`,
   genericButton: `btn btn-outline-light`,
-  genericButtonBlock: `btn btn-outline-light btn-block`,
+  genericButtonBlock: `btn btn-outline-light d-block w-100`,
   headerColor: bgColor,
   modalConfirmClass: `btn btn-outline-light`,
   modalDangerClass: `btn btn-danger`,

--- a/src/theme/helperClasses.ts
+++ b/src/theme/helperClasses.ts
@@ -3,5 +3,5 @@ export const centerContentClass = 'd-flex align-items-center justify-content-cen
 export const navbarStyles = {
   btn: 'btn btn-outline-light btn-sm mx-2',
   headerClass: 'pt-2 d-print-none d-flex justify-content-center align-items-center',
-  link: 'font-weight-bold text-light mx-2',
+  link: 'fw-bold text-light mx-2',
 }

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -9,7 +9,7 @@ const LightTheme: ITheme = {
   cardHeader: `card-header bg-themeLightBlue text-white`,
   dropzone: `dropzone`,
   genericButton: `btn btn-outline-dark`,
-  genericButtonBlock: `btn btn-outline-dark btn-block`,
+  genericButtonBlock: `btn btn-outline-dark d-block w-100`,
   headerColor: `bg-themeDarkBluePrimary`,
   modalConfirmClass: `btn btn-outline-dark`,
   modalDangerClass: `btn btn-outline-danger`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,12 +67,17 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.13.8", "@babel/runtime@^7.14.0", "@babel/runtime@^7.15.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.15.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.5.tgz#11edb98f8aeec529b82b211028177679144242db"
   integrity sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==
   dependencies:
     regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.24.7", "@babel/runtime@^7.26.0":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
 
 "@emotion/cache@^11.1.3":
   version "11.1.3"
@@ -326,6 +331,27 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.3.0.tgz#6d86b8cb322660f03d3f0aa94b99bdd8e172d570"
   integrity sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==
 
+"@internationalized/date@^3.12.2":
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/@internationalized/date/-/date-3.12.2.tgz#08a65edd2a29775e22c168ddc029fb54bf9b8a85"
+  integrity sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@internationalized/number@^3.6.7":
+  version "3.6.7"
+  resolved "https://registry.yarnpkg.com/@internationalized/number/-/number-3.6.7.tgz#5a0a8fa413b5f8679a59dcf37e2a74dc508b8371"
+  integrity sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@internationalized/string@^3.2.9":
+  version "3.2.9"
+  resolved "https://registry.yarnpkg.com/@internationalized/string/-/string-3.2.9.tgz#0e50385c411eac1275d91cdeb56dd7fbc234997f"
+  integrity sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
 "@jest/expect-utils@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.7.0.tgz#023efe5d26a8a70f21677d0a1afc0f0a44e3a1c6"
@@ -431,10 +457,23 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@popperjs/core@^2.8.6":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
-  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
+"@popperjs/core@^2.11.8":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
+"@react-aria/ssr@^3.5.0":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.10.1.tgz#d082600c811e35e8ab780c55c47b5d731359aaf7"
+  integrity sha512-jn038/ZYmu6DpfXJ6r2U9zFFppjbc9wnApPJSCxao2RZVEqep4YyoniHSy8qv6V21/xyS4IV7W9a+X2jOjSuag==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-types/shared@^3.36.0":
+  version "3.36.0"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.36.0.tgz#52e713c6bae8e117967bf1d19d89db3a56219037"
+  integrity sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==
 
 "@reduxjs/toolkit@1.9.7":
   version "1.9.7"
@@ -446,18 +485,34 @@
     redux-thunk "^2.4.2"
     reselect "^4.1.8"
 
-"@restart/context@^2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@restart/context/-/context-2.1.4.tgz#a99d87c299a34c28bd85bb489cb07bfd23149c02"
-  integrity sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q==
-
-"@restart/hooks@^0.3.26":
-  version "0.3.26"
-  resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.3.26.tgz#ade155a7b0b014ef1073391dda46972c3a14a129"
-  integrity sha512-7Hwk2ZMYm+JLWcb7R9qIXk1OoUg1Z+saKWqZXlrvFwT3w6UArVNWgxYOzf+PJoK9zZejp8okPAKTctthhXLt5g==
+"@restart/hooks@^0.4.9":
+  version "0.4.16"
+  resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.4.16.tgz#95ae8ac1cc7e2bd4fed5e39800ff85604c6d59fb"
+  integrity sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==
   dependencies:
-    lodash "^4.17.20"
-    lodash-es "^4.17.20"
+    dequal "^2.0.3"
+
+"@restart/hooks@^0.5.0":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.5.1.tgz#6776b3859e33aea72b23b81fc47021edf17fd247"
+  integrity sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==
+  dependencies:
+    dequal "^2.0.3"
+
+"@restart/ui@^1.9.4":
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/@restart/ui/-/ui-1.9.4.tgz#9d61f56f2647f5ab8a33d87b278b9ce183511a26"
+  integrity sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
+    "@popperjs/core" "^2.11.8"
+    "@react-aria/ssr" "^3.5.0"
+    "@restart/hooks" "^0.5.0"
+    "@types/warning" "^3.0.3"
+    dequal "^2.0.3"
+    dom-helpers "^5.2.0"
+    uncontrollable "^8.0.4"
+    warning "^4.0.3"
 
 "@rollup/rollup-android-arm-eabi@4.22.4":
   version "4.22.4"
@@ -630,6 +685,13 @@
   resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.3.tgz#cc7463bd02949611c6329596fccd2b0ec782b0e9"
   integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
 
+"@swc/helpers@^0.5.0":
+  version "0.5.23"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.23.tgz#19287d0d86d962b111376039a50c792902c9a86a"
+  integrity sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==
+  dependencies:
+    tslib "^2.8.0"
+
 "@swc/types@^0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.9.tgz#e67cdcc2e4dd74a3cef4474b465eb398e7ae83e2"
@@ -669,11 +731,6 @@
   dependencies:
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
-
-"@types/invariant@^2.2.33":
-  version "2.2.34"
-  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.34.tgz#05e4f79f465c2007884374d4795452f995720bbe"
-  integrity sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.6"
@@ -749,10 +806,15 @@
   resolved "https://registry.yarnpkg.com/@types/pdfjs-dist/-/pdfjs-dist-2.7.1.tgz#3f463b18849ef64e1879bf983ab36c40b3f26da0"
   integrity sha512-5qfC+w0bL0IaPYR3Jg3IwdN1SB/xEPnofLvguML272PtA7T+oz6tftXwXjjfNfnw9wDCwx+5N0QfjPnNu5lGEw==
 
-"@types/prop-types@*", "@types/prop-types@^15.7.3":
+"@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/prop-types@^15.7.12":
+  version "15.7.15"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.15.tgz#e6e5a86d602beaca71ce5163fadf5f95d70931c7"
+  integrity sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==
 
 "@types/qs@6.9.7":
   version "6.9.7"
@@ -841,43 +903,15 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-transition-group@^4.4.1":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.1.tgz#e1a3cb278df7f47f17b5082b1b3da17170bd44b1"
-  integrity sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==
-  dependencies:
-    "@types/react" "*"
+"@types/react-transition-group@^4.4.6":
+  version "4.4.12"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.12.tgz#b5d76568485b02a307238270bfe96cb51ee2a044"
+  integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
 
-"@types/react@*":
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
-  integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
-
-"@types/react@17.0.43":
+"@types/react@*", "@types/react@17.0.43", "@types/react@>=16.9.11":
   version "17.0.43"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.43.tgz#4adc142887dd4a2601ce730bc56c3436fdb07a55"
   integrity sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@>=16.14.8":
-  version "17.0.11"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.11.tgz#67fcd0ddbf5a0b083a0f94e926c7d63f3b836451"
-  integrity sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@>=16.9.11":
-  version "17.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
-  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -911,10 +945,10 @@
     "@types/cookiejar" "*"
     "@types/node" "*"
 
-"@types/warning@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
-  integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
+"@types/warning@^3.0.3":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.4.tgz#ebc0c83180dc83994d902bbd51ab0af8a445b1f9"
+  integrity sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg==
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -1170,6 +1204,13 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+aria-hidden@^1.2.3:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.6.tgz#73051c9b088114c795b1ea414e9c0fff874ffc1a"
+  integrity sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==
+  dependencies:
+    tslib "^2.0.0"
+
 array-buffer-byte-length@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz#fabe8bc193fea865f317fe7807085ee0dee5aead"
@@ -1393,10 +1434,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
   integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
 
-bootstrap@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.0.tgz#97b9f29ac98f98dfa43bf7468262d84392552fd7"
-  integrity sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==
+bootstrap@5.3.8:
+  version "5.3.8"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.8.tgz#6401a10057a22752d21f4e19055508980656aeed"
+  integrity sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1588,10 +1629,10 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
-classnames@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
-  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+classnames@^2.3.2:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -1601,6 +1642,11 @@ cliui@^7.0.2:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
+
+clsx@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 codepage@~1.15.0:
   version "1.15.0"
@@ -1889,6 +1935,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
 
 dezalgo@1.0.3:
   version "1.0.3"
@@ -3678,11 +3729,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.20:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
-
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -4346,6 +4392,21 @@ raf-schd@^4.0.2:
   resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
   integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
 
+react-aria@^3.48.0:
+  version "3.50.0"
+  resolved "https://registry.yarnpkg.com/react-aria/-/react-aria-3.50.0.tgz#75cb002c8ff94be3bc1afb6f717b37c6d0548119"
+  integrity sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==
+  dependencies:
+    "@internationalized/date" "^3.12.2"
+    "@internationalized/number" "^3.6.7"
+    "@internationalized/string" "^3.2.9"
+    "@react-types/shared" "^3.36.0"
+    "@swc/helpers" "^0.5.0"
+    aria-hidden "^1.2.3"
+    clsx "^2.0.0"
+    react-stately "3.48.0"
+    use-sync-external-store "^1.6.0"
+
 react-beautiful-dnd@13.1.1:
   version "13.1.1"
   resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz#b0f3087a5840920abf8bb2325f1ffa46d8c4d0a2"
@@ -4359,26 +4420,22 @@ react-beautiful-dnd@13.1.1:
     redux "^4.0.4"
     use-memo-one "^1.1.1"
 
-react-bootstrap@1.6.4:
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-1.6.4.tgz#94d5d2422e26bba277656d3529128e14f838b7ca"
-  integrity sha512-z3BhBD4bEZuLP8VrYqAD7OT7axdcSkkyvWBWnS2U/4MhyabUihrUyucPWkan7aMI1XIHbmH4LCpEtzWGfx/yfA==
+react-bootstrap@2.10.10:
+  version "2.10.10"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-2.10.10.tgz#be0b0d951a69987152d75c0e6986c80425efdf21"
+  integrity sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==
   dependencies:
-    "@babel/runtime" "^7.14.0"
-    "@restart/context" "^2.1.4"
-    "@restart/hooks" "^0.3.26"
-    "@types/invariant" "^2.2.33"
-    "@types/prop-types" "^15.7.3"
-    "@types/react" ">=16.14.8"
-    "@types/react-transition-group" "^4.4.1"
-    "@types/warning" "^3.0.0"
-    classnames "^2.3.1"
+    "@babel/runtime" "^7.24.7"
+    "@restart/hooks" "^0.4.9"
+    "@restart/ui" "^1.9.4"
+    "@types/prop-types" "^15.7.12"
+    "@types/react-transition-group" "^4.4.6"
+    classnames "^2.3.2"
     dom-helpers "^5.2.1"
     invariant "^2.2.4"
-    prop-types "^15.7.2"
+    prop-types "^15.8.1"
     prop-types-extra "^1.1.0"
-    react-overlays "^5.1.1"
-    react-transition-group "^4.4.1"
+    react-transition-group "^4.4.5"
     uncontrollable "^7.2.1"
     warning "^4.0.3"
 
@@ -4448,20 +4505,6 @@ react-modal@3.16.1:
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
 
-react-overlays@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-5.1.1.tgz#2e7cf49744b56537c7828ccb94cfc63dd778ae4f"
-  integrity sha512-eCN2s2/+GVZzpnId4XVWtvDPYYBD2EtOGP74hE+8yDskPzFy9+pV1H3ZZihxuRdEbQzzacySaaDkR7xE0ydl4Q==
-  dependencies:
-    "@babel/runtime" "^7.13.8"
-    "@popperjs/core" "^2.8.6"
-    "@restart/hooks" "^0.3.26"
-    "@types/warning" "^3.0.0"
-    dom-helpers "^5.2.0"
-    prop-types "^15.7.2"
-    uncontrollable "^7.2.1"
-    warning "^4.0.3"
-
 react-redux@7.2.8:
   version "7.2.8"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.8.tgz#a894068315e65de5b1b68899f9c6ee0923dd28de"
@@ -4528,6 +4571,18 @@ react-select@5.2.2:
     prop-types "^15.6.0"
     react-transition-group "^4.3.0"
 
+react-stately@3.48.0:
+  version "3.48.0"
+  resolved "https://registry.yarnpkg.com/react-stately/-/react-stately-3.48.0.tgz#80b658d91a20b35f9803102302268a477ba819e4"
+  integrity sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==
+  dependencies:
+    "@internationalized/date" "^3.12.2"
+    "@internationalized/number" "^3.6.7"
+    "@internationalized/string" "^3.2.9"
+    "@react-types/shared" "^3.36.0"
+    "@swc/helpers" "^0.5.0"
+    use-sync-external-store "^1.6.0"
+
 react-switch@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/react-switch/-/react-switch-6.0.0.tgz#bd4a2dea08f211b8a32e55e8314fd44bc1ec947e"
@@ -4535,10 +4590,20 @@ react-switch@6.0.0:
   dependencies:
     prop-types "^15.7.2"
 
-react-transition-group@^4.3.0, react-transition-group@^4.4.1:
+react-transition-group@^4.3.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
   integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+
+react-transition-group@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
   dependencies:
     "@babel/runtime" "^7.5.5"
     dom-helpers "^5.0.1"
@@ -5431,6 +5496,11 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
+tslib@^2.0.0, tslib@^2.8.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 tslib@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
@@ -5584,6 +5654,11 @@ uncontrollable@^7.2.1:
     invariant "^2.2.4"
     react-lifecycles-compat "^3.0.4"
 
+uncontrollable@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-8.0.4.tgz#a0a8307f638795162fafd0550f4a1efa0f8c5eb6"
+  integrity sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==
+
 undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
@@ -5621,6 +5696,11 @@ use-memo-one@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"
   integrity sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==
+
+use-sync-external-store@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
 util-deprecate@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Closes #1176. Part of the Phase 2 package track (#1728).

`bootstrap` 4.6.0 → 5.3.8 and `react-bootstrap` 1.6.4 → 2.10.10. **This is a technical upgrade only — the rendered product should not change.** Everything below exists to make that claim checkable rather than aspirational.

## How parity was verified

A computed-style probe walked ~70 selectors on 5 routes (`/`, `/faq`, `/subscribe`, `/join`, `/redeem`) × {1440px, 375px} × {light, dark}, capturing 40 properties plus the bounding box of each element: **19,152 property comparisons per run.** The Bootstrap 4.6 baseline was captured from this branch's own merge-base before any change, and every iteration was diffed against it.

| pass | differing property-groups |
| --- | --- |
| first build on Bootstrap 5 | **130** |
| after the variable pins | 67 |
| after the `.row > *` fixes | 23 |
| final | **14 — none of which change a rendered box** |

The 14 residuals are computed values with no painted consequence: `text-align: left` → `start` (identical in LTR), an unbound `max-width: 100%`, a 4px radius on a transparent borderless `.btn-group`, `min-height: 1px` (an IE flexbox hack Bootstrap dropped), and `hr`'s `height: 0` → `1px` — where the *painted* rect is `330x1` in both, because 4.6 drew the line with `border-top` on a zero-height box.

A static probe only sees what a signed-out page paints on first render. Everything else was compared by **running a Bootstrap 4.6 server on the unmodified branch alongside this one** and measuring the same element in both:

- **Print modal** — every element lands on the same y-coordinate; box 459px vs 461px.
- **Input group** (`.input-group-append` removal) — byte-identical: group 558×38, input 467×38, button 92×38, same radii, same 1px border overlap.
- **Reminder dropdown** (`alignRight` → `align="end"`) — menu is 316×168 and right-aligned in both.
- **Table, list-group row, alerts, inputs, select** — measured line-for-line identical (see below).
- **Import modal, Play mode** — visually indistinguishable.

## What needed more than a class rename

Bootstrap 5 changed ~70 default variable values. `src/css/theme.scss` pins the 4.6 values the product was built against, each annotated with the default it replaces. The behaviour changes that needed real fixes:

1. **`.row > *`** now applies gutters, `width: 100%`, and `flex-shrink: 0` to *every* direct child of a row; 4.6 only styled `col`-classed children. Eight non-column row children opt out. Left alone, the navbar wrapped onto two lines and cards gained a 15px inner inset.
2. **Conversely**, `col-*` used *outside* a row lost its padding, because 4.6 put the gutter on the column classes themselves. Seven such elements are restored by one rule.
3. **`.card`** — 5.3 hardcodes `color: var(--bs-body-color)`, not routed through any Sass variable. It painted dark body text inside dark-theme cards.
4. **Filled-button text** — 5.3 picks it with `color-contrast()` at a 4.5:1 floor, which turned **the Subscribe CTAs' text black**. `$min-contrast-ratio: 2.5` reproduces 4.6's `color-yiq()` decision for all eight theme colours (white on primary/secondary/success/danger/info/dark, black on warning/light).

## Found by external review (Codex, gpt-5.5)

An external pass caught the blind spot in the above: the probe never renders alerts, the saved-armies list, the gift table, or the import preview. All seven findings were reproduced side by side against 4.6 and fixed:

- **Alert text and border colours.** 4.6 derived a variant with `theme-color-level()` — text a 48% shade, border a 72% tint. 5.3's `*-text-emphasis` / `*-border-subtle` scale is 60% both ways, so `alert-danger` text went `#721c24` → `#58151c` and its border `#f5c6cb` → `#f1aeb5`. Backgrounds were already correct. DESIGN.md calls alerts "the standard way this product reports the outcome of an account operation" — this was every account flow.
- **Text inputs** — colour `#495057` → `#212529`, border `#ced4da` → `#dee2e6`, placeholder from flat grey to 75% of body colour.
- **`<select class="form-control">`** (the import preview's ruleset picker) **lost its native dropdown arrow**: 5.x adds `appearance: none` to `.form-control`. It also sat 1px shorter than adjacent inputs.
- **Saved-army rows** carry `list-group-item` *and* `card-body`. In 4.6 `_list-group.scss` is imported after `_card.scss`, so list-group padding won at equal specificity; the compat rule added here sat after the whole framework and beat it. Scoped with `:not(.list-group-item)`, and the list-group padding is now pinned too.
- **Table** cell padding (`.75rem` → `.5rem`) and border structure (4.6 draws a leading border per cell plus a 2px header rule; 5.x a trailing one, header rule opt-in).
- **Three more non-column `.row` children** in the gift list. The buttons take `w-auto` *without* `px-0`, because `.btn` is declared after `.row > *` in Bootstrap's source, so its own padding already wins.

## Two deliberate removals

- **`.jumbotron` / `.jumbotron-fluid`** are gone from Bootstrap 5. On the masthead they contributed only `padding-inline: 0` and `border-radius: 0` once the element's own utilities applied — which a bare `<div>` already has. Dropped rather than reimplemented; measured identical before and after.
- **`g-0`** on the FAQ row was *dead* under 4.6 (which spells it `no-gutters`), so the row has always rendered *with* gutters. The upgrade would have brought it to life and narrowed every FAQ card. Removed to preserve current rendering — reviving a style that has never shipped is a design change, not a migration.

## Two documentation corrections

Both found by measurement, both already wrong before this PR:

- DESIGN.md said card padding is `0.75rem` vertical / `1.25rem` horizontal. The **body** is actually `1.25rem` on all four sides: 4.6's `.card-body` passed `$card-spacer-x` as a single value, so `$card-spacer-y` never reached it. 5.x fixed that; `theme.scss` pins the old behaviour so the page doesn't tighten.
- DESIGN.md said "the product has no square badge". The inline `Sale!` flash beside a plan title is one.

DESIGN.md also gains **The Parity Pin Rule**, because those pins are now load-bearing parts of the design system: a future reader who assumes a stock Bootstrap 5 default will be wrong about a dozen values.

## Also

`@types/react` is pinned to `17.0.43` via `resolutions` — react-bootstrap 2.x pulls a v19 copy that breaks the typecheck. The lockfile collapses every range to 17.0.43, so `--frozen-lockfile` reproduces it.

## Test plan

```
yarn lint            # clean
yarn tsc --noEmit    # clean
yarn test --run      # 831 passed (62 files)
yarn build           # ok — CSS 233.56 kB / 32.99 kB gzip
```

`homePresentation.test.tsx`'s masthead assertion moved off `.jumbotron` to the themed, print-suppressed header block.

To repeat the visual check: run this branch and `aos4-migration` on two ports and compare `/`, `/faq`, `/subscribe` at desktop and 375px in both themes, plus the print and import modals and the reminder overflow menu.

### Not verified interactively

`/profile` and its gift / saved-army surfaces are behind Auth0, so they were verified by rendering their exact markup against both stylesheets rather than by driving the live page. **Worth a signed-in look before merge** — specifically the gift-subscription rows, the saved-armies list, and the purchase table.

**17 files fail `prettier --check` on this branch — all pre-existing drift on `aos4-migration`, none touched here** (verified by set intersection with the diff). Not fixed, to keep the diff reviewable.

## Post-deploy

No operational impact: no API, data, or infrastructure change. Frontend assets only.
