### PR TITLE
fix(subscribe): tell already-subscribed visitors the truth

### DIFF
--- a/src/components/helpers/alreadySubscribed.tsx
+++ b/src/components/helpers/alreadySubscribed.tsx
@@ -1,24 +1,52 @@
 import Navbar from 'components/page/navbar'
 import { useTheme } from 'context/useTheme'
-import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { logClick } from 'utils/analytics'
 import { ROUTES } from 'utils/env'
 
+/**
+ * Shown on /subscribe, /join, and /redeem when the visitor already has an active subscription.
+ *
+ * It is never a post-purchase confirmation: Stripe's success URL returns to `/` and gift purchases
+ * return to /profile, so the only way to reach this screen is to arrive at one of those three pages
+ * already subscribed. The old copy — "You are now subscribed :) Thanks!" — claimed the visit had
+ * just done something, which was wrong in every path that can render it.
+ */
 const AlreadySubscribed = () => {
   const { theme } = useTheme()
 
-  useEffect(() => {
-    const timer = window.setTimeout(() => window.location.replace(ROUTES.HOME), 1000)
-    return () => window.clearTimeout(timer)
-  }, [])
-
   return (
-    <div className={`d-block ${theme.text}`}>
+    <div className={`d-block ${theme.bgColor} ${theme.text}`}>
       <div className={`py-2 ${theme.headerColor}`}>
         <Navbar />
       </div>
-      <div className="row d-flex justify-content-center align-items-center">
-        <div className="col mx-5 my-5 py-5 px-5">
-          <h1 className="text-center">You are now subscribed :) Thanks!</h1>
+      {/*
+        The .row used to sit outside any .container, so its -15px gutters ran the page 15px wider
+        than the viewport and scrolled it sideways at every width — the exact failure DESIGN.md
+        names under Layout.
+      */}
+      <div className={`container ${theme.bgColor} RedemptionContainer py-5`}>
+        <div className="row justify-content-center">
+          <div className="col RedemptionColumn text-center">
+            {/* Announced: it replaces the loading screen, so it is not present at first render. */}
+            <div role="status">
+              <h1 className="h2 mb-3">You&apos;re already subscribed</h1>
+              <p className="lead">Thanks for supporting AoS Reminders.</p>
+            </div>
+            {/*
+              The screen used to redirect home 1000ms after mount — a full-page
+              window.location.replace on a hard timer, too short to read the sentence and impossible
+              to cancel (WCAG 2.2.1). This is the destination that timer was guessing at, named for
+              what the visitor came here to find out.
+            */}
+            <Link
+              className={`${theme.genericButton} btn-lg`}
+              onClick={() => logClick('AlreadySubscribed-Profile')}
+              to={ROUTES.PROFILE}
+            >
+              Manage my subscription
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -32,7 +32,8 @@ small {
 }
 
 /*
- * /join and /redeem are one short form on an otherwise empty page. Both used to borrow
+ * /join, /redeem, and the already-subscribed screen they share are one short form or message on an
+ * otherwise empty page. The two redemption routes used to borrow
  * `.LoadingContainer`, whose 35vh top padding is right for two lines of loading text and wrong for
  * a form that grows an error block underneath it — on a 667px phone that padding alone pushed the
  * control 233px down the page. A centred min-height places the form optically on a tall screen and

--- a/src/tests/aos4/accountRoutes.test.tsx
+++ b/src/tests/aos4/accountRoutes.test.tsx
@@ -177,7 +177,7 @@ describe('established account routes', () => {
     expect(container.querySelector('[src="/img/dark_mode1.mp4"]')).toBeNull()
   })
 
-  it('preserves the active-subscriber redirect screen', async () => {
+  it('shows the already-subscribed screen instead of the plans for an active subscriber', async () => {
     subscription.isSubscribed = true
     subscription.isActive = true
 
@@ -193,8 +193,15 @@ describe('established account routes', () => {
       await Promise.resolve()
     })
 
-    expect(container.textContent).toContain('You are now subscribed :) Thanks!')
+    /*
+     * The screen is only reachable by arriving already subscribed — Stripe returns to `/` and gift
+     * purchases to /profile — so it must not claim the visit just subscribed the user.
+     */
+    expect(container.textContent).toContain("You're already subscribed")
+    expect(container.textContent).not.toContain('now subscribed')
     expect(container.textContent).not.toContain('Subscription Plans')
+    // It used to bounce to the home page on a 1000ms timer instead of offering somewhere to go.
+    expect(container.querySelector('a[href="/profile"]')).not.toBeNull()
   })
 
   it('preserves the established profile cards and subscription controls', async () => {


### PR DESCRIPTION
The screen shown on `/subscribe`, `/join`, and `/redeem` when the visitor already has an active subscription said **"You are now subscribed :) Thanks!"** — claiming the visit had just done something.

It never has. Stripe's success URL returns to `/` (`pricingPlans.tsx:97`) and gift purchases return to `/profile` (`giftSubscriptions.tsx:215`), so this is **not** a post-purchase confirmation. The only way to reach it is to arrive at one of those three pages already subscribed — which makes the copy wrong on every path that can render it.

It's most misleading in the case that matters most: someone opening a second coupon or gift link while already subscribed is told they just subscribed, then bounced away in one second before they can ask why their code did nothing.

## Changes

- **Copy is now "You're already subscribed"**, true on every reachable path, with the thanks kept.
- **Removed the 1000ms auto-redirect home.** It was a full-page `window.location.replace` on a hard timer — too short to read the sentence, and impossible to cancel (WCAG 2.2.1 *Timing Adjustable*). A link to `/profile`, where subscription state actually lives, replaces the destination that timer was guessing at.
- **`role="status"`** on the message: it replaces the loading screen, so it isn't present at first render.
- **Fixed a 15px horizontal overflow.** The `.row` sat outside any `.container`, so its negative gutters ran the page wider than the viewport and scrolled it sideways — the exact failure DESIGN.md names under Layout. Measured at 390px and 1024px: **15px before, 0 after.**
- **Added `theme.bgColor`.** Only `theme.text` was set, so in dark theme the white text sat on an unthemed surface. Verified in both themes — 15.4:1 for text and 14.61:1 for the control on Midnight Slate.
- **Sized to match the redemption pages this screen stands in for**: `h1` at `h2` (32px), and a 48px control rather than 38px, which was under the 44px target size PRODUCT.md calls first-class.

## What I did not do

The screen can't explain what happens to an unredeemed coupon or gift when you're already subscribed — whether it stacks, extends, or is simply unused. I don't know the answer and didn't invent one; the `/profile` link is the honest recovery. Worth settling separately if the answer is known.

## Testing

1. With an active subscription, visit `/subscribe`, `/join`, and `/redeem` → each shows "You're already subscribed" and **stays there** rather than bouncing home after a second.
2. "Manage my subscription" navigates to `/profile` in-app (no full page reload).
3. Check for sideways scroll at 390px — there was a 15px overflow at every width before this.
4. Toggle dark mode on `/profile`, then visit `/subscribe` — the screen should be Midnight Slate with an outline-light button, not white text on an unthemed background.

The existing characterization test `preserves the active-subscriber redirect screen` pinned the old copy; it's renamed and updated to assert the new copy, the absence of "now subscribed", and the presence of the `/profile` link. 852 tests pass.

https://claude.ai/code/session_014db9JAAR7Sbw2Xkc2g7uEL
