### PR TITLE
feat(import): report failed roster inputs

### DIFF
--- a/src/components/input/importArmy/failedImportReport.ts
+++ b/src/components/input/importArmy/failedImportReport.ts
@@ -1,0 +1,79 @@
+import type { Aos4ImportDiagnostic } from '../../../aos4/import'
+import { GITHUB_URL } from 'utils/env'
+
+interface FailedImportReport {
+  diagnostics: readonly Aos4ImportDiagnostic[]
+  file: Blob
+  fileName: string
+}
+
+const MAX_ISSUE_DIAGNOSTICS = 10
+const REPORT_FILE_NAME = 'aos-reminders-failed-import'
+
+const githubAttachmentName = (fileName: string): string => {
+  const lowerName = fileName.toLocaleLowerCase('en')
+  if (lowerName.endsWith('.rosz')) return `${REPORT_FILE_NAME}.rosz.zip`
+  if (lowerName.endsWith('.ros')) return `${REPORT_FILE_NAME}.ros.xml`
+  if (lowerName.endsWith('.json')) return `${REPORT_FILE_NAME}.json`
+  if (lowerName.endsWith('.zip')) return `${REPORT_FILE_NAME}.zip`
+  if (lowerName.endsWith('.xml')) return `${REPORT_FILE_NAME}.xml`
+  if (lowerName.endsWith('.log')) return `${REPORT_FILE_NAME}.log`
+  return `${REPORT_FILE_NAME}.txt`
+}
+
+const issueBody = (attachmentName: string, diagnostics: readonly Aos4ImportDiagnostic[]): string => {
+  const diagnosticLines = diagnostics
+    .slice(0, MAX_ISSUE_DIAGNOSTICS)
+    .map(diagnostic => {
+      const line = diagnostic.line ? `, line ${diagnostic.line}` : ''
+      return `- \`${diagnostic.code}\` (${diagnostic.severity}${line})`
+    })
+    .join('\n')
+  const remainingDiagnostics =
+    diagnostics.length > MAX_ISSUE_DIAGNOSTICS
+      ? `\n- ${diagnostics.length - MAX_ISSUE_DIAGNOSTICS} more diagnostics omitted from this draft.`
+      : ''
+
+  return `## Failed import
+
+AoS Reminders could not import this roster.
+
+## Reproduction file
+
+Attach the downloaded \`${attachmentName}\` file to this issue before submitting it. Its contents are
+the exact roster input that failed. Its generic name and any extra \`.xml\`, \`.zip\`, or \`.txt\`
+suffix only make the file type attachable on GitHub.
+
+GitHub issues are public. Please remove any private information before attaching the file.
+The original filename, roster content, and diagnostic messages were not added to this draft.
+
+## Import diagnostics
+
+${diagnosticLines || '- No diagnostic was available.'}${remainingDiagnostics}
+`
+}
+
+const createFailedImportIssueUrl = (
+  attachmentName: string,
+  diagnostics: readonly Aos4ImportDiagnostic[]
+): string => {
+  const url = new URL(`${GITHUB_URL}/issues/new`, 'https://aosreminders.com')
+  url.searchParams.set('title', '[BUG] Failed roster import')
+  url.searchParams.set('body', issueBody(attachmentName, diagnostics))
+  return url.toString()
+}
+
+export const sendFailedImportReport = ({ diagnostics, file, fileName }: FailedImportReport): void => {
+  const attachmentName = githubAttachmentName(fileName)
+  window.open(createFailedImportIssueUrl(attachmentName, diagnostics), '_blank', 'noopener,noreferrer')
+
+  const downloadUrl = URL.createObjectURL(file)
+  const download = document.createElement('a')
+  download.href = downloadUrl
+  download.download = attachmentName
+  download.hidden = true
+  document.body.appendChild(download)
+  download.click()
+  download.remove()
+  window.setTimeout(() => URL.revokeObjectURL(downloadUrl), 0)
+}

--- a/src/components/input/importArmy/importArmyModal.tsx
+++ b/src/components/input/importArmy/importArmyModal.tsx
@@ -15,6 +15,7 @@ import {
   MAX_ROSTER_FILE_BYTES,
 } from '../../../importers/aos4'
 import { createAos4DocumentId } from 'utils/createAos4DocumentId'
