### PR TITLE
test(import): cover singular model counts and five-member renown bundles

### DIFF
--- a/src/tests/aos4/importOfficialApp.test.ts
+++ b/src/tests/aos4/importOfficialApp.test.ts
@@ -223,6 +223,21 @@ describe('official AoS app text import', () => {
       expect(labelled(parsed, 'warscroll')).toEqual(['Terradon Riders', 'Terradon Riders (2 models)'])
     })
 
+    it('keeps a singular model count too', () => {
+      // The app writes "(1 model)", not "(1 models)", and the catalog carries the variant under
+      // that exact spelling — so the singular has to survive as faithfully as the plural.
+      const parsed = decode(
+        "Grand Alliance Chaos | Maggotkin of Nurgle | Nurgle's Menagerie",
+        'Auxiliary Units',
+        'Pusgoyle Blightlords (190)',
+        'Pusgoyle Blightlords (1 model) (110)'
+      )
+      expect(labelled(parsed, 'warscroll')).toEqual([
+        'Pusgoyle Blightlords',
+        'Pusgoyle Blightlords (1 model)',
+      ])
+    })
+
     it('keeps every faction terrain entry, not just the first', () => {
       const parsed = decode(
         'Grand Alliance Destruction | Ogor Mawtribes | Greedy Eaters',

--- a/src/tests/fixtures/aos4/import/official-app/README.md
+++ b/src/tests/fixtures/aos4/import/official-app/README.md
@@ -78,6 +78,8 @@ Fail closed on malformed or hostile input, never on an illegal army.
 | `dot-001-and-in-unit-name` | the boundary in one list: a spell lore row **is** split on ` and `, while `Blue Horrors and Brimstone Horrors` is one unit and must not be |
 | `hos-001-auxiliary-only` | no `Regiment N` sections at all — the roster goes straight from the header to `Auxiliary Units` |
 | `hh-001-renown-stress` | 18 dashless regiments of renown, 51 members, one bundle repeated four times — the densest renown case in the corpus |
+| `mon-001-singular-model-count` | `Pusgoyle Blightlords (1 model) (110)` — the singular `model`, which resolves to a different warscroll than the plural entry beside it |
+| `skv-001-renown-manifestation-members` | the largest list in the corpus (117 selections, 57 renown members), with five-member bundles whose members include manifestations |
 
 ## Points are dropped on purpose
 

--- a/src/tests/fixtures/aos4/import/official-app/lists/mon-001-singular-model-count/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/mon-001-singular-model-count/expected.json
@@ -1,0 +1,250 @@
+{
+  "id": "mon-001-singular-model-count",
+  "diagnostics": [],
+  "proposedName": "Nurg1",
+  "declaredFaction": "Maggotkin of Nurgle",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Nurgle's Menagerie"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of Malignance"
+    },
+    {
+      "line": 8,
+      "kindHint": "prayer-lore",
+      "label": "Lore of Virulence"
+    },
+    {
+      "line": 8,
+      "kindHint": "prayer-lore",
+      "label": "Benedictions of Sickness"
+    },
+    {
+      "line": 12,
+      "kindHint": "warscroll",
+      "label": "Doktor Festus",
+      "isLegends": true
+    },
+    {
+      "line": 16,
+      "kindHint": "warscroll",
+      "label": "Beast of Nurgle"
+    },
+    {
+      "line": 17,
+      "kindHint": "warscroll",
+      "label": "Beast of Nurgle"
+    },
+    {
+      "line": 18,
+      "kindHint": "warscroll",
+      "label": "Belga the Cystwitch"
+    },
+    {
+      "line": 19,
+      "kindHint": "warscroll",
+      "label": "Bloab Rotspawned"
+    },
+    {
+      "line": 20,
+      "kindHint": "warscroll",
+      "label": "Cankerborn"
+    },
+    {
+      "line": 21,
+      "kindHint": "warscroll",
+      "label": "Doktor Festus",
+      "isLegends": true
+    },
+    {
+      "line": 23,
+      "kindHint": "warscroll",
+      "label": "Epidemius, Tallyman of Nurgle",
+      "isLegends": true
+    },
+    {
+      "line": 25,
+      "kindHint": "warscroll",
+      "label": "Festus the Leechlord"
+    },
+    {
+      "line": 26,
+      "kindHint": "warscroll",
+      "label": "Gelgus Pust"
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Grandfather's Gardeners",
+      "isLegends": true
+    },
+    {
+      "line": 29,
+      "kindHint": "warscroll",
+      "label": "Great Unclean One"
+    },
+    {
+      "line": 30,
+      "kindHint": "warscroll",
+      "label": "Gutrot Spume"
+    },
+    {
+      "line": 31,
+      "kindHint": "warscroll",
+      "label": "Harbinger of Decay"
+    },
+    {
+      "line": 32,
+      "kindHint": "warscroll",
+      "label": "Horticulous Slimux"
+    },
+    {
+      "line": 33,
+      "kindHint": "warscroll",
+      "label": "Lord of Afflictions"
+    },
+    {
+      "line": 34,
+      "kindHint": "warscroll",
+      "label": "Lord of Blights"
+    },
+    {
+      "line": 35,
+      "kindHint": "warscroll",
+      "label": "Lord of Plagues"
+    },
+    {
+      "line": 36,
+      "kindHint": "warscroll",
+      "label": "Morbidex Twiceborn"
+    },
+    {
+      "line": 37,
+      "kindHint": "warscroll",
+      "label": "Nurglings"
+    },
+    {
+      "line": 38,
+      "kindHint": "warscroll",
+      "label": "Orghotts Daemonspew"
+    },
+    {
+      "line": 39,
+      "kindHint": "warscroll",
+      "label": "Pestigors"
+    },
+    {
+      "line": 40,
+      "kindHint": "warscroll",
+      "label": "Plague Drones"
+    },
+    {
+      "line": 41,
+      "kindHint": "warscroll",
+      "label": "Plaguebearers"
+    },
+    {
+      "line": 42,
+      "kindHint": "warscroll",
+      "label": "Pox-Wretches"
+    },
+    {
+      "line": 43,
+      "kindHint": "warscroll",
+      "label": "Poxbringer, Herald of Nurgle"
+    },
+    {
+      "line": 44,
+      "kindHint": "warscroll",
+      "label": "Pusgoyle Blightlords"
+    },
+    {
+      "line": 45,
+      "kindHint": "warscroll",
+      "label": "Pusgoyle Blightlords (1 model)"
+    },
+    {
+      "line": 46,
+      "kindHint": "warscroll",
+      "label": "Putrid Blightkings"
+    },
+    {
+      "line": 47,
+      "kindHint": "warscroll",
+      "label": "Rotbringer Sorcerer"
+    },
+    {
+      "line": 48,
+      "kindHint": "warscroll",
+      "label": "Rotigus"
+    },
+    {
+      "line": 49,
+      "kindHint": "warscroll",
+      "label": "Rotmire Creed"
+    },
+    {
+      "line": 50,
+      "kindHint": "warscroll",
+      "label": "Rotswords"
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Putrid Blightkings"
+    },
+    {
+      "line": 52,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Sloven Knights"
+    },
+    {
+      "line": 53,
+      "kindHint": "warscroll",
+      "label": "Shaman Foulhoof"
+    },
+    {
+      "line": 54,
+      "kindHint": "warscroll",
+      "label": "Sloppity Bilepiper, Herald of Nurgle"
+    },
+    {
+      "line": 55,
+      "kindHint": "warscroll",
+      "label": "Sloven Knights"
+    },
+    {
+      "line": 56,
+      "kindHint": "warscroll",
+      "label": "Spoilpox Scrivener, Herald of Nurgle"
+    },
+    {
+      "line": 57,
+      "kindHint": "warscroll",
+      "label": "The Glottkin"
+    },
+    {
+      "line": 58,
+      "kindHint": "warscroll",
+      "label": "The Wurmspat",
+      "isLegends": true
+    },
+    {
+      "line": 62,
+      "kindHint": "warscroll",
+      "label": "Feculent Gnarlmaw"
+    },
+    {
+      "line": 63,
+      "kindHint": "warscroll",
+      "label": "Feculent Gnarlmaw"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/mon-001-singular-model-count/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/mon-001-singular-model-count/list.txt
@@ -1,0 +1,66 @@
+Nurg1 22430/3000 pts
+-----
+Grand Alliance Chaos | Maggotkin of Nurgle | Nurgle's Menagerie
+General's Handbook 2026-27
+Auxiliaries: 40 (+15600 Points)
+Drops: 41
+Spell Lore - Lore of Malignance
+Prayer Lore - Lore of Virulence and Benedictions of Sickness
+Battle Tactics Cards: Legend of the Parch
+-----
+Regiment 1
+Doktor Festus (100)
+• Legends
+-----
+Auxiliary Units
+Beast of Nurgle (100)
+Beast of Nurgle (100)
+Belga the Cystwitch (130)
+Bloab Rotspawned (260)
+Cankerborn (180)
+Doktor Festus (100)
+• Legends
+Epidemius, Tallyman of Nurgle (130)
+• Legends
+Festus the Leechlord (290)
+Gelgus Pust (200)
+Grandfather's Gardeners (110)
+• Legends
+Great Unclean One (380)
+Gutrot Spume (100)
+Harbinger of Decay (140)
+Horticulous Slimux (140)
+Lord of Afflictions (170)
+Lord of Blights (140)
+Lord of Plagues (120)
+Morbidex Twiceborn (250)
+Nurglings (100)
+Orghotts Daemonspew (260)
+Pestigors (140)
+Plague Drones (150)
+Plaguebearers (130)
+Pox-Wretches (110)
+Poxbringer, Herald of Nurgle (90)
+Pusgoyle Blightlords (190)
+Pusgoyle Blightlords (1 model) (110)
+Putrid Blightkings (130)
+Rotbringer Sorcerer (100)
+Rotigus (420)
+Rotmire Creed (110)
+Rotswords (210)
+Scourge of Aqshy: Putrid Blightkings (140)
+Scourge of Aqshy: Sloven Knights (210)
+Shaman Foulhoof (110)
+Sloppity Bilepiper, Herald of Nurgle (90)
+Sloven Knights (180)
+Spoilpox Scrivener, Herald of Nurgle (80)
+The Glottkin (470)
+The Wurmspat (160)
+• Legends
+-----
+Faction Terrain
+Feculent Gnarlmaw
+Feculent Gnarlmaw
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/skv-001-renown-manifestation-members/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/skv-001-renown-manifestation-members/expected.json
@@ -1,0 +1,659 @@
+{
+  "id": "skv-001-renown-manifestation-members",
+  "diagnostics": [],
+  "proposedName": "Skaven1",
+  "declaredFaction": "Skaven",
+  "declaredContext": "General's Handbook 2025-26",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Fleshmeld Menagerie"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of Ruin"
+    },
+    {
+      "line": 8,
+      "kindHint": "prayer-lore",
+      "label": "Noxious Prayers"
+    },
+    {
+      "line": 9,
+      "kindHint": "manifestation-lore",
+      "label": "Manifestations of Doom"
+    },
+    {
+      "line": 13,
+      "kindHint": "warscroll",
+      "label": "Clawlord"
+    },
+    {
+      "line": 14,
+      "kindHint": "warscroll",
+      "label": "Clanrats"
+    },
+    {
+      "line": 15,
+      "kindHint": "warscroll",
+      "label": "Spiteclaw's Swarm",
+      "isLegends": true
+    },
+    {
+      "line": 17,
+      "kindHint": "warscroll",
+      "label": "Stormvermin"
+    },
+    {
+      "line": 21,
+      "kindHint": "warscroll",
+      "label": "Gunnar Brand",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 22,
+      "kindHint": "warscroll",
+      "label": "Singri Brand",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 23,
+      "kindHint": "warscroll",
+      "label": "The Oathsworn Kin",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 25,
+      "kindHint": "warscroll",
+      "label": "Outlaw Conqueror Cogfort",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Sloppity Bilepiper, Herald of Nurgle",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 28,
+      "kindHint": "warscroll",
+      "label": "Beast of Nurgle",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 29,
+      "kindHint": "warscroll",
+      "label": "Beast of Nurgle",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 31,
+      "kindHint": "warscroll",
+      "label": "Mortisan Ossifector",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 32,
+      "kindHint": "warscroll",
+      "label": "Gothizzar Harvester",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 33,
+      "kindHint": "warscroll",
+      "label": "Mortek Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 34,
+      "kindHint": "warscroll",
+      "label": "Mortek Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 36,
+      "kindHint": "warscroll",
+      "label": "Ogroid Myrmidon",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 37,
+      "kindHint": "warscroll",
+      "label": "Fomoroid Crusher",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 38,
+      "kindHint": "warscroll",
+      "label": "Mindstealer Sphiranx",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 40,
+      "kindHint": "warscroll",
+      "label": "Chaos Lord on Daemonic Mount",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 41,
+      "kindHint": "warscroll",
+      "label": "Chaos Knights",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 42,
+      "kindHint": "warscroll",
+      "label": "Chaos Warriors",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 44,
+      "kindHint": "warscroll",
+      "label": "Mask of the Deceiver",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 46,
+      "kindHint": "warscroll",
+      "label": "Shardspeaker of Slaanesh",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 47,
+      "kindHint": "warscroll",
+      "label": "Blissbarb Archers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 49,
+      "kindHint": "warscroll",
+      "label": "Nurglings",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 50,
+      "kindHint": "warscroll",
+      "label": "Nurglings",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 52,
+      "kindHint": "warscroll",
+      "label": "Warstomper Mega-Gargant",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 54,
+      "kindHint": "warscroll",
+      "label": "Harbinger of Decay",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 55,
+      "kindHint": "warscroll",
+      "label": "Pusgoyle Blightlords",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 56,
+      "kindHint": "warscroll",
+      "label": "Putrid Blightkings",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 58,
+      "kindHint": "warscroll",
+      "label": "Outlaw Cannonade Cogfort",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 60,
+      "kindHint": "warscroll",
+      "label": "Ashen Elder",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 61,
+      "kindHint": "warscroll",
+      "label": "Dominator Engine with Bane Maces",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 63,
+      "kindHint": "warscroll",
+      "label": "Magister on Disc of Tzeentch",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 64,
+      "kindHint": "warscroll",
+      "label": "Gaunt Summoner on Disc of Tzeentch",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 65,
+      "kindHint": "warscroll",
+      "label": "Screamers of Tzeentch",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 67,
+      "kindHint": "warscroll",
+      "label": "Loonboss",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 68,
+      "kindHint": "warscroll",
+      "label": "Dankhold Troggoth",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 70,
+      "kindHint": "warscroll",
+      "label": "Mancrusher Gargant",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 72,
+      "kindHint": "warscroll",
+      "label": "Contorted Epitome",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 73,
+      "kindHint": "warscroll",
+      "label": "Dreadful Visage",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 74,
+      "kindHint": "warscroll",
+      "label": "Mesmerising Mirror",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 75,
+      "kindHint": "warscroll",
+      "label": "Wheels of Excruciation",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 77,
+      "kindHint": "warscroll",
+      "label": "Magister",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 78,
+      "kindHint": "warscroll",
+      "label": "Burning Sigil of Tzeentch",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 79,
+      "kindHint": "warscroll",
+      "label": "Daemonic Simulacrum",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 80,
+      "kindHint": "warscroll",
+      "label": "Pink Horrors",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 81,
+      "kindHint": "warscroll",
+      "label": "Tome of Eyes",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 83,
+      "kindHint": "warscroll",
+      "label": "Daemonsmith",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 84,
+      "kindHint": "warscroll",
+      "label": "Deathshrieker Rocket Battery",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 85,
+      "kindHint": "warscroll",
+      "label": "Tormentor Bombard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 87,
+      "kindHint": "warscroll",
+      "label": "Spoilpox Scrivener, Herald of Nurgle",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 88,
+      "kindHint": "warscroll",
+      "label": "Feculent Gnarlmaw",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 89,
+      "kindHint": "warscroll",
+      "label": "Plaguebearers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 91,
+      "kindHint": "warscroll",
+      "label": "Skarbrand",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 93,
+      "kindHint": "warscroll",
+      "label": "Slaughterpriest",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 94,
+      "kindHint": "warscroll",
+      "label": "Bloodreavers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 95,
+      "kindHint": "warscroll",
+      "label": "Skullreapers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 97,
+      "kindHint": "warscroll",
+      "label": "Slaughterpriest",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 98,
+      "kindHint": "warscroll",
+      "label": "Bloodreavers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 99,
+      "kindHint": "warscroll",
+      "label": "Skullreapers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 102,
+      "kindHint": "warscroll",
+      "label": "Acolyte Globadiers"
+    },
+    {
+      "line": 103,
+      "kindHint": "warscroll",
+      "label": "Arch-Warlock"
+    },
+    {
+      "line": 104,
+      "kindHint": "warscroll",
+      "label": "Brood Terror"
+    },
+    {
+      "line": 105,
+      "kindHint": "warscroll",
+      "label": "Clanrats"
+    },
+    {
+      "line": 106,
+      "kindHint": "warscroll",
+      "label": "Clawlord"
+    },
+    {
+      "line": 107,
+      "kindHint": "warscroll",
+      "label": "Clawlord on Gnaw-beast"
+    },
+    {
+      "line": 108,
+      "kindHint": "warscroll",
+      "label": "Deathmaster"
+    },
+    {
+      "line": 109,
+      "kindHint": "warscroll",
+      "label": "Deathmaster Crixxit"
+    },
+    {
+      "line": 110,
+      "kindHint": "warscroll",
+      "label": "Doom-Flayers"
+    },
+    {
+      "line": 111,
+      "kindHint": "warscroll",
+      "label": "Doomwheel"
+    },
+    {
+      "line": 112,
+      "kindHint": "warscroll",
+      "label": "Grey Seer"
+    },
+    {
+      "line": 113,
+      "kindHint": "warscroll",
+      "label": "Grey Seer on Screaming Bell"
+    },
+    {
+      "line": 114,
+      "kindHint": "warscroll",
+      "label": "Gutter Runners"
+    },
+    {
+      "line": 115,
+      "kindHint": "warscroll",
+      "label": "Hell Pit Abomination"
+    },
+    {
+      "line": 116,
+      "kindHint": "warscroll",
+      "label": "Krittok Foulblade"
+    },
+    {
+      "line": 117,
+      "kindHint": "warscroll",
+      "label": "Lord Skreech Verminking"
+    },
+    {
+      "line": 118,
+      "kindHint": "warscroll",
+      "label": "Master Moulder"
+    },
+    {
+      "line": 119,
+      "kindHint": "warscroll",
+      "label": "Night Runners"
+    },
+    {
+      "line": 120,
+      "kindHint": "warscroll",
+      "label": "Plague Censer Bearers",
+      "isLegends": true
+    },
+    {
+      "line": 122,
+      "kindHint": "warscroll",
+      "label": "Plague Monks"
+    },
+    {
+      "line": 123,
+      "kindHint": "warscroll",
+      "label": "Plague Priest",
+      "isLegends": true
+    },
+    {
+      "line": 125,
+      "kindHint": "warscroll",
+      "label": "Plague Priest on Plague Furnace"
+    },
+    {
+      "line": 126,
+      "kindHint": "warscroll",
+      "label": "Plagueclaw"
+    },
+    {
+      "line": 127,
+      "kindHint": "warscroll",
+      "label": "Plaguepack"
+    },
+    {
+      "line": 128,
+      "kindHint": "warscroll",
+      "label": "Rat Ogors"
+    },
+    {
+      "line": 129,
+      "kindHint": "warscroll",
+      "label": "Ratling Guns"
+    },
+    {
+      "line": 130,
+      "kindHint": "warscroll",
+      "label": "Ratling Warpblaster"
+    },
+    {
+      "line": 131,
+      "kindHint": "warscroll",
+      "label": "Scourge of Ghyran Brood Terror"
+    },
+    {
+      "line": 132,
+      "kindHint": "warscroll",
+      "label": "Scourge of Ghyran Grey Seer on Screaming Bell"
+    },
+    {
+      "line": 133,
+      "kindHint": "warscroll",
+      "label": "Skabbik's Plaguepack",
+      "isLegends": true
+    },
+    {
+      "line": 135,
+      "kindHint": "warscroll",
+      "label": "Skittershank's Clawpack",
+      "isLegends": true
+    },
+    {
+      "line": 137,
+      "kindHint": "warscroll",
+      "label": "Spiteclaw's Swarm",
+      "isLegends": true
+    },
+    {
+      "line": 139,
+      "kindHint": "warscroll",
+      "label": "Stormfiends"
+    },
+    {
+      "line": 140,
+      "kindHint": "warscroll",
+      "label": "Stormfiends"
+    },
+    {
+      "line": 141,
+      "kindHint": "warscroll",
+      "label": "Stormvermin"
+    },
+    {
+      "line": 142,
+      "kindHint": "warscroll",
+      "label": "Thanquol on Boneripper"
+    },
+    {
+      "line": 143,
+      "kindHint": "warscroll",
+      "label": "Verminlord Corruptor"
+    },
+    {
+      "line": 144,
+      "kindHint": "warscroll",
+      "label": "Verminlord Deceiver"
+    },
+    {
+      "line": 145,
+      "kindHint": "warscroll",
+      "label": "Verminlord Warbringer"
+    },
+    {
+      "line": 146,
+      "kindHint": "warscroll",
+      "label": "Verminlord Warpseer"
+    },
+    {
+      "line": 147,
+      "kindHint": "warscroll",
+      "label": "Vizzik Skour, Prophet of the Horned Rat"
+    },
+    {
+      "line": 148,
+      "kindHint": "warscroll",
+      "label": "Warlock Bombardier"
+    },
+    {
+      "line": 149,
+      "kindHint": "warscroll",
+      "label": "Warlock Engineer"
+    },
+    {
+      "line": 150,
+      "kindHint": "warscroll",
+      "label": "Warlock Galvaneer"
+    },
+    {
+      "line": 151,
+      "kindHint": "warscroll",
+      "label": "Warp Lightning Cannon"
+    },
+    {
+      "line": 152,
+      "kindHint": "warscroll",
+      "label": "Warp-Grinder"
+    },
+    {
+      "line": 153,
+      "kindHint": "warscroll",
+      "label": "Warpfire Throwers"
+    },
+    {
+      "line": 154,
+      "kindHint": "warscroll",
+      "label": "Warplock Jezzails"
+    },
+    {
+      "line": 155,
+      "kindHint": "warscroll",
+      "label": "Warpvolt Scourgers"
+    },
+    {
+      "line": 156,
+      "kindHint": "warscroll",
+      "label": "Warpvolt Scourgers"
+    },
+    {
+      "line": 157,
+      "kindHint": "warscroll",
+      "label": "Zikkit's Tunnelpack",
+      "isLegends": true
+    },
+    {
+      "line": 161,
+      "kindHint": "warscroll",
+      "label": "Gnawhole"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/skv-001-renown-manifestation-members/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/skv-001-renown-manifestation-members/list.txt
@@ -1,0 +1,164 @@
+Skaven1 42140/1500 pts
+-----
+Grand Alliance Chaos | Skaven | Fleshmeld Menagerie
+General's Handbook 2025-26
+Auxiliaries: 51 (+25500 Points)
+Drops: 75
+Spell Lore - Lore of Ruin
+Prayer Lore - Noxious Prayers
+Manifestation Lore - Manifestations of Doom
+Battle Tactics Cards: Wrathful Cycles
+-----
+Regiment 1
+Clawlord (70)
+Clanrats (150)
+Spiteclaw's Swarm (100)
+• Legends
+Stormvermin (110)
+-----
+Regiments of Renown
+Brand's Oathbound (200)
+Gunnar Brand
+Singri Brand
+The Oathsworn Kin
+Cogfort Raiders (450)
+Outlaw Conqueror Cogfort
+Diseased Revellers (310)
+Sloppity Bilepiper, Herald of Nurgle
+Beast of Nurgle
+Beast of Nurgle
+Enforcers of the Tithe (470)
+Mortisan Ossifector
+Gothizzar Harvester
+Mortek Guard
+Mortek Guard
+Hargax's Pit-Beasts (390)
+Ogroid Myrmidon
+Fomoroid Crusher
+Mindstealer Sphiranx
+Lord Skaldior's Chosen (530)
+Chaos Lord on Daemonic Mount
+Chaos Knights
+Chaos Warriors
+Mask of the Deceiver (170)
+Mask of the Deceiver
+Mist-Clad Revellers (260)
+Shardspeaker of Slaanesh
+Blissbarb Archers
+Nurgle's Gift (180)
+Nurglings
+Nurglings
+One-eyed Grunnock (410)
+Warstomper Mega-Gargant
+Phulgoth's Shudderhood (530)
+Harbinger of Decay
+Pusgoyle Blightlords
+Putrid Blightkings
+Rogue Engine (470)
+Outlaw Cannonade Cogfort
+Seeker of the Dread Dirge (260)
+Ashen Elder
+Dominator Engine with Bane Maces
+Seekers of Silver (380)
+Magister on Disc of Tzeentch
+Gaunt Summoner on Disc of Tzeentch
+Screamers of Tzeentch
+Snerk's Trogg-Fer-Hire (220)
+Loonboss
+Dankhold Troggoth
+Stumblefoot Gargant (140)
+Mancrusher Gargant
+The Accursed Reflection (150)
+Contorted Epitome
+Dreadful Visage
+Mesmerising Mirror
+Wheels of Excruciation
+The Coven of Thryx (280)
+Magister
+Burning Sigil of Tzeentch
+Daemonic Simulacrum
+Pink Horrors
+Tome of Eyes
+The Curse-Steel Battery (380)
+Daemonsmith
+Deathshrieker Rocket Battery
+Tormentor Bombard
+The Pustules (200)
+Spoilpox Scrivener, Herald of Nurgle
+Feculent Gnarlmaw
+Plaguebearers
+The Exiled One (390)
+Skarbrand
+The Red Revelation (380)
+Slaughterpriest
+Bloodreavers
+Skullreapers
+The Red Revelation (380)
+Slaughterpriest
+Bloodreavers
+Skullreapers
+-----
+Auxiliary Units
+Acolyte Globadiers (90)
+Arch-Warlock (140)
+Brood Terror (220)
+Clanrats (150)
+Clawlord (70)
+Clawlord on Gnaw-beast (110)
+Deathmaster (120)
+Deathmaster Crixxit (150)
+Doom-Flayers (100)
+Doomwheel (100)
+Grey Seer (110)
+Grey Seer on Screaming Bell (310)
+Gutter Runners (150)
+Hell Pit Abomination (200)
+Krittok Foulblade (140)
+Lord Skreech Verminking (380)
+Master Moulder (80)
+Night Runners (130)
+Plague Censer Bearers (160)
+• Legends
+Plague Monks (140)
+Plague Priest (110)
+• Legends
+Plague Priest on Plague Furnace (350)
+Plagueclaw (100)
+Plaguepack (130)
+Rat Ogors (140)
+Ratling Guns (170)
+Ratling Warpblaster (110)
+Scourge of Ghyran Brood Terror (240)
+Scourge of Ghyran Grey Seer on Screaming Bell (330)
+Skabbik's Plaguepack (100)
+• Legends
+Skittershank's Clawpack (100)
+• Legends
+Spiteclaw's Swarm (100)
+• Legends
+Stormfiends (230)
+Stormfiends (230)
+Stormvermin (110)
+Thanquol on Boneripper (310)
+Verminlord Corruptor (260)
+Verminlord Deceiver (390)
+Verminlord Warbringer (260)
+Verminlord Warpseer (300)
+Vizzik Skour, Prophet of the Horned Rat (340)
+Warlock Bombardier (90)
+Warlock Engineer (100)
+Warlock Galvaneer (120)
+Warp Lightning Cannon (120)
+Warp-Grinder (100)
+Warpfire Throwers (120)
+Warplock Jezzails (120)
+Warpvolt Scourgers (170)
+Warpvolt Scourgers (170)
+Zikkit's Tunnelpack (110)
+• Legends
+-----
+Faction Terrain
+Gnawhole
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466


### PR DESCRIPTION
Two more real Storm Forge exports. **Neither needed a parser change.**

## `mon-001-singular-model-count`

Maggotkin, and the line that matters:

```
Pusgoyle Blightlords (1 model) (110)
```

The singular `model`, not `models`. The catalog spells its variant the same way and holds **three** distinct related warscrolls — `Pusgoyle Blightlords`, `Pusgoyle Blightlords (1 model)`, and a singular `Pusgoyle Blightlord`. Verified against the shipped catalog that the two in this list resolve to the correct *distinct* entries rather than collapsing onto one another:

```
"Pusgoyle Blightlords"           -> "Pusgoyle Blightlords"
"Pusgoyle Blightlords (1 model)" -> "Pusgoyle Blightlords (1 model)"
```

That is exact-first matching doing its job — the lenient fallback strips the count and would make the pair ambiguous. 46 of 47 resolve; the miss is `Gelgus Pust`, absent from the catalog (#1783).

Also carries a two-pick prayer lore row and two identical `Feculent Gnarlmaw` terrain entries.

## `skv-001-renown-manifestation-members`

The largest list in the corpus — 117 selections, 57 of them regiment of renown members. Two things it adds:

- **Five-member bundles.** `The Coven of Thryx (280)` lists Magister, Burning Sigil of Tzeentch, Daemonic Simulacrum, Pink Horrors and Tome of Eyes. All five are captured, the container dropped.
- **Manifestations as renown members.** `Burning Sigil of Tzeentch`, `Tome of Eyes`, `Mesmerising Mirror`, `Wheels of Excruciation` are manifestations rather than units. The bundled-member rule treats them identically, which is right — but none will resolve until the manifestation gap in #1783 is closed.

## Testing

- `yarn test --run` — 979 tests across 67 files
- `yarn tsc --noEmit` and `yarn lint` clean
- No existing golden changed