### PR TITLE
feat(banner): welcome returning visitors back to an updated site

### DIFF
--- a/src/components/info/banners/app_banner.tsx
+++ b/src/components/info/banners/app_banner.tsx
@@ -1,0 +1,14 @@
+import { NotificationBanner } from 'components/info/banners/notification_banner'
+
+const AppBanner = () => {
+  return (
+    <NotificationBanner enableLog name="2026-aos4-welcome-back" variant="info">
+      <span>
+        <strong>Welcome back!</strong> AoS Reminders is being updated to the latest and greatest. Please
+        excuse any bugs as we get the kinks sorted out. We&apos;re so glad to see you back!
+      </span>
+    </NotificationBanner>
+  )
+}
+
+export default AppBanner

--- a/src/components/info/banners/notification_banner.tsx
+++ b/src/components/info/banners/notification_banner.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react'
+import { centerContentClass } from 'theme/helperClasses'
+import { TBootstrapTypes } from 'types/theme'
+import { logClick, logEvent } from 'utils/analytics'
+
+const storageKey = (name: string) => `aos-reminders:aos4:banner:${name}`
+
+const isDismissed = (name: string): boolean => {
+  try {
+    return window.localStorage.getItem(storageKey(name)) === 'hidden'
+  } catch {
+    // Browser storage can be unavailable in privacy modes. Showing the banner is the safe default.
+    return false
+  }
+}
+
+const rememberDismissal = (name: string) => {
+  try {
+    window.localStorage.setItem(storageKey(name), 'hidden')
+  } catch {
+    // The banner stays closed for this session and returns on the next load.
+  }
+}
+
+interface IBannerProps {
+  enableLog?: boolean
+  name: string
+  persistClose?: boolean
+  variant?: TBootstrapTypes
+}
+
+/**
+ * Re-usable component that can broadcast application notifications.
+ * Closing it is remembered in local storage, keyed by name.
+ */
+export const NotificationBanner = ({
+  children,
+  enableLog = false,
+  name,
+  persistClose = true,
+  variant = 'primary',
+}: React.PropsWithChildren<IBannerProps>) => {
+  const [isOn, setIsOn] = useState(() => !(persistClose && isDismissed(name)))
+
+  useEffect(() => {
+    if (enableLog && isOn) logEvent(`Display-${name}`)
+  }, [enableLog, isOn, name])
+
+  const handleClose = () => {
+    setIsOn(false)
+    if (persistClose) rememberDismissal(name)
+    if (enableLog) logClick(`Close-${name}`)
+  }
+
+  if (!isOn) return null
+
+  return (
+    <div className={`alert alert-${variant} text-center fade show d-flex my-0 d-print-none`} role="alert">
+      <div className={`flex-grow-1 ${centerContentClass}`}>{children}</div>
+      {/*
+        flex-shrink-0 keeps the 24px hit box intact. Without it the long banner text squeezes the
+        close button's 1em width down to ~13px, taking the control under the WCAG 2.5.8 floor.
+      */}
+      <button
+        type="button"
+        className="btn-close align-self-start ms-2 flex-shrink-0"
+        aria-label="Close notification"
+        onClick={handleClose}
+      />
+    </div>
+  )
+}

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -9,6 +9,7 @@ import {
   createAos4ReminderViewModel,
   type Aos4ReminderViewModel,
 } from '../../aos4/view'
+import AppBanner from 'components/info/banners/app_banner'
 import Reminders, { type ReminderSourceLink } from 'components/info/reminders'
 import ArmyBuilder from 'components/input/army_builder'
 import { useSubscriberAction } from 'components/input/importArmy/subscriberAction'
@@ -229,6 +230,8 @@ const HomeContent = () => {
         onFactionChange={selectFaction}
         onToggleGameMode={() => setIsGameMode(current => !current)}
       />
+
+      <AppBanner />
 
       {!isGameMode && <ArmyBuilder builder={builder} onSetGroupSelections={setSelections} />}
 

--- a/src/tests/aos4/legacyIsolation.test.ts
+++ b/src/tests/aos4/legacyIsolation.test.ts
@@ -112,6 +112,8 @@ describe('AoS 4 legacy isolation', () => {
       'components/helpers/link.tsx',
       'components/helpers/spinner.tsx',
       'components/helpers/suspenseFallbacks.tsx',
+      'components/info/banners/app_banner.tsx',
+      'components/info/banners/notification_banner.tsx',
       'components/info/donate.tsx',
       'components/info/offline.tsx',
       'components/info/reminders.tsx',


### PR DESCRIPTION
## What

Restores the dismissible app banner, with new copy for returning visitors:

> **Welcome back!** AoS Reminders is being updated to the latest and greatest. Please excuse any bugs as we get the kinks sorted out. We're so glad to see you back!

## Why

Production still shows the 2024 "this site is no longer actively maintained" notice. The AoS 4 cutover deleted `src/components/info/banners/` wholesale along with the rest of the AoS 3 shell, so there was nothing left to edit — the banner pair is rebuilt rather than modified.

## Notes

- `notification_banner.tsx` is Bootstrap 5-native (`btn-close`, `ms-2`) instead of the retired 4.6 markup (`close`, `ml-2`). Dismissal persists under the versioned key `aos-reminders:aos4:banner:<name>`, and `localStorage` access is guarded so privacy modes fall back to showing the banner rather than throwing.
- Display and close still log to GA, via `logEvent`/`logClick` — the old `logDisplay` helper went away with `utils/localStore`.
- `info` variant, not the `warning` the goodbye banner used. Warning reads as a problem; this message isn't one.
- **`flex-shrink-0` on the close button is load-bearing.** `.btn-close`'s `1em` width is a flex basis, so the long banner text squeezed the control to 21.5×24 — under the 24px WCAG 2.5.8 floor that #1782 established. Measured 24×24 after.
- `Home` imports the banner eagerly rather than lazily as the old one did. It renders above the fold and weighs almost nothing, so a separate chunk would only delay it.
- The presentation-shell allowlist in `legacyIsolation.test.ts` is exhaustive, so both new files are listed there.

## Testing instructions

1. `yarn start`, open the app. The banner sits directly under the masthead, above the builder.
2. Click the ×. It disappears; reload and it stays gone.
3. `localStorage.removeItem('aos-reminders:aos4:banner:2026-aos4-welcome-back')` and reload — it's back.
4. Toggle dark theme and confirm it still reads well (the alert keeps its own light surface, as the previous banner did).

Verified locally: renders correctly in both themes; at a 390px-wide container the text wraps without colliding with the close button and there's no horizontal overflow. `yarn lint`, `yarn tsc --noEmit`, and `yarn test --run` (856 tests / 66 files) all pass.

https://claude.ai/code/session_01VBi45V9jhNrgcDJohBdDNW
