### PR TITLE
test(import): cover model counts and a Legends-heavy renown army

### DIFF
--- a/src/tests/aos4/importOfficialApp.test.ts
+++ b/src/tests/aos4/importOfficialApp.test.ts
@@ -139,6 +139,19 @@ describe('official AoS app text import', () => {
       ])
     })
 
+    it('splits a lore row but never a unit name, in the same list', () => {
+      // Both shapes appear together in a real Tzeentch export. Only lore rows are lists; a unit
+      // line is one name however many conjunctions it holds.
+      const parsed = decode(
+        'Grand Alliance Chaos | Disciples of Tzeentch | Denizens of the Silver Towers',
+        'Spell Lore - Lore of Change and Lore of Fate',
+        'Auxiliary Units',
+        'Blue Horrors and Brimstone Horrors (120)'
+      )
+      expect(labelled(parsed, 'spell-lore')).toEqual(['Lore of Change', 'Lore of Fate'])
+      expect(labelled(parsed, 'warscroll')).toEqual(['Blue Horrors and Brimstone Horrors'])
+    })
+
     it('does not split a battle formation whose own name contains "and"', () => {
       // `Pioneers and Scavengers` and `Mutants and Mad Things` are single formations. Lore rows are
       // lists; a formation row never is, so it must survive the conjunction untouched.
@@ -253,6 +266,29 @@ describe('official AoS app text import', () => {
       )
       expect(parsed?.selections.find(s => s.label === 'Megaboss')?.isRegimentOfRenown).toBeUndefined()
       expect(parsed?.selections.find(s => s.label === 'Beast-skewer Killbow')?.isRegimentOfRenown).toBe(true)
+    })
+
+    it('marks faction terrain as Legends when the bullet follows it', () => {
+      // A wholly retired faction marks its terrain too, so the bullet is not confined to units.
+      const parsed = decode(
+        'Grand Alliance Chaos | Beasts of Chaos | Marauding Brayherd',
+        'Faction Terrain',
+        'Herdstone',
+        '• Legends'
+      )
+      expect(parsed?.selections.find(s => s.label === 'Herdstone')?.isLegends).toBe(true)
+      expect(parsed?.allowsLegends).toBe(true)
+    })
+
+    it('decodes a roster that declares no units at all', () => {
+      // An empty list has no section headers, so header detection cannot lean on finding one.
+      const parsed = decode('Cities of Sigmar | Allies of the Free Cities', 'Army of Renown')
+
+      expect(parsed?.proposedName).toBe('Test')
+      expect(parsed?.declaredFaction).toBe('Cities of Sigmar')
+      expect(parsed?.selections).toEqual([
+        expect.objectContaining({ label: 'Allies of the Free Cities', kindHint: 'battle-formation' }),
+      ])
     })
 
     it('ignores roster bookkeeping the app emits alongside composition', () => {

--- a/src/tests/aos4/importOfficialApp.test.ts
+++ b/src/tests/aos4/importOfficialApp.test.ts
@@ -197,6 +197,19 @@ describe('official AoS app text import', () => {
       expect(labelled(parsed, 'warscroll')).toEqual(['Freeguild Fusiliers'])
     })
 
+    it('keeps a model count in the label but drops the points beside it', () => {
+      // `Terradon Riders (2 models) (70)` carries two parenthesised suffixes. Only the points are
+      // bookkeeping — the catalog ships the size variant as its own warscroll, so the count is part
+      // of the identity and has to survive for the roster to pick the right one.
+      const parsed = decode(
+        'Grand Alliance Order | Seraphon | Sunclaw Starhost',
+        'Regiment 1',
+        'Terradon Riders (90)',
+        'Terradon Riders (2 models) (70)'
+      )
+      expect(labelled(parsed, 'warscroll')).toEqual(['Terradon Riders', 'Terradon Riders (2 models)'])
+    })
+
     it('keeps every faction terrain entry, not just the first', () => {
       const parsed = decode(
         'Grand Alliance Destruction | Ogor Mawtribes | Greedy Eaters',

--- a/src/tests/fixtures/aos4/import/official-app/README.md
+++ b/src/tests/fixtures/aos4/import/official-app/README.md
@@ -68,6 +68,8 @@ Fail closed on malformed or hostile input, never on an illegal army.
 | `idk-001-renown-army-no-lore` | an Army of Renown with no lore, drops or tactics rows at all — header, regiments and terrain only |
 | `ko-001-renown-army-repeats` | a two-part Army of Renown header with a `• Legends` mark mid-regiment and repeated units across two regiments |
 | `lrl-001-multi-lore` | a spell lore row holding three lores and a manifestation row holding seven, both with points suffixes, plus two identical faction terrain entries |
+| `ser-002-model-counts` | `Terradon Riders (2 models) (70)` — a model count and a points cost on one line — plus three identical faction terrain entries |
+| `sce-002-renown-army-legends` | 17 `• Legends` marks in one list, mixed straight and curly apostrophes, two pointed faction terrain entries |
 
 ## Points are dropped on purpose
 

--- a/src/tests/fixtures/aos4/import/official-app/README.md
+++ b/src/tests/fixtures/aos4/import/official-app/README.md
@@ -71,6 +71,13 @@ Fail closed on malformed or hostile input, never on an illegal army.
 | `ser-002-model-counts` | `Terradon Riders (2 models) (70)` — a model count and a points cost on one line — plus three identical faction terrain entries |
 | `sce-002-renown-army-legends` | 17 `• Legends` marks in one list, mixed straight and curly apostrophes, two pointed faction terrain entries |
 | `syl-001-outcasts` | the app writes `Scourge of Aqshy: X` where the catalog carries `Scourge of Aqshy X` — label normalisation absorbs the colon, and this pins it |
+| `cos-002-empty-roster` | a roster with no units at all — no section headers, so header detection cannot lean on finding one |
+| `boc-001-all-legends` | a wholly retired faction: every unit marked `• Legends`, including the faction terrain |
+| `bok-001-baleful-lords` | a small two-part Army of Renown over points, with regiments numbered 1, 3 and 5 |
+| `bok-002-multi-prayer-lore` | a prayer lore row holding two lores, and the misspelling in the app output (`Blood Blesssings`) kept verbatim |
+| `dot-001-and-in-unit-name` | the boundary in one list: a spell lore row **is** split on ` and `, while `Blue Horrors and Brimstone Horrors` is one unit and must not be |
+| `hos-001-auxiliary-only` | no `Regiment N` sections at all — the roster goes straight from the header to `Auxiliary Units` |
+| `hh-001-renown-stress` | 18 dashless regiments of renown, 51 members, one bundle repeated four times — the densest renown case in the corpus |
 
 ## Points are dropped on purpose
 

--- a/src/tests/fixtures/aos4/import/official-app/README.md
+++ b/src/tests/fixtures/aos4/import/official-app/README.md
@@ -70,6 +70,7 @@ Fail closed on malformed or hostile input, never on an illegal army.
 | `lrl-001-multi-lore` | a spell lore row holding three lores and a manifestation row holding seven, both with points suffixes, plus two identical faction terrain entries |
 | `ser-002-model-counts` | `Terradon Riders (2 models) (70)` — a model count and a points cost on one line — plus three identical faction terrain entries |
 | `sce-002-renown-army-legends` | 17 `• Legends` marks in one list, mixed straight and curly apostrophes, two pointed faction terrain entries |
+| `syl-001-outcasts` | the app writes `Scourge of Aqshy: X` where the catalog carries `Scourge of Aqshy X` — label normalisation absorbs the colon, and this pins it |
 
 ## Points are dropped on purpose
 

--- a/src/tests/fixtures/aos4/import/official-app/lists/boc-001-all-legends/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/boc-001-all-legends/expected.json
@@ -1,0 +1,204 @@
+{
+  "id": "boc-001-all-legends",
+  "diagnostics": [],
+  "proposedName": "Boc1",
+  "declaredFaction": "Beasts of Chaos",
+  "declaredContext": "General's Handbook 2025-26",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Marauding Brayherd"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of the Twisted Wilds"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Bestial Manifestations"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Twilit Sorceries"
+    },
+    {
+      "line": 11,
+      "kindHint": "warscroll",
+      "label": "Doombull",
+      "isLegends": true
+    },
+    {
+      "line": 15,
+      "kindHint": "warscroll",
+      "label": "Great Bray-Shaman",
+      "isLegends": true
+    },
+    {
+      "line": 19,
+      "kindHint": "warscroll",
+      "label": "Beastlord",
+      "isLegends": true
+    },
+    {
+      "line": 21,
+      "kindHint": "warscroll",
+      "label": "Beastlord",
+      "isLegends": true
+    },
+    {
+      "line": 23,
+      "kindHint": "warscroll",
+      "label": "Beasts of Chaos Chaos Spawn",
+      "isLegends": true
+    },
+    {
+      "line": 25,
+      "kindHint": "warscroll",
+      "label": "Bestigors",
+      "isLegends": true
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Bullgors",
+      "isLegends": true
+    },
+    {
+      "line": 29,
+      "kindHint": "warscroll",
+      "label": "Centigors",
+      "isLegends": true
+    },
+    {
+      "line": 31,
+      "kindHint": "warscroll",
+      "label": "Chaos Gargant",
+      "isLegends": true
+    },
+    {
+      "line": 33,
+      "kindHint": "warscroll",
+      "label": "Chaos Warhounds",
+      "isLegends": true
+    },
+    {
+      "line": 35,
+      "kindHint": "warscroll",
+      "label": "Chimera",
+      "isLegends": true
+    },
+    {
+      "line": 37,
+      "kindHint": "warscroll",
+      "label": "Cockatrice",
+      "isLegends": true
+    },
+    {
+      "line": 39,
+      "kindHint": "warscroll",
+      "label": "Cygor",
+      "isLegends": true
+    },
+    {
+      "line": 41,
+      "kindHint": "warscroll",
+      "label": "Doombull",
+      "isLegends": true
+    },
+    {
+      "line": 43,
+      "kindHint": "warscroll",
+      "label": "Dragon Ogors",
+      "isLegends": true
+    },
+    {
+      "line": 45,
+      "kindHint": "warscroll",
+      "label": "Ghorgon",
+      "isLegends": true
+    },
+    {
+      "line": 47,
+      "kindHint": "warscroll",
+      "label": "Gors",
+      "isLegends": true
+    },
+    {
+      "line": 49,
+      "kindHint": "warscroll",
+      "label": "Grashrak's Despoilers",
+      "isLegends": true
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Jabberslythe",
+      "isLegends": true
+    },
+    {
+      "line": 53,
+      "kindHint": "warscroll",
+      "label": "Razorgor",
+      "isLegends": true
+    },
+    {
+      "line": 55,
+      "kindHint": "warscroll",
+      "label": "Tuskgor Chariots",
+      "isLegends": true
+    },
+    {
+      "line": 57,
+      "kindHint": "warscroll",
+      "label": "Tuskgor Chariots",
+      "isLegends": true
+    },
+    {
+      "line": 59,
+      "kindHint": "warscroll",
+      "label": "Tuskgor Chariots",
+      "isLegends": true
+    },
+    {
+      "line": 61,
+      "kindHint": "warscroll",
+      "label": "Ungor Raiders",
+      "isLegends": true
+    },
+    {
+      "line": 63,
+      "kindHint": "warscroll",
+      "label": "Ungors",
+      "isLegends": true
+    },
+    {
+      "line": 67,
+      "kindHint": "warscroll",
+      "label": "Beastlord",
+      "isLegends": true
+    },
+    {
+      "line": 69,
+      "kindHint": "warscroll",
+      "label": "Doombull",
+      "isLegends": true
+    },
+    {
+      "line": 71,
+      "kindHint": "warscroll",
+      "label": "Dragon Ogor Shaggoth",
+      "isLegends": true
+    },
+    {
+      "line": 75,
+      "kindHint": "warscroll",
+      "label": "Herdstone",
+      "isLegends": true
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/boc-001-all-legends/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/boc-001-all-legends/list.txt
@@ -1,0 +1,79 @@
+Boc1 4150/1000 pts
+-----
+Grand Alliance Chaos | Beasts of Chaos | Marauding Brayherd
+General's Handbook 2025-26
+Auxiliaries: 3 (+60 Points)
+Drops: 6
+Spell Lore - Lore of the Twisted Wilds
+Manifestation Lore - Bestial Manifestations and Twilit Sorceries
+-----
+Regiment 1
+Doombull (170)
+• Legends
+---
+Regiment 3
+Great Bray-Shaman (140)
+• Legends
+---
+Regiment 5
+Beastlord (150)
+• Legends
+Beastlord (150)
+• Legends
+Beasts of Chaos Chaos Spawn (70)
+• Legends
+Bestigors (220)
+• Legends
+Bullgors (170)
+• Legends
+Centigors (170)
+• Legends
+Chaos Gargant (140)
+• Legends
+Chaos Warhounds (130)
+• Legends
+Chimera (200)
+• Legends
+Cockatrice (150)
+• Legends
+Cygor (170)
+• Legends
+Doombull (170)
+• Legends
+Dragon Ogors (200)
+• Legends
+Ghorgon (180)
+• Legends
+Gors (100)
+• Legends
+Grashrak's Despoilers (100)
+• Legends
+Jabberslythe (190)
+• Legends
+Razorgor (70)
+• Legends
+Tuskgor Chariots (110)
+• Legends
+Tuskgor Chariots (110)
+• Legends
+Tuskgor Chariots (110)
+• Legends
+Ungor Raiders (90)
+• Legends
+Ungors (90)
+• Legends
+-----
+Auxiliary Units
+Beastlord (150)
+• Legends
+Doombull (170)
+• Legends
+Dragon Ogor Shaggoth (220)
+• Legends
+-----
+Faction Terrain
+Herdstone
+• Legends
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/bok-001-baleful-lords/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/bok-001-baleful-lords/expected.json
@@ -1,0 +1,70 @@
+{
+  "id": "bok-001-baleful-lords",
+  "diagnostics": [],
+  "proposedName": "Khorne1",
+  "declaredFaction": "Blades of Khorne",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": false,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "The Baleful Lords"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Morbid Conjuration"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Krondspine Incarnate"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Aetherwrought Machineries"
+    },
+    {
+      "line": 12,
+      "kindHint": "warscroll",
+      "label": "Bloodthirster of Unfettered Fury"
+    },
+    {
+      "line": 15,
+      "kindHint": "warscroll",
+      "label": "Skarbrand"
+    },
+    {
+      "line": 18,
+      "kindHint": "warscroll",
+      "label": "Skarbrand"
+    },
+    {
+      "line": 21,
+      "kindHint": "warscroll",
+      "label": "Bloodthirster of Insensate Rage"
+    },
+    {
+      "line": 22,
+      "kindHint": "warscroll",
+      "label": "Bloodthirster of Unfettered Fury"
+    },
+    {
+      "line": 23,
+      "kindHint": "warscroll",
+      "label": "Skarbrand"
+    },
+    {
+      "line": 24,
+      "kindHint": "warscroll",
+      "label": "Wrath of Khorne Bloodthirster"
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Skull Altar"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/bok-001-baleful-lords/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/bok-001-baleful-lords/list.txt
@@ -1,0 +1,30 @@
+Khorne1 3020/2000 pts
+-----
+Blades of Khorne | The Baleful Lords
+Army of Renown
+General's Handbook 2026-27
+Auxiliaries: 4 (+120 Points)
+Drops: 7
+Manifestation Lore - Morbid Conjuration (20 Points), Krondspine Incarnate and Aetherwrought Machineries
+Battle Tactics Cards: Burning for Vengeance
+-----
+Regiment 1
+Bloodthirster of Unfettered Fury (390)
+---
+Regiment 3
+Skarbrand (430)
+---
+Regiment 5
+Skarbrand (430)
+-----
+Auxiliary Units
+Bloodthirster of Insensate Rage (410)
+Bloodthirster of Unfettered Fury (390)
+Skarbrand (430)
+Wrath of Khorne Bloodthirster (400)
+-----
+Faction Terrain
+Skull Altar
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/bok-002-multi-prayer-lore/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/bok-002-multi-prayer-lore/expected.json
@@ -1,0 +1,350 @@
+{
+  "id": "bok-002-multi-prayer-lore",
+  "diagnostics": [],
+  "proposedName": "Khorne2",
+  "declaredFaction": "Blades of Khorne",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Brass Stampede"
+    },
+    {
+      "line": 7,
+      "kindHint": "prayer-lore",
+      "label": "Proclamations of Murder"
+    },
+    {
+      "line": 7,
+      "kindHint": "prayer-lore",
+      "label": "Blood Blesssings of Khorne"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Judgements of Khorne"
+    },
+    {
+      "line": 11,
+      "kindHint": "warscroll",
+      "label": "Bloodstoker"
+    },
+    {
+      "line": 14,
+      "kindHint": "warscroll",
+      "label": "Bloodmaster, Herald of Khorne"
+    },
+    {
+      "line": 17,
+      "kindHint": "warscroll",
+      "label": "Karanak"
+    },
+    {
+      "line": 20,
+      "kindHint": "warscroll",
+      "label": "Scyla Anfingrimm",
+      "isLegends": true
+    },
+    {
+      "line": 22,
+      "kindHint": "warscroll",
+      "label": "Blood Warriors"
+    },
+    {
+      "line": 23,
+      "kindHint": "warscroll",
+      "label": "Bloodreavers"
+    },
+    {
+      "line": 24,
+      "kindHint": "warscroll",
+      "label": "Bloodreavers"
+    },
+    {
+      "line": 25,
+      "kindHint": "warscroll",
+      "label": "Claws of Karanak"
+    },
+    {
+      "line": 26,
+      "kindHint": "warscroll",
+      "label": "Garrek's Reavers",
+      "isLegends": true
+    },
+    {
+      "line": 28,
+      "kindHint": "warscroll",
+      "label": "Gorechosen of Dromm",
+      "isLegends": true
+    },
+    {
+      "line": 30,
+      "kindHint": "warscroll",
+      "label": "Kamandora’s Blades",
+      "isLegends": true
+    },
+    {
+      "line": 32,
+      "kindHint": "warscroll",
+      "label": "Khorgorath"
+    },
+    {
+      "line": 33,
+      "kindHint": "warscroll",
+      "label": "Khorgorath"
+    },
+    {
+      "line": 34,
+      "kindHint": "warscroll",
+      "label": "Magore's Fiends",
+      "isLegends": true
+    },
+    {
+      "line": 36,
+      "kindHint": "warscroll",
+      "label": "Mighty Skullcrushers"
+    },
+    {
+      "line": 37,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Blood Warriors"
+    },
+    {
+      "line": 38,
+      "kindHint": "warscroll",
+      "label": "Skullreapers"
+    },
+    {
+      "line": 39,
+      "kindHint": "warscroll",
+      "label": "Wrathmongers"
+    },
+    {
+      "line": 42,
+      "kindHint": "warscroll",
+      "label": "Skullmaster, Herald of Khorne",
+      "isLegends": true
+    },
+    {
+      "line": 44,
+      "kindHint": "warscroll",
+      "label": "Bloodcrushers"
+    },
+    {
+      "line": 45,
+      "kindHint": "warscroll",
+      "label": "Skull Cannon"
+    },
+    {
+      "line": 48,
+      "kindHint": "warscroll",
+      "label": "Blood Warriors"
+    },
+    {
+      "line": 49,
+      "kindHint": "warscroll",
+      "label": "Bloodcrushers"
+    },
+    {
+      "line": 50,
+      "kindHint": "warscroll",
+      "label": "Bloodletters"
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Bloodmaster, Herald of Khorne"
+    },
+    {
+      "line": 52,
+      "kindHint": "warscroll",
+      "label": "Bloodreavers"
+    },
+    {
+      "line": 53,
+      "kindHint": "warscroll",
+      "label": "Bloodsecrator"
+    },
+    {
+      "line": 54,
+      "kindHint": "warscroll",
+      "label": "Bloodsecrator"
+    },
+    {
+      "line": 55,
+      "kindHint": "warscroll",
+      "label": "Bloodstoker"
+    },
+    {
+      "line": 56,
+      "kindHint": "warscroll",
+      "label": "Bloodthirster of Insensate Rage"
+    },
+    {
+      "line": 57,
+      "kindHint": "warscroll",
+      "label": "Bloodthirster of Unfettered Fury"
+    },
+    {
+      "line": 58,
+      "kindHint": "warscroll",
+      "label": "Claws of Karanak"
+    },
+    {
+      "line": 59,
+      "kindHint": "warscroll",
+      "label": "Deathbringer"
+    },
+    {
+      "line": 60,
+      "kindHint": "warscroll",
+      "label": "Flesh Hounds"
+    },
+    {
+      "line": 61,
+      "kindHint": "warscroll",
+      "label": "Garrek's Reavers",
+      "isLegends": true
+    },
+    {
+      "line": 63,
+      "kindHint": "warscroll",
+      "label": "Gorechosen of Dromm",
+      "isLegends": true
+    },
+    {
+      "line": 65,
+      "kindHint": "warscroll",
+      "label": "Herald of Khorne on Blood Throne"
+    },
+    {
+      "line": 66,
+      "kindHint": "warscroll",
+      "label": "Kamandora’s Blades",
+      "isLegends": true
+    },
+    {
+      "line": 68,
+      "kindHint": "warscroll",
+      "label": "Karanak"
+    },
+    {
+      "line": 69,
+      "kindHint": "warscroll",
+      "label": "Khorgorath"
+    },
+    {
+      "line": 70,
+      "kindHint": "warscroll",
+      "label": "Lord of Khorne on Juggernaut",
+      "isLegends": true
+    },
+    {
+      "line": 72,
+      "kindHint": "warscroll",
+      "label": "Magore's Fiends",
+      "isLegends": true
+    },
+    {
+      "line": 74,
+      "kindHint": "warscroll",
+      "label": "Mighty Lord of Khorne"
+    },
+    {
+      "line": 75,
+      "kindHint": "warscroll",
+      "label": "Mighty Skullcrushers"
+    },
+    {
+      "line": 76,
+      "kindHint": "warscroll",
+      "label": "Realmgore Ritualist"
+    },
+    {
+      "line": 77,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Blood Warriors"
+    },
+    {
+      "line": 78,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Bloodletters"
+    },
+    {
+      "line": 79,
+      "kindHint": "warscroll",
+      "label": "Scyla Anfingrimm",
+      "isLegends": true
+    },
+    {
+      "line": 81,
+      "kindHint": "warscroll",
+      "label": "Skarbrand"
+    },
+    {
+      "line": 82,
+      "kindHint": "warscroll",
+      "label": "Skarr Bloodwrath",
+      "isLegends": true
+    },
+    {
+      "line": 84,
+      "kindHint": "warscroll",
+      "label": "Skull Cannon"
+    },
+    {
+      "line": 85,
+      "kindHint": "warscroll",
+      "label": "Skull Cannon"
+    },
+    {
+      "line": 86,
+      "kindHint": "warscroll",
+      "label": "Skullgrinder"
+    },
+    {
+      "line": 87,
+      "kindHint": "warscroll",
+      "label": "Skullmaster, Herald of Khorne",
+      "isLegends": true
+    },
+    {
+      "line": 89,
+      "kindHint": "warscroll",
+      "label": "Skullreapers"
+    },
+    {
+      "line": 90,
+      "kindHint": "warscroll",
+      "label": "Skulltaker"
+    },
+    {
+      "line": 91,
+      "kindHint": "warscroll",
+      "label": "Slaughterpriest"
+    },
+    {
+      "line": 92,
+      "kindHint": "warscroll",
+      "label": "Valkia The Bloody",
+      "isLegends": true
+    },
+    {
+      "line": 94,
+      "kindHint": "warscroll",
+      "label": "Wrath of Khorne Bloodthirster"
+    },
+    {
+      "line": 95,
+      "kindHint": "warscroll",
+      "label": "Wrathmongers"
+    },
+    {
+      "line": 98,
+      "kindHint": "warscroll",
+      "label": "Skull Altar"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/bok-002-multi-prayer-lore/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/bok-002-multi-prayer-lore/list.txt
@@ -1,0 +1,101 @@
+Khorne2 23750/2000 pts
+-----
+Grand Alliance Chaos | Blades of Khorne | Brass Stampede
+General's Handbook 2026-27
+Auxiliaries: 39 (+14820 Points)
+Drops: 44
+Prayer Lore - Proclamations of Murder and Blood Blesssings of Khorne
+Manifestation Lore - Judgements of Khorne
+-----
+Regiment 1
+Bloodstoker (100)
+---
+Regiment 2
+Bloodmaster, Herald of Khorne (120)
+---
+Regiment 3
+Karanak (110)
+---
+Regiment 4
+Scyla Anfingrimm (130)
+• Legends
+Blood Warriors (180)
+Bloodreavers (80)
+Bloodreavers (80)
+Claws of Karanak (100)
+Garrek's Reavers (70)
+• Legends
+Gorechosen of Dromm (190)
+• Legends
+Kamandora’s Blades (90)
+• Legends
+Khorgorath (120)
+Khorgorath (120)
+Magore's Fiends (120)
+• Legends
+Mighty Skullcrushers (200)
+Scourge of Aqshy: Blood Warriors (190)
+Skullreapers (170)
+Wrathmongers (130)
+---
+Regiment 5
+Skullmaster, Herald of Khorne (130)
+• Legends
+Bloodcrushers (130)
+Skull Cannon (130)
+-----
+Auxiliary Units
+Blood Warriors (180)
+Bloodcrushers (130)
+Bloodletters (150)
+Bloodmaster, Herald of Khorne (120)
+Bloodreavers (80)
+Bloodsecrator (110)
+Bloodsecrator (110)
+Bloodstoker (100)
+Bloodthirster of Insensate Rage (410)
+Bloodthirster of Unfettered Fury (390)
+Claws of Karanak (100)
+Deathbringer (120)
+Flesh Hounds (100)
+Garrek's Reavers (70)
+• Legends
+Gorechosen of Dromm (190)
+• Legends
+Herald of Khorne on Blood Throne (160)
+Kamandora’s Blades (90)
+• Legends
+Karanak (110)
+Khorgorath (120)
+Lord of Khorne on Juggernaut (200)
+• Legends
+Magore's Fiends (120)
+• Legends
+Mighty Lord of Khorne (110)
+Mighty Skullcrushers (200)
+Realmgore Ritualist (110)
+Scourge of Aqshy: Blood Warriors (190)
+Scourge of Aqshy: Bloodletters (150)
+Scyla Anfingrimm (130)
+• Legends
+Skarbrand (430)
+Skarr Bloodwrath (140)
+• Legends
+Skull Cannon (130)
+Skull Cannon (130)
+Skullgrinder (110)
+Skullmaster, Herald of Khorne (130)
+• Legends
+Skullreapers (170)
+Skulltaker (120)
+Slaughterpriest (120)
+Valkia The Bloody (180)
+• Legends
+Wrath of Khorne Bloodthirster (400)
+Wrathmongers (130)
+-----
+Faction Terrain
+Skull Altar
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/cos-002-empty-roster/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/cos-002-empty-roster/expected.json
@@ -1,0 +1,15 @@
+{
+  "id": "cos-002-empty-roster",
+  "diagnostics": [],
+  "proposedName": "Empty cos",
+  "declaredFaction": "Cities of Sigmar",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": false,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Allies of the Free Cities"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/cos-002-empty-roster/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/cos-002-empty-roster/list.txt
@@ -1,0 +1,8 @@
+Empty cos 0/3000 pts
+-----
+Cities of Sigmar | Allies of the Free Cities
+Army of Renown
+General's Handbook 2026-27
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/dot-001-and-in-unit-name/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/dot-001-and-in-unit-name/expected.json
@@ -1,0 +1,243 @@
+{
+  "id": "dot-001-and-in-unit-name",
+  "diagnostics": [],
+  "proposedName": "Dot1",
+  "declaredFaction": "Disciples of Tzeentch",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Denizens of the Silver Towers"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of Change"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of Fate"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Manifestations of Tzeentch"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Aetherwrought Machineries"
+    },
+    {
+      "line": 11,
+      "kindHint": "warscroll",
+      "label": "Fatemaster on Disc of Tzeentch",
+      "isLegends": true
+    },
+    {
+      "line": 15,
+      "kindHint": "warscroll",
+      "label": "Fatemaster"
+    },
+    {
+      "line": 18,
+      "kindHint": "warscroll",
+      "label": "Fluxmaster, Herald of Tzeentch on Disc",
+      "isLegends": true
+    },
+    {
+      "line": 22,
+      "kindHint": "warscroll",
+      "label": "The Blue Scribes",
+      "isLegends": true
+    },
+    {
+      "line": 26,
+      "kindHint": "warscroll",
+      "label": "Blue Horrors and Brimstone Horrors"
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Burning Chariot of Tzeentch"
+    },
+    {
+      "line": 28,
+      "kindHint": "warscroll",
+      "label": "Burning Chariot of Tzeentch"
+    },
+    {
+      "line": 29,
+      "kindHint": "warscroll",
+      "label": "Changecaster, Herald of Tzeentch"
+    },
+    {
+      "line": 30,
+      "kindHint": "warscroll",
+      "label": "Chaos Spawn of Tzeentch"
+    },
+    {
+      "line": 31,
+      "kindHint": "warscroll",
+      "label": "Curseling, Eye of Tzeentch"
+    },
+    {
+      "line": 32,
+      "kindHint": "warscroll",
+      "label": "Ephilim's Pandaemonium",
+      "isLegends": true
+    },
+    {
+      "line": 34,
+      "kindHint": "warscroll",
+      "label": "Exalted Flamer of Tzeentch"
+    },
+    {
+      "line": 35,
+      "kindHint": "warscroll",
+      "label": "Eyes of the Nine",
+      "isLegends": true
+    },
+    {
+      "line": 37,
+      "kindHint": "warscroll",
+      "label": "Fatemaster"
+    },
+    {
+      "line": 38,
+      "kindHint": "warscroll",
+      "label": "Fatemaster on Disc of Tzeentch",
+      "isLegends": true
+    },
+    {
+      "line": 40,
+      "kindHint": "warscroll",
+      "label": "Fateskimmer, Herald of Tzeentch on Burning Chariot"
+    },
+    {
+      "line": 41,
+      "kindHint": "warscroll",
+      "label": "Flamers of Tzeentch"
+    },
+    {
+      "line": 42,
+      "kindHint": "warscroll",
+      "label": "Fluxmaster, Herald of Tzeentch on Disc",
+      "isLegends": true
+    },
+    {
+      "line": 44,
+      "kindHint": "warscroll",
+      "label": "Gaunt Summoner"
+    },
+    {
+      "line": 45,
+      "kindHint": "warscroll",
+      "label": "Gaunt Summoner on Disc of Tzeentch"
+    },
+    {
+      "line": 46,
+      "kindHint": "warscroll",
+      "label": "Jade Obelisk"
+    },
+    {
+      "line": 47,
+      "kindHint": "warscroll",
+      "label": "Kairic Acolytes"
+    },
+    {
+      "line": 48,
+      "kindHint": "warscroll",
+      "label": "Kairos Fateweaver"
+    },
+    {
+      "line": 49,
+      "kindHint": "warscroll",
+      "label": "Lord of Change"
+    },
+    {
+      "line": 50,
+      "kindHint": "warscroll",
+      "label": "Magister"
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Magister on Disc of Tzeentch"
+    },
+    {
+      "line": 52,
+      "kindHint": "warscroll",
+      "label": "Ogroid Thaumaturge"
+    },
+    {
+      "line": 53,
+      "kindHint": "warscroll",
+      "label": "Pink Horrors"
+    },
+    {
+      "line": 54,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Ogroid Thaumaturge"
+    },
+    {
+      "line": 55,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Screamers of Tzeentch"
+    },
+    {
+      "line": 56,
+      "kindHint": "warscroll",
+      "label": "Screamers of Tzeentch"
+    },
+    {
+      "line": 57,
+      "kindHint": "warscroll",
+      "label": "Screamers of Tzeentch"
+    },
+    {
+      "line": 58,
+      "kindHint": "warscroll",
+      "label": "The Blue Scribes",
+      "isLegends": true
+    },
+    {
+      "line": 60,
+      "kindHint": "warscroll",
+      "label": "The Changeling"
+    },
+    {
+      "line": 61,
+      "kindHint": "warscroll",
+      "label": "Tzaangor Enlightened"
+    },
+    {
+      "line": 62,
+      "kindHint": "warscroll",
+      "label": "Tzaangor Enlightened on Foot"
+    },
+    {
+      "line": 63,
+      "kindHint": "warscroll",
+      "label": "Tzaangor Shaman"
+    },
+    {
+      "line": 64,
+      "kindHint": "warscroll",
+      "label": "Tzaangor Skyfires"
+    },
+    {
+      "line": 65,
+      "kindHint": "warscroll",
+      "label": "Tzaangors"
+    },
+    {
+      "line": 68,
+      "kindHint": "warscroll",
+      "label": "Argent Shard"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/dot-001-and-in-unit-name/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/dot-001-and-in-unit-name/list.txt
@@ -1,0 +1,71 @@
+Dot1 17810/2500 pts
+-----
+Grand Alliance Chaos | Disciples of Tzeentch | Denizens of the Silver Towers
+General's Handbook 2026-27
+Auxiliaries: 35 (+11900 Points)
+Drops: 39
+Spell Lore - Lore of Change and Lore of Fate
+Manifestation Lore - Manifestations of Tzeentch and Aetherwrought Machineries
+-----
+Regiment 1
+Fatemaster on Disc of Tzeentch (160)
+• Legends
+---
+Regiment 3
+Fatemaster (150)
+---
+Regiment 4
+Fluxmaster, Herald of Tzeentch on Disc (180)
+• Legends
+---
+Regiment 5
+The Blue Scribes (180)
+• Legends
+-----
+Auxiliary Units
+Blue Horrors and Brimstone Horrors (120)
+Burning Chariot of Tzeentch (120)
+Burning Chariot of Tzeentch (120)
+Changecaster, Herald of Tzeentch (140)
+Chaos Spawn of Tzeentch (60)
+Curseling, Eye of Tzeentch (170)
+Ephilim's Pandaemonium (100)
+• Legends
+Exalted Flamer of Tzeentch (120)
+Eyes of the Nine (100)
+• Legends
+Fatemaster (150)
+Fatemaster on Disc of Tzeentch (160)
+• Legends
+Fateskimmer, Herald of Tzeentch on Burning Chariot (140)
+Flamers of Tzeentch (130)
+Fluxmaster, Herald of Tzeentch on Disc (180)
+• Legends
+Gaunt Summoner (180)
+Gaunt Summoner on Disc of Tzeentch (210)
+Jade Obelisk (100)
+Kairic Acolytes (90)
+Kairos Fateweaver (400)
+Lord of Change (380)
+Magister (140)
+Magister on Disc of Tzeentch (150)
+Ogroid Thaumaturge (110)
+Pink Horrors (170)
+Scourge of Aqshy: Ogroid Thaumaturge (140)
+Scourge of Aqshy: Screamers of Tzeentch (110)
+Screamers of Tzeentch (80)
+Screamers of Tzeentch (80)
+The Blue Scribes (180)
+• Legends
+The Changeling (140)
+Tzaangor Enlightened (200)
+Tzaangor Enlightened on Foot (110)
+Tzaangor Shaman (130)
+Tzaangor Skyfires (160)
+Tzaangors (170)
+-----
+Faction Terrain
+Argent Shard
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/hh-001-renown-stress/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/hh-001-renown-stress/expected.json
@@ -1,0 +1,447 @@
+{
+  "id": "hh-001-renown-stress",
+  "diagnostics": [],
+  "proposedName": "Hh1",
+  "declaredFaction": "Helsmiths of Hashut",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Daemonsmith Cabal"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of Infernal Power"
+    },
+    {
+      "line": 8,
+      "kindHint": "prayer-lore",
+      "label": "Prayers of the Scorched Sect"
+    },
+    {
+      "line": 9,
+      "kindHint": "manifestation-lore",
+      "label": "Twilit Sorceries"
+    },
+    {
+      "line": 9,
+      "kindHint": "manifestation-lore",
+      "label": "Aetherwrought Machineries"
+    },
+    {
+      "line": 12,
+      "kindHint": "warscroll",
+      "label": "Daemonsmith on Infernal Taurus"
+    },
+    {
+      "line": 15,
+      "kindHint": "warscroll",
+      "label": "Daemonsmith"
+    },
+    {
+      "line": 19,
+      "kindHint": "warscroll",
+      "label": "Gunnar Brand",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 20,
+      "kindHint": "warscroll",
+      "label": "Singri Brand",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 21,
+      "kindHint": "warscroll",
+      "label": "The Oathsworn Kin",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 23,
+      "kindHint": "warscroll",
+      "label": "Outlaw Conqueror Cogfort",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 25,
+      "kindHint": "warscroll",
+      "label": "Sloppity Bilepiper, Herald of Nurgle",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 26,
+      "kindHint": "warscroll",
+      "label": "Beast of Nurgle",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Beast of Nurgle",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 29,
+      "kindHint": "warscroll",
+      "label": "Mortisan Ossifector",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 30,
+      "kindHint": "warscroll",
+      "label": "Gothizzar Harvester",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 31,
+      "kindHint": "warscroll",
+      "label": "Mortek Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 32,
+      "kindHint": "warscroll",
+      "label": "Mortek Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 34,
+      "kindHint": "warscroll",
+      "label": "Ogroid Myrmidon",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 35,
+      "kindHint": "warscroll",
+      "label": "Fomoroid Crusher",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 36,
+      "kindHint": "warscroll",
+      "label": "Mindstealer Sphiranx",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 38,
+      "kindHint": "warscroll",
+      "label": "Chaos Lord on Daemonic Mount",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 39,
+      "kindHint": "warscroll",
+      "label": "Chaos Knights",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 40,
+      "kindHint": "warscroll",
+      "label": "Chaos Warriors",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 42,
+      "kindHint": "warscroll",
+      "label": "Mask of the Deceiver",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 44,
+      "kindHint": "warscroll",
+      "label": "Shardspeaker of Slaanesh",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 45,
+      "kindHint": "warscroll",
+      "label": "Blissbarb Archers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 47,
+      "kindHint": "warscroll",
+      "label": "Nurglings",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 48,
+      "kindHint": "warscroll",
+      "label": "Nurglings",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 50,
+      "kindHint": "warscroll",
+      "label": "Warstomper Mega-Gargant",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 52,
+      "kindHint": "warscroll",
+      "label": "Harbinger of Decay",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 53,
+      "kindHint": "warscroll",
+      "label": "Pusgoyle Blightlords",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 54,
+      "kindHint": "warscroll",
+      "label": "Putrid Blightkings",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 56,
+      "kindHint": "warscroll",
+      "label": "Outlaw Cannonade Cogfort",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 58,
+      "kindHint": "warscroll",
+      "label": "Magister on Disc of Tzeentch",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 59,
+      "kindHint": "warscroll",
+      "label": "Gaunt Summoner on Disc of Tzeentch",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 60,
+      "kindHint": "warscroll",
+      "label": "Screamers of Tzeentch",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 62,
+      "kindHint": "warscroll",
+      "label": "Mancrusher Gargant",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 64,
+      "kindHint": "warscroll",
+      "label": "Contorted Epitome",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 65,
+      "kindHint": "warscroll",
+      "label": "Dreadful Visage",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 66,
+      "kindHint": "warscroll",
+      "label": "Mesmerising Mirror",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 67,
+      "kindHint": "warscroll",
+      "label": "Wheels of Excruciation",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 69,
+      "kindHint": "warscroll",
+      "label": "Skarbrand",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 71,
+      "kindHint": "warscroll",
+      "label": "Spoilpox Scrivener, Herald of Nurgle",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 72,
+      "kindHint": "warscroll",
+      "label": "Feculent Gnarlmaw",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 73,
+      "kindHint": "warscroll",
+      "label": "Plaguebearers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 75,
+      "kindHint": "warscroll",
+      "label": "Slaughterpriest",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 76,
+      "kindHint": "warscroll",
+      "label": "Bloodreavers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 77,
+      "kindHint": "warscroll",
+      "label": "Skullreapers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 79,
+      "kindHint": "warscroll",
+      "label": "Slaughterpriest",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 80,
+      "kindHint": "warscroll",
+      "label": "Bloodreavers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 81,
+      "kindHint": "warscroll",
+      "label": "Skullreapers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 83,
+      "kindHint": "warscroll",
+      "label": "Slaughterpriest",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 84,
+      "kindHint": "warscroll",
+      "label": "Bloodreavers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 85,
+      "kindHint": "warscroll",
+      "label": "Skullreapers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 87,
+      "kindHint": "warscroll",
+      "label": "Slaughterpriest",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 88,
+      "kindHint": "warscroll",
+      "label": "Bloodreavers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 89,
+      "kindHint": "warscroll",
+      "label": "Skullreapers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 92,
+      "kindHint": "warscroll",
+      "label": "Anointed Sentinels"
+    },
+    {
+      "line": 93,
+      "kindHint": "warscroll",
+      "label": "Ashen Elder"
+    },
+    {
+      "line": 94,
+      "kindHint": "warscroll",
+      "label": "Bull Centaurs"
+    },
+    {
+      "line": 95,
+      "kindHint": "warscroll",
+      "label": "Daemonsmith"
+    },
+    {
+      "line": 96,
+      "kindHint": "warscroll",
+      "label": "Daemonsmith on Infernal Taurus"
+    },
+    {
+      "line": 97,
+      "kindHint": "warscroll",
+      "label": "Deathshrieker Rocket Battery"
+    },
+    {
+      "line": 98,
+      "kindHint": "warscroll",
+      "label": "Dominator Engine with Bane Maces"
+    },
+    {
+      "line": 99,
+      "kindHint": "warscroll",
+      "label": "Dominator Engine with Immolation Cannons"
+    },
+    {
+      "line": 100,
+      "kindHint": "warscroll",
+      "label": "Hobgrotz Vandalz"
+    },
+    {
+      "line": 101,
+      "kindHint": "warscroll",
+      "label": "Infernal Cohort with Hashutite Blades"
+    },
+    {
+      "line": 102,
+      "kindHint": "warscroll",
+      "label": "Infernal Cohort with Hashutite Spears"
+    },
+    {
+      "line": 103,
+      "kindHint": "warscroll",
+      "label": "Infernal Razers with Blunderbusses"
+    },
+    {
+      "line": 104,
+      "kindHint": "warscroll",
+      "label": "Infernal Razers with Flamehurlers"
+    },
+    {
+      "line": 105,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Anointed Sentinels"
+    },
+    {
+      "line": 106,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Daemonsmith on Infernal Taurus"
+    },
+    {
+      "line": 107,
+      "kindHint": "warscroll",
+      "label": "The Blood of the Bull",
+      "isLegends": true
+    },
+    {
+      "line": 109,
+      "kindHint": "warscroll",
+      "label": "Tormentor Bombard"
+    },
+    {
+      "line": 110,
+      "kindHint": "warscroll",
+      "label": "Urak Taar, the First Daemonsmith"
+    },
+    {
+      "line": 111,
+      "kindHint": "warscroll",
+      "label": "War Despot"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/hh-001-renown-stress/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/hh-001-renown-stress/list.txt
@@ -1,0 +1,114 @@
+Hh1 13840/2500 pts
+-----
+Grand Alliance Chaos | Helsmiths of Hashut | Daemonsmith Cabal
+General's Handbook 2026-27
+Auxiliaries: 19 (+3420 Points)
+Drops: 42
+Spell Lore - Lore of Infernal Power
+Prayer Lore - Prayers of the Scorched Sect
+Manifestation Lore - Twilit Sorceries and Aetherwrought Machineries
+-----
+Regiment 2
+Daemonsmith on Infernal Taurus (290)
+---
+Regiment 3
+Daemonsmith (80)
+-----
+Regiments of Renown
+Brand's Oathbound (200)
+Gunnar Brand
+Singri Brand
+The Oathsworn Kin
+Cogfort Raiders (450)
+Outlaw Conqueror Cogfort
+Diseased Revellers (310)
+Sloppity Bilepiper, Herald of Nurgle
+Beast of Nurgle
+Beast of Nurgle
+Enforcers of the Tithe (470)
+Mortisan Ossifector
+Gothizzar Harvester
+Mortek Guard
+Mortek Guard
+Hargax's Pit-Beasts (390)
+Ogroid Myrmidon
+Fomoroid Crusher
+Mindstealer Sphiranx
+Lord Skaldior's Chosen (530)
+Chaos Lord on Daemonic Mount
+Chaos Knights
+Chaos Warriors
+Mask of the Deceiver (170)
+Mask of the Deceiver
+Mist-Clad Revellers (260)
+Shardspeaker of Slaanesh
+Blissbarb Archers
+Nurgle's Gift (180)
+Nurglings
+Nurglings
+One-eyed Grunnock (410)
+Warstomper Mega-Gargant
+Phulgoth's Shudderhood (530)
+Harbinger of Decay
+Pusgoyle Blightlords
+Putrid Blightkings
+Rogue Engine (470)
+Outlaw Cannonade Cogfort
+Seekers of Silver (380)
+Magister on Disc of Tzeentch
+Gaunt Summoner on Disc of Tzeentch
+Screamers of Tzeentch
+Stumblefoot Gargant (140)
+Mancrusher Gargant
+The Accursed Reflection (150)
+Contorted Epitome
+Dreadful Visage
+Mesmerising Mirror
+Wheels of Excruciation
+The Exiled One (390)
+Skarbrand
+The Pustules (200)
+Spoilpox Scrivener, Herald of Nurgle
+Feculent Gnarlmaw
+Plaguebearers
+The Red Revelation (380)
+Slaughterpriest
+Bloodreavers
+Skullreapers
+The Red Revelation (380)
+Slaughterpriest
+Bloodreavers
+Skullreapers
+The Red Revelation (380)
+Slaughterpriest
+Bloodreavers
+Skullreapers
+The Red Revelation (380)
+Slaughterpriest
+Bloodreavers
+Skullreapers
+-----
+Auxiliary Units
+Anointed Sentinels (130)
+Ashen Elder (120)
+Bull Centaurs (190)
+Daemonsmith (80)
+Daemonsmith on Infernal Taurus (290)
+Deathshrieker Rocket Battery (140)
+Dominator Engine with Bane Maces (150)
+Dominator Engine with Immolation Cannons (160)
+Hobgrotz Vandalz (70)
+Infernal Cohort with Hashutite Blades (90)
+Infernal Cohort with Hashutite Spears (90)
+Infernal Razers with Blunderbusses (110)
+Infernal Razers with Flamehurlers (90)
+Scourge of Aqshy: Anointed Sentinels (170)
+Scourge of Aqshy: Daemonsmith on Infernal Taurus (350)
+The Blood of the Bull (120)
+• Legends
+Tormentor Bombard (130)
+Urak Taar, the First Daemonsmith (340)
+War Despot (80)
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/hos-001-auxiliary-only/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/hos-001-auxiliary-only/expected.json
@@ -1,0 +1,216 @@
+{
+  "id": "hos-001-auxiliary-only",
+  "diagnostics": [],
+  "proposedName": "Slaanesh1",
+  "declaredFaction": "Hedonites of Slaanesh",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Godseeker Cavalcade"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of Extravagance"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Manifestations of Depravity"
+    },
+    {
+      "line": 11,
+      "kindHint": "warscroll",
+      "label": "Bladebringer, Herald on Exalted Chariot"
+    },
+    {
+      "line": 12,
+      "kindHint": "warscroll",
+      "label": "Bladebringer, Herald on Hellflayer",
+      "isLegends": true
+    },
+    {
+      "line": 14,
+      "kindHint": "warscroll",
+      "label": "Bladebringer, Herald on Seeker Chariot",
+      "isLegends": true
+    },
+    {
+      "line": 16,
+      "kindHint": "warscroll",
+      "label": "Blissbarb Archers"
+    },
+    {
+      "line": 17,
+      "kindHint": "warscroll",
+      "label": "Blissbarb Seekers"
+    },
+    {
+      "line": 18,
+      "kindHint": "warscroll",
+      "label": "Contorted Epitome"
+    },
+    {
+      "line": 19,
+      "kindHint": "warscroll",
+      "label": "Daemonettes"
+    },
+    {
+      "line": 20,
+      "kindHint": "warscroll",
+      "label": "Dexcessa, the Talon of Slaanesh"
+    },
+    {
+      "line": 21,
+      "kindHint": "warscroll",
+      "label": "Exalted Chariot",
+      "isLegends": true
+    },
+    {
+      "line": 23,
+      "kindHint": "warscroll",
+      "label": "Fiends"
+    },
+    {
+      "line": 24,
+      "kindHint": "warscroll",
+      "label": "Glutos Orscollion, Lord of Gluttony"
+    },
+    {
+      "line": 25,
+      "kindHint": "warscroll",
+      "label": "Hellflayer"
+    },
+    {
+      "line": 26,
+      "kindHint": "warscroll",
+      "label": "Hellstriders"
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Infernal Enrapturess, Herald of Slaanesh"
+    },
+    {
+      "line": 28,
+      "kindHint": "warscroll",
+      "label": "Keeper of Secrets"
+    },
+    {
+      "line": 29,
+      "kindHint": "warscroll",
+      "label": "Lord of Hubris"
+    },
+    {
+      "line": 30,
+      "kindHint": "warscroll",
+      "label": "Lord of Hysteria"
+    },
+    {
+      "line": 31,
+      "kindHint": "warscroll",
+      "label": "Lord of Pain"
+    },
+    {
+      "line": 32,
+      "kindHint": "warscroll",
+      "label": "Myrmidesh Painbringers"
+    },
+    {
+      "line": 33,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Blissbarb Seekers"
+    },
+    {
+      "line": 34,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Infernal Enrapturess, Herald of Slaanesh"
+    },
+    {
+      "line": 35,
+      "kindHint": "warscroll",
+      "label": "Seeker Chariot"
+    },
+    {
+      "line": 36,
+      "kindHint": "warscroll",
+      "label": "Seekers"
+    },
+    {
+      "line": 37,
+      "kindHint": "warscroll",
+      "label": "Shalaxi Helbane"
+    },
+    {
+      "line": 38,
+      "kindHint": "warscroll",
+      "label": "Shardspeaker of Slaanesh"
+    },
+    {
+      "line": 39,
+      "kindHint": "warscroll",
+      "label": "Sigvald, Prince of Slaanesh"
+    },
+    {
+      "line": 40,
+      "kindHint": "warscroll",
+      "label": "Slaangor Fiendbloods"
+    },
+    {
+      "line": 41,
+      "kindHint": "warscroll",
+      "label": "Slickblade Seekers"
+    },
+    {
+      "line": 42,
+      "kindHint": "warscroll",
+      "label": "Syll'Esske, the Vengeful Allegiance"
+    },
+    {
+      "line": 43,
+      "kindHint": "warscroll",
+      "label": "Symbaresh Twinsouls"
+    },
+    {
+      "line": 44,
+      "kindHint": "warscroll",
+      "label": "Synessa, the Voice of Slaanesh"
+    },
+    {
+      "line": 45,
+      "kindHint": "warscroll",
+      "label": "The Dread Pageant",
+      "isLegends": true
+    },
+    {
+      "line": 47,
+      "kindHint": "warscroll",
+      "label": "The Masque"
+    },
+    {
+      "line": 48,
+      "kindHint": "warscroll",
+      "label": "The Thricefold Discord",
+      "isLegends": true
+    },
+    {
+      "line": 50,
+      "kindHint": "warscroll",
+      "label": "Thricefold Discord"
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Viceleader, Herald of Slaanesh",
+      "isLegends": true
+    },
+    {
+      "line": 55,
+      "kindHint": "warscroll",
+      "label": "Fane of Slaanesh"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/hos-001-auxiliary-only/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/hos-001-auxiliary-only/list.txt
@@ -1,0 +1,58 @@
+Slaanesh1 18670/1500 pts
+-----
+Grand Alliance Chaos | Hedonites of Slaanesh | Godseeker Cavalcade
+General's Handbook 2026-27
+Auxiliaries: 36 (+12600 Points)
+Drops: 36
+Spell Lore - Lore of Extravagance
+Manifestation Lore - Manifestations of Depravity
+-----
+Auxiliary Units
+Bladebringer, Herald on Exalted Chariot (130)
+Bladebringer, Herald on Hellflayer (140)
+• Legends
+Bladebringer, Herald on Seeker Chariot (130)
+• Legends
+Blissbarb Archers (140)
+Blissbarb Seekers (160)
+Contorted Epitome (150)
+Daemonettes (110)
+Dexcessa, the Talon of Slaanesh (280)
+Exalted Chariot (120)
+• Legends
+Fiends (150)
+Glutos Orscollion, Lord of Gluttony (460)
+Hellflayer (130)
+Hellstriders (150)
+Infernal Enrapturess, Herald of Slaanesh (100)
+Keeper of Secrets (420)
+Lord of Hubris (110)
+Lord of Hysteria (120)
+Lord of Pain (120)
+Myrmidesh Painbringers (120)
+Scourge of Aqshy: Blissbarb Seekers (150)
+Scourge of Aqshy: Infernal Enrapturess, Herald of Slaanesh (90)
+Seeker Chariot (80)
+Seekers (130)
+Shalaxi Helbane (410)
+Shardspeaker of Slaanesh (120)
+Sigvald, Prince of Slaanesh (240)
+Slaangor Fiendbloods (140)
+Slickblade Seekers (170)
+Syll'Esske, the Vengeful Allegiance (250)
+Symbaresh Twinsouls (120)
+Synessa, the Voice of Slaanesh (250)
+The Dread Pageant (110)
+• Legends
+The Masque (120)
+The Thricefold Discord (130)
+• Legends
+Thricefold Discord (180)
+Viceleader, Herald of Slaanesh (140)
+• Legends
+-----
+Faction Terrain
+Fane of Slaanesh
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/ij-001-renown-heavy/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/ij-001-renown-heavy/expected.json
@@ -111,172 +111,206 @@
     {
       "line": 38,
       "kindHint": "warscroll",
-      "label": "Beast-skewer Killbow"
+      "label": "Beast-skewer Killbow",
+      "isRegimentOfRenown": true
     },
     {
       "line": 39,
       "kindHint": "warscroll",
-      "label": "Man-skewer Boltboyz"
+      "label": "Man-skewer Boltboyz",
+      "isRegimentOfRenown": true
     },
     {
       "line": 40,
       "kindHint": "warscroll",
-      "label": "Man-skewer Boltboyz"
+      "label": "Man-skewer Boltboyz",
+      "isRegimentOfRenown": true
     },
     {
       "line": 42,
       "kindHint": "warscroll",
-      "label": "Gatebreaker Mega-Gargant"
+      "label": "Gatebreaker Mega-Gargant",
+      "isRegimentOfRenown": true
     },
     {
       "line": 44,
       "kindHint": "warscroll",
-      "label": "Rabble-Rowza"
+      "label": "Rabble-Rowza",
+      "isRegimentOfRenown": true
     },
     {
       "line": 45,
       "kindHint": "warscroll",
-      "label": "Gobbapalooza"
+      "label": "Gobbapalooza",
+      "isRegimentOfRenown": true
     },
     {
       "line": 46,
       "kindHint": "warscroll",
-      "label": "Squig Herd"
+      "label": "Squig Herd",
+      "isRegimentOfRenown": true
     },
     {
       "line": 47,
       "kindHint": "warscroll",
-      "label": "Squig Hoppers"
+      "label": "Squig Hoppers",
+      "isRegimentOfRenown": true
     },
     {
       "line": 49,
       "kindHint": "warscroll",
-      "label": "Kraken-eater Mega-Gargant"
+      "label": "Kraken-eater Mega-Gargant",
+      "isRegimentOfRenown": true
     },
     {
       "line": 51,
       "kindHint": "warscroll",
-      "label": "Outlaw Conqueror Cogfort"
+      "label": "Outlaw Conqueror Cogfort",
+      "isRegimentOfRenown": true
     },
     {
       "line": 53,
       "kindHint": "warscroll",
-      "label": "Swampboss Skumdrekk"
+      "label": "Swampboss Skumdrekk",
+      "isRegimentOfRenown": true
     },
     {
       "line": 54,
       "kindHint": "warscroll",
-      "label": "Hobgrot Slittaz"
+      "label": "Hobgrot Slittaz",
+      "isRegimentOfRenown": true
     },
     {
       "line": 55,
       "kindHint": "warscroll",
-      "label": "Hobgrot Slittaz"
+      "label": "Hobgrot Slittaz",
+      "isRegimentOfRenown": true
     },
     {
       "line": 57,
       "kindHint": "warscroll",
-      "label": "Endrinmaster with Dirigible Suit"
+      "label": "Endrinmaster with Dirigible Suit",
+      "isRegimentOfRenown": true
     },
     {
       "line": 58,
       "kindHint": "warscroll",
-      "label": "Grundstok Gunhauler"
+      "label": "Grundstok Gunhauler",
+      "isRegimentOfRenown": true
     },
     {
       "line": 59,
       "kindHint": "warscroll",
-      "label": "Skywardens"
+      "label": "Skywardens",
+      "isRegimentOfRenown": true
     },
     {
       "line": 61,
       "kindHint": "warscroll",
-      "label": "Ogroid Myrmidon"
+      "label": "Ogroid Myrmidon",
+      "isRegimentOfRenown": true
     },
     {
       "line": 62,
       "kindHint": "warscroll",
-      "label": "Ogroid Thaumaturge"
+      "label": "Ogroid Thaumaturge",
+      "isRegimentOfRenown": true
     },
     {
       "line": 63,
       "kindHint": "warscroll",
-      "label": "Ogroid Theridons"
+      "label": "Ogroid Theridons",
+      "isRegimentOfRenown": true
     },
     {
       "line": 65,
       "kindHint": "warscroll",
-      "label": "Mask of the Deceiver"
+      "label": "Mask of the Deceiver",
+      "isRegimentOfRenown": true
     },
     {
       "line": 67,
       "kindHint": "warscroll",
-      "label": "Nurglings"
+      "label": "Nurglings",
+      "isRegimentOfRenown": true
     },
     {
       "line": 68,
       "kindHint": "warscroll",
-      "label": "Nurglings"
+      "label": "Nurglings",
+      "isRegimentOfRenown": true
     },
     {
       "line": 70,
       "kindHint": "warscroll",
-      "label": "Beast-smasher Mega-Gargant"
+      "label": "Beast-smasher Mega-Gargant",
+      "isRegimentOfRenown": true
     },
     {
       "line": 72,
       "kindHint": "warscroll",
-      "label": "Warstomper Mega-Gargant"
+      "label": "Warstomper Mega-Gargant",
+      "isRegimentOfRenown": true
     },
     {
       "line": 74,
       "kindHint": "warscroll",
-      "label": "Outlaw Cannonade Cogfort"
+      "label": "Outlaw Cannonade Cogfort",
+      "isRegimentOfRenown": true
     },
     {
       "line": 76,
       "kindHint": "warscroll",
-      "label": "Loonboss"
+      "label": "Loonboss",
+      "isRegimentOfRenown": true
     },
     {
       "line": 77,
       "kindHint": "warscroll",
-      "label": "Dankhold Troggoth"
+      "label": "Dankhold Troggoth",
+      "isRegimentOfRenown": true
     },
     {
       "line": 79,
       "kindHint": "warscroll",
-      "label": "Loonboss"
+      "label": "Loonboss",
+      "isRegimentOfRenown": true
     },
     {
       "line": 80,
       "kindHint": "warscroll",
-      "label": "Loonsmasha Fanatics"
+      "label": "Loonsmasha Fanatics",
+      "isRegimentOfRenown": true
     },
     {
       "line": 81,
       "kindHint": "warscroll",
-      "label": "Moonclan Stabbas"
+      "label": "Moonclan Stabbas",
+      "isRegimentOfRenown": true
     },
     {
       "line": 83,
       "kindHint": "warscroll",
-      "label": "Mancrusher Gargant"
+      "label": "Mancrusher Gargant",
+      "isRegimentOfRenown": true
     },
     {
       "line": 85,
       "kindHint": "warscroll",
-      "label": "Grand Justice Gormayne"
+      "label": "Grand Justice Gormayne",
+      "isRegimentOfRenown": true
     },
     {
       "line": 86,
       "kindHint": "warscroll",
-      "label": "Cryptguard"
+      "label": "Cryptguard",
+      "isRegimentOfRenown": true
     },
     {
       "line": 87,
       "kindHint": "warscroll",
-      "label": "Royal Decapitator"
+      "label": "Royal Decapitator",
+      "isRegimentOfRenown": true
     },
     {
       "line": 90,

--- a/src/tests/fixtures/aos4/import/official-app/lists/sce-001-exported-version-format/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/sce-001-exported-version-format/expected.json
@@ -30,12 +30,14 @@
     {
       "line": 13,
       "kindHint": "warscroll",
-      "label": "Freeguild Fusiliers"
+      "label": "Freeguild Fusiliers",
+      "isRegimentOfRenown": true
     },
     {
       "line": 14,
       "kindHint": "warscroll",
-      "label": "Freeguild Marshal"
+      "label": "Freeguild Marshal",
+      "isRegimentOfRenown": true
     }
   ]
 }

--- a/src/tests/fixtures/aos4/import/official-app/lists/sce-002-renown-army-legends/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/sce-002-renown-army-legends/expected.json
@@ -1,0 +1,402 @@
+{
+  "id": "sce-002-renown-army-legends",
+  "diagnostics": [],
+  "proposedName": "Sce1",
+  "declaredFaction": "Stormcast Eternals",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Ruination Brotherhood"
+    },
+    {
+      "line": 8,
+      "kindHint": "prayer-lore",
+      "label": "Ruination Brotherhood Prayer Lore"
+    },
+    {
+      "line": 9,
+      "kindHint": "manifestation-lore",
+      "label": "Twilit Sorceries"
+    },
+    {
+      "line": 9,
+      "kindHint": "manifestation-lore",
+      "label": "Morbid Conjuration"
+    },
+    {
+      "line": 9,
+      "kindHint": "manifestation-lore",
+      "label": "Forbidden Power"
+    },
+    {
+      "line": 9,
+      "kindHint": "manifestation-lore",
+      "label": "Primal Energy"
+    },
+    {
+      "line": 9,
+      "kindHint": "manifestation-lore",
+      "label": "Krondspine Incarnate"
+    },
+    {
+      "line": 9,
+      "kindHint": "manifestation-lore",
+      "label": "Aetherwrought Machineries"
+    },
+    {
+      "line": 13,
+      "kindHint": "warscroll",
+      "label": "Knight-Azyros"
+    },
+    {
+      "line": 16,
+      "kindHint": "warscroll",
+      "label": "Knight-Questor"
+    },
+    {
+      "line": 19,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Iridan the Witness"
+    },
+    {
+      "line": 22,
+      "kindHint": "warscroll",
+      "label": "Tornus the Redeemed"
+    },
+    {
+      "line": 23,
+      "kindHint": "warscroll",
+      "label": "Annihilators"
+    },
+    {
+      "line": 24,
+      "kindHint": "warscroll",
+      "label": "Annihilators with Meteoric Grandhammers"
+    },
+    {
+      "line": 25,
+      "kindHint": "warscroll",
+      "label": "Decimators",
+      "isLegends": true
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Domitan’s Stormcoven",
+      "isLegends": true
+    },
+    {
+      "line": 29,
+      "kindHint": "warscroll",
+      "label": "Judicators with Boltstorm Crossbows",
+      "isLegends": true
+    },
+    {
+      "line": 31,
+      "kindHint": "warscroll",
+      "label": "Judicators with Skybolt Bows",
+      "isLegends": true
+    },
+    {
+      "line": 33,
+      "kindHint": "warscroll",
+      "label": "Judicators with Skybolt Bows",
+      "isLegends": true
+    },
+    {
+      "line": 35,
+      "kindHint": "warscroll",
+      "label": "Knight-Azyros"
+    },
+    {
+      "line": 36,
+      "kindHint": "warscroll",
+      "label": "Knight-Azyros"
+    },
+    {
+      "line": 37,
+      "kindHint": "warscroll",
+      "label": "Knight-Questor"
+    },
+    {
+      "line": 38,
+      "kindHint": "warscroll",
+      "label": "Liberators"
+    },
+    {
+      "line": 39,
+      "kindHint": "warscroll",
+      "label": "Lord-Terminos"
+    },
+    {
+      "line": 40,
+      "kindHint": "warscroll",
+      "label": "Praetors"
+    },
+    {
+      "line": 41,
+      "kindHint": "warscroll",
+      "label": "Prosecutors"
+    },
+    {
+      "line": 42,
+      "kindHint": "warscroll",
+      "label": "Protectors",
+      "isLegends": true
+    },
+    {
+      "line": 44,
+      "kindHint": "warscroll",
+      "label": "Questor Soulsworn"
+    },
+    {
+      "line": 45,
+      "kindHint": "warscroll",
+      "label": "Reclusians"
+    },
+    {
+      "line": 46,
+      "kindHint": "warscroll",
+      "label": "Retributors",
+      "isLegends": true
+    },
+    {
+      "line": 48,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Stormstrike Palladors"
+    },
+    {
+      "line": 49,
+      "kindHint": "warscroll",
+      "label": "Steelheart’s Champions",
+      "isLegends": true
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Stormcoven"
+    },
+    {
+      "line": 52,
+      "kindHint": "warscroll",
+      "label": "Stormstrike Chariot"
+    },
+    {
+      "line": 53,
+      "kindHint": "warscroll",
+      "label": "Stormstrike Palladors"
+    },
+    {
+      "line": 54,
+      "kindHint": "warscroll",
+      "label": "Vanquishers"
+    },
+    {
+      "line": 55,
+      "kindHint": "warscroll",
+      "label": "Vigilors"
+    },
+    {
+      "line": 56,
+      "kindHint": "warscroll",
+      "label": "Vindictors"
+    },
+    {
+      "line": 57,
+      "kindHint": "warscroll",
+      "label": "Vindictors"
+    },
+    {
+      "line": 58,
+      "kindHint": "warscroll",
+      "label": "Xandire's Truthseekers",
+      "isLegends": true
+    },
+    {
+      "line": 62,
+      "kindHint": "warscroll",
+      "label": "Annihilators"
+    },
+    {
+      "line": 63,
+      "kindHint": "warscroll",
+      "label": "Annihilators with Meteoric Grandhammers"
+    },
+    {
+      "line": 64,
+      "kindHint": "warscroll",
+      "label": "Decimators",
+      "isLegends": true
+    },
+    {
+      "line": 66,
+      "kindHint": "warscroll",
+      "label": "Domitan’s Stormcoven",
+      "isLegends": true
+    },
+    {
+      "line": 68,
+      "kindHint": "warscroll",
+      "label": "Ionus Cryptborn, Warden of Lost Souls"
+    },
+    {
+      "line": 69,
+      "kindHint": "warscroll",
+      "label": "Iridan the Witness"
+    },
+    {
+      "line": 70,
+      "kindHint": "warscroll",
+      "label": "Judicators with Boltstorm Crossbows",
+      "isLegends": true
+    },
+    {
+      "line": 72,
+      "kindHint": "warscroll",
+      "label": "Judicators with Skybolt Bows",
+      "isLegends": true
+    },
+    {
+      "line": 74,
+      "kindHint": "warscroll",
+      "label": "Knight-Azyros"
+    },
+    {
+      "line": 75,
+      "kindHint": "warscroll",
+      "label": "Knight-Questor"
+    },
+    {
+      "line": 76,
+      "kindHint": "warscroll",
+      "label": "Liberators"
+    },
+    {
+      "line": 77,
+      "kindHint": "warscroll",
+      "label": "Lord-Terminos"
+    },
+    {
+      "line": 78,
+      "kindHint": "warscroll",
+      "label": "Lord-Veritant"
+    },
+    {
+      "line": 79,
+      "kindHint": "warscroll",
+      "label": "Lord-Vigilant on Gryph-Stalker"
+    },
+    {
+      "line": 80,
+      "kindHint": "warscroll",
+      "label": "Lord-Vigilant on Morrgryph"
+    },
+    {
+      "line": 81,
+      "kindHint": "warscroll",
+      "label": "Praetors"
+    },
+    {
+      "line": 82,
+      "kindHint": "warscroll",
+      "label": "Prosecutors"
+    },
+    {
+      "line": 83,
+      "kindHint": "warscroll",
+      "label": "Protectors",
+      "isLegends": true
+    },
+    {
+      "line": 85,
+      "kindHint": "warscroll",
+      "label": "Questor Soulsworn"
+    },
+    {
+      "line": 86,
+      "kindHint": "warscroll",
+      "label": "Reclusians"
+    },
+    {
+      "line": 87,
+      "kindHint": "warscroll",
+      "label": "Retributors",
+      "isLegends": true
+    },
+    {
+      "line": 89,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Iridan the Witness"
+    },
+    {
+      "line": 90,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Stormstrike Palladors"
+    },
+    {
+      "line": 91,
+      "kindHint": "warscroll",
+      "label": "Steelheart’s Champions",
+      "isLegends": true
+    },
+    {
+      "line": 93,
+      "kindHint": "warscroll",
+      "label": "Stormcoven"
+    },
+    {
+      "line": 94,
+      "kindHint": "warscroll",
+      "label": "Stormstrike Chariot"
+    },
+    {
+      "line": 95,
+      "kindHint": "warscroll",
+      "label": "Stormstrike Chariot"
+    },
+    {
+      "line": 96,
+      "kindHint": "warscroll",
+      "label": "Stormstrike Palladors"
+    },
+    {
+      "line": 97,
+      "kindHint": "warscroll",
+      "label": "Tornus the Redeemed"
+    },
+    {
+      "line": 98,
+      "kindHint": "warscroll",
+      "label": "Vanquishers"
+    },
+    {
+      "line": 99,
+      "kindHint": "warscroll",
+      "label": "Vigilors"
+    },
+    {
+      "line": 100,
+      "kindHint": "warscroll",
+      "label": "Vindictors"
+    },
+    {
+      "line": 101,
+      "kindHint": "warscroll",
+      "label": "Xandire's Truthseekers",
+      "isLegends": true
+    },
+    {
+      "line": 105,
+      "kindHint": "warscroll",
+      "label": "Stormreach Portal"
+    },
+    {
+      "line": 106,
+      "kindHint": "warscroll",
+      "label": "Stormreach Portal"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/sce-002-renown-army-legends/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/sce-002-renown-army-legends/list.txt
@@ -1,0 +1,109 @@
+Sce1 20850/3000 pts
+-----
+Stormcast Eternals | Ruination Brotherhood
+Army of Renown
+General's Handbook 2026-27
+Auxiliaries: 33 (+10560 Points)
+Drops: 37
+Prayer Lore - Ruination Brotherhood Prayer Lore
+Manifestation Lore - Twilit Sorceries, Morbid Conjuration (20 Points), Forbidden Power (20 Points), Primal Energy (10 Points), Krondspine Incarnate and Aetherwrought Machineries
+Battle Tactics Cards: Blazing Onslaught, Burning for Vengeance, Flanking Firestorm, Legend of the Parch, Siege of Ashes and Smokescreen
+-----
+Regiment 1
+Knight-Azyros (110)
+---
+Regiment 2
+Knight-Questor (110)
+---
+Regiment 3
+Scourge of Aqshy: Iridan the Witness (320)
+---
+Regiment 5
+Tornus the Redeemed (150)
+Annihilators (130)
+Annihilators with Meteoric Grandhammers (180)
+Decimators (240)
+• Legends
+Domitan’s Stormcoven (210)
+• Legends
+Judicators with Boltstorm Crossbows (160)
+• Legends
+Judicators with Skybolt Bows (140)
+• Legends
+Judicators with Skybolt Bows (140)
+• Legends
+Knight-Azyros (110)
+Knight-Azyros (110)
+Knight-Questor (110)
+Liberators (90)
+Lord-Terminos (140)
+Praetors (120)
+Prosecutors (150)
+Protectors (220)
+• Legends
+Questor Soulsworn (210)
+Reclusians (140)
+Retributors (170)
+• Legends
+Scourge of Aqshy: Stormstrike Palladors (220)
+Steelheart’s Champions (110)
+• Legends
+Stormcoven (210)
+Stormstrike Chariot (110)
+Stormstrike Palladors (180)
+Vanquishers (90)
+Vigilors (140)
+Vindictors (90)
+Vindictors (90)
+Xandire's Truthseekers (130)
+• Legends
+-----
+Auxiliary Units
+Annihilators (130)
+Annihilators with Meteoric Grandhammers (180)
+Decimators (240)
+• Legends
+Domitan’s Stormcoven (210)
+• Legends
+Ionus Cryptborn, Warden of Lost Souls (340)
+Iridan the Witness (260)
+Judicators with Boltstorm Crossbows (160)
+• Legends
+Judicators with Skybolt Bows (140)
+• Legends
+Knight-Azyros (110)
+Knight-Questor (110)
+Liberators (90)
+Lord-Terminos (140)
+Lord-Veritant (110)
+Lord-Vigilant on Gryph-Stalker (120)
+Lord-Vigilant on Morrgryph (160)
+Praetors (120)
+Prosecutors (150)
+Protectors (220)
+• Legends
+Questor Soulsworn (210)
+Reclusians (140)
+Retributors (170)
+• Legends
+Scourge of Aqshy: Iridan the Witness (320)
+Scourge of Aqshy: Stormstrike Palladors (220)
+Steelheart’s Champions (110)
+• Legends
+Stormcoven (210)
+Stormstrike Chariot (110)
+Stormstrike Chariot (110)
+Stormstrike Palladors (180)
+Tornus the Redeemed (150)
+Vanquishers (90)
+Vigilors (140)
+Vindictors (90)
+Xandire's Truthseekers (130)
+• Legends
+-----
+Faction Terrain
+Stormreach Portal (20)
+Stormreach Portal (20)
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/ser-002-model-counts/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/ser-002-model-counts/expected.json
@@ -1,0 +1,328 @@
+{
+  "id": "ser-002-model-counts",
+  "diagnostics": [],
+  "proposedName": "Serpahin1",
+  "declaredFaction": "Seraphon",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Sunclaw Starhost"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of Primal Jungles"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of Celestial Manipulation"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Twilit Sorceries"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Morbid Conjuration"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Primal Energy"
+    },
+    {
+      "line": 12,
+      "kindHint": "warscroll",
+      "label": "Terradon Chief"
+    },
+    {
+      "line": 13,
+      "kindHint": "warscroll",
+      "label": "Bastiladon with Ark of Sotek"
+    },
+    {
+      "line": 14,
+      "kindHint": "warscroll",
+      "label": "Bastiladon with Solar Engine"
+    },
+    {
+      "line": 15,
+      "kindHint": "warscroll",
+      "label": "Raptadon Chargers"
+    },
+    {
+      "line": 16,
+      "kindHint": "warscroll",
+      "label": "Raptadon Hunters"
+    },
+    {
+      "line": 17,
+      "kindHint": "warscroll",
+      "label": "Ripperdactyl Riders"
+    },
+    {
+      "line": 18,
+      "kindHint": "warscroll",
+      "label": "Spawn of Chotec"
+    },
+    {
+      "line": 19,
+      "kindHint": "warscroll",
+      "label": "Stegadon"
+    },
+    {
+      "line": 20,
+      "kindHint": "warscroll",
+      "label": "Terradon Riders"
+    },
+    {
+      "line": 21,
+      "kindHint": "warscroll",
+      "label": "Terradon Riders (2 models)"
+    },
+    {
+      "line": 22,
+      "kindHint": "warscroll",
+      "label": "Terrawings"
+    },
+    {
+      "line": 25,
+      "kindHint": "warscroll",
+      "label": "Saurus Astrolith Bearer"
+    },
+    {
+      "line": 28,
+      "kindHint": "warscroll",
+      "label": "Saurus Oldblood"
+    },
+    {
+      "line": 31,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Saurus Scar-Veteran on Aggradon"
+    },
+    {
+      "line": 34,
+      "kindHint": "warscroll",
+      "label": "Slann Starmaster"
+    },
+    {
+      "line": 37,
+      "kindHint": "warscroll",
+      "label": "Aggradon Lancers"
+    },
+    {
+      "line": 38,
+      "kindHint": "warscroll",
+      "label": "Bastiladon with Ark of Sotek"
+    },
+    {
+      "line": 39,
+      "kindHint": "warscroll",
+      "label": "Bastiladon with Solar Engine"
+    },
+    {
+      "line": 40,
+      "kindHint": "warscroll",
+      "label": "Engine of the Gods"
+    },
+    {
+      "line": 41,
+      "kindHint": "warscroll",
+      "label": "Hunters of Huanchi with Dartpipes"
+    },
+    {
+      "line": 42,
+      "kindHint": "warscroll",
+      "label": "Hunters of Huanchi with Starstone Bolas"
+    },
+    {
+      "line": 43,
+      "kindHint": "warscroll",
+      "label": "Kroxigor"
+    },
+    {
+      "line": 44,
+      "kindHint": "warscroll",
+      "label": "Kroxigor Warspawned"
+    },
+    {
+      "line": 45,
+      "kindHint": "warscroll",
+      "label": "Lord Kroak"
+    },
+    {
+      "line": 46,
+      "kindHint": "warscroll",
+      "label": "Raptadon Chargers"
+    },
+    {
+      "line": 47,
+      "kindHint": "warscroll",
+      "label": "Raptadon Hunters"
+    },
+    {
+      "line": 48,
+      "kindHint": "warscroll",
+      "label": "Ripperdactyl Chief"
+    },
+    {
+      "line": 49,
+      "kindHint": "warscroll",
+      "label": "Ripperdactyl Riders"
+    },
+    {
+      "line": 50,
+      "kindHint": "warscroll",
+      "label": "Ripperdactyl Riders (2 models)"
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Saurus Astrolith Bearer"
+    },
+    {
+      "line": 52,
+      "kindHint": "warscroll",
+      "label": "Saurus Guard"
+    },
+    {
+      "line": 53,
+      "kindHint": "warscroll",
+      "label": "Saurus Oldblood"
+    },
+    {
+      "line": 54,
+      "kindHint": "warscroll",
+      "label": "Saurus Oldblood on Carnosaur"
+    },
+    {
+      "line": 55,
+      "kindHint": "warscroll",
+      "label": "Saurus Scar-Veteran on Aggradon"
+    },
+    {
+      "line": 56,
+      "kindHint": "warscroll",
+      "label": "Saurus Scar-Veteran on Carnosaur"
+    },
+    {
+      "line": 57,
+      "kindHint": "warscroll",
+      "label": "Saurus Warriors"
+    },
+    {
+      "line": 58,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Saurus Scar-Veteran on Aggradon"
+    },
+    {
+      "line": 59,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Slann Starmaster"
+    },
+    {
+      "line": 60,
+      "kindHint": "warscroll",
+      "label": "Skink Oracle on Troglodon"
+    },
+    {
+      "line": 61,
+      "kindHint": "warscroll",
+      "label": "Skink Starpriest"
+    },
+    {
+      "line": 62,
+      "kindHint": "warscroll",
+      "label": "Skink Starseer"
+    },
+    {
+      "line": 63,
+      "kindHint": "warscroll",
+      "label": "Skinks"
+    },
+    {
+      "line": 64,
+      "kindHint": "warscroll",
+      "label": "Slann Starmaster"
+    },
+    {
+      "line": 65,
+      "kindHint": "warscroll",
+      "label": "Spawn of Chotec"
+    },
+    {
+      "line": 66,
+      "kindHint": "warscroll",
+      "label": "Stegadon"
+    },
+    {
+      "line": 67,
+      "kindHint": "warscroll",
+      "label": "Stegadon Chief"
+    },
+    {
+      "line": 68,
+      "kindHint": "warscroll",
+      "label": "Sunblood Pack"
+    },
+    {
+      "line": 69,
+      "kindHint": "warscroll",
+      "label": "Terradon Chief"
+    },
+    {
+      "line": 70,
+      "kindHint": "warscroll",
+      "label": "Terradon Riders"
+    },
+    {
+      "line": 71,
+      "kindHint": "warscroll",
+      "label": "Terradon Riders (2 models)"
+    },
+    {
+      "line": 72,
+      "kindHint": "warscroll",
+      "label": "Terrawings"
+    },
+    {
+      "line": 73,
+      "kindHint": "warscroll",
+      "label": "The Jaws of Itzl",
+      "isLegends": true
+    },
+    {
+      "line": 75,
+      "kindHint": "warscroll",
+      "label": "The Starblood Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 77,
+      "kindHint": "warscroll",
+      "label": "The Starblood Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 81,
+      "kindHint": "warscroll",
+      "label": "Realmshaper Engine"
+    },
+    {
+      "line": 82,
+      "kindHint": "warscroll",
+      "label": "Realmshaper Engine"
+    },
+    {
+      "line": 83,
+      "kindHint": "warscroll",
+      "label": "Realmshaper Engine"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/ser-002-model-counts/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/ser-002-model-counts/list.txt
@@ -1,0 +1,86 @@
+Serpahin1 22460/3000 pts
+-----
+Grand Alliance Order | Seraphon | Sunclaw Starhost
+General's Handbook 2026-27
+Auxiliaries: 39 (+14820 Points)
+Drops: 44
+Spell Lore - Lore of Primal Jungles and Lore of Celestial Manipulation
+Manifestation Lore - Twilit Sorceries, Morbid Conjuration (20 Points) and Primal Energy (10 Points)
+Battle Tactics Cards: Siege of Ashes and Smokescreen
+-----
+Regiment 1
+Terradon Chief (100)
+Bastiladon with Ark of Sotek (230)
+Bastiladon with Solar Engine (200)
+Raptadon Chargers (140)
+Raptadon Hunters (120)
+Ripperdactyl Riders (100)
+Spawn of Chotec (100)
+Stegadon (150)
+Terradon Riders (90)
+Terradon Riders (2 models) (70)
+Terrawings (70)
+---
+Regiment 2
+Saurus Astrolith Bearer (100)
+---
+Regiment 3
+Saurus Oldblood (90)
+---
+Regiment 4
+Scourge of Aqshy: Saurus Scar-Veteran on Aggradon (130)
+---
+Regiment 5
+Slann Starmaster (260)
+-----
+Auxiliary Units
+Aggradon Lancers (200)
+Bastiladon with Ark of Sotek (230)
+Bastiladon with Solar Engine (200)
+Engine of the Gods (150)
+Hunters of Huanchi with Dartpipes (80)
+Hunters of Huanchi with Starstone Bolas (90)
+Kroxigor (200)
+Kroxigor Warspawned (200)
+Lord Kroak (410)
+Raptadon Chargers (140)
+Raptadon Hunters (120)
+Ripperdactyl Chief (110)
+Ripperdactyl Riders (100)
+Ripperdactyl Riders (2 models) (70)
+Saurus Astrolith Bearer (100)
+Saurus Guard (110)
+Saurus Oldblood (90)
+Saurus Oldblood on Carnosaur (220)
+Saurus Scar-Veteran on Aggradon (140)
+Saurus Scar-Veteran on Carnosaur (200)
+Saurus Warriors (140)
+Scourge of Aqshy: Saurus Scar-Veteran on Aggradon (130)
+Scourge of Aqshy: Slann Starmaster (230)
+Skink Oracle on Troglodon (200)
+Skink Starpriest (90)
+Skink Starseer (140)
+Skinks (80)
+Slann Starmaster (260)
+Spawn of Chotec (100)
+Stegadon (150)
+Stegadon Chief (160)
+Sunblood Pack (150)
+Terradon Chief (100)
+Terradon Riders (90)
+Terradon Riders (2 models) (70)
+Terrawings (70)
+The Jaws of Itzl (120)
+• Legends
+The Starblood Stalkers (110)
+• Legends
+The Starblood Stalkers (110)
+• Legends
+-----
+Faction Terrain
+Realmshaper Engine
+Realmshaper Engine
+Realmshaper Engine
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/sob-001-renown-no-terrain/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/sob-001-renown-no-terrain/expected.json
@@ -69,22 +69,26 @@
     {
       "line": 26,
       "kindHint": "warscroll",
-      "label": "Mortisan Ossifector"
+      "label": "Mortisan Ossifector",
+      "isRegimentOfRenown": true
     },
     {
       "line": 27,
       "kindHint": "warscroll",
-      "label": "Gothizzar Harvester"
+      "label": "Gothizzar Harvester",
+      "isRegimentOfRenown": true
     },
     {
       "line": 28,
       "kindHint": "warscroll",
-      "label": "Mortek Guard"
+      "label": "Mortek Guard",
+      "isRegimentOfRenown": true
     },
     {
       "line": 29,
       "kindHint": "warscroll",
-      "label": "Mortek Guard"
+      "label": "Mortek Guard",
+      "isRegimentOfRenown": true
     },
     {
       "line": 32,

--- a/src/tests/fixtures/aos4/import/official-app/lists/syl-001-outcasts/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/syl-001-outcasts/expected.json
@@ -1,0 +1,286 @@
+{
+  "id": "syl-001-outcasts",
+  "diagnostics": [],
+  "proposedName": "Syl1",
+  "declaredFaction": "Sylvaneth",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Outcasts"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of the Deepwood"
+    },
+    {
+      "line": 8,
+      "kindHint": "prayer-lore",
+      "label": "Lore of the Spirit-Song"
+    },
+    {
+      "line": 9,
+      "kindHint": "manifestation-lore",
+      "label": "Twilit Sorceries"
+    },
+    {
+      "line": 9,
+      "kindHint": "manifestation-lore",
+      "label": "Manifestations of the Deepwood"
+    },
+    {
+      "line": 13,
+      "kindHint": "warscroll",
+      "label": "Belthanos, First Thorn of Kurnoth"
+    },
+    {
+      "line": 16,
+      "kindHint": "warscroll",
+      "label": "Arch-Revenant"
+    },
+    {
+      "line": 19,
+      "kindHint": "warscroll",
+      "label": "Branchwych"
+    },
+    {
+      "line": 22,
+      "kindHint": "warscroll",
+      "label": "Grove Guardian"
+    },
+    {
+      "line": 25,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Treelord Ancient"
+    },
+    {
+      "line": 26,
+      "kindHint": "warscroll",
+      "label": "Arch-Revenant"
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Dryads"
+    },
+    {
+      "line": 28,
+      "kindHint": "warscroll",
+      "label": "Gossamid Archers"
+    },
+    {
+      "line": 29,
+      "kindHint": "warscroll",
+      "label": "Kurnoth Hunters with Greatbows"
+    },
+    {
+      "line": 30,
+      "kindHint": "warscroll",
+      "label": "Kurnoth Hunters with Greatscythes"
+    },
+    {
+      "line": 31,
+      "kindHint": "warscroll",
+      "label": "Kurnoth Hunters with Greatswords"
+    },
+    {
+      "line": 32,
+      "kindHint": "warscroll",
+      "label": "Kurnoth’s Heralds",
+      "isLegends": true
+    },
+    {
+      "line": 34,
+      "kindHint": "warscroll",
+      "label": "Revenant Seekers"
+    },
+    {
+      "line": 35,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Kurnoth Hunters with Greatswords"
+    },
+    {
+      "line": 36,
+      "kindHint": "warscroll",
+      "label": "Skaeth's Wild Hunt",
+      "isLegends": true
+    },
+    {
+      "line": 38,
+      "kindHint": "warscroll",
+      "label": "Spite-Revenants"
+    },
+    {
+      "line": 39,
+      "kindHint": "warscroll",
+      "label": "Spiterider Lancers"
+    },
+    {
+      "line": 40,
+      "kindHint": "warscroll",
+      "label": "The Twistweald"
+    },
+    {
+      "line": 41,
+      "kindHint": "warscroll",
+      "label": "Tree-Revenants"
+    },
+    {
+      "line": 42,
+      "kindHint": "warscroll",
+      "label": "Treelord"
+    },
+    {
+      "line": 43,
+      "kindHint": "warscroll",
+      "label": "Ylthari's Guardians",
+      "isLegends": true
+    },
+    {
+      "line": 47,
+      "kindHint": "warscroll",
+      "label": "Alarielle the Everqueen"
+    },
+    {
+      "line": 48,
+      "kindHint": "warscroll",
+      "label": "Arch-Revenant"
+    },
+    {
+      "line": 49,
+      "kindHint": "warscroll",
+      "label": "Belthanos, First Thorn of Kurnoth"
+    },
+    {
+      "line": 50,
+      "kindHint": "warscroll",
+      "label": "Branchwych"
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Dryads"
+    },
+    {
+      "line": 52,
+      "kindHint": "warscroll",
+      "label": "Drycha Hamadreth"
+    },
+    {
+      "line": 53,
+      "kindHint": "warscroll",
+      "label": "Gossamid Archers"
+    },
+    {
+      "line": 54,
+      "kindHint": "warscroll",
+      "label": "Grove Guardian"
+    },
+    {
+      "line": 55,
+      "kindHint": "warscroll",
+      "label": "Kurnoth Hunters with Greatbows"
+    },
+    {
+      "line": 56,
+      "kindHint": "warscroll",
+      "label": "Kurnoth Hunters with Greatscythes"
+    },
+    {
+      "line": 57,
+      "kindHint": "warscroll",
+      "label": "Kurnoth Hunters with Greatswords"
+    },
+    {
+      "line": 58,
+      "kindHint": "warscroll",
+      "label": "Kurnoth’s Heralds",
+      "isLegends": true
+    },
+    {
+      "line": 60,
+      "kindHint": "warscroll",
+      "label": "Revenant Seekers"
+    },
+    {
+      "line": 61,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Kurnoth Hunters with Greatswords"
+    },
+    {
+      "line": 62,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Treelord Ancient"
+    },
+    {
+      "line": 63,
+      "kindHint": "warscroll",
+      "label": "Skaeth's Wild Hunt",
+      "isLegends": true
+    },
+    {
+      "line": 65,
+      "kindHint": "warscroll",
+      "label": "Spirit of Durthu"
+    },
+    {
+      "line": 66,
+      "kindHint": "warscroll",
+      "label": "Spite-Revenants"
+    },
+    {
+      "line": 67,
+      "kindHint": "warscroll",
+      "label": "Spiterider Lancers"
+    },
+    {
+      "line": 68,
+      "kindHint": "warscroll",
+      "label": "The Lady of Vines"
+    },
+    {
+      "line": 69,
+      "kindHint": "warscroll",
+      "label": "The Twistweald"
+    },
+    {
+      "line": 70,
+      "kindHint": "warscroll",
+      "label": "Tree-Revenants"
+    },
+    {
+      "line": 71,
+      "kindHint": "warscroll",
+      "label": "Treelord"
+    },
+    {
+      "line": 72,
+      "kindHint": "warscroll",
+      "label": "Treelord Ancient"
+    },
+    {
+      "line": 73,
+      "kindHint": "warscroll",
+      "label": "Warsong Revenant"
+    },
+    {
+      "line": 74,
+      "kindHint": "warscroll",
+      "label": "Ylthari's Guardians",
+      "isLegends": true
+    },
+    {
+      "line": 78,
+      "kindHint": "warscroll",
+      "label": "Awakened Wyldwood"
+    },
+    {
+      "line": 79,
+      "kindHint": "warscroll",
+      "label": "Awakened Wyldwood"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/syl-001-outcasts/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/syl-001-outcasts/list.txt
@@ -1,0 +1,82 @@
+Syl1 15350/3000 pts
+-----
+Grand Alliance Order | Sylvaneth | Outcasts
+General's Handbook 2026-27
+Auxiliaries: 26 (+6500 Points)
+Drops: 31
+Spell Lore - Lore of the Deepwood
+Prayer Lore - Lore of the Spirit-Song
+Manifestation Lore - Twilit Sorceries and Manifestations of the Deepwood
+Battle Tactics Cards: Burning for Vengeance
+-----
+Regiment 1
+Belthanos, First Thorn of Kurnoth (290)
+---
+Regiment 2
+Arch-Revenant (110)
+---
+Regiment 3
+Branchwych (100)
+---
+Regiment 4
+Grove Guardian (220)
+---
+Regiment 5
+Scourge of Aqshy: Treelord Ancient (290)
+Arch-Revenant (110)
+Dryads (100)
+Gossamid Archers (120)
+Kurnoth Hunters with Greatbows (190)
+Kurnoth Hunters with Greatscythes (200)
+Kurnoth Hunters with Greatswords (210)
+Kurnoth’s Heralds (110)
+• Legends
+Revenant Seekers (180)
+Scourge of Aqshy: Kurnoth Hunters with Greatswords (240)
+Skaeth's Wild Hunt (90)
+• Legends
+Spite-Revenants (100)
+Spiterider Lancers (230)
+The Twistweald (140)
+Tree-Revenants (110)
+Treelord (240)
+Ylthari's Guardians (140)
+• Legends
+-----
+Auxiliary Units
+Alarielle the Everqueen (620)
+Arch-Revenant (110)
+Belthanos, First Thorn of Kurnoth (290)
+Branchwych (100)
+Dryads (100)
+Drycha Hamadreth (250)
+Gossamid Archers (120)
+Grove Guardian (220)
+Kurnoth Hunters with Greatbows (190)
+Kurnoth Hunters with Greatscythes (200)
+Kurnoth Hunters with Greatswords (210)
+Kurnoth’s Heralds (110)
+• Legends
+Revenant Seekers (180)
+Scourge of Aqshy: Kurnoth Hunters with Greatswords (240)
+Scourge of Aqshy: Treelord Ancient (290)
+Skaeth's Wild Hunt (90)
+• Legends
+Spirit of Durthu (320)
+Spite-Revenants (100)
+Spiterider Lancers (230)
+The Lady of Vines (280)
+The Twistweald (140)
+Tree-Revenants (110)
+Treelord (240)
+Treelord Ancient (280)
+Warsong Revenant (170)
+Ylthari's Guardians (140)
+• Legends
+-----
+Faction Terrain
+Awakened Wyldwood
+Awakened Wyldwood
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/support/officialAppFixtures.ts
+++ b/src/tests/support/officialAppFixtures.ts
@@ -55,6 +55,7 @@ export const officialAppGolden = (id: string): unknown => {
             label: selection.label,
             ...(selection.count === undefined ? {} : { count: selection.count }),
             ...(selection.isLegends ? { isLegends: true } : {}),
+            ...(selection.isRegimentOfRenown ? { isRegimentOfRenown: true } : {}),
           })),
         }
       : { parsedRoster: null }),


### PR DESCRIPTION
Two more real Storm Forge exports. **Neither needed a parser change** — both already decode correctly after #1787 and #1788. These pin the behaviour so it stays that way.

## `ser-002-model-counts`

Seraphon, and the interesting line is:

```
Terradon Riders (2 models) (70)
```

Two parenthesised suffixes on one line. Only the points are bookkeeping — the catalog ships `Terradon Riders` and `Terradon Riders (2 models)` as **separate warscrolls**, so the model count is part of the identity and has to survive for the roster to pick the right one. `normalizeImportLabelExact` already prefers the exact form for precisely this reason; the parser just has to not eat it.

Verified end to end: 60 of 63 selections resolve against the shipped catalog, and the only three misses are the manifestations tracked in #1783. Also carries three identical `Realmshaper Engine` terrain entries, all kept.

## `sce-002-renown-army-legends`

A Stormcast Army of Renown with the densest Legends usage seen so far — 17 `• Legends` marks in one list, all landing on the right unit. Straight and curly apostrophes appear in the same list (`Xandire's Truthseekers` vs `Domitan’s Stormcoven`), and both survive; label normalisation reduces all punctuation to spaces, so the two forms compare equal against the catalog either way. Two pointed faction terrain entries (`Stormreach Portal (20)` twice), both kept with points stripped.

## Testing

- `yarn test --run` — 935 tests across 67 files
- `yarn tsc --noEmit` and `yarn lint` clean
- Resolution checked per fixture; every remaining miss across all 14 lists is catalog data in #1783