### PR TITLE
docs: link companion repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ Read [AGENTS.md](AGENTS.md) for the current Phase 2 scope and migration constrai
 [Phase 1 plan](docs/plans/2026-07-27-001-refactor-aos4-domain-and-data-pipeline-plan.md) remains the
 completed requirements and decision history.
 
+## Companion repositories
+
+- [REST API](https://github.com/daviseford/aos-reminders-rest-api)
+- [Subscription API](https://github.com/daviseford/aos-reminders-subscription-api)
+- [Subscription admin console](https://github.com/daviseford/aos-reminders-admin)
+
+These companion repositories are private.
+
 ## Pull requests and deployment
 
 Migration PRs target `aos4-migration`, never `master`. Every push to `master` builds and deploys the


### PR DESCRIPTION
## Summary

Makes the companion REST API, subscription API, and subscription admin console discoverable from
the main project README. The repositories are identified as private; no runtime or generated files
changed.

Related: daviseford/aos-reminders#1772

## Validation

- `yarn lint`
- `yarn tsc --noEmit`
- `yarn test --run` — 66 files and 856 tests passed
- `yarn build`
- `yarn data:aos4:verify:beta` — 79,294 passed, 0 findings, 0 cannot-verify
- `git diff --check`

No post-deploy monitoring is needed for this documentation-only change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
