### PR TITLE
fix(faq): rebuild the FAQ as a grouped reference page

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -372,7 +372,8 @@ Three, in descending order of how deliberate they look:
   how Bootstrap draws focus on buttons and inputs. Not decorative and not optional — it is the
   visible keyboard-focus indicator, and nothing may suppress it.
 - **Card lift** (`shadow-sm`, `0 .125rem .25rem rgba(0,0,0,.075)`): exactly two places — the
-  subscription plan cards (`payment/pricingPlans.tsx`) and the FAQ entry cards (`routes/Faq.tsx`). Both are standalone marketing/reference cards on secondary
+  subscription plan cards (`payment/pricingPlans.tsx`) and the FAQ section cards
+  (`routes/Faq.tsx`). Both are standalone marketing/reference cards on secondary
   routes, not part of the reminders surface, and neither is reproduced by the reminder or builder
   cards. Treat it as incumbent, not as licence to spread `shadow-sm` onto the game screen.
 
@@ -527,7 +528,7 @@ the opposite mode is a dead stop in the tab order.
 ### Named Rules
 
 **The Dead Class Rule.** A class in JSX that no rule defines is a design intention that silently
-never happened, and this codebase has a habit of them. Checked against the compiled bundle, six
+never happened, and this codebase has a habit of them. Checked against the compiled bundle, five
 are live in `src/components/` today:
 
 | Class | Where | What was intended |
@@ -536,7 +537,6 @@ are live in `src/components/` today:
 | `fade-out` | `helpers/suspenseFallbacks.tsx` | A fade on "Loading…" |
 | `btn-pill` | `payment/pricingPlans.tsx` | A rounded Subscribe CTA (`rounded-pill` is the real class) |
 | `btn-md` | `routes/Profile.tsx` | A medium button; Bootstrap only ships `btn-sm`/`btn-lg` |
-| `h-md-250` | `routes/Faq.tsx` | A fixed FAQ card height |
 | `pricing-card-title` | `payment/pricingPlans.tsx` | Carried over from a Bootstrap example |
 
 The first two matter most to this record. The product has essentially no motion — the only
@@ -548,7 +548,8 @@ Verify a new utility class exists before relying on it — `grep` the compiled C
 which Bootstrap version this is. A seventh entry, `g-0` on the FAQ row, left this table in the 5.3
 upgrade: it was Bootstrap 5 syntax written while the project was still on 4.6, so it had never done
 anything, and the upgrade would have brought it to life and narrowed every FAQ card. It was deleted
-rather than honoured, because reviving a style that has never shipped is a design change. That is
+rather than honoured, because reviving a style that has never shipped is a design change. An eighth,
+`h-md-250` on the same row, left with the FAQ rebuild that replaced that layout outright. That is
 the general remedy for this table: a dead class is removed or implemented deliberately, never left
 to switch itself on during an upgrade.
 

--- a/src/components/routes/Faq.tsx
+++ b/src/components/routes/Faq.tsx
@@ -1,46 +1,346 @@
+import { LinkNewTab } from 'components/helpers/link'
 import { LoadingHeader } from 'components/helpers/suspenseFallbacks'
+import Contact from 'components/page/contact'
 import Footer from 'components/page/footer'
 import { useTheme } from 'context/useTheme'
 import { lazy, Suspense, useEffect } from 'react'
+import { Link } from 'react-router-dom'
 import { logPageView } from 'utils/analytics'
+import { GITHUB_URL, ROUTES } from 'utils/env'
 
 const Navbar = lazy(() => import('components/page/navbar'))
