### PR TITLE
fix(redemption): polish the /join and /redeem pages

### DIFF
--- a/src/components/page/redemption.tsx
+++ b/src/components/page/redemption.tsx
@@ -10,7 +10,8 @@ export const RedemptionLogin = ({
 }: React.PropsWithChildren<{ handleClick: (event: React.MouseEvent) => unknown }>) => (
   <div>
     {children}
-    <p>
+    {/* Standing account-flow guidance, so it takes the same .lead voice as the preamble above it. */}
+    <p className="lead">
       First, you&apos;re going to need to create an account and log in. Once you&apos;ve done that, we&apos;ll
       set your subscription up!
     </p>
@@ -21,15 +22,18 @@ export const RedemptionLogin = ({
 )
 
 export const RedemptionSuccess = () => (
-  <>
-    <h5>Woohoo! You&apos;re all set!</h5>
-    <h2 className="my-2">
-      <FaRegSmileBeam />
-    </h2>
+  // The outcome replaces the form in place, so it has to announce itself.
+  <div role="status">
+    {/* Sized by class, not by heading level: this sits under the page <h1>, so it is an <h2>. */}
+    <h2 className="h5">Woohoo! You&apos;re all set!</h2>
+    {/* The glyph was an <h2> whose only content was a decorative icon — an empty heading. */}
+    <div className="h2 my-2">
+      <FaRegSmileBeam aria-hidden="true" />
+    </div>
     <GenericButton className="btn btn-success btn-lg" onClick={() => window.location.replace(ROUTES.PROFILE)}>
       Take me to my Profile!
     </GenericButton>
-  </>
+  </div>
 )
 
 export const RedemptionError = ({ error, showButton }: { error: string; showButton: boolean }) => (
@@ -37,14 +41,20 @@ export const RedemptionError = ({ error, showButton }: { error: string; showButt
     {showButton && (
       <GenericButton className="btn btn-danger btn-lg" disabled>
         Error!
-        <FaRegFrown className="ms-2" />
+        <FaRegFrown aria-hidden="true" className="ms-2" />
       </GenericButton>
     )}
-    <p className="pt-3">We&apos;re sorry. There was an error redeeming your subscription.</p>
-    <p>
-      <code>{error}</code>
-    </p>
-    <p>If you continue to receive this error, please get in contact with us using the links below.</p>
+    {/*
+      The message arrives after the attempt, so it needs announcing. The contact row below is
+      standing chrome and stays outside the live region.
+    */}
+    <div role="alert">
+      <p className="pt-3">We&apos;re sorry. There was an error redeeming your subscription.</p>
+      <p>
+        <code className="RedemptionErrorDetail">{error}</code>
+      </p>
+      <p>If you continue to receive this error, please get in contact with us using the links below.</p>
+    </div>
     <div className="row text-center pt-2 pb-3">
       <div className="col">
         <Contact size="small" />

--- a/src/components/routes/Join.tsx
+++ b/src/components/routes/Join.tsx
@@ -12,6 +12,13 @@ import { SubscriptionApi } from '../../api/subscriptionApi'
 
 const Navbar = lazy(() => import('components/page/navbar'))
 
+/**
+ * The shortest code the form will submit — the same length the Redeem button used to appear at. The
+ * API is the authority on what a real coupon looks like; this only keeps an obvious typo from
+ * costing a round trip.
+ */
+const MIN_COUPON_LENGTH = 7
+
 const Join = () => {
   const { isLoading, user } = useAuth0()
   const { getSubscription, isActive } = useSubscription()
@@ -33,39 +40,58 @@ const Join = () => {
   if (isActive) return <AlreadySubscribed />
 
   return (
-    <div className={`d-block ${theme.bgColor}`}>
+    <div className={`d-block ${theme.bgColor} ${theme.text}`}>
       <div className={`${theme.headerColor} py-2`}>
         <Suspense fallback={<LoadingHeader />}>
           <Navbar />
         </Suspense>
       </div>
-      <div
-        className={`container ${theme.bgColor} d-flex flex-column align-items-center justify-content-center LoadingContainer`}
-      >
-        <div className="col text-center">{user ? <RedeemSection /> : <Login />}</div>
+      <div className={`container ${theme.bgColor} RedemptionContainer py-5`}>
+        <div className="row justify-content-center">
+          {/*
+            A real .col inside a .row: RedemptionError renders a .row of contact links, and a row
+            whose parent carries no gutter padding overhangs it by 15px a side.
+          */}
+          <div className="col RedemptionColumn text-center">
+            {/*
+              The page's only <h1> — /join rendered no heading at all — and it stays put across the
+              login, form, success, and error views so the four states read as one page rather than
+              four unrelated screens. Sized at h2, matching /subscribe's.
+            */}
+            <h1 className="h2 mb-3">Redeem your coupon</h1>
+            {user ? <RedeemSection /> : <Login />}
+          </div>
+        </div>
       </div>
     </div>
   )
 }
 
-const Preamble = () => <p>Congratulations! We&apos;ll help you redeem your coupon code ASAP!</p>
+const Preamble = () => (
+  <p className="lead">Congratulations! We&apos;ll help you redeem your coupon code ASAP!</p>
+)
 
 const RedeemSection = () => {
   const { user } = useAuth0()
-  const [couponId, setCouponId] = useState<string | null>(null)
+  const [couponId, setCouponId] = useState('')
+  const [isRedeeming, setIsRedeeming] = useState(false)
   const [success, setSuccess] = useState(false)
   const [error, setError] = useState('')
 
-  if (!couponId && success) return <RedemptionSuccess />
-  if (!couponId && error) return <RedemptionError error={error} showButton={false} />
+  // Pasted codes routinely carry a trailing space, which the API can only reject.
+  const code = couponId.trim()
+  // The email is the account key the API redeems against, so without one the button cannot work —
+  // and an enabled button that silently does nothing is worse than a disabled one.
+  const canRedeem = code.length >= MIN_COUPON_LENGTH && !!user?.email && !isRedeeming
 
-  const handleRedeem = async (event: React.MouseEvent) => {
+  const handleRedeem = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const userName = user?.email
-    if (!couponId || !userName) return
+    if (!canRedeem || !userName) return
 
+    setIsRedeeming(true)
     try {
-      const { body } = await SubscriptionApi.redeemCoupon({ couponId, userName })
+      const { body } = await SubscriptionApi.redeemCoupon({ couponId: code, userName })
       if (body.error) {
         setError(body.error)
       } else {
@@ -76,39 +102,69 @@ const RedeemSection = () => {
     } catch (caught) {
       console.error(caught)
       setError('An unknown error occurred.')
+    } finally {
+      setIsRedeeming(false)
     }
   }
 
+  if (success) return <RedemptionSuccess />
+
   return (
-    <div>
-      {!success && (
-        <p>
-          You&apos;re currently logged in as <strong>{user?.email || ''}</strong>.
-          <br />
-          <br />
-          If you&apos;re ready to redeem your coupon code, just enter it below.
-        </p>
-      )}
-      {!success && (
-        <div className="row justify-content-center pb-3">
-          <div className="col col-md-6 col-xl-3">
-            <input
-              className="form-control form-control-lg"
-              type="text"
-              placeholder="ABC_123"
-              onChange={event => setCouponId(event.target.value || null)}
-            />
-          </div>
+    <>
+      {/*
+        Two sentences, two paragraphs. They were one paragraph split by a <br />, which `balance`
+        treats as a single block and wraps worse than no balancing at all.
+      */}
+      <p className="lead mb-1">
+        You&apos;re currently logged in as <strong>{user?.email || ''}</strong>.
+      </p>
+      <p className="lead">If you&apos;re ready to redeem your coupon code, just enter it below.</p>
+      {/*
+        A real <form>, so the phone keyboard's Go key submits. The field was a bare input with a
+        placeholder standing in for its label, and pressing Enter did nothing.
+      */}
+      <form onSubmit={handleRedeem}>
+        <div className="mb-3 RedemptionCodeField mx-auto">
+          <label className="mb-1" htmlFor="coupon-code">
+            Coupon code
+          </label>
+          <input
+            // Mobile keyboards capitalise the first character, silently mangling the code.
+            autoCapitalize="off"
+            autoComplete="off"
+            autoCorrect="off"
+            className="form-control form-control-lg text-center"
+            enterKeyHint="go"
+            id="coupon-code"
+            onChange={event => {
+              setCouponId(event.target.value)
+              // The error belongs to the code that produced it.
+              setError('')
+            }}
+            placeholder="ABC_123"
+            spellCheck={false}
+            type="text"
+            value={couponId}
+          />
         </div>
-      )}
-      {!success && couponId && couponId.length >= 7 && (
-        <GenericButton className="btn btn-primary btn-lg" onClick={handleRedeem}>
-          Redeem
+        {/*
+          Mounted and disabled rather than absent: the button used to appear only once the code was
+          long enough, so a short code left the page with no visible way forward and nothing to
+          explain why. Disabling it while the request is in flight stops a double redemption.
+        */}
+        <GenericButton className="btn btn-primary btn-lg" disabled={!canRedeem} type="submit">
+          {isRedeeming ? (
+            <>
+              <span aria-hidden="true" className="spinner-border spinner-border-sm me-2" role="status" />
+              Redeeming
+            </>
+          ) : (
+            'Redeem'
+          )}
         </GenericButton>
-      )}
-      {success && <RedemptionSuccess />}
+      </form>
       {error && <RedemptionError error={error} showButton={false} />}
-    </div>
+    </>
   )
 }
 

--- a/src/components/routes/Redeem.tsx
+++ b/src/components/routes/Redeem.tsx
@@ -2,6 +2,7 @@ import { useAuth0 } from '@auth0/auth0-react'
 import AlreadySubscribed from 'components/helpers/alreadySubscribed'
 import { LoadingBody, LoadingHeader } from 'components/helpers/suspenseFallbacks'
 import GenericButton from 'components/input/generic_button'
+import Contact from 'components/page/contact'
 import { RedemptionError, RedemptionLogin, RedemptionSuccess } from 'components/page/redemption'
 import { useSubscription } from 'context/useSubscription'
 import { useTheme } from 'context/useTheme'
@@ -50,78 +51,131 @@ const Redeem = () => {
   if (isActive) return <AlreadySubscribed />
 
   return (
-    <div className={`d-block ${theme.bgColor}`}>
+    <div className={`d-block ${theme.bgColor} ${theme.text}`}>
       <div className={`${theme.headerColor} py-2`}>
         <Suspense fallback={<LoadingHeader />}>
           <Navbar />
         </Suspense>
       </div>
-      <div
-        className={`container ${theme.bgColor} d-flex flex-column align-items-center justify-content-center LoadingContainer`}
-      >
-        <div className="col text-center">{user ? <RedeemSection /> : <Login />}</div>
+      <div className={`container ${theme.bgColor} RedemptionContainer py-5`}>
+        <div className="row justify-content-center">
+          {/*
+            A real .col inside a .row: the error and missing-link states render a .row of contact
+            links, and a row whose parent carries no gutter padding overhangs it by 15px a side.
+          */}
+          <div className="col RedemptionColumn text-center">
+            {/*
+              The page's only <h1> — /redeem rendered no heading at all — and it stays put across the
+              login, confirm, success, error, and missing-link views so they read as one page rather
+              than five unrelated screens. Sized at h2, matching /subscribe's.
+            */}
+            <h1 className="h2 mb-3">Redeem your gift</h1>
+            {user ? <RedeemSection /> : <Login />}
+          </div>
+        </div>
       </div>
     </div>
   )
 }
 
 const Preamble = () => (
-  <p>Congratulations! One of your friends has decided that you deserve a subscription to AoS Reminders!</p>
+  <p className="lead">
+    Congratulations! One of your friends has decided that you deserve a subscription to AoS Reminders!
+  </p>
+)
+
+/*
+ * A dead end in the incumbent: the message named the problem and offered nothing to do about it.
+ * The contact row is the same recovery the error path already gives.
+ */
+const MissingRedemption = () => (
+  <>
+    <p className="lead">
+      We couldn&apos;t locate a subscription id. You may have arrived here via a malformed link.
+    </p>
+    <div className="row text-center pt-2 pb-3">
+      <div className="col">
+        <Contact size="small" />
+      </div>
+    </div>
+  </>
 )
 
 const RedeemSection = () => {
   const { user } = useAuth0()
-  const redemption = queryRedemption()
+  /*
+   * Captured once. It used to be re-read on every render while handleRedeem cleared the cache
+   * mid-flow, so what the page believed it was holding depended on when it last re-rendered — and a
+   * response carrying neither `error` nor `success` could land the user on "malformed link" after a
+   * gift had already been spent.
+   */
+  const [redemption] = useState(queryRedemption)
+  const [isRedeeming, setIsRedeeming] = useState(false)
   const [success, setSuccess] = useState(false)
   const [error, setError] = useState('')
 
-  if (!redemption && success) return <RedemptionSuccess />
-  if (!redemption && error) return <RedemptionError error={error} showButton />
-  if (!redemption) {
-    return <p>We couldn&apos;t locate a subscription id. You may have arrived here via a malformed link.</p>
-  }
+  // The email is the account key the API redeems against, so without one the button cannot work.
+  const canRedeem = !!redemption && !!user?.email && !isRedeeming
 
   const handleRedeem = async (event: React.MouseEvent) => {
     event.preventDefault()
     const userName = user?.email
-    if (!userName) return
+    if (!canRedeem || !redemption || !userName) return
 
+    setIsRedeeming(true)
     try {
       const { body } = await SubscriptionApi.redeemGift({
         giftId: redemption.giftId,
         userId: redemption.userId,
         userName,
       })
-      RedemptionStorage.clear()
-      if (body.error) return setError(body.error)
-      if (body.success) {
-        setSuccess(true)
+      if (body.error) {
+        setError(body.error)
+      } else if (body.success) {
+        // Cleared only once the gift is actually spent. Clearing on failure too used to throw away
+        // the one copy of the id whenever the link's query string was no longer in the address bar.
+        RedemptionStorage.clear()
         logEvent('Redeemed-Gift')
+        setSuccess(true)
+      } else {
+        // A response that confirms nothing is a failure, not a silent no-op.
+        setError('An unknown error occurred.')
       }
     } catch (caught) {
       console.error(caught)
       setError('An unknown error occurred.')
+    } finally {
+      setIsRedeeming(false)
     }
   }
 
+  if (!redemption) return <MissingRedemption />
+  if (success) return <RedemptionSuccess />
+  if (error) return <RedemptionError error={error} showButton />
+
   return (
-    <div>
-      {!error && !success && <Preamble />}
-      {!error && !success && (
-        <p>
-          You&apos;re currently logged in as <strong>{user?.email}</strong>.
-          <br />
-          If you&apos;re ready to redeem this gifted subscription, click the button below!
-        </p>
-      )}
-      {!error && !success && (
-        <GenericButton className="btn btn-primary btn-lg" onClick={handleRedeem}>
-          Redeem
-        </GenericButton>
-      )}
-      {success && <RedemptionSuccess />}
-      {error && <RedemptionError error={error} showButton />}
-    </div>
+    <>
+      <Preamble />
+      {/*
+        Two sentences, two paragraphs. They were one paragraph split by a <br />, which `balance`
+        treats as a single block and wraps worse than no balancing at all.
+      */}
+      <p className="lead mb-1">
+        You&apos;re currently logged in as <strong>{user?.email}</strong>.
+      </p>
+      <p className="lead">If you&apos;re ready to redeem this gifted subscription, click the button below!</p>
+      {/* Disabled while the request is in flight, so a second click cannot spend the gift twice. */}
+      <GenericButton className="btn btn-primary btn-lg" disabled={!canRedeem} onClick={handleRedeem}>
+        {isRedeeming ? (
+          <>
+            <span aria-hidden="true" className="spinner-border spinner-border-sm me-2" role="status" />
+            Redeeming
+          </>
+        ) : (
+          'Redeem'
+        )}
+      </GenericButton>
+    </>
   )
 }
 

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -32,6 +32,49 @@ small {
 }
 
 /*
+ * /join and /redeem are one short form on an otherwise empty page. Both used to borrow
+ * `.LoadingContainer`, whose 35vh top padding is right for two lines of loading text and wrong for
+ * a form that grows an error block underneath it — on a 667px phone that padding alone pushed the
+ * control 233px down the page. A centred min-height places the form optically on a tall screen and
+ * lets it grow from the top on a short one.
+ */
+.RedemptionContainer {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-height: 70vh;
+}
+
+/*
+ * Four short sentences and a field. 38rem holds the guidance at roughly 60 characters a line, and
+ * `balance` keeps centred copy off a one-word last line — the paragraphs are set centred, where a
+ * ragged orphan is the most visible thing on the page. Browsers without it wrap as they do today.
+ */
+.RedemptionColumn {
+    max-width: 38rem;
+
+    h1,
+    p {
+        text-wrap: balance;
+    }
+}
+
+/* A coupon code is seven-ish characters. A full-width field promises a paragraph. */
+.RedemptionCodeField {
+    max-width: 18rem;
+}
+
+/*
+ * Bootstrap's default `code` pink measures 3.82:1 on white — under AA — and it carries the one line
+ * of a failed redemption the player has to read back to us. The monospace face already marks the
+ * string as the server's own words, so the colour was only decorating. Inherit rather than pick a
+ * literal, so the surrounding theme slot stays the single source of the text colour.
+ */
+.RedemptionErrorDetail {
+    color: inherit;
+}
+
+/*
  * Card titles are <h2> so the document outline is correct at every viewport. The size is set here
  * rather than by picking a heading level, which is what the h4/h5 swap used to do. 1.5rem matches
  * the h4 these replaced; the breakpoint overrides further down are unchanged.


### PR DESCRIPTION
`/join` and `/redeem` were the least finished surfaces in the product, despite serving the highest-intent visitor there is: someone holding a coupon or a gift. Both were two grey sentences and a button floating in an empty page, with no heading of any kind, and both carried state-machine bugs that could strand a user mid-redemption.

Refinement only — no redesign. The incumbent copy is unchanged except for the two added headings and a field label.

## Broken behaviour

- **`/join` hid the Redeem button until the code reached 7 characters.** Type six and the page had no visible way forward and nothing explaining why. The button is now always mounted and disabled below the same threshold — the set of codes that can be submitted is unchanged.
- **`/join` destroyed the form permanently if you cleared the field after a failed redeem.** `if (!couponId && error) return <RedemptionError…>` was copied from `/redeem`, where the same condition is a stable URL parse; here it keyed off a mutable input value. Deleting your code to retype it swapped the page for an error screen with no way back.
- **`/redeem` re-read its redemption on every render while `handleRedeem` cleared the cache mid-flow.** What the component believed it was holding depended on when it last re-rendered. A response carrying neither `error` nor `success` set no state at all — and if the query string was no longer in the address bar, the next render dropped through to *"You may have arrived here via a malformed link"* **after the gift had already been spent.** `redemption` is now captured once at mount, and a response that confirms nothing is treated as a failure.
- **`/redeem` cleared `RedemptionStorage` on failure as well as success**, throwing away the only remaining copy of the gift id whenever the link's query string wasn't in the address bar — the gift became unredeemable through the UI. It now clears only once the gift is actually spent, which is what the `catch` branch already did.
- **Neither page had an in-flight state**, so a double click fired two redemptions. Both now disable with the codebase's existing inline spinner pattern.
- **Both enabled their action with no `user.email`**, which the handler returns early on — an enabled button that silently does nothing.
- **`/join` had no `<form>`**, so Enter and the phone keyboard's Go key did nothing.
- **`/redeem`'s "malformed link" state was a dead end** — problem named, nothing to do about it. It now carries the same `<Contact>` row the error path already uses.
- Codes are trimmed before submit; `autoCapitalize="off"` stops mobile keyboards capitalising the first character.

## Accessibility

- **Neither page had an `<h1>`.** Added *"Redeem your coupon"* / *"Redeem your gift"*, persisting across every view so the states read as one page rather than four or five unrelated screens. Sized at `h2`, matching what `/subscribe` already does.
- **`/join`'s coupon field had no label** — the placeholder `ABC_123` was standing in for one.
- **The success screen's `<h2>` contained only a decorative smiley** (an empty heading) and an `<h5>` preceded it. Both are now sized by class and render identically.
- Error and success announce themselves (`role="alert"` / `role="status"`); decorative icons get `aria-hidden`.
- **The error detail `<code>` measured 3.82:1 on white** under Bootstrap 4 and fails under Bootstrap 5's `#d63384` too — on the one line the player has to read back to us. It now inherits the theme slot: **11.51:1**. Monospace already marks it as the server's words.

## Layout

- Both shells move off `.LoadingContainer`'s 35vh top padding — right for two lines of loading text, wrong for a form that grows an error block underneath it. On a 667px phone that padding alone pushed the control 233px down the page. Replaced with a centred `min-height`.
- Content capped at 38rem (~60ch) with `text-wrap: balance`, and the two-sentence guidance split into real paragraphs: `balance` treats a `<br />` as one block and wrapped it *worse* than no balancing (541px + "below!" alone, versus 298/300 once split).
- Prose takes `.lead`, the role DESIGN.md assigns to account-flow guidance and that `/subscribe` already uses.

## Testing

1. `/join` signed out → heading, preamble, Log In / Sign Up.
2. `/join` signed in → labelled field, Redeem disabled. Type 6 characters — still disabled. Type a 7th — enabled. Press **Enter** — submits. Paste a code with a trailing space — still enabled, and the space is trimmed off the request.
3. Submit a bad code → error appears with the code echoed; start typing again → the error clears and the form is still there.
4. `/redeem?redeem=<id>&referrer=<id>` signed in → confirm view, single click, button disables with a spinner while in flight.
5. `/redeem` with no query string and nothing cached → "malformed link" message **with** contact links.
6. Check all of the above at 390px and at desktop width, and tab through with the keyboard — focus rings on the field and button.

## Notes

- Rebased onto `aos4-migration` rather than the branch this was written on, which predated the Bootstrap 5.3 and React 19 merges. `ml-2`/`mr-2` → `ms-2`/`me-2` and `.form-group` → `mb-3` accordingly. Re-verified every state against 5.3 after the rebase — headings, `.lead`, field and button heights, contrast, and the contact `.row` matching its `.col` all measured again, not assumed.
- **Not changed, deliberately:** the disabled `Error! ☹` button on `/redeem`'s error state (decorative disabled control, but `showButton` is an explicit prop and `/join` already passes `false`); `/redeem` still offers no retry after an error (there is nothing to edit and resubmit, unlike `/join`); and `AlreadySubscribed`'s "You are now subscribed :) Thanks!", which is wrong when you *arrive* already subscribed but is shared with `/subscribe`.

https://claude.ai/code/session_014db9JAAR7Sbw2Xkc2g7uEL
