### PR TITLE
fix(css): extract two design tokens, and fix a 1.80:1 dropzone contrast failure

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -15,6 +15,11 @@ colors:
   danger-red: "#dc3545"
   warning-amber: "#ffc107"
   info-cyan: "#17a2b8"
+  muted-ink: "#4d5a63"
+  dropzone-accent: "#2196f3"
+  modal-edge: "#000000"
+  modal-scrim: "rgba(0, 0, 0, 0.9)"
+  print-tag-edge: "rgba(0, 0, 0, 0.45)"
 typography:
   display:
     fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif"
@@ -42,8 +47,44 @@ typography:
     fontWeight: 700
     lineHeight: 1.35
     letterSpacing: "0.03em"
+  explainer:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif"
+    fontSize: "0.78rem"
+    fontWeight: 400
+    lineHeight: 1.35
+    fontStyle: "italic"
+  fine-print:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif"
+    fontSize: "12px"
+    fontWeight: 400
+    lineHeight: 1.5
+  mono:
+    fontFamily: "source-code-pro, Menlo, Monaco, Consolas, Courier New, monospace"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.5
+  title-compact:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif"
+    fontSize: "1.1rem"
+    fontWeight: 500
+    lineHeight: 1.2
+  body-print:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif"
+    fontSize: "0.9rem"
+    fontWeight: 400
+    lineHeight: 1.5
+titleSizes:
+  base: "1.5rem"
+  sm: "1.1rem"
+  xs: "1rem"
+  xxs: "0.8rem"
+  print: "1.1rem"
+bodySizes:
+  base: "1rem"
+  print: "0.9rem"
 rounded:
   none: "0"
+  none-dropzone: "2px"
   chip: "3px"
   md: "0.25rem"
   pill: "10rem"

--- a/docs/design/2026-07-30-mobile-accessibility-audit.md
+++ b/docs/design/2026-07-30-mobile-accessibility-audit.md
@@ -18,9 +18,12 @@ or the exact source line cited; measured values are quoted verbatim.
 | 1 | Accessibility | 3/4 | +1 | 85 reminder tag buttons are 20 px tall, under the 24 px WCAG 2.5.8 minimum |
 | 2 | Performance | 2/4 | — | One initial chunk is 1.42 MB gzipped — 94% of all shipped JS |
 | 3 | Responsive Design | 3/4 | +1 | Target sizes, not layout, are what still fails on a phone |
-| 4 | Theming | 3/4 | — | Zero contrast failures in either theme; 9 undocumented literal colours remain in `index.scss` |
+| 4 | Theming | 3/4 → **4/4** | +1 | Zero contrast failures in either theme; the literal-colour drift was closed by the amendment below |
 | 5 | Implementation Integrity | 3/4 | +1 | Four dead classes survive, two of them the loading screen's only intended motion |
-| **Total** | | **14/20** | **+3** | **Good — address weak dimensions** |
+| **Total** | | **14/20** → **15/20** | **+4** | **Good — address weak dimensions** |
+
+Scored 14/20 as published; 15/20 after the `/impeccable extract` amendment at the end of this
+document, which also records a P1 contrast failure this pass had missed.
 
 Previous score: **11/20** (Acceptable). **17 of the 23 prior findings are fixed**, including the sole
 P0 and nine of ten P1s.
@@ -274,3 +277,48 @@ None.
   but a real-device pass is still worth doing before launch.
 - No `prefers-reduced-motion` audit beyond `Subscribe.tsx` was needed: the product has one CSS
   transition (the dropzone border) and no other motion.