+import { sendFailedImportReport } from './failedImportReport'
 import ImportPreview from './importPreview'
 
 interface ImportArmyModalProps {
@@ -49,8 +50,9 @@ const ImportArmyModal = ({
   const [selectedContextId, setSelectedContextId] = useState('')
   const [isProcessing, setIsProcessing] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
-  const [droppedFileName, setDroppedFileName] = useState('')
+  const [droppedFile, setDroppedFile] = useState<File>()
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const filePreviewRequestRef = useRef(0)
 
   const preview = useMemo(() => {
     if (!decoded?.parsedRoster) return undefined
@@ -72,39 +74,47 @@ const ImportArmyModal = ({
   ]
   const hasErrors = diagnostics.some(diagnostic => diagnostic.severity === 'error')
   const canApply = Boolean(preview?.proposedDocument) && !hasErrors
+  const canReport = Boolean(decoded && hasErrors && (mode === 'paste' ? text : droppedFile))
 
   const chooseMode = (nextMode: ImportMode) => {
+    filePreviewRequestRef.current += 1
     setMode(nextMode)
     setDecoded(undefined)
     setSelectedContextId('')
-    setDroppedFileName('')
+    setDroppedFile(undefined)
+    setIsProcessing(false)
   }
 
   const previewText = () => {
+    filePreviewRequestRef.current += 1
     setSelectedContextId('')
+    setIsProcessing(false)
     setDecoded(decodeAos4TextRoster(text))
   }
 
   const previewFile = async (file?: File) => {
     if (!file) return
+    const requestId = filePreviewRequestRef.current + 1
+    filePreviewRequestRef.current = requestId
     setSelectedContextId('')
-    setDroppedFileName(file.name)
+    setDecoded(undefined)
+    setDroppedFile(file)
     if (file.size > MAX_ROSTER_FILE_BYTES) {
+      setIsProcessing(false)
       setDecoded(createRosterFileTooLargeResult())
       return
     }
     setIsProcessing(true)
     try {
-      setDecoded(
-        await decodeAos4RosterFile({
-          name: file.name,
-          bytes: new Uint8Array(await file.arrayBuffer()),
-        })
-      )
+      const result = await decodeAos4RosterFile({
+        name: file.name,
+        bytes: new Uint8Array(await file.arrayBuffer()),
+      })
+      if (filePreviewRequestRef.current === requestId) setDecoded(result)
     } catch {
-      setDecoded(unexpectedFileError())
+      if (filePreviewRequestRef.current === requestId) setDecoded(unexpectedFileError())
     } finally {
-      setIsProcessing(false)
+      if (filePreviewRequestRef.current === requestId) setIsProcessing(false)
     }
   }
 
@@ -127,6 +137,25 @@ const ImportArmyModal = ({
   const apply = () => {
     if (!canApply || !preview?.proposedDocument) return
     onApply(preview.proposedDocument)
+  }
+
+  const reportFailedImport = () => {
+    if (!canReport) return
+    if (mode === 'paste') {
+      sendFailedImportReport({
+        diagnostics,
+        file: new Blob([text], { type: 'text/plain;charset=utf-8' }),
+        fileName: 'aos-reminders-failed-import.txt',
+      })
+      return
+    }
+    if (droppedFile) {
+      sendFailedImportReport({
+        diagnostics,
+        file: droppedFile,
+        fileName: droppedFile.name,
+      })
+    }
   }
 
   return (
@@ -205,7 +234,8 @@ const ImportArmyModal = ({
               Drag and drop your roster here
             </label>
             <p className="small text-center mb-2">
-              AoS app or Listbot text (.txt), or New Recruit roster (.ros or .rosz)
+              AoS app or Listbot text (.txt), or New Recruit roster (.ros or .rosz). Failed .json imports can
+              also be reported.
             </p>
             <button
               className={theme.genericButton}
@@ -214,9 +244,9 @@ const ImportArmyModal = ({
             >
               Choose a file
             </button>
-            {!!droppedFileName && <p className="small mt-2 mb-0">{droppedFileName}</p>}
+            {!!droppedFile && <p className="small mt-2 mb-0">{droppedFile.name}</p>}
             <input
-              accept=".txt,.ros,.rosz,text/plain,application/xml,application/zip"
+              accept=".txt,.ros,.rosz,.json,text/plain,application/json,application/xml,application/zip"
               className="visually-hidden"
               id="import-roster-file"
               onChange={event => void previewFile(event.target.files?.[0])}
@@ -234,6 +264,23 @@ const ImportArmyModal = ({
           preview={preview}
           selectedContextId={selectedContextId}
         />
+
+        {canReport && (
+          <div className="mt-3">
+            <p className="small mb-2">
+              Help us reproduce this import error. This downloads an exact copy of the failed roster and opens
+              a GitHub issue draft without the roster content or original filename. Attach the downloaded file
+              before submitting. GitHub issues are public, so remove any private information first.
+            </p>
+            <button
+              className={`${theme.genericButton} d-block w-100`}
+              onClick={reportFailedImport}
+              type="button"
+            >
+              Send to devs
+            </button>
+          </div>
+        )}
 
         <div className="row mt-4">
           <div className="col-6">

--- a/src/tests/aos4/importUi.test.tsx
+++ b/src/tests/aos4/importUi.test.tsx
@@ -113,6 +113,22 @@ const findButton = (container: HTMLElement, label: string): HTMLButtonElement =>
 const dropEventData = (file: File): Parameters<typeof Simulate.drop>[1] =>
   ({ dataTransfer: { files: [file] } }) as unknown as Parameters<typeof Simulate.drop>[1]
 
+const readBlobText = (blob: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onerror = () => reject(reader.error)
+    reader.onload = () => resolve(String(reader.result))
+    reader.readAsText(blob)
+  })
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(next => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
 const SubscriberActionHarness = ({ onAuthorized }: { onAuthorized: () => void }) => {
   const action = useSubscriberAction({ onAuthorized, origin: 'SubscriberActionTest' })
   return (
@@ -234,6 +250,7 @@ describe('AoS 4 import modal', () => {
       unmountComponentAtNode(container)
     })
     container.remove()
+    vi.restoreAllMocks()
   })
 
   it('previews and atomically applies a supported pasted roster with a fresh local document', () => {
@@ -242,6 +259,7 @@ describe('AoS 4 import modal', () => {
     expect(container.textContent).toContain('Warhammer Age of Sigmar app')
     expect(container.textContent).toContain('Stormcast Eternals')
     expect(container.textContent).toContain('Thunderhead Host')
+    expect(container.textContent).not.toContain('Send to devs')
     const apply = findButton(container, 'Import Army')
     expect(apply.disabled).toBe(false)
 
@@ -258,6 +276,51 @@ describe('AoS 4 import modal', () => {
     expect(onApply.mock.calls[0][0].explicitSelectionIds.length).toBeGreaterThan(1)
   })
 
+  it('opens a reproducible GitHub report and downloads the exact failed pasted roster', async () => {
+    const pastedRoster = officialRoster().replace('Stormcast Eternals', 'Private Player Name')
+    const createObjectUrl = vi.fn<(blob: Blob) => string>().mockReturnValue('blob:failed-import')
+    const revokeObjectUrl = vi.fn()
+    Object.defineProperties(URL, {
+      createObjectURL: { configurable: true, value: createObjectUrl },
+      revokeObjectURL: { configurable: true, value: revokeObjectUrl },
+    })
+    const downloaded: { href?: string; name?: string } = {}
+    const downloadClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {
+      const download = document.querySelector<HTMLAnchorElement>('a[download]')!
+      downloaded.href = download.href
+      downloaded.name = download.download
+    })
+    const openIssue = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+    pasteAndPreview(pastedRoster)
+
+    expect(container.textContent).toContain('GitHub issues are public')
+    const report = findButton(container, 'Send to devs')
+    act(() => {
+      Simulate.click(report)
+    })
+
+    expect(createObjectUrl).toHaveBeenCalledTimes(1)
+    const downloadedBlob = createObjectUrl.mock.calls[0][0] as Blob
+    expect(await readBlobText(downloadedBlob)).toBe(pastedRoster)
+    expect(downloaded).toEqual({
+      href: 'blob:failed-import',
+      name: 'aos-reminders-failed-import.txt',
+    })
+    expect(downloadClick).toHaveBeenCalledTimes(1)
+
+    const issueUrl = new URL(openIssue.mock.calls[0][0] as string)
+    expect(issueUrl.origin + issueUrl.pathname).toBe('https://github.com/daviseford/aos-reminders/issues/new')
+    expect(issueUrl.searchParams.get('title')).toContain('Failed roster import')
+    expect(issueUrl.searchParams.get('body')).toContain('aos-reminders-failed-import.txt')
+    expect(issueUrl.searchParams.get('body')).toContain('missing-faction')
+    expect(issueUrl.searchParams.get('body')).not.toContain(pastedRoster)
+    expect(issueUrl.searchParams.get('body')).not.toContain('Private Player Name')
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:failed-import')
+  })
+
   /**
    * A name we cannot place is shown and skipped, not treated as a dead end. The player came from a
    * builder where the unit exists, so the useful outcome is the rest of the army plus a note about
@@ -272,6 +335,7 @@ describe('AoS 4 import modal', () => {
     pasteAndPreview(officialRoster('Definitely Unknown Unit'))
 
     expect(container.textContent).toContain('Definitely Unknown Unit')
+    expect(container.textContent).not.toContain('Send to devs')
     expect(findButton(container, 'Import Army').disabled).toBe(false)
 
     act(() => {
@@ -363,6 +427,7 @@ describe('AoS 4 import modal', () => {
     })
 
     expect(input.accept).toContain('.txt')
+    expect(input.accept).toContain('.json')
     expect(container.textContent).toContain('Listbot 4.0')
     expect(findButton(container, 'Import Army').disabled).toBe(false)
 
@@ -398,6 +463,133 @@ describe('AoS 4 import modal', () => {
     expect(arrayBuffer).not.toHaveBeenCalled()
     expect(container.textContent).toContain(`Roster files must be ${MAX_ROSTER_FILE_BYTES} bytes or smaller.`)
     expect(findButton(container, 'Import Army').disabled).toBe(true)
+  })
+
+  it('downloads an exact GitHub-compatible copy of a failed .rosz upload', async () => {
+    const rosterBytes = new Uint8Array([0x50, 0x4b, 0x03])
+    const file = new File([rosterBytes], 'private-player-name.rosz', { type: 'application/zip' })
+    Object.defineProperty(file, 'arrayBuffer', {
+      value: async () => rosterBytes.buffer,
+    })
+    const createObjectUrl = vi.fn<(blob: Blob) => string>().mockReturnValue('blob:failed-rosz')
+    Object.defineProperties(URL, {
+      createObjectURL: { configurable: true, value: createObjectUrl },
+      revokeObjectURL: { configurable: true, value: vi.fn() },
+    })
+    const downloaded: { name?: string } = {}
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {
+      downloaded.name = document.querySelector<HTMLAnchorElement>('a[download]')!.download
+    })
+    const openIssue = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]')!
+    Object.defineProperty(input, 'files', { configurable: true, value: [file] })
+
+    await act(async () => {
+      Simulate.change(input)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(container.textContent).toContain('not a valid ZIP archive')
+
+    act(() => {
+      Simulate.click(findButton(container, 'Send to devs'))
+    })
+
+    expect(createObjectUrl).toHaveBeenCalledWith(file)
+    expect(downloaded.name).toBe('aos-reminders-failed-import.rosz.zip')
+    const issueUrl = new URL(openIssue.mock.calls[0][0] as string)
+    expect(issueUrl.searchParams.get('title')).not.toContain('private-player-name')
+    expect(issueUrl.searchParams.get('body')).not.toContain('private-player-name')
+    expect(issueUrl.searchParams.get('body')).toContain('aos-reminders-failed-import.rosz.zip')
+    expect(issueUrl.searchParams.get('body')).toContain('unsafe-input')
+  })
+
+  it('allows a failed JSON upload to be reported with its exact bytes', async () => {
+    const rosterJson = '{"name":"Private JSON Roster"}'
+    const file = new File([rosterJson], 'private-roster.json', { type: 'application/json' })
+    Object.defineProperty(file, 'arrayBuffer', {
+      value: async () => new TextEncoder().encode(rosterJson).buffer,
+    })
+    const createObjectUrl = vi.fn<(blob: Blob) => string>().mockReturnValue('blob:failed-json')
+    Object.defineProperties(URL, {
+      createObjectURL: { configurable: true, value: createObjectUrl },
+      revokeObjectURL: { configurable: true, value: vi.fn() },
+    })
+    const downloaded: { name?: string } = {}
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {
+      downloaded.name = document.querySelector<HTMLAnchorElement>('a[download]')!.download
+    })
+    const openIssue = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]')!
+    Object.defineProperty(input, 'files', { configurable: true, value: [file] })
+
+    await act(async () => {
+      Simulate.change(input)
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+    expect(container.textContent).toContain('Choose a .txt, .ros, or .rosz roster file')
+
+    act(() => {
+      Simulate.click(findButton(container, 'Send to devs'))
+    })
+
+    expect(createObjectUrl).toHaveBeenCalledWith(file)
+    expect(downloaded.name).toBe('aos-reminders-failed-import.json')
+    const issueUrl = new URL(openIssue.mock.calls[0][0] as string)
+    expect(issueUrl.searchParams.get('body')).toContain('unsupported-source')
+    expect(issueUrl.searchParams.get('body')).not.toContain('private-roster')
+    expect(issueUrl.searchParams.get('body')).not.toContain('Private JSON Roster')
+  })
+
+  it('keeps the report file paired with the latest upload when reads finish out of order', async () => {
+    const firstRead = deferred<ArrayBuffer>()
+    const firstFile = new File([''], 'first.rosz', { type: 'application/zip' })
+    Object.defineProperty(firstFile, 'arrayBuffer', {
+      value: () => firstRead.promise,
+    })
+    const secondText = 'This is the latest unsupported roster.'
+    const secondFile = new File([secondText], 'latest.txt', { type: 'text/plain' })
+    Object.defineProperty(secondFile, 'arrayBuffer', {
+      value: async () => new TextEncoder().encode(secondText).buffer,
+    })
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]')!
+
+    Object.defineProperty(input, 'files', { configurable: true, value: [firstFile] })
+    act(() => {
+      Simulate.change(input)
+    })
+
+    Object.defineProperty(input, 'files', { configurable: true, value: [secondFile] })
+    await act(async () => {
+      Simulate.change(input)
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+    expect(container.textContent).toContain('not a supported current official app or Listbot 4.0 export')
+
+    await act(async () => {
+      firstRead.resolve(new Uint8Array([0x50, 0x4b, 0x03]).buffer)
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    expect(container.textContent).toContain('not a supported current official app or Listbot 4.0 export')
+    expect(container.textContent).not.toContain('not a valid ZIP archive')
+
+    const createObjectUrl = vi.fn<(blob: Blob) => string>().mockReturnValue('blob:latest-import')
+    Object.defineProperties(URL, {
+      createObjectURL: { configurable: true, value: createObjectUrl },
+      revokeObjectURL: { configurable: true, value: vi.fn() },
+    })
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined)
+    const openIssue = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+    act(() => {
+      Simulate.click(findButton(container, 'Send to devs'))
+    })
+
+    expect(createObjectUrl).toHaveBeenCalledWith(secondFile)
+    const issueUrl = new URL(openIssue.mock.calls[0][0] as string)
+    expect(issueUrl.searchParams.get('body')).toContain('unsupported-source')
+    expect(issueUrl.searchParams.get('body')).not.toContain('unsafe-input')
   })
 
   it('cancels without applying or persisting the raw roster', () => {

--- a/src/tests/aos4/legacyIsolation.test.ts
+++ b/src/tests/aos4/legacyIsolation.test.ts
@@ -120,6 +120,7 @@ describe('AoS 4 legacy isolation', () => {
       'components/info/reminders.tsx',
       'components/input/army_builder.tsx',
       'components/input/generic_button.tsx',
+      'components/input/importArmy/failedImportReport.ts',
       'components/input/importArmy/importArmyModal.tsx',
       'components/input/importArmy/importPreview.tsx',
       'components/input/importArmy/subscriberAction.tsx',


### PR DESCRIPTION
## Summary

Failed imports now give players a direct “Send to devs” recovery path instead of leaving them at an
unactionable parser error. The action downloads the exact failed input and opens a privacy-safe
GitHub issue draft; the player reviews the public-report warning and attaches the downloaded file
manually.

Pasted text, JSON, ROS, and ROSZ failures use generic GitHub-compatible attachment names. Roster
contents, original filenames, and diagnostic messages stay out of the issue URL, while bounded
diagnostic codes retain useful triage context. Overlapping file reads are sequence-guarded so a
late result cannot pair one roster's diagnostics with another roster's attachment.

## Data and generated output

No rules sources, effective dates, reconciliation decisions, accepted inputs, or generated catalog
files changed.

## Validation

- `yarn lint`
- `tsc --noEmit`
- `yarn test --run --minWorkers=2 --maxWorkers=2` — 67 files and 983 tests passed
- `yarn build`
- `yarn data:aos4:verify:beta` — 79,294 pass, 0 findings, 0 cannot-verify
- Manually exercised the failed-import flow at desktop and mobile widths with no console errors

## Coverage gaps

Browser issue creation and download behavior is covered with mocked browser APIs; validation did not
submit a real public GitHub issue or upload a roster.

Related: #1786
