### PR TITLE
fix(import): split every lore row, not just manifestations

### DIFF
--- a/src/importers/aos4/officialApp.ts
+++ b/src/importers/aos4/officialApp.ts
@@ -230,11 +230,11 @@ export const parseOfficialAppRoster = (lines: Aos4ImportLine[]): Aos4ParsedRoste
     const lore = line.text.match(lorePattern)
     if (lore) {
       const kindHint = loreKind(lore[1])
-      // Manifestations are picked individually now — `Manifestation Lore - A (20 Points), B and C`
-      // is three selections, not one lore named after all of them.
-      const labels =
-        kindHint === 'manifestation-lore' ? splitConjoinedList(lore[2]) : [lore[2].trim()]
-      labels.forEach(label => {
+      // Every lore row can hold several picks — `Spell Lore - Lore of Hysh, Lore of the Awakened
+      // Realms and Lore of Prismatic Resonance (10 Points)` is three selections, not one lore named
+      // after all of them. Safe to split because no lore the catalog carries has a comma or the
+      // word "and" in its name; battle formations do (`Pioneers and Scavengers`) and are not split.
+      splitConjoinedList(lore[2]).forEach(label => {
         selections.push({ line: line.number, label: stripPointsSuffix(label), kindHint })
       })
       return

--- a/src/tests/aos4/importOfficialApp.test.ts
+++ b/src/tests/aos4/importOfficialApp.test.ts
@@ -125,6 +125,27 @@ describe('official AoS app text import', () => {
       ])
     })
 
+    it('splits a spell lore row holding several picks', () => {
+      // Not just manifestations — a spell lore row carries multiple lores too, with the points
+      // suffix on the row rather than on each member.
+      const parsed = decode(
+        'Grand Alliance Order | Lumineth Realm-lords | Warhost of Duality (20 Points)',
+        'Spell Lore - Lore of Hysh, Lore of the Awakened Realms and Lore of Prismatic Resonance (10 Points)'
+      )
+      expect(labelled(parsed, 'spell-lore')).toEqual([
+        'Lore of Hysh',
+        'Lore of the Awakened Realms',
+        'Lore of Prismatic Resonance',
+      ])
+    })
+
+    it('does not split a battle formation whose own name contains "and"', () => {
+      // `Pioneers and Scavengers` and `Mutants and Mad Things` are single formations. Lore rows are
+      // lists; a formation row never is, so it must survive the conjunction untouched.
+      const parsed = decode('Grand Alliance Chaos | Slaves to Darkness | Pioneers and Scavengers')
+      expect(labelled(parsed, 'battle-formation')).toEqual(['Pioneers and Scavengers'])
+    })
+
     it('leaves a single-valued lore and a name containing "and" intact', () => {
       const parsed = decode(
         'Grand Alliance Order | Cities of Sigmar | Grudgebound War Throng',

--- a/src/tests/fixtures/aos4/import/official-app/README.md
+++ b/src/tests/fixtures/aos4/import/official-app/README.md
@@ -67,6 +67,7 @@ Fail closed on malformed or hostile input, never on an illegal army.
 | `fs-001-older-handbook` | `General's Handbook 2024-25`, two seasons back, and no battle tactics line |
 | `idk-001-renown-army-no-lore` | an Army of Renown with no lore, drops or tactics rows at all — header, regiments and terrain only |
 | `ko-001-renown-army-repeats` | a two-part Army of Renown header with a `• Legends` mark mid-regiment and repeated units across two regiments |
+| `lrl-001-multi-lore` | a spell lore row holding three lores and a manifestation row holding seven, both with points suffixes, plus two identical faction terrain entries |
 
 ## Points are dropped on purpose
 

--- a/src/tests/fixtures/aos4/import/official-app/lists/lrl-001-multi-lore/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/lrl-001-multi-lore/expected.json
@@ -1,0 +1,334 @@
+{
+  "id": "lrl-001-multi-lore",
+  "diagnostics": [],
+  "proposedName": "Lrl1",
+  "declaredFaction": "Lumineth Realm-lords",
+  "declaredContext": "General's Handbook 2025-26",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Warhost of Duality"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of Hysh"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of the Awakened Realms"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of Prismatic Resonance"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Twilit Sorceries"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Morbid Conjuration"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Forbidden Power"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Manifestations of Hysh"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Primal Energy"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Krondspine Incarnate"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Aetherwrought Machineries"
+    },
+    {
+      "line": 12,
+      "kindHint": "warscroll",
+      "label": "Archmage Teclis and Celennar, Spirit of Hysh"
+    },
+    {
+      "line": 13,
+      "kindHint": "warscroll",
+      "label": "Alarith Spirit of the Mountain"
+    },
+    {
+      "line": 14,
+      "kindHint": "warscroll",
+      "label": "Alarith Stoneguard"
+    },
+    {
+      "line": 15,
+      "kindHint": "warscroll",
+      "label": "Hurakan Spirit of the Wind"
+    },
+    {
+      "line": 16,
+      "kindHint": "warscroll",
+      "label": "Hurakan Windchargers"
+    },
+    {
+      "line": 17,
+      "kindHint": "warscroll",
+      "label": "Myari's Purifiers",
+      "isLegends": true
+    },
+    {
+      "line": 19,
+      "kindHint": "warscroll",
+      "label": "Scourge of Ghyran The Light of Eltharion"
+    },
+    {
+      "line": 20,
+      "kindHint": "warscroll",
+      "label": "Scourge of Ghyran Vanari Bannerblade"
+    },
+    {
+      "line": 21,
+      "kindHint": "warscroll",
+      "label": "The Light of Eltharion"
+    },
+    {
+      "line": 22,
+      "kindHint": "warscroll",
+      "label": "Thyrielle's Zephyrites",
+      "isLegends": true
+    },
+    {
+      "line": 24,
+      "kindHint": "warscroll",
+      "label": "Vanari Auralan Sentinels"
+    },
+    {
+      "line": 25,
+      "kindHint": "warscroll",
+      "label": "Vanari Auralan Wardens"
+    },
+    {
+      "line": 26,
+      "kindHint": "warscroll",
+      "label": "Vanari Bannerblade"
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Vanari Bladelords"
+    },
+    {
+      "line": 28,
+      "kindHint": "warscroll",
+      "label": "Vanari Dawnriders"
+    },
+    {
+      "line": 29,
+      "kindHint": "warscroll",
+      "label": "Vanari Dawnriders"
+    },
+    {
+      "line": 30,
+      "kindHint": "warscroll",
+      "label": "Vanari Dawnriders"
+    },
+    {
+      "line": 31,
+      "kindHint": "warscroll",
+      "label": "Vanari Lord Regent"
+    },
+    {
+      "line": 32,
+      "kindHint": "warscroll",
+      "label": "Vanari Starshard Ballista"
+    },
+    {
+      "line": 33,
+      "kindHint": "warscroll",
+      "label": "Vanari Starshard Ballista"
+    },
+    {
+      "line": 34,
+      "kindHint": "warscroll",
+      "label": "Ydrilan Riverblades"
+    },
+    {
+      "line": 37,
+      "kindHint": "warscroll",
+      "label": "Alarith Stonemage"
+    },
+    {
+      "line": 40,
+      "kindHint": "warscroll",
+      "label": "Ellania and Ellathor, Eclipsian Warsages"
+    },
+    {
+      "line": 43,
+      "kindHint": "warscroll",
+      "label": "Avalenor, The Stoneheart King"
+    },
+    {
+      "line": 46,
+      "kindHint": "warscroll",
+      "label": "Vanari Lord Regent on Lightcourser"
+    },
+    {
+      "line": 49,
+      "kindHint": "warscroll",
+      "label": "Alarith Spirit of the Mountain"
+    },
+    {
+      "line": 50,
+      "kindHint": "warscroll",
+      "label": "Alarith Stoneguard"
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Alarith Stonemage"
+    },
+    {
+      "line": 52,
+      "kindHint": "warscroll",
+      "label": "Archmage Teclis and Celennar, Spirit of Hysh"
+    },
+    {
+      "line": 53,
+      "kindHint": "warscroll",
+      "label": "Avalenor, The Stoneheart King"
+    },
+    {
+      "line": 54,
+      "kindHint": "warscroll",
+      "label": "Ellania and Ellathor, Eclipsian Warsages"
+    },
+    {
+      "line": 55,
+      "kindHint": "warscroll",
+      "label": "Hurakan Windchargers"
+    },
+    {
+      "line": 56,
+      "kindHint": "warscroll",
+      "label": "Hurakan Windmage"
+    },
+    {
+      "line": 57,
+      "kindHint": "warscroll",
+      "label": "Lyrior Uthralle, Warden of Ymetrica"
+    },
+    {
+      "line": 58,
+      "kindHint": "warscroll",
+      "label": "Myari's Purifiers",
+      "isLegends": true
+    },
+    {
+      "line": 60,
+      "kindHint": "warscroll",
+      "label": "Scinari Calligrave"
+    },
+    {
+      "line": 61,
+      "kindHint": "warscroll",
+      "label": "Scinari Cathallar"
+    },
+    {
+      "line": 62,
+      "kindHint": "warscroll",
+      "label": "Scinari Enlightener"
+    },
+    {
+      "line": 63,
+      "kindHint": "warscroll",
+      "label": "Scinari Loreseeker"
+    },
+    {
+      "line": 64,
+      "kindHint": "warscroll",
+      "label": "Scourge of Ghyran The Light of Eltharion"
+    },
+    {
+      "line": 65,
+      "kindHint": "warscroll",
+      "label": "Scourge of Ghyran Vanari Bannerblade"
+    },
+    {
+      "line": 66,
+      "kindHint": "warscroll",
+      "label": "Sevireth, Lord of the Seventh Wind"
+    },
+    {
+      "line": 67,
+      "kindHint": "warscroll",
+      "label": "The Light of Eltharion"
+    },
+    {
+      "line": 68,
+      "kindHint": "warscroll",
+      "label": "Thyrielle's Zephyrites",
+      "isLegends": true
+    },
+    {
+      "line": 70,
+      "kindHint": "warscroll",
+      "label": "Vanari Auralan Sentinels"
+    },
+    {
+      "line": 71,
+      "kindHint": "warscroll",
+      "label": "Vanari Auralan Wardens"
+    },
+    {
+      "line": 72,
+      "kindHint": "warscroll",
+      "label": "Vanari Bannerblade"
+    },
+    {
+      "line": 73,
+      "kindHint": "warscroll",
+      "label": "Vanari Dawnriders"
+    },
+    {
+      "line": 74,
+      "kindHint": "warscroll",
+      "label": "Vanari Lord Regent"
+    },
+    {
+      "line": 75,
+      "kindHint": "warscroll",
+      "label": "Vanari Lord Regent on Lightcourser"
+    },
+    {
+      "line": 76,
+      "kindHint": "warscroll",
+      "label": "Ydrilan Riverblades"
+    },
+    {
+      "line": 79,
+      "kindHint": "warscroll",
+      "label": "Shrine Luminor"
+    },
+    {
+      "line": 80,
+      "kindHint": "warscroll",
+      "label": "Shrine Luminor"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/lrl-001-multi-lore/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/lrl-001-multi-lore/list.txt
@@ -1,0 +1,83 @@
+Lrl1 17180/3000 pts
+-----
+Grand Alliance Order | Lumineth Realm-lords | Warhost of Duality (20 Points)
+General's Handbook 2025-26
+Auxiliaries: 26 (+6500 Points)
+Drops: 31
+Spell Lore - Lore of Hysh, Lore of the Awakened Realms and Lore of Prismatic Resonance (10 Points)
+Manifestation Lore - Twilit Sorceries, Morbid Conjuration (20 Points), Forbidden Power (20 Points), Manifestations of Hysh, Primal Energy (10 Points), Krondspine Incarnate and Aetherwrought Machineries
+Battle Tactics Cards: Attuned to Ghyran, Intercept and Recover, Master The Paths, Restless Energy, Scouting Force and Wrathful Cycles
+-----
+Regiment 1
+Archmage Teclis and Celennar, Spirit of Hysh (640)
+Alarith Spirit of the Mountain (310)
+Alarith Stoneguard (130)
+Hurakan Spirit of the Wind (270)
+Hurakan Windchargers (170)
+Myari's Purifiers (130)
+• Legends
+Scourge of Ghyran The Light of Eltharion (280)
+Scourge of Ghyran Vanari Bannerblade (140)
+The Light of Eltharion (300)
+Thyrielle's Zephyrites (190)
+• Legends
+Vanari Auralan Sentinels (150)
+Vanari Auralan Wardens (120)
+Vanari Bannerblade (130)
+Vanari Bladelords (150)
+Vanari Dawnriders (200)
+Vanari Dawnriders (200)
+Vanari Dawnriders (200)
+Vanari Lord Regent (110)
+Vanari Starshard Ballista (100)
+Vanari Starshard Ballista (100)
+Ydrilan Riverblades (150)
+---
+Regiment 2
+Alarith Stonemage (120)
+---
+Regiment 3
+Ellania and Ellathor, Eclipsian Warsages (310)
+---
+Regiment 4
+Avalenor, The Stoneheart King (400)
+---
+Regiment 5
+Vanari Lord Regent on Lightcourser (150)
+-----
+Auxiliary Units
+Alarith Spirit of the Mountain (310)
+Alarith Stoneguard (130)
+Alarith Stonemage (120)
+Archmage Teclis and Celennar, Spirit of Hysh (640)
+Avalenor, The Stoneheart King (400)
+Ellania and Ellathor, Eclipsian Warsages (310)
+Hurakan Windchargers (170)
+Hurakan Windmage (140)
+Lyrior Uthralle, Warden of Ymetrica (260)
+Myari's Purifiers (130)
+• Legends
+Scinari Calligrave (130)
+Scinari Cathallar (130)
+Scinari Enlightener (180)
+Scinari Loreseeker (130)
+Scourge of Ghyran The Light of Eltharion (280)
+Scourge of Ghyran Vanari Bannerblade (140)
+Sevireth, Lord of the Seventh Wind (350)
+The Light of Eltharion (300)
+Thyrielle's Zephyrites (190)
+• Legends
+Vanari Auralan Sentinels (150)
+Vanari Auralan Wardens (120)
+Vanari Bannerblade (130)
+Vanari Dawnriders (200)
+Vanari Lord Regent (110)
+Vanari Lord Regent on Lightcourser (150)
+Ydrilan Riverblades (150)
+-----
+Faction Terrain
+Shrine Luminor
+Shrine Luminor
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466


### PR DESCRIPTION
Follow-up to #1787, from a Lumineth list that exposed a shape the first pass missed.

## The bug

Spell lore rows hold several picks, exactly like manifestation rows:

```
Spell Lore - Lore of Hysh, Lore of the Awakened Realms and Lore of Prismatic Resonance (10 Points)
```

#1787 only split manifestations, so this arrived as a single selection labelled after all three lores and matched nothing. The split now applies to spell, prayer and manifestation rows alike.

## Why splitting these is safe

No lore the generated catalog carries has a comma or the word "and" in its name — checked across all `spell-lore`, `prayer-lore` and `manifestation-lore` content-groups. Battle formations *do*: `Pioneers and Scavengers` and `Mutants and Mad Things`. A formation row is never a list, so it stays unsplit, and there is a test pinning that.

Splitting still only breaks the final comma segment on `" and "`, so a member named with the word survives ahead of the conjunction.

## Fixture

`lrl-001-multi-lore` is the source list: three lores on the spell row, seven on the manifestation row, both carrying points suffixes, plus two identical `Shrine Luminor` terrain entries. It parses to 64 selections.

No existing golden changed — a single-valued row passes through the split untouched.

## Testing

- `yarn test --run` — 926 tests across 67 files
- `yarn tsc --noEmit` and `yarn lint` clean