+
+/*
+ * A reading column, not a card gallery. The previous layout was Bootstrap's featured-blog-post
+ * example: three cards at col-md-8/col-lg-6/col-xl-5 that tiled 2-up and orphaned the third, with
+ * the screenshots sized 200x250 regardless of what they actually were.
+ *
+ * The measure is set per breakpoint to hold answers near 75 characters a line. Sections reuse the
+ * product's own card + Signal Teal header, so the FAQ reads as part of the same manual as the
+ * reminders screen rather than as a marketing page bolted onto the side.
+ */
+const columnClass = 'col-12 col-md-11 col-lg-8 col-xl-7 col-xxl-5'
+
+/*
+ * width/height are the size the screenshot is drawn at, kept on the asset's true ratio and always
+ * below its capture size so nothing is upscaled. .img-fluid supplies max-width: 100% and
+ * height: auto, so the pair reserves the correct box before the image loads and shrinks
+ * proportionally on a narrow screen. Both were previously declared 200x250 whatever they were,
+ * which reserved 180px the wide one never used and rendered it at 200x70 — unreadable.
+ */
+interface IFaqImage {
+  alt: string
+  height: number
+  src: string
+  width: number
+}
+
+interface IFaqEntry {
+  answer: React.ReactNode
+  /** Anchor target, so a question can be linked to directly. */
+  id: string
+  image?: IFaqImage
+  question: string
+}
+
+interface IFaqSection {
+  entries: IFaqEntry[]
+  id: string
+  title: string
+}
+
+const GithubIssuesLink = () => (
+  <LinkNewTab className="FaqLink" href={`${GITHUB_URL}/issues`} label="Faq-GithubIssues">
+    open an issue on Github
+  </LinkNewTab>
+)
+
+const WahapediaLink = () => (
+  <LinkNewTab className="FaqLink" href="//wahapedia.ru/aos4/the-rules/" label="Faq-Wahapedia">
+    Wahapedia
+  </LinkNewTab>
+)
+
+const ProfileLink = ({ children }: React.PropsWithChildren<object>) => (
+  <Link className="FaqLink" to={ROUTES.PROFILE}>
+    {children}
+  </Link>
+)
+
+/*
+ * Every claim below is checked against what the app ships today. Control names are bolded and
+ * spelled exactly as they appear in the interface so they can be found by eye.
+ */
+const FaqSections: IFaqSection[] = [
+  {
+    id: 'getting-started',
+    title: 'Getting started',
+    entries: [
+      {
+        id: 'what-is-this',
+        question: 'What does AoS Reminders actually do?',
+        answer: (
+          <>
+            You give it the army you are bringing. It works out every ability that army grants you and lists
+            those abilities under the window they fire in — deployment, each of the seven turn phases, the
+            start and end of a battle round, and reactions to your opponent. It is not a rules search. It is
+            your list, in turn order.
+          </>
+        ),
+      },
+      {
+        id: 'import-a-roster',
+        question: 'Do I have to build my list here?',
+        answer: (
+          <>
+            No. <strong>Import Army</strong> takes the roster you already made: text exported from the
+            official Warhammer Age of Sigmar app or from Listbot 4.0, and New Recruit .ros or .rosz files. You
+            can paste the text or drop the file in. An imported roster sets your selections — it is never
+            treated as a rules authority.
+          </>
+        ),
+      },
+      {
+        id: 'edit-and-play',
+        question: 'What is the difference between Edit and Play mode?',
+        answer: (
+          <>
+            Edit is for the desk: you get the faction picker, the army builder, and the toolbar, and rules you
+            have hidden are still listed. Play is for the table: the builder and the toolbar disappear, hidden
+            rules drop out completely, and what is left is what fires in this game. The switch sits at the top
+            of the home page.
+          </>
+        ),
+      },
+      {
+        id: 'hide-reminders',
+        question: 'How do I get rid of reminders I already know?',
+        answer: (
+          <>
+            Open the ⋯ menu on any reminder and choose <strong>Hide rule</strong>. It stays out of Play mode
+            until you change your mind — <strong>Show Hidden</strong> in the toolbar keeps a count and brings
+            them all back at once. The same menu has <strong>Add note</strong> for writing your own line under
+            a rule, and you can drag reminders into a different order within their phase.
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    id: 'at-the-table',
+    title: 'At the table',
+    entries: [
+      {
+        id: 'print-and-pdf',
+        question: 'Can I take this to the table on paper?',
+        answer: (
+          <>
+            Yes, and it costs nothing. <strong>Download PDF</strong> in the toolbar builds the sheet in your
+            browser — <strong>Standard</strong> for larger type in a single column, <strong>Compact</strong>{' '}
+            for two columns and fewer pages — on A4 or US Letter. Your notes come with it, and anything you
+            hid stays hidden.
+          </>
+        ),
+      },
+      {
+        id: 'offline',
+        question: 'Does it work without a signal?',
+        answer: (
+          <>
+            Partly, and I would not count on it. No rules data is fetched while you play — the whole corpus
+            ships with the page — and your current army is kept in this browser, so a connection that drops
+            mid-game does not take your reminders with it. But there is no offline cache yet: if the tab is
+            not already open, a dead connection is a dead page. Venue signal being what it is, take the PDF.
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    id: 'rules-and-data',
+    title: 'Rules and data',
+    entries: [
+      {
+        id: 'which-edition',
+        question: 'Which rules does this cover?',
+        answer: (
+          <>
+            Age of Sigmar fourth edition, defaulting to the current General&apos;s Handbook 2026-27 season.
+            Third edition is gone: armies you saved under the old third-edition site are not carried across,
+            and are cleared out when the app loads.
+          </>
+        ),
+      },
+      {
+        id: 'where-rules-come-from',
+        question: 'Where do the rules come from?',
+        answer: (
+          <>
+            Games Workshop publications are the authority. <WahapediaLink /> is used to find and cross-check
+            coverage. Every reminder carries its source in the ⋯ menu, and anything drawn from a Games
+            Workshop publication is badged <strong>Official</strong> and links to the document it came from.
+            Powered by Wahapedia.
+          </>
+        ),
+      },
+      {
+        id: 'wrong-or-missing-rule',
+        question: "I've noticed an incorrect or missing rule!",
+        answer: (
+          <>
+            <p>
+              Please tell me. Corrections go into the rules data and are re-verified against the sources, so
+              the fix reaches everyone rather than only your army. Naming the faction and the warscroll or
+              ability makes it much faster to track down.
+            </p>
+            <p className="mb-2">
+              The best route is to <GithubIssuesLink />. Discord and email work too.
+            </p>
+            <Contact size="small" />
+          </>
+        ),
+      },
+      {
+        id: 'is-this-official',
+        question: 'Is this an official Games Workshop app?',
+        answer: (
+          <>
+            No. AoS Reminders is unofficial and fan-made, is in no way endorsed or sanctioned by Games
+            Workshop, and takes no credit for their content. I build and run it on my own time.
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    id: 'account',
+    title: 'Account and subscription',
+    entries: [
+      {
+        id: 'what-subscription-includes',
+        question: 'What does a subscription get me?',
+        answer: (
+          <>
+            <strong>My Armies</strong> keeps your armies on your account so they follow you between devices —
+            save, load, rename, update, and delete. <strong>Share Army</strong> creates a link a friend can
+            open to take their own copy of the list. And dark theme. Everything else — the builder, importing,
+            reminders, notes, hiding, reordering, and the PDF — is free, and stays free. See{' '}
+            <Link className="FaqLink" to={ROUTES.SUBSCRIBE}>
+              the plans
+            </Link>
+            .
+          </>
+        ),
+      },
+      {
+        id: 'dark-theme',
+        question: 'How do I turn on dark theme?',
+        answer: (
+          <>
+            Subscribe, then switch <strong>Visual Theme</strong> on your <ProfileLink>Profile</ProfileLink>.
+            It is stored against your account, so it follows you to your other devices.
+          </>
+        ),
+      },
+      {
+        id: 'cannot-log-in',
+        question: "I can't recover my password!",
+        answer: (
+          <>
+            If you signed up with Google, there is no AoS Reminders password to recover — use{' '}
+            <strong>Continue with Google</strong> on the log in screen rather than the email and password
+            fields.
+          </>
+        ),
+        // Captured at 382x500.
+        image: {
+          alt: 'The AoS Reminders log in screen, with the "Continue with Google" button below the email and password fields.',
+          height: 360,
+          src: '/img/faq_continue_with_google.png',
+          width: 275,
+        },
+      },
+      {
+        id: 'unsubscribe',
+        question: 'How do I unsubscribe?',
+        answer: (
+          <>
+            Log in, open your <ProfileLink>Profile</ProfileLink>, and click{' '}
+            <strong>Cancel Subscription</strong>. You keep every subscription feature until the end of the
+            period you have already paid for.
+          </>
+        ),
+        // Captured at 800x280.
+        image: {
+          alt: 'The Profile page, with the "Cancel Subscription" button beneath the subscription details.',
+          height: 140,
+          src: '/img/faq_unsubscribe.png',
+          width: 400,
+        },
+      },
+      {
+        id: 'card-details',
+        question: 'Do you store my card details?',
+        answer: (
+          <>
+            No. There is no card field anywhere on this site. Payment happens on Stripe&apos;s own hosted
+            checkout or through PayPal&apos;s button, and they manage the subscription from there — including
+            cancelling it.
+          </>
+        ),
+      },
+      {
+        id: 'gift',
+        question: 'Can I give a subscription to someone else?',
+        answer: (
+          <>
+            Yes. <strong>Gift a Subscription</strong> on your <ProfileLink>Profile</ProfileLink> charges you
+            once — it is not a recurring subscription — and gives you a one-time-use link to send on.
+          </>
+        ),
+      },
+    ],
+  },
+]
 
 const Faq = () => {
   const { theme } = useTheme()
 
   useEffect(() => {
     logPageView()
+    /*
+     * Questions carry anchors now, so /faq#unsubscribe has to survive arrival. Scrolling to the top
+     * unconditionally would land the reader back at the masthead every time.
+     */
+    const { hash } = window.location
+    const target = hash ? document.getElementById(hash.slice(1)) : null
+    /*
+     * `instant` is required, not a preference. Bootstrap 5.3 sets `scroll-behavior: smooth` on
+     * `:root` (4.6 did not), so a bare scrollIntoView() starts an animation from the top that the
+     * browser's own load-time scroll handling cancels — the reader lands at the masthead and the
+     * anchor silently does nothing. An arrival jump should be instant anyway; the smooth behaviour
+     * still applies to the section links, which is where it reads well.
+     */
+    if (target) return target.scrollIntoView({ behavior: 'instant' })
     window.scrollTo(0, 0)
   }, [])
 
   return (
     <div className={`d-block ${theme.bgColor}`}>
-      <div className={`${theme.headerColor} py-2`}>
+      <div className={`${theme.headerColor} py-2 d-print-none`}>
         <Suspense fallback={<LoadingHeader />}>
           <Navbar />
         </Suspense>
       </div>
-      <PageHeader />
 
-      <div className={`container ${theme.bgColor} ${theme.text}`}>
-        <div className="row">
-          <FaqEntry
-            title="I can't recover my password!"
-            text={`If you're attempting to recover your password, and you're not seeing a recovery email - please try clicking "Continue with Google" when you see the log in.`}
-            imgUrl="/img/faq_continue_with_google.png"
-            imgAlt='The AoS Reminders log in screen, with the "Continue with Google" button below the email and password fields.'
-          />
-          <FaqEntry
-            title="How do I unsubscribe?"
-            text={`Log in and then visit your Profile. From there, please click "Cancel Subscription"`}
-            imgUrl="/img/faq_unsubscribe.png"
-            imgAlt='The Profile page, with the "Cancel Subscription" button beneath the subscription details.'
-          />
-          <FaqEntry
-            title="I've noticed an incorrect or missing rule!"
-            text="Please ping me on Discord, email me, or open a new issue on Github."
-          />
+      <div className={`container ${theme.bgColor} ${theme.text} pt-3 pb-5`}>
+        <div className="row justify-content-center">
+          <div className={columnClass}>
+            <PageHeader />
+            {FaqSections.map(section => (
+              <FaqSectionCard key={section.id} section={section} />
+            ))}
+          </div>
         </div>
       </div>
 
@@ -49,54 +349,70 @@ const Faq = () => {
   )
 }
 
-interface FaqEntryProps {
-  imgAlt?: string
-  imgUrl?: string
-  text: string
-  title: string
-}
-
-const FaqEntry = ({ title, text, imgUrl = '', imgAlt = '' }: FaqEntryProps) => (
-  <div className="col-12 col-md-8 col-lg-6 col-xl-5 mx-xl-1">
+const PageHeader = () => (
+  <div className="text-center">
+    {/* Rendered at h2 size so the page gains a top-level heading without a visual change. */}
+    <h1 className="h2">Frequently Asked Questions</h1>
     {/*
-      `g-0` was removed rather than migrated. It is Bootstrap 5 syntax that did nothing under 4.6
-      (which spelled it `no-gutters`), so this row has always rendered *with* gutters: the bordered
-      box is pulled 15px wider than its column and the image column carries 15px of padding. The
-      upgrade would have brought the class to life and quietly narrowed every FAQ card, which is a
-      visual change this migration is not authorised to make. Restoring the zero-gutter intent is a
-      design decision for another day.
+      A flex row, not a line of inline links. JSX leaves no whitespace between siblings, so an
+      inline row has no break opportunity and ran 546px wide in a 371px viewport, scrolling the
+      whole page sideways. Each title stays whole (text-nowrap) and the row wraps between them.
     */}
-    <div className="row border rounded overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative">
-      <div className="col p-4 d-flex flex-column position-static">
-        {/* Sits directly under the page h1, so it is an h2. .h3 keeps the existing type scale. */}
-        <h2 className="mb-0 h3">{title}</h2>
-        <p className="card-text mb-auto">{text}</p>
-      </div>
-      {imgUrl && (
-        <div className="col-12 col-sm-auto align-self-center">
-          <img
-            className="mx-auto mb-4 img-fluid bg-white"
-            src={imgUrl}
-            alt={imgAlt}
-            width="200"
-            height="250"
-            loading="lazy"
-          />
-        </div>
-      )}
-    </div>
+    <nav aria-label="Sections" className="d-flex flex-wrap justify-content-center d-print-none">
+      {FaqSections.map(section => (
+        <a className="FaqLink text-nowrap mx-2 mb-1" href={`#${section.id}`} key={section.id}>
+          {section.title}
+        </a>
+      ))}
+    </nav>
+    <hr />
   </div>
 )
 
-const PageHeader = () => {
+const FaqSectionCard = ({ section }: { section: IFaqSection }) => {
   const { theme } = useTheme()
+
   return (
-    <div className={`container ${theme.bgColor} ${theme.text} text-center mt-3 pb-2`}>
-      {/* Rendered at h2 size so the page gains a top-level heading without a visual change. */}
-      <h1 className="h2">Frequently Asked Questions</h1>
-      <hr />
+    <div className={`${theme.card} mb-4 shadow-sm`} id={section.id}>
+      <div className={theme.cardHeader}>
+        {/* Sits directly under the page h1, matching every other section header in the product. */}
+        <h2 className="CardHeaderTitle">{section.title}</h2>
+      </div>
+      <div className={theme.cardBody}>
+        {section.entries.map(entry => (
+          <FaqEntry key={entry.id} entry={entry} />
+        ))}
+      </div>
     </div>
   )
 }
+
+const FaqEntry = ({ entry }: { entry: IFaqEntry }) => {
+  const { isDark } = useTheme()
+
+  return (
+    <div className={`FaqEntry PageBreak ${isDark ? 'FaqEntry-Dark' : ''}`}>
+      {/* .h5 keeps the question below the section header in size without changing its outline level. */}
+      <h3 className="h5 mb-2" id={entry.id}>
+        {entry.question}
+      </h3>
+      <div className="mb-0">{entry.answer}</div>
+      {entry.image && <FaqFigure image={entry.image} />}
+    </div>
+  )
+}
+
+const FaqFigure = ({ image }: { image: IFaqImage }) => (
+  <figure className="figure d-block mt-3 mb-0">
+    <img
+      alt={image.alt}
+      className="figure-img img-fluid bg-white border rounded mb-0"
+      height={image.height}
+      loading="lazy"
+      src={image.src}
+      width={image.width}
+    />
+  </figure>
+)
 
 export default Faq

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -96,6 +96,37 @@ small {
     font-size: 11px;
 }
 
+/*
+ * FAQ. Entries stack inside a section card and a hairline separates them, so the Signal Teal
+ * section header stays the only colour on the page. The light value is the same hairline Bootstrap
+ * draws around a card; on Midnight Slate that hairline is invisible, so dark supplies its own.
+ */
+.FaqEntry + .FaqEntry {
+    margin-block-start: 1.25rem;
+    padding-block-start: 1.25rem;
+    border-block-start: 1px solid rgba(0, 0, 0, 0.125);
+}
+
+.FaqEntry-Dark + .FaqEntry-Dark {
+    border-block-start-color: rgba(255, 255, 255, 0.2);
+}
+
+/*
+ * Links here inherit the theme's text colour instead of Bootstrap's $primary. #007bff sits at
+ * 2.6:1 on Midnight Slate, under the 4.5:1 minimum, and the Signal-Colour Rule reserves Action Blue
+ * for the controls that commit. The underline carries "this is a link" in both themes.
+ */
+.FaqLink {
+    color: inherit;
+    text-decoration: underline;
+
+    &:hover,
+    &:focus {
+        color: inherit;
+        text-decoration: underline;
+    }
+}
+
 .text-white-75 {
     color: rgba(255, 255, 255, 0.75) !important;
 }


### PR DESCRIPTION
Rebuilds `/faq` from three ragged cards into a grouped reference page, and takes it from 3 questions to 16.

## Why

The page was Bootstrap's featured-blog-post example, half-adapted, and had drifted a long way from the Field Manual thesis in DESIGN.md:

- **Ragged grid.** `col-12 col-md-8 col-lg-6 col-xl-5` tiled two-up and orphaned the third card on its own row.
- **Screenshots sized wrong.** Both were declared `200x250` regardless of what they were. `faq_unsubscribe.png` is actually 800x280, so it reserved 180px it never used and then rendered at 200x70 — too small to read.
- **Invisible in dark theme.** The cards used a plain `border`, which is `rgba(0,0,0,.125)` and disappears on Midnight Slate.
- **Dead scaffolding.** `h-md-250` and `g-0` (both in DESIGN.md's dead-class table), plus `position-static`/`position-relative` stretched-link scaffolding with no stretched link, and `mb-auto` fighting `card-text`.
- **The contact answer linked nothing.** It named Discord, email, and Github as plain text.

## What changed

One reading column holding **68–69ch from 768px to 1920px**, with questions grouped under four Signal Teal section headers — the product's own card primitive, so the FAQ reads as part of the same manual as the reminders screen rather than as a marketing page bolted on the side.

Sections: Getting started · At the table · Rules and data · Account and subscription.

- Sections read `theme.card`, so dark theme gets its own edge; entries are separated by a hairline that is themed per mode.
- Screenshots carry display dimensions on their true ratio, below capture size, so the box is reserved correctly and **nothing shifts on load**.
- Every question has an `id`, so `/faq#unsubscribe` works, and arriving on a hash is no longer stomped by the unconditional `scrollTo(0, 0)`. A compact section index sits under the `h1`.
- The "incorrect or missing rule" answer now renders the shared `<Contact />` control, so Github/Email/Discord are actually reachable at the point of the question.
- Explicit print behaviour: the masthead and section index are `d-print-none`, entries carry `PageBreak`.
- Links use a `.FaqLink` class that inherits the theme's text colour instead of Bootstrap's `$primary` — `#007bff` sits at **2.6:1** on Midnight Slate, under the 4.5:1 minimum, and the Signal-Colour Rule reserves Action Blue for controls that commit.

## Copy accuracy

Every claim was checked against the source before it was written. Two things are **deliberately not claimed**:

- **The app is not offline-capable.** `src/service-worker.ts` and `serviceWorkerRegistration.ts` exist and `register()` is called, but `vite.config.mts` has no PWA plugin, so `service-worker.js` is never emitted — and `import.meta.env.PUBLIC_URL` is defined nowhere, so `swUrl` resolves to `undefined/service-worker.js`. `PRODUCT.md:77` still claims "PWA with a service worker"; that is stale. The FAQ says the rules data ships with the page and the army is kept in the browser, but that there is no offline cache yet.
- **A share link is not a read-only view.** The recipient gets a fully editable local copy; the modal copy says so.

Control names are spelled exactly as they appear in the UI (`Import Army`, `Hide rule`, `Show Hidden`, `Add note`, `Download PDF`, `Standard`/`Compact`, `My Armies`, `Share Army`, `Visual Theme`, `Cancel Subscription`, `Gift a Subscription`).

## One Bootstrap 5 regression fixed along the way

This branch was written against 4.6 and rebased onto the 5.3 + React 19 upgrades. One real incompatibility surfaced: **Bootstrap 5.3 sets `scroll-behavior: smooth` on `:root`** (4.6 did not), so a bare `scrollIntoView()` starts an animation that page load cancels — the anchor silently did nothing and the reader landed at the masthead. The arrival scroll now passes `behavior: 'instant'`; smooth still applies to the in-page section links, which is where it reads well.

Worth knowing for any other programmatic scrolling on this branch.

## DESIGN.md

`h-md-250` leaves the dead-class table with the layout that carried it (`g-0` had already been removed by the 5.3 upgrade), and the Elevation section now calls them FAQ *section* cards.

## Testing

- Verified in light and dark, on the rebased 5.3 + React 19 stack.
- Swept **320 → 1920px**: no horizontal overflow at any width, measure holds at 68–69ch from 768px up, both screenshots keep their aspect ratio at every size.
- Confirmed no layout shift on image load (measured before/after).
- Keyboard focus ring intact on the new links.
- `yarn lint`, `tsc`, `yarn build`, and the full suite (**843 tests, 63 files**) all pass.

To review: open `/faq`, then try `/faq#unsubscribe` directly and click through the section index. Check both themes and a phone width.

---

https://claude.ai/code/session_01QKr1y1J73tBa3ZMo8JEau3