+
+## Amendment — 2026-07-30, after `/impeccable extract`
+
+Running the recommended `extract` pass on the P3 literal-colour drift surfaced a defect this audit
+had missed, and closed the P3 itself. Both are recorded here rather than by rewriting the findings
+above, so the original pass stays readable as what it was.
+
+### New: [P1] Dropzone instructions were 1.80:1 — WCAG 1.4.3 AA
+
+- **Location**: `src/css/index.scss` `.dropzone { color: #bdbdbd }` over `background-color: #fafafa`
+- **Found**: while assessing whether `#bdbdbd` was worth promoting to a token
+- **Evidence**: measured live with the import modal open, light theme — the dropzone's own
+  instructions, `"Drag and drop your roster here"` (16 px, 700) and
+  `"AoS app or Listbot text (.txt), or New Recruit roster (.ros or .rosz)"` (12 px, 400), both
+  inherited `rgb(189, 189, 189)` on `rgb(250, 250, 250)` for **1.80:1**. The sibling "Choose a file"
+  button was unaffected at 11.02:1 because it carries its own colour.
+- **Why this pass missed it**: contrast was measured on `/` in both themes, and the dropzone only
+  exists inside the import modal. Modal surfaces were not opened. **Route-level contrast sweeps are
+  not sufficient — every modal and overlay needs its own pass.**
+- **Impact**: the two lines that tell a player what the import accepts were effectively invisible on
+  the surface whose entire job is explaining the import. PRODUCT.md records that players commonly
+  arrive with a roster built elsewhere, so this is on a primary path, not a corner.
+- **Fixed in this amendment**: replaced with the muted ink already used by the timing-tag explainer,
+  measured at **6.80:1** on the same background. Bootstrap 5.3's own `.text-muted` (`#6c757d`) was
+  rejected: it measures **4.49:1** against `#fafafa` and misses AA by a hair.
+
+### Resolved: [P3] literal values in `index.scss`
+
+Detector findings across `src/css`, `src/components`, and `src/theme` went **17 → 0**.
+
+- **Promoted to tokens** (`src/css/theme.scss`): `$themeMutedInk` (`#4d5a63`, now two uses with one
+  intent — tag explainer and dropzone) and `$themeDropzoneAccent` (`#2196f3`, three uses plus a
+  derived `rgba($themeDropzoneAccent, 0.08)` drag fill that had been hand-expanded to
+  `rgba(33, 150, 243, 0.08)`).
+- **Recorded in DESIGN.md's frontmatter**: the values whose *prose* the record already described but
+  whose machine-readable block omitted — the print tag edge, modal edge and scrim, the mono stack,
+  fine print at 12 px, the explainer step at 0.78 rem, the dropzone radius, and the `.CardHeaderTitle`
+  responsive and print ramp. This was the bulk of the drift: the design record was correct in
+  English and incomplete in YAML.
+- **Not tokenised**: the dropzone's `#eeeeee` / `#fafafa` / `black` / `whitesmoke` neutrals, each used
+  once with no defect. Extract's own rule is that a value earns a token at three uses with one
+  intent; one-off values earn documentation instead.
+
+Theming moves 3/4 → 4/4. The remaining P1s (target size, bundle) are unchanged, so the total is
+**15/20**.

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -298,7 +298,7 @@ small {
     text-align: start;
 
     &.ReminderTags-Light {
-        color: #4d5a63;
+        color: $themeMutedInk;
     }
 
     &.ReminderTags-Dark {
@@ -502,18 +502,23 @@ small {
     border-color: #eeeeee;
     border-style: dashed;
     background-color: #fafafa;
-    color: #bdbdbd;
+    /*
+     * Was #bdbdbd, which put the dropzone's own instructions at 1.80:1 against this background —
+     * both the "Drag and drop your roster here" label and the accepted-formats line. This is the
+     * same muted ink the timing-tag explainer uses, and measures 6.80:1 here.
+     */
+    color: $themeMutedInk;
     outline: none;
     transition: border 0.24s ease-in-out;
 }
 
 .dropzone:focus {
-    border-color: #2196f3;
+    border-color: $themeDropzoneAccent;
 }
 
 .dropzone.is-dragging {
-    border-color: #2196f3;
-    background-color: rgba(33, 150, 243, 0.08);
+    border-color: $themeDropzoneAccent;
+    background-color: rgba($themeDropzoneAccent, 0.08);
 }
 
 .dropzone.disabled {
@@ -528,7 +533,7 @@ small {
 }
 
 .dropzone-dark:focus {
-    border-color: #2196f3;
+    border-color: $themeDropzoneAccent;
 }
 
 .dropzone-dark.disabled {

--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -15,6 +15,16 @@ $themeLightGray: #e9ecef;
  */
 $themeProfileHeaderDark: mix($themeLightBlue, $themeDarkBlueSecondary, 30%);
 
+/*
+ * Muted secondary text in light theme — the timing-tag explainer and the import dropzone's
+ * instructions. Bootstrap's own `text-muted` (#6c757d) measures 4.49:1 against the dropzone's
+ * #fafafa and so misses AA by a hair; this reaches 6.80:1 on the same surface.
+ */
+$themeMutedInk: #4d5a63;
+
+/* The dropzone's focus and drag-over accent. The drag-over fill is this colour at 8%. */
+$themeDropzoneAccent: #2196f3;
+
 /* Override default Bootstrap variables */
 $grid-breakpoints: (
     xs: 0,


### PR DESCRIPTION
The `/impeccable extract` pass the 2026-07-30 audit recommended for its P3 literal
drift. It surfaced a defect the audit itself had missed.

## The defect

`.dropzone` set `color: #bdbdbd` over `background-color: #fafafa`. Both of its own
instruction lines inherit that colour:

| Text | Measured |
|---|---|
| "Drag and drop your roster here" (16px/700) | **1.80:1** |
| "AoS app or Listbot text (.txt), or New Recruit roster…" (12px/400) | **1.80:1** |
| "Choose a file" (carries its own colour) | 11.02:1 — unaffected |

WCAG 1.4.3 AA needs 4.5:1. The two lines that tell a player what the import accepts
were effectively invisible on the surface whose only job is explaining the import —
and PRODUCT.md records that players commonly arrive with a roster built elsewhere,
so this is a primary path.

**Why the audit missed it:** contrast was measured on `/` in both themes, and the
dropzone only exists inside the import modal. I never opened one. The audit amendment
records the lesson: route-level contrast sweeps aren't sufficient, modals need their own.

**Fix:** the muted ink the timing-tag explainer already uses — **6.80:1** on the same
background, verified live with the modal open. Bootstrap 5.3's own `.text-muted`
(`#6c757d`) was rejected: **4.49:1** against `#fafafa`, missing AA by a hair.

## The extract

Detector findings across `src/css`, `src/components`, `src/theme`: **17 → 0**.

**Promoted to tokens** — both clear the "three uses, one intent" bar or consolidate a
duplicate rather than inventing a value:
- `$themeMutedInk` (`#4d5a63`) — tag explainer + dropzone
- `$themeDropzoneAccent` (`#2196f3`) — three uses, plus a drag fill that had been
  hand-expanded to `rgba(33, 150, 243, 0.08)` and is now derived from the token

**Recorded in DESIGN.md frontmatter** — this was the bulk of it. The design record
already described these in prose; the machine-readable block just didn't list them,
which is why they read as drift: print tag edge, modal edge and scrim, the mono stack,
fine print at 12px, the explainer step, the dropzone radius, and the `.CardHeaderTitle`
responsive/print ramp.

**Deliberately not tokenised:** the dropzone's `#eeeeee` / `#fafafa` / `black` /
`whitesmoke` neutrals — one use each, no defect. Extract's own rule is that a value
earns a token at three uses with one intent; one-off values earn documentation.

## Verification

- Contrast fix measured live in the open modal: 1.80 → **6.80:1**, both texts pass AA
- Detector: 17 → **0**
- `tsc` clean, `eslint` clean, **852 tests pass**, production build succeeds
- Screenshot-checked: the dropzone still reads as muted and subordinate to "Choose a file"

The audit is **amended in place** rather than rewritten, so the original pass stays
readable as what it was. Theming 3/4 → 4/4; total 14/20 → 15/20.

https://claude.ai/code/session_01VBi45V9jhNrgcDJohBdDNW
