### PR TITLE
test(import): cover size variants, single-member bundles and emoji names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ src/tests/fixtures/intake/*
 .impeccable/
 /.claude/worktrees
 /.worktrees/
+
+# Vite writes these while loading an ESM config, and they can land mid-commit
+vite.config.*.timestamp-*

--- a/src/tests/fixtures/aos4/import/official-app/README.md
+++ b/src/tests/fixtures/aos4/import/official-app/README.md
@@ -80,6 +80,11 @@ Fail closed on malformed or hostile input, never on an illegal army.
 | `hh-001-renown-stress` | 18 dashless regiments of renown, 51 members, one bundle repeated four times — the densest renown case in the corpus |
 | `mon-001-singular-model-count` | `Pusgoyle Blightlords (1 model) (110)` — the singular `model`, which resolves to a different warscroll than the plural entry beside it |
 | `skv-001-renown-manifestation-members` | the largest list in the corpus (117 selections, 57 renown members), with five-member bundles whose members include manifestations |
+| `std-001-duplicate-renown-bundles` | the same renown bundle bought twice with identical members, and 82 drops — the widest roster in the corpus |
+| `fec-001-size-variants` | four `(2 models)` size variants alongside their base warscrolls; the only fixture that resolves **65/65** against the shipped catalog |
+| `nh-001-emoji-name-renown` | an emoji in the roster name, and a renown bundle whose lone member repeats the container name (`Blades of the Hollow King`) |
+| `obr-001-single-member-bundles` | renown bundles of a single member, and the same-name bundle again from a different faction |
+| `sbg-001-emoji-only-name` | a roster name that is nothing but emoji, and `Blades of the Hollow King` as a plain auxiliary unit rather than a renown bundle |
 
 ## Points are dropped on purpose
 

--- a/src/tests/fixtures/aos4/import/official-app/lists/fec-001-size-variants/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/fec-001-size-variants/expected.json
@@ -1,0 +1,340 @@
+{
+  "id": "fec-001-size-variants",
+  "diagnostics": [],
+  "proposedName": "Fec1",
+  "declaredFaction": "Flesh-eater Courts",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Knightly Echelon"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of Madness"
+    },
+    {
+      "line": 8,
+      "kindHint": "prayer-lore",
+      "label": "Rites of Delusion"
+    },
+    {
+      "line": 9,
+      "kindHint": "manifestation-lore",
+      "label": "Manifested Insanity"
+    },
+    {
+      "line": 13,
+      "kindHint": "warscroll",
+      "label": "Abhorrant Ghoul King"
+    },
+    {
+      "line": 14,
+      "kindHint": "warscroll",
+      "label": "Crypt Flayers"
+    },
+    {
+      "line": 15,
+      "kindHint": "warscroll",
+      "label": "Crypt Flayers (2 models)"
+    },
+    {
+      "line": 16,
+      "kindHint": "warscroll",
+      "label": "Crypt Ghouls"
+    },
+    {
+      "line": 17,
+      "kindHint": "warscroll",
+      "label": "Crypt Haunter Courtier"
+    },
+    {
+      "line": 18,
+      "kindHint": "warscroll",
+      "label": "Crypt Horrors"
+    },
+    {
+      "line": 19,
+      "kindHint": "warscroll",
+      "label": "Crypt Horrors (2 models)"
+    },
+    {
+      "line": 20,
+      "kindHint": "warscroll",
+      "label": "Crypt Horrors (2 models)"
+    },
+    {
+      "line": 21,
+      "kindHint": "warscroll",
+      "label": "Crypt Horrors (2 models)"
+    },
+    {
+      "line": 22,
+      "kindHint": "warscroll",
+      "label": "Crypt Infernal Courtier"
+    },
+    {
+      "line": 23,
+      "kindHint": "warscroll",
+      "label": "Cryptguard"
+    },
+    {
+      "line": 24,
+      "kindHint": "warscroll",
+      "label": "Grand Justice Gormayne"
+    },
+    {
+      "line": 25,
+      "kindHint": "warscroll",
+      "label": "High Falconer Felgryn"
+    },
+    {
+      "line": 26,
+      "kindHint": "warscroll",
+      "label": "Marrowscroll Herald"
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Morbheg Knights"
+    },
+    {
+      "line": 28,
+      "kindHint": "warscroll",
+      "label": "Royal Beastflayers"
+    },
+    {
+      "line": 29,
+      "kindHint": "warscroll",
+      "label": "Royal Decapitator"
+    },
+    {
+      "line": 30,
+      "kindHint": "warscroll",
+      "label": "Royal Terrorgheist"
+    },
+    {
+      "line": 31,
+      "kindHint": "warscroll",
+      "label": "Royal Zombie Dragon"
+    },
+    {
+      "line": 32,
+      "kindHint": "warscroll",
+      "label": "Royal Zombie Dragon"
+    },
+    {
+      "line": 33,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Royal Decapitator"
+    },
+    {
+      "line": 34,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Varghulf Courtier"
+    },
+    {
+      "line": 35,
+      "kindHint": "warscroll",
+      "label": "The Grymwatch",
+      "isLegends": true
+    },
+    {
+      "line": 37,
+      "kindHint": "warscroll",
+      "label": "The Skinnerkin",
+      "isLegends": true
+    },
+    {
+      "line": 39,
+      "kindHint": "warscroll",
+      "label": "Varghulf Courtier"
+    },
+    {
+      "line": 42,
+      "kindHint": "warscroll",
+      "label": "Abhorrant Ghoul King"
+    },
+    {
+      "line": 45,
+      "kindHint": "warscroll",
+      "label": "Abhorrant Archregent"
+    },
+    {
+      "line": 46,
+      "kindHint": "warscroll",
+      "label": "Abhorrant Cardinal"
+    },
+    {
+      "line": 47,
+      "kindHint": "warscroll",
+      "label": "Abhorrant Ghoul King"
+    },
+    {
+      "line": 48,
+      "kindHint": "warscroll",
+      "label": "Abhorrant Ghoul King on Royal Terrorgheist"
+    },
+    {
+      "line": 49,
+      "kindHint": "warscroll",
+      "label": "Abhorrant Ghoul King on Royal Zombie Dragon"
+    },
+    {
+      "line": 50,
+      "kindHint": "warscroll",
+      "label": "Abhorrant Gorewarden"
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Crypt Flayers"
+    },
+    {
+      "line": 52,
+      "kindHint": "warscroll",
+      "label": "Crypt Flayers (2 models)"
+    },
+    {
+      "line": 53,
+      "kindHint": "warscroll",
+      "label": "Crypt Flayers (2 models)"
+    },
+    {
+      "line": 54,
+      "kindHint": "warscroll",
+      "label": "Crypt Ghast Courtier",
+      "isLegends": true
+    },
+    {
+      "line": 56,
+      "kindHint": "warscroll",
+      "label": "Crypt Ghouls"
+    },
+    {
+      "line": 57,
+      "kindHint": "warscroll",
+      "label": "Crypt Haunter Courtier"
+    },
+    {
+      "line": 58,
+      "kindHint": "warscroll",
+      "label": "Crypt Horrors"
+    },
+    {
+      "line": 59,
+      "kindHint": "warscroll",
+      "label": "Crypt Horrors (2 models)"
+    },
+    {
+      "line": 60,
+      "kindHint": "warscroll",
+      "label": "Crypt Infernal Courtier"
+    },
+    {
+      "line": 61,
+      "kindHint": "warscroll",
+      "label": "Cryptguard"
+    },
+    {
+      "line": 62,
+      "kindHint": "warscroll",
+      "label": "Grand Justice Gormayne"
+    },
+    {
+      "line": 63,
+      "kindHint": "warscroll",
+      "label": "High Falconer Felgryn"
+    },
+    {
+      "line": 64,
+      "kindHint": "warscroll",
+      "label": "Marrowscroll Herald"
+    },
+    {
+      "line": 65,
+      "kindHint": "warscroll",
+      "label": "Morbheg Knights"
+    },
+    {
+      "line": 66,
+      "kindHint": "warscroll",
+      "label": "Nagash, Supreme Lord of the Undead"
+    },
+    {
+      "line": 67,
+      "kindHint": "warscroll",
+      "label": "Royal Beastflayers"
+    },
+    {
+      "line": 68,
+      "kindHint": "warscroll",
+      "label": "Royal Decapitator"
+    },
+    {
+      "line": 69,
+      "kindHint": "warscroll",
+      "label": "Royal Terrorgheist"
+    },
+    {
+      "line": 70,
+      "kindHint": "warscroll",
+      "label": "Royal Zombie Dragon"
+    },
+    {
+      "line": 71,
+      "kindHint": "warscroll",
+      "label": "Royal Zombie Dragon"
+    },
+    {
+      "line": 72,
+      "kindHint": "warscroll",
+      "label": "Royal Zombie Dragon"
+    },
+    {
+      "line": 73,
+      "kindHint": "warscroll",
+      "label": "Royal Zombie Dragon"
+    },
+    {
+      "line": 74,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Royal Decapitator"
+    },
+    {
+      "line": 75,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Varghulf Courtier"
+    },
+    {
+      "line": 76,
+      "kindHint": "warscroll",
+      "label": "The Grymwatch",
+      "isLegends": true
+    },
+    {
+      "line": 78,
+      "kindHint": "warscroll",
+      "label": "The Skinnerkin",
+      "isLegends": true
+    },
+    {
+      "line": 80,
+      "kindHint": "warscroll",
+      "label": "Ushoran, Mortarch of Delusion"
+    },
+    {
+      "line": 81,
+      "kindHint": "warscroll",
+      "label": "Varghulf Courtier"
+    },
+    {
+      "line": 84,
+      "kindHint": "warscroll",
+      "label": "Charnel Throne"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/fec-001-size-variants/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/fec-001-size-variants/list.txt
@@ -1,0 +1,87 @@
+Fec1 20850/2500 pts
+-----
+Grand Alliance Death | Flesh-eater Courts | Knightly Echelon
+General's Handbook 2026-27
+Auxiliaries: 34 (+11220 Points)
+Drops: 36
+Spell Lore - Lore of Madness
+Prayer Lore - Rites of Delusion
+Manifestation Lore - Manifested Insanity
+Battle Tactics Cards: Smokescreen
+-----
+Regiment 1
+Abhorrant Ghoul King (110)
+Crypt Flayers (160)
+Crypt Flayers (2 models) (90)
+Crypt Ghouls (140)
+Crypt Haunter Courtier (120)
+Crypt Horrors (160)
+Crypt Horrors (2 models) (100)
+Crypt Horrors (2 models) (100)
+Crypt Horrors (2 models) (100)
+Crypt Infernal Courtier (140)
+Cryptguard (120)
+Grand Justice Gormayne (130)
+High Falconer Felgryn (120)
+Marrowscroll Herald (100)
+Morbheg Knights (170)
+Royal Beastflayers (110)
+Royal Decapitator (100)
+Royal Terrorgheist (240)
+Royal Zombie Dragon (260)
+Royal Zombie Dragon (260)
+Scourge of Aqshy: Royal Decapitator (100)
+Scourge of Aqshy: Varghulf Courtier (110)
+The Grymwatch (80)
+• Legends
+The Skinnerkin (80)
+• Legends
+Varghulf Courtier (100)
+---
+Regiment 5
+Abhorrant Ghoul King (110)
+-----
+Auxiliary Units
+Abhorrant Archregent (140)
+Abhorrant Cardinal (130)
+Abhorrant Ghoul King (110)
+Abhorrant Ghoul King on Royal Terrorgheist (400)
+Abhorrant Ghoul King on Royal Zombie Dragon (400)
+Abhorrant Gorewarden (150)
+Crypt Flayers (160)
+Crypt Flayers (2 models) (90)
+Crypt Flayers (2 models) (90)
+Crypt Ghast Courtier (80)
+• Legends
+Crypt Ghouls (140)
+Crypt Haunter Courtier (120)
+Crypt Horrors (160)
+Crypt Horrors (2 models) (100)
+Crypt Infernal Courtier (140)
+Cryptguard (120)
+Grand Justice Gormayne (130)
+High Falconer Felgryn (120)
+Marrowscroll Herald (100)
+Morbheg Knights (170)
+Nagash, Supreme Lord of the Undead (750)
+Royal Beastflayers (110)
+Royal Decapitator (100)
+Royal Terrorgheist (240)
+Royal Zombie Dragon (260)
+Royal Zombie Dragon (260)
+Royal Zombie Dragon (260)
+Royal Zombie Dragon (260)
+Scourge of Aqshy: Royal Decapitator (100)
+Scourge of Aqshy: Varghulf Courtier (110)
+The Grymwatch (80)
+• Legends
+The Skinnerkin (80)
+• Legends
+Ushoran, Mortarch of Delusion (450)
+Varghulf Courtier (100)
+-----
+Faction Terrain
+Charnel Throne (10)
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/nh-001-emoji-name-renown/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/nh-001-emoji-name-renown/expected.json
@@ -1,0 +1,589 @@
+{
+  "id": "nh-001-emoji-name-renown",
+  "diagnostics": [],
+  "proposedName": "Night haunt one ❤️❤️",
+  "declaredFaction": "Nighthaunt",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Quicksilver Gheists"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of the Underworlds"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Infernal Sorceries"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Aetherwrought Machineries"
+    },
+    {
+      "line": 12,
+      "kindHint": "warscroll",
+      "label": "Guardian of Souls"
+    },
+    {
+      "line": 16,
+      "kindHint": "warscroll",
+      "label": "Outlaw Conqueror Cogfort",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 18,
+      "kindHint": "warscroll",
+      "label": "Blades of the Hollow King",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 20,
+      "kindHint": "warscroll",
+      "label": "Gatebreaker Mega-Gargant",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 22,
+      "kindHint": "warscroll",
+      "label": "Vokmortian, Master of the Bone-tithe",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 23,
+      "kindHint": "warscroll",
+      "label": "Immortis Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 24,
+      "kindHint": "warscroll",
+      "label": "Mortek Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 26,
+      "kindHint": "warscroll",
+      "label": "Marrowscroll Herald",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Crypt Flayers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 28,
+      "kindHint": "warscroll",
+      "label": "Crypt Ghouls",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 29,
+      "kindHint": "warscroll",
+      "label": "Crypt Horrors",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 31,
+      "kindHint": "warscroll",
+      "label": "Mortisan Ossifector",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 32,
+      "kindHint": "warscroll",
+      "label": "Mortek Crawler",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 34,
+      "kindHint": "warscroll",
+      "label": "Mask of the Deceiver",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 36,
+      "kindHint": "warscroll",
+      "label": "Neferata, Mortarch of Blood",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 37,
+      "kindHint": "warscroll",
+      "label": "Barrow Knights",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 38,
+      "kindHint": "warscroll",
+      "label": "Deathrattle Skeletons",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 39,
+      "kindHint": "warscroll",
+      "label": "Deathrattle Skeletons",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 41,
+      "kindHint": "warscroll",
+      "label": "Outlaw Cannonade Cogfort",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 43,
+      "kindHint": "warscroll",
+      "label": "Katakros, Mortarch of the Necropolis",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 44,
+      "kindHint": "warscroll",
+      "label": "Immortis Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 45,
+      "kindHint": "warscroll",
+      "label": "Immortis Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 47,
+      "kindHint": "warscroll",
+      "label": "Mancrusher Gargant",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 49,
+      "kindHint": "warscroll",
+      "label": "Revenant Draconith",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Royal Terrorgheist",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 53,
+      "kindHint": "warscroll",
+      "label": "Treelord",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 54,
+      "kindHint": "warscroll",
+      "label": "Spite-Revenants",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 55,
+      "kindHint": "warscroll",
+      "label": "Spite-Revenants",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 57,
+      "kindHint": "warscroll",
+      "label": "Arkhan the Black, Mortarch of Sacrament",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 58,
+      "kindHint": "warscroll",
+      "label": "Morghast Archai",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 59,
+      "kindHint": "warscroll",
+      "label": "Morghast Harbingers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 61,
+      "kindHint": "warscroll",
+      "label": "Grand Justice Gormayne",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 62,
+      "kindHint": "warscroll",
+      "label": "Cryptguard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 63,
+      "kindHint": "warscroll",
+      "label": "Royal Decapitator",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 65,
+      "kindHint": "warscroll",
+      "label": "Ushoran, Mortarch of Delusion",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 66,
+      "kindHint": "warscroll",
+      "label": "Cryptguard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 67,
+      "kindHint": "warscroll",
+      "label": "Morbheg Knights",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 69,
+      "kindHint": "warscroll",
+      "label": "Mannfred von Carstein, Mortarch of Night",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 70,
+      "kindHint": "warscroll",
+      "label": "Barrow Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 71,
+      "kindHint": "warscroll",
+      "label": "Fell Bats",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 72,
+      "kindHint": "warscroll",
+      "label": "Fell Bats",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 74,
+      "kindHint": "warscroll",
+      "label": "Corpse Cart",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 75,
+      "kindHint": "warscroll",
+      "label": "Deadwalker Zombies",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 78,
+      "kindHint": "warscroll",
+      "label": "Awlrach the Drowner"
+    },
+    {
+      "line": 79,
+      "kindHint": "warscroll",
+      "label": "Black Coach"
+    },
+    {
+      "line": 80,
+      "kindHint": "warscroll",
+      "label": "Bladegheist Revenants"
+    },
+    {
+      "line": 81,
+      "kindHint": "warscroll",
+      "label": "Cairn Wraith",
+      "isLegends": true
+    },
+    {
+      "line": 83,
+      "kindHint": "warscroll",
+      "label": "Chainghasts"
+    },
+    {
+      "line": 84,
+      "kindHint": "warscroll",
+      "label": "Chainrasps"
+    },
+    {
+      "line": 85,
+      "kindHint": "warscroll",
+      "label": "Craventhrone Guard"
+    },
+    {
+      "line": 86,
+      "kindHint": "warscroll",
+      "label": "Dreadblade Harrows"
+    },
+    {
+      "line": 87,
+      "kindHint": "warscroll",
+      "label": "Dreadscythe Harridans"
+    },
+    {
+      "line": 88,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 90,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 92,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 94,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 96,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 98,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 100,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 102,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 104,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 106,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 108,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 110,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 112,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 114,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 116,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 118,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 120,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 122,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 124,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 126,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 128,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 130,
+      "kindHint": "warscroll",
+      "label": "Glaivewraith Stalkers",
+      "isLegends": true
+    },
+    {
+      "line": 132,
+      "kindHint": "warscroll",
+      "label": "Grimghast Reapers"
+    },
+    {
+      "line": 133,
+      "kindHint": "warscroll",
+      "label": "Guardian of Souls"
+    },
+    {
+      "line": 134,
+      "kindHint": "warscroll",
+      "label": "Hexwraiths"
+    },
+    {
+      "line": 135,
+      "kindHint": "warscroll",
+      "label": "Knight of Shrouds"
+    },
+    {
+      "line": 136,
+      "kindHint": "warscroll",
+      "label": "Knight of Shrouds on Ethereal Steed"
+    },
+    {
+      "line": 137,
+      "kindHint": "warscroll",
+      "label": "Krulghast Cruciator"
+    },
+    {
+      "line": 138,
+      "kindHint": "warscroll",
+      "label": "Kurdoss Valentian, the Craven King"
+    },
+    {
+      "line": 139,
+      "kindHint": "warscroll",
+      "label": "Lady Olynder, Mortarch of Grief"
+    },
+    {
+      "line": 140,
+      "kindHint": "warscroll",
+      "label": "Lord Executioner"
+    },
+    {
+      "line": 141,
+      "kindHint": "warscroll",
+      "label": "Lord Vitriolic"
+    },
+    {
+      "line": 142,
+      "kindHint": "warscroll",
+      "label": "Myrmourn Banshees"
+    },
+    {
+      "line": 143,
+      "kindHint": "warscroll",
+      "label": "Nagash, Supreme Lord of the Undead"
+    },
+    {
+      "line": 144,
+      "kindHint": "warscroll",
+      "label": "Pyregheists"
+    },
+    {
+      "line": 145,
+      "kindHint": "warscroll",
+      "label": "Reikenor the Grimhailer"
+    },
+    {
+      "line": 146,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Black Coach"
+    },
+    {
+      "line": 147,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Spirit Hosts"
+    },
+    {
+      "line": 148,
+      "kindHint": "warscroll",
+      "label": "Scriptor Mortis"
+    },
+    {
+      "line": 149,
+      "kindHint": "warscroll",
+      "label": "Spirit Hosts"
+    },
+    {
+      "line": 150,
+      "kindHint": "warscroll",
+      "label": "Spirit Torment"
+    },
+    {
+      "line": 151,
+      "kindHint": "warscroll",
+      "label": "The Headsmen's Curse",
+      "isLegends": true
+    },
+    {
+      "line": 153,
+      "kindHint": "warscroll",
+      "label": "Thorns of the Briar Queen",
+      "isLegends": true
+    },
+    {
+      "line": 155,
+      "kindHint": "warscroll",
+      "label": "Tomb Banshee",
+      "isLegends": true
+    },
+    {
+      "line": 157,
+      "kindHint": "warscroll",
+      "label": "Tomb Banshee",
+      "isLegends": true
+    },
+    {
+      "line": 161,
+      "kindHint": "warscroll",
+      "label": "Nexus of Grief"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/nh-001-emoji-name-renown/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/nh-001-emoji-name-renown/list.txt
@@ -1,0 +1,164 @@
+Night haunt one ❤️❤️ 44560/3000 pts
+-----
+Grand Alliance Death | Nighthaunt | Quicksilver Gheists (40 Points)
+General's Handbook 2026-27
+Auxiliaries: 54 (+28620 Points)
+Drops: 74
+Spell Lore - Lore of the Underworlds
+Manifestation Lore - Infernal Sorceries and Aetherwrought Machineries
+Battle Tactics Cards: Flanking Firestorm
+-----
+Regiment 1
+Guardian of Souls (100)
+-----
+Regiments of Renown
+Cogfort Raiders (450)
+Outlaw Conqueror Cogfort
+Blades of the Hollow King (260)
+Blades of the Hollow King
+Big Drogg Fort-Kicka (450)
+Gatebreaker Mega-Gargant
+Heralds of the Bone-tithe (510)
+Vokmortian, Master of the Bone-tithe
+Immortis Guard
+Mortek Guard
+Jerrion's Delegation (480)
+Marrowscroll Herald
+Crypt Flayers
+Crypt Ghouls
+Crypt Horrors
+Karahtet's Siege Breaker (360)
+Mortisan Ossifector
+Mortek Crawler
+Mask of the Deceiver (170)
+Mask of the Deceiver
+Neferata's Royal Echelon (760)
+Neferata, Mortarch of Blood
+Barrow Knights
+Deathrattle Skeletons
+Deathrattle Skeletons
+Rogue Engine (470)
+Outlaw Cannonade Cogfort
+Scions of the Necropolis (770)
+Katakros, Mortarch of the Necropolis
+Immortis Guard
+Immortis Guard
+Stumblefoot Gargant (140)
+Mancrusher Gargant
+The Beast of Castle Sternieste (190)
+Revenant Draconith
+The Horror of Hallow's Watch (230)
+Royal Terrorgheist
+The Lost-Song Spirits (370)
+Treelord
+Spite-Revenants
+Spite-Revenants
+The Liche's Hand (790)
+Arkhan the Black, Mortarch of Sacrament
+Morghast Archai
+Morghast Harbingers
+The Scarlet Jury (300)
+Grand Justice Gormayne
+Cryptguard
+Royal Decapitator
+The Summerking's Entourage (640)
+Ushoran, Mortarch of Delusion
+Cryptguard
+Morbheg Knights
+The Sternieste Garrison (680)
+Mannfred von Carstein, Mortarch of Night
+Barrow Guard
+Fell Bats
+Fell Bats
+Veremord's Shamblers (210)
+Corpse Cart
+Deadwalker Zombies
+-----
+Auxiliary Units
+Awlrach the Drowner (110)
+Black Coach (200)
+Bladegheist Revenants (200)
+Cairn Wraith (130)
+• Legends
+Chainghasts (90)
+Chainrasps (100)
+Craventhrone Guard (100)
+Dreadblade Harrows (140)
+Dreadscythe Harridans (190)
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Glaivewraith Stalkers (100)
+• Legends
+Grimghast Reapers (190)
+Guardian of Souls (100)
+Hexwraiths (150)
+Knight of Shrouds (100)
+Knight of Shrouds on Ethereal Steed (160)
+Krulghast Cruciator (150)
+Kurdoss Valentian, the Craven King (160)
+Lady Olynder, Mortarch of Grief (320)
+Lord Executioner (160)
+Lord Vitriolic (120)
+Myrmourn Banshees (100)
+Nagash, Supreme Lord of the Undead (750)
+Pyregheists (180)
+Reikenor the Grimhailer (200)
+Scourge of Aqshy: Black Coach (290)
+Scourge of Aqshy: Spirit Hosts (100)
+Scriptor Mortis (110)
+Spirit Hosts (110)
+Spirit Torment (110)
+The Headsmen's Curse (150)
+• Legends
+Thorns of the Briar Queen (140)
+• Legends
+Tomb Banshee (130)
+• Legends
+Tomb Banshee (130)
+• Legends
+-----
+Faction Terrain
+Nexus of Grief
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/obr-001-single-member-bundles/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/obr-001-single-member-bundles/expected.json
@@ -1,0 +1,459 @@
+{
+  "id": "obr-001-single-member-bundles",
+  "diagnostics": [],
+  "proposedName": "Ossiarch1",
+  "declaredFaction": "Ossiarch Bonereapers",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Remorseless Conquerors"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of Ossian Sorcery"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Horrors of the Necropolis"
+    },
+    {
+      "line": 12,
+      "kindHint": "warscroll",
+      "label": "Katakros, Mortarch of the Necropolis"
+    },
+    {
+      "line": 16,
+      "kindHint": "warscroll",
+      "label": "Gatebreaker Mega-Gargant",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 18,
+      "kindHint": "warscroll",
+      "label": "Blades of the Hollow King",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 20,
+      "kindHint": "warscroll",
+      "label": "Outlaw Conqueror Cogfort",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 22,
+      "kindHint": "warscroll",
+      "label": "Black Coach",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 24,
+      "kindHint": "warscroll",
+      "label": "Scriptor Mortis",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 25,
+      "kindHint": "warscroll",
+      "label": "Craventhrone Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 26,
+      "kindHint": "warscroll",
+      "label": "Craventhrone Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 28,
+      "kindHint": "warscroll",
+      "label": "Endrinmaster with Dirigible Suit",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 29,
+      "kindHint": "warscroll",
+      "label": "Grundstok Gunhauler",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 30,
+      "kindHint": "warscroll",
+      "label": "Skywardens",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 32,
+      "kindHint": "warscroll",
+      "label": "Marrowscroll Herald",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 33,
+      "kindHint": "warscroll",
+      "label": "Crypt Flayers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 34,
+      "kindHint": "warscroll",
+      "label": "Crypt Ghouls",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 35,
+      "kindHint": "warscroll",
+      "label": "Crypt Horrors",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 37,
+      "kindHint": "warscroll",
+      "label": "Mask of the Deceiver",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 39,
+      "kindHint": "warscroll",
+      "label": "Neferata, Mortarch of Blood",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 40,
+      "kindHint": "warscroll",
+      "label": "Barrow Knights",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 41,
+      "kindHint": "warscroll",
+      "label": "Deathrattle Skeletons",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 42,
+      "kindHint": "warscroll",
+      "label": "Deathrattle Skeletons",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 44,
+      "kindHint": "warscroll",
+      "label": "Outlaw Cannonade Cogfort",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 46,
+      "kindHint": "warscroll",
+      "label": "Codewright",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 47,
+      "kindHint": "warscroll",
+      "label": "Grundstok Thunderers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 48,
+      "kindHint": "warscroll",
+      "label": "Grundstok Thunderers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 50,
+      "kindHint": "warscroll",
+      "label": "Loonboss",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Dankhold Troggoth",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 53,
+      "kindHint": "warscroll",
+      "label": "Mancrusher Gargant",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 55,
+      "kindHint": "warscroll",
+      "label": "Revenant Draconith",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 57,
+      "kindHint": "warscroll",
+      "label": "Royal Terrorgheist",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 59,
+      "kindHint": "warscroll",
+      "label": "Lady Olynder, Mortarch of Grief",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 60,
+      "kindHint": "warscroll",
+      "label": "Dreadscythe Harridans",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 61,
+      "kindHint": "warscroll",
+      "label": "Myrmourn Banshees",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 62,
+      "kindHint": "warscroll",
+      "label": "Myrmourn Banshees",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 64,
+      "kindHint": "warscroll",
+      "label": "Grand Justice Gormayne",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 65,
+      "kindHint": "warscroll",
+      "label": "Cryptguard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 66,
+      "kindHint": "warscroll",
+      "label": "Royal Decapitator",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 68,
+      "kindHint": "warscroll",
+      "label": "Treelord",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 69,
+      "kindHint": "warscroll",
+      "label": "Spite-Revenants",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 70,
+      "kindHint": "warscroll",
+      "label": "Spite-Revenants",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 72,
+      "kindHint": "warscroll",
+      "label": "Corpse Cart",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 73,
+      "kindHint": "warscroll",
+      "label": "Deadwalker Zombies",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 75,
+      "kindHint": "warscroll",
+      "label": "Ushoran, Mortarch of Delusion",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 76,
+      "kindHint": "warscroll",
+      "label": "Cryptguard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 77,
+      "kindHint": "warscroll",
+      "label": "Morbheg Knights",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 79,
+      "kindHint": "warscroll",
+      "label": "Mannfred von Carstein, Mortarch of Night",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 80,
+      "kindHint": "warscroll",
+      "label": "Barrow Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 81,
+      "kindHint": "warscroll",
+      "label": "Fell Bats",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 82,
+      "kindHint": "warscroll",
+      "label": "Fell Bats",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 85,
+      "kindHint": "warscroll",
+      "label": "Arch-Kavalos Zandtos"
+    },
+    {
+      "line": 86,
+      "kindHint": "warscroll",
+      "label": "Arkhan the Black, Mortarch of Sacrament"
+    },
+    {
+      "line": 87,
+      "kindHint": "warscroll",
+      "label": "Gothizzar Harvester"
+    },
+    {
+      "line": 88,
+      "kindHint": "warscroll",
+      "label": "Immortis Guard"
+    },
+    {
+      "line": 89,
+      "kindHint": "warscroll",
+      "label": "Kainan's Reapers",
+      "isLegends": true
+    },
+    {
+      "line": 91,
+      "kindHint": "warscroll",
+      "label": "Katakros, Mortarch of the Necropolis"
+    },
+    {
+      "line": 92,
+      "kindHint": "warscroll",
+      "label": "Kavalos Deathriders"
+    },
+    {
+      "line": 93,
+      "kindHint": "warscroll",
+      "label": "Kavalos War Chariot"
+    },
+    {
+      "line": 94,
+      "kindHint": "warscroll",
+      "label": "Liege-Kavalos"
+    },
+    {
+      "line": 95,
+      "kindHint": "warscroll",
+      "label": "Liege-Kavalos on War Chariot"
+    },
+    {
+      "line": 96,
+      "kindHint": "warscroll",
+      "label": "Liege-Mortek"
+    },
+    {
+      "line": 97,
+      "kindHint": "warscroll",
+      "label": "Morghast Archai"
+    },
+    {
+      "line": 98,
+      "kindHint": "warscroll",
+      "label": "Morghast Harbingers"
+    },
+    {
+      "line": 99,
+      "kindHint": "warscroll",
+      "label": "Mortek Crawler"
+    },
+    {
+      "line": 100,
+      "kindHint": "warscroll",
+      "label": "Mortek Guard"
+    },
+    {
+      "line": 101,
+      "kindHint": "warscroll",
+      "label": "Mortek Triaxes"
+    },
+    {
+      "line": 102,
+      "kindHint": "warscroll",
+      "label": "Mortis Reapers"
+    },
+    {
+      "line": 103,
+      "kindHint": "warscroll",
+      "label": "Mortisan Boneshaper"
+    },
+    {
+      "line": 104,
+      "kindHint": "warscroll",
+      "label": "Mortisan Ossifector"
+    },
+    {
+      "line": 105,
+      "kindHint": "warscroll",
+      "label": "Mortisan Soulmason"
+    },
+    {
+      "line": 106,
+      "kindHint": "warscroll",
+      "label": "Mortisan Soulreaper"
+    },
+    {
+      "line": 107,
+      "kindHint": "warscroll",
+      "label": "Nagash, Supreme Lord of the Undead"
+    },
+    {
+      "line": 108,
+      "kindHint": "warscroll",
+      "label": "Necropolis Stalkers"
+    },
+    {
+      "line": 109,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Mortis Reapers"
+    },
+    {
+      "line": 110,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Vokmortian, Master of the Bone-tithe"
+    },
+    {
+      "line": 111,
+      "kindHint": "warscroll",
+      "label": "Teratic Cohort"
+    },
+    {
+      "line": 112,
+      "kindHint": "warscroll",
+      "label": "Thanatek's Tithe",
+      "isLegends": true
+    },
+    {
+      "line": 114,
+      "kindHint": "warscroll",
+      "label": "Vokmortian, Master of the Bone-tithe"
+    },
+    {
+      "line": 117,
+      "kindHint": "warscroll",
+      "label": "Bone-tithe Nexus"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/obr-001-single-member-bundles/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/obr-001-single-member-bundles/list.txt
@@ -1,0 +1,120 @@
+Ossiarch1 21500/2500 pts
+-----
+Grand Alliance Death | Ossiarch Bonereapers | Remorseless Conquerors
+General's Handbook 2026-27
+Auxiliaries: 28 (+7560 Points)
+Drops: 50
+Spell Lore - Lore of Ossian Sorcery
+Manifestation Lore - Horrors of the Necropolis
+Battle Tactics Cards: Siege of Ashes
+-----
+Regiment 1
+Katakros, Mortarch of the Necropolis (470)
+-----
+Regiments of Renown
+Big Drogg Fort-Kicka (450)
+Gatebreaker Mega-Gargant
+Blades of the Hollow King (260)
+Blades of the Hollow King
+Cogfort Raiders (450)
+Outlaw Conqueror Cogfort
+Casket of Resurrections (200)
+Black Coach
+Craventhrone Executioners (290)
+Scriptor Mortis
+Craventhrone Guard
+Craventhrone Guard
+Exile Scavengers (410)
+Endrinmaster with Dirigible Suit
+Grundstok Gunhauler
+Skywardens
+Jerrion's Delegation (480)
+Marrowscroll Herald
+Crypt Flayers
+Crypt Ghouls
+Crypt Horrors
+Mask of the Deceiver (170)
+Mask of the Deceiver
+Neferata's Royal Echelon (760)
+Neferata, Mortarch of Blood
+Barrow Knights
+Deathrattle Skeletons
+Deathrattle Skeletons
+Rogue Engine (470)
+Outlaw Cannonade Cogfort
+Sky-Port Profiteers (350)
+Codewright
+Grundstok Thunderers
+Grundstok Thunderers
+Snerk's Trogg-Fer-Hire (220)
+Loonboss
+Dankhold Troggoth
+Stumblefoot Gargant (140)
+Mancrusher Gargant
+The Beast of Castle Sternieste (190)
+Revenant Draconith
+The Horror of Hallow's Watch (230)
+Royal Terrorgheist
+The Sorrowmourn Choir (590)
+Lady Olynder, Mortarch of Grief
+Dreadscythe Harridans
+Myrmourn Banshees
+Myrmourn Banshees
+The Scarlet Jury (300)
+Grand Justice Gormayne
+Cryptguard
+Royal Decapitator
+The Lost-Song Spirits (370)
+Treelord
+Spite-Revenants
+Spite-Revenants
+Veremord's Shamblers (210)
+Corpse Cart
+Deadwalker Zombies
+The Summerking's Entourage (640)
+Ushoran, Mortarch of Delusion
+Cryptguard
+Morbheg Knights
+The Sternieste Garrison (680)
+Mannfred von Carstein, Mortarch of Night
+Barrow Guard
+Fell Bats
+Fell Bats
+-----
+Auxiliary Units
+Arch-Kavalos Zandtos (220)
+Arkhan the Black, Mortarch of Sacrament (440)
+Gothizzar Harvester (200)
+Immortis Guard (170)
+Kainan's Reapers (140)
+• Legends
+Katakros, Mortarch of the Necropolis (470)
+Kavalos Deathriders (150)
+Kavalos War Chariot (150)
+Liege-Kavalos (180)
+Liege-Kavalos on War Chariot (210)
+Liege-Mortek (120)
+Morghast Archai (250)
+Morghast Harbingers (240)
+Mortek Crawler (250)
+Mortek Guard (110)
+Mortek Triaxes (140)
+Mortis Reapers (110)
+Mortisan Boneshaper (140)
+Mortisan Ossifector (110)
+Mortisan Soulmason (140)
+Mortisan Soulreaper (120)
+Nagash, Supreme Lord of the Undead (830)
+Necropolis Stalkers (130)
+Scourge of Aqshy: Mortis Reapers (90)
+Scourge of Aqshy: Vokmortian, Master of the Bone-tithe (180)
+Teratic Cohort (90)
+Thanatek's Tithe (90)
+• Legends
+Vokmortian, Master of the Bone-tithe (140)
+-----
+Faction Terrain
+Bone-tithe Nexus
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/sbg-001-emoji-only-name/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/sbg-001-emoji-only-name/expected.json
@@ -1,0 +1,471 @@
+{
+  "id": "sbg-001-emoji-only-name",
+  "diagnostics": [],
+  "proposedName": "😎🇺🇸🇺🇸😎",
+  "declaredFaction": "Soulblight Gravelords",
+  "declaredContext": "General's Handbook 2025-26",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Legions of Ulfenkarn"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of Undeath"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Manifestations of the Grave"
+    },
+    {
+      "line": 12,
+      "kindHint": "warscroll",
+      "label": "Cado Ezechiar, The Hollow King",
+      "isLegends": true
+    },
+    {
+      "line": 14,
+      "kindHint": "warscroll",
+      "label": "Askurgan Trueblades"
+    },
+    {
+      "line": 15,
+      "kindHint": "warscroll",
+      "label": "Barrow Guard"
+    },
+    {
+      "line": 16,
+      "kindHint": "warscroll",
+      "label": "Deadwalker Zombies"
+    },
+    {
+      "line": 20,
+      "kindHint": "warscroll",
+      "label": "Gatebreaker Mega-Gargant",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 22,
+      "kindHint": "warscroll",
+      "label": "Black Coach",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 24,
+      "kindHint": "warscroll",
+      "label": "Outlaw Conqueror Cogfort",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 26,
+      "kindHint": "warscroll",
+      "label": "Endrinmaster with Dirigible Suit",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Grundstok Gunhauler",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 28,
+      "kindHint": "warscroll",
+      "label": "Skywardens",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 30,
+      "kindHint": "warscroll",
+      "label": "Mortisan Ossifector",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 31,
+      "kindHint": "warscroll",
+      "label": "Gothizzar Harvester",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 32,
+      "kindHint": "warscroll",
+      "label": "Mortek Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 33,
+      "kindHint": "warscroll",
+      "label": "Mortek Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 35,
+      "kindHint": "warscroll",
+      "label": "Scriptor Mortis",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 36,
+      "kindHint": "warscroll",
+      "label": "Craventhrone Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 37,
+      "kindHint": "warscroll",
+      "label": "Craventhrone Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 39,
+      "kindHint": "warscroll",
+      "label": "Vokmortian, Master of the Bone-tithe",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 40,
+      "kindHint": "warscroll",
+      "label": "Immortis Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 41,
+      "kindHint": "warscroll",
+      "label": "Mortek Guard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 43,
+      "kindHint": "warscroll",
+      "label": "Marrowscroll Herald",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 44,
+      "kindHint": "warscroll",
+      "label": "Crypt Flayers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 45,
+      "kindHint": "warscroll",
+      "label": "Crypt Ghouls",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 46,
+      "kindHint": "warscroll",
+      "label": "Crypt Horrors",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 48,
+      "kindHint": "warscroll",
+      "label": "Mortisan Ossifector",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 49,
+      "kindHint": "warscroll",
+      "label": "Mortek Crawler",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Mask of the Deceiver",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 54,
+      "kindHint": "warscroll",
+      "label": "Askurgan Trueblades"
+    },
+    {
+      "line": 55,
+      "kindHint": "warscroll",
+      "label": "Barrow Guard"
+    },
+    {
+      "line": 56,
+      "kindHint": "warscroll",
+      "label": "Barrow Knights"
+    },
+    {
+      "line": 57,
+      "kindHint": "warscroll",
+      "label": "Belladamma Volga, First of the Vyrkos"
+    },
+    {
+      "line": 58,
+      "kindHint": "warscroll",
+      "label": "Blades of the Hollow King"
+    },
+    {
+      "line": 59,
+      "kindHint": "warscroll",
+      "label": "Blood Knights"
+    },
+    {
+      "line": 60,
+      "kindHint": "warscroll",
+      "label": "Bloodseeker Palanquin",
+      "isLegends": true
+    },
+    {
+      "line": 62,
+      "kindHint": "warscroll",
+      "label": "Cado Ezechiar, The Hollow King",
+      "isLegends": true
+    },
+    {
+      "line": 64,
+      "kindHint": "warscroll",
+      "label": "Corpse Cart"
+    },
+    {
+      "line": 65,
+      "kindHint": "warscroll",
+      "label": "Coven Throne"
+    },
+    {
+      "line": 66,
+      "kindHint": "warscroll",
+      "label": "Deadwalker Zombies"
+    },
+    {
+      "line": 67,
+      "kindHint": "warscroll",
+      "label": "Deathrattle Skeletons"
+    },
+    {
+      "line": 68,
+      "kindHint": "warscroll",
+      "label": "Dire Wolves"
+    },
+    {
+      "line": 69,
+      "kindHint": "warscroll",
+      "label": "Fell Bats"
+    },
+    {
+      "line": 70,
+      "kindHint": "warscroll",
+      "label": "Gorslav the Gravekeeper",
+      "isLegends": true
+    },
+    {
+      "line": 72,
+      "kindHint": "warscroll",
+      "label": "Ivya Volga, The Outcast"
+    },
+    {
+      "line": 73,
+      "kindHint": "warscroll",
+      "label": "Kosargi Nightguard",
+      "isLegends": true
+    },
+    {
+      "line": 75,
+      "kindHint": "warscroll",
+      "label": "Kritza, the Rat Prince"
+    },
+    {
+      "line": 76,
+      "kindHint": "warscroll",
+      "label": "Lady Annika, the Thirsting Blade"
+    },
+    {
+      "line": 77,
+      "kindHint": "warscroll",
+      "label": "Lauka Vai, Mother of Nightmares"
+    },
+    {
+      "line": 78,
+      "kindHint": "warscroll",
+      "label": "Mannfred von Carstein, Mortarch of Night"
+    },
+    {
+      "line": 79,
+      "kindHint": "warscroll",
+      "label": "Mortis Engine"
+    },
+    {
+      "line": 80,
+      "kindHint": "warscroll",
+      "label": "Nagash, Supreme Lord of the Undead"
+    },
+    {
+      "line": 81,
+      "kindHint": "warscroll",
+      "label": "Necromancer"
+    },
+    {
+      "line": 82,
+      "kindHint": "warscroll",
+      "label": "Neferata, Mortarch of Blood"
+    },
+    {
+      "line": 83,
+      "kindHint": "warscroll",
+      "label": "Prince Vhordrai"
+    },
+    {
+      "line": 84,
+      "kindHint": "warscroll",
+      "label": "Radukar the Beast"
+    },
+    {
+      "line": 85,
+      "kindHint": "warscroll",
+      "label": "Radukar the Wolf"
+    },
+    {
+      "line": 86,
+      "kindHint": "warscroll",
+      "label": "Revenant Draconith"
+    },
+    {
+      "line": 87,
+      "kindHint": "warscroll",
+      "label": "Scourge of Ghyran Corpse Cart"
+    },
+    {
+      "line": 88,
+      "kindHint": "warscroll",
+      "label": "Scourge of Ghyran Corpse Cart"
+    },
+    {
+      "line": 89,
+      "kindHint": "warscroll",
+      "label": "Scourge of Ghyran Sekhar, Fang of Nulahmia"
+    },
+    {
+      "line": 90,
+      "kindHint": "warscroll",
+      "label": "Sekhar, Fang of Nulahmia"
+    },
+    {
+      "line": 91,
+      "kindHint": "warscroll",
+      "label": "Terrorgheist",
+      "isLegends": true
+    },
+    {
+      "line": 93,
+      "kindHint": "warscroll",
+      "label": "Terrorgheist",
+      "isLegends": true
+    },
+    {
+      "line": 95,
+      "kindHint": "warscroll",
+      "label": "The Crimson Court",
+      "isLegends": true
+    },
+    {
+      "line": 97,
+      "kindHint": "warscroll",
+      "label": "The Exiled Dead",
+      "isLegends": true
+    },
+    {
+      "line": 99,
+      "kindHint": "warscroll",
+      "label": "The Sepulchral Guard",
+      "isLegends": true
+    },
+    {
+      "line": 101,
+      "kindHint": "warscroll",
+      "label": "The Sons of Velmorn",
+      "isLegends": true
+    },
+    {
+      "line": 103,
+      "kindHint": "warscroll",
+      "label": "Torgillius the Chamberlain",
+      "isLegends": true
+    },
+    {
+      "line": 105,
+      "kindHint": "warscroll",
+      "label": "Vampire Lord"
+    },
+    {
+      "line": 106,
+      "kindHint": "warscroll",
+      "label": "Vampire Lord on Nightmare Steed"
+    },
+    {
+      "line": 107,
+      "kindHint": "warscroll",
+      "label": "Vampire Lord on Zombie Dragon",
+      "isLegends": true
+    },
+    {
+      "line": 109,
+      "kindHint": "warscroll",
+      "label": "Vargheists"
+    },
+    {
+      "line": 110,
+      "kindHint": "warscroll",
+      "label": "Vargskyr",
+      "isLegends": true
+    },
+    {
+      "line": 112,
+      "kindHint": "warscroll",
+      "label": "Vargskyr",
+      "isLegends": true
+    },
+    {
+      "line": 114,
+      "kindHint": "warscroll",
+      "label": "Vengorian Lord"
+    },
+    {
+      "line": 115,
+      "kindHint": "warscroll",
+      "label": "Vyrkos Blood-born",
+      "isLegends": true
+    },
+    {
+      "line": 117,
+      "kindHint": "warscroll",
+      "label": "Watch Captain Halgrim",
+      "isLegends": true
+    },
+    {
+      "line": 119,
+      "kindHint": "warscroll",
+      "label": "Wight King"
+    },
+    {
+      "line": 120,
+      "kindHint": "warscroll",
+      "label": "Wight King on Skeletal Steed"
+    },
+    {
+      "line": 121,
+      "kindHint": "warscroll",
+      "label": "Wight Lord on Skeletal Steed"
+    },
+    {
+      "line": 122,
+      "kindHint": "warscroll",
+      "label": "Zondara's Gravebreakers",
+      "isLegends": true
+    },
+    {
+      "line": 126,
+      "kindHint": "warscroll",
+      "label": "Cursed Sepulchre"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/sbg-001-emoji-only-name/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/sbg-001-emoji-only-name/list.txt
@@ -1,0 +1,129 @@
+😎🇺🇸🇺🇸😎 41620/2000 pts
+-----
+Grand Alliance Death | Soulblight Gravelords | Legions of Ulfenkarn
+General's Handbook 2025-26
+Auxiliaries: 53 (+27560 Points)
+Drops: 64
+Spell Lore - Lore of Undeath
+Manifestation Lore - Manifestations of the Grave
+Battle Tactics Cards: Attuned to Ghyran and Intercept and Recover
+-----
+Regiment 1
+Cado Ezechiar, The Hollow King (150)
+• Legends
+Askurgan Trueblades (140)
+Barrow Guard (130)
+Deadwalker Zombies (120)
+-----
+Regiments of Renown
+Big Drogg Fort-Kicka (450)
+Gatebreaker Mega-Gargant
+Casket of Resurrections (200)
+Black Coach
+Cogfort Raiders (450)
+Outlaw Conqueror Cogfort
+Exile Scavengers (410)
+Endrinmaster with Dirigible Suit
+Grundstok Gunhauler
+Skywardens
+Enforcers of the Tithe (470)
+Mortisan Ossifector
+Gothizzar Harvester
+Mortek Guard
+Mortek Guard
+Craventhrone Executioners (290)
+Scriptor Mortis
+Craventhrone Guard
+Craventhrone Guard
+Heralds of the Bone-tithe (510)
+Vokmortian, Master of the Bone-tithe
+Immortis Guard
+Mortek Guard
+Jerrion's Delegation (480)
+Marrowscroll Herald
+Crypt Flayers
+Crypt Ghouls
+Crypt Horrors
+Karahtet's Siege Breaker (360)
+Mortisan Ossifector
+Mortek Crawler
+Mask of the Deceiver (170)
+Mask of the Deceiver
+-----
+Auxiliary Units
+Askurgan Trueblades (140)
+Barrow Guard (130)
+Barrow Knights (190)
+Belladamma Volga, First of the Vyrkos (200)
+Blades of the Hollow King (270)
+Blood Knights (220)
+Bloodseeker Palanquin (220)
+• Legends
+Cado Ezechiar, The Hollow King (150)
+• Legends
+Corpse Cart (70)
+Coven Throne (230)
+Deadwalker Zombies (120)
+Deathrattle Skeletons (90)
+Dire Wolves (150)
+Fell Bats (80)
+Gorslav the Gravekeeper (120)
+• Legends
+Ivya Volga, The Outcast (100)
+Kosargi Nightguard (110)
+• Legends
+Kritza, the Rat Prince (70)
+Lady Annika, the Thirsting Blade (100)
+Lauka Vai, Mother of Nightmares (200)
+Mannfred von Carstein, Mortarch of Night (410)
+Mortis Engine (230)
+Nagash, Supreme Lord of the Undead (750)
+Necromancer (110)
+Neferata, Mortarch of Blood (450)
+Prince Vhordrai (470)
+Radukar the Beast (250)
+Radukar the Wolf (130)
+Revenant Draconith (180)
+Scourge of Ghyran Corpse Cart (80)
+Scourge of Ghyran Corpse Cart (80)
+Scourge of Ghyran Sekhar, Fang of Nulahmia (190)
+Sekhar, Fang of Nulahmia (160)
+Terrorgheist (220)
+• Legends
+Terrorgheist (220)
+• Legends
+The Crimson Court (210)
+• Legends
+The Exiled Dead (140)
+• Legends
+The Sepulchral Guard (110)
+• Legends
+The Sons of Velmorn (130)
+• Legends
+Torgillius the Chamberlain (180)
+• Legends
+Vampire Lord (140)
+Vampire Lord on Nightmare Steed (180)
+Vampire Lord on Zombie Dragon (400)
+• Legends
+Vargheists (120)
+Vargskyr (140)
+• Legends
+Vargskyr (140)
+• Legends
+Vengorian Lord (200)
+Vyrkos Blood-born (150)
+• Legends
+Watch Captain Halgrim (110)
+• Legends
+Wight King (80)
+Wight King on Skeletal Steed (180)
+Wight Lord on Skeletal Steed (110)
+Zondara's Gravebreakers (120)
+• Legends
+-----
+Faction Terrain
+Cursed Sepulchre
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466

--- a/src/tests/fixtures/aos4/import/official-app/lists/std-001-duplicate-renown-bundles/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/std-001-duplicate-renown-bundles/expected.json
@@ -1,0 +1,695 @@
+{
+  "id": "std-001-duplicate-renown-bundles",
+  "diagnostics": [],
+  "proposedName": "Std1",
+  "declaredFaction": "Slaves to Darkness",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": true,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Godswrath Warband"
+    },
+    {
+      "line": 7,
+      "kindHint": "spell-lore",
+      "label": "Lore of the Damned"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Primal Energy"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Manifestations of Malevolence"
+    },
+    {
+      "line": 12,
+      "kindHint": "warscroll",
+      "label": "Centaurion Marshal"
+    },
+    {
+      "line": 16,
+      "kindHint": "warscroll",
+      "label": "Outlaw Conqueror Cogfort",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 18,
+      "kindHint": "warscroll",
+      "label": "Sloppity Bilepiper, Herald of Nurgle",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 19,
+      "kindHint": "warscroll",
+      "label": "Beast of Nurgle",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 20,
+      "kindHint": "warscroll",
+      "label": "Beast of Nurgle",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 22,
+      "kindHint": "warscroll",
+      "label": "Endrinmaster with Dirigible Suit",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 23,
+      "kindHint": "warscroll",
+      "label": "Grundstok Gunhauler",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 24,
+      "kindHint": "warscroll",
+      "label": "Skywardens",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 26,
+      "kindHint": "warscroll",
+      "label": "Krittok Foulblade",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 27,
+      "kindHint": "warscroll",
+      "label": "Doom-Flayers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 28,
+      "kindHint": "warscroll",
+      "label": "Stormvermin",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 30,
+      "kindHint": "warscroll",
+      "label": "Mask of the Deceiver",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 32,
+      "kindHint": "warscroll",
+      "label": "Shardspeaker of Slaanesh",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 33,
+      "kindHint": "warscroll",
+      "label": "Blissbarb Archers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 35,
+      "kindHint": "warscroll",
+      "label": "Nurglings",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 36,
+      "kindHint": "warscroll",
+      "label": "Nurglings",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 38,
+      "kindHint": "warscroll",
+      "label": "Warstomper Mega-Gargant",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 40,
+      "kindHint": "warscroll",
+      "label": "Harbinger of Decay",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 41,
+      "kindHint": "warscroll",
+      "label": "Pusgoyle Blightlords",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 42,
+      "kindHint": "warscroll",
+      "label": "Putrid Blightkings",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 44,
+      "kindHint": "warscroll",
+      "label": "Outlaw Cannonade Cogfort",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 46,
+      "kindHint": "warscroll",
+      "label": "Ashen Elder",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 47,
+      "kindHint": "warscroll",
+      "label": "Dominator Engine with Bane Maces",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 49,
+      "kindHint": "warscroll",
+      "label": "Magister on Disc of Tzeentch",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 50,
+      "kindHint": "warscroll",
+      "label": "Gaunt Summoner on Disc of Tzeentch",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 51,
+      "kindHint": "warscroll",
+      "label": "Screamers of Tzeentch",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 53,
+      "kindHint": "warscroll",
+      "label": "Loonboss",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 54,
+      "kindHint": "warscroll",
+      "label": "Dankhold Troggoth",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 56,
+      "kindHint": "warscroll",
+      "label": "Varghulf Courtier",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 57,
+      "kindHint": "warscroll",
+      "label": "Morbheg Knights",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 59,
+      "kindHint": "warscroll",
+      "label": "Mancrusher Gargant",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 61,
+      "kindHint": "warscroll",
+      "label": "Contorted Epitome",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 62,
+      "kindHint": "warscroll",
+      "label": "Dreadful Visage",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 63,
+      "kindHint": "warscroll",
+      "label": "Mesmerising Mirror",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 64,
+      "kindHint": "warscroll",
+      "label": "Wheels of Excruciation",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 66,
+      "kindHint": "warscroll",
+      "label": "Magister",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 67,
+      "kindHint": "warscroll",
+      "label": "Burning Sigil of Tzeentch",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 68,
+      "kindHint": "warscroll",
+      "label": "Daemonic Simulacrum",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 69,
+      "kindHint": "warscroll",
+      "label": "Pink Horrors",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 70,
+      "kindHint": "warscroll",
+      "label": "Tome of Eyes",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 72,
+      "kindHint": "warscroll",
+      "label": "Daemonsmith",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 73,
+      "kindHint": "warscroll",
+      "label": "Deathshrieker Rocket Battery",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 74,
+      "kindHint": "warscroll",
+      "label": "Tormentor Bombard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 76,
+      "kindHint": "warscroll",
+      "label": "Skarbrand",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 78,
+      "kindHint": "warscroll",
+      "label": "Spoilpox Scrivener, Herald of Nurgle",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 79,
+      "kindHint": "warscroll",
+      "label": "Feculent Gnarlmaw",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 80,
+      "kindHint": "warscroll",
+      "label": "Plaguebearers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 82,
+      "kindHint": "warscroll",
+      "label": "Slaughterpriest",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 83,
+      "kindHint": "warscroll",
+      "label": "Bloodreavers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 84,
+      "kindHint": "warscroll",
+      "label": "Skullreapers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 86,
+      "kindHint": "warscroll",
+      "label": "Grand Justice Gormayne",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 87,
+      "kindHint": "warscroll",
+      "label": "Cryptguard",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 88,
+      "kindHint": "warscroll",
+      "label": "Royal Decapitator",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 90,
+      "kindHint": "warscroll",
+      "label": "Warlock Galvaneer",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 91,
+      "kindHint": "warscroll",
+      "label": "Ratling Warpblaster",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 92,
+      "kindHint": "warscroll",
+      "label": "Warpvolt Scourgers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 94,
+      "kindHint": "warscroll",
+      "label": "Warlock Galvaneer",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 95,
+      "kindHint": "warscroll",
+      "label": "Ratling Warpblaster",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 96,
+      "kindHint": "warscroll",
+      "label": "Warpvolt Scourgers",
+      "isRegimentOfRenown": true
+    },
+    {
+      "line": 99,
+      "kindHint": "warscroll",
+      "label": "Abraxia, Spear of the Everchosen"
+    },
+    {
+      "line": 100,
+      "kindHint": "warscroll",
+      "label": "Archaon, the Everchosen"
+    },
+    {
+      "line": 101,
+      "kindHint": "warscroll",
+      "label": "Be'lakor, the Dark Master"
+    },
+    {
+      "line": 102,
+      "kindHint": "warscroll",
+      "label": "Centaurion Marshal"
+    },
+    {
+      "line": 103,
+      "kindHint": "warscroll",
+      "label": "Chaos Chariot"
+    },
+    {
+      "line": 104,
+      "kindHint": "warscroll",
+      "label": "Chaos Chariot"
+    },
+    {
+      "line": 105,
+      "kindHint": "warscroll",
+      "label": "Chaos Chosen"
+    },
+    {
+      "line": 106,
+      "kindHint": "warscroll",
+      "label": "Chaos Furies"
+    },
+    {
+      "line": 107,
+      "kindHint": "warscroll",
+      "label": "Chaos Knights"
+    },
+    {
+      "line": 108,
+      "kindHint": "warscroll",
+      "label": "Chaos Legionnaires"
+    },
+    {
+      "line": 109,
+      "kindHint": "warscroll",
+      "label": "Chaos Lord"
+    },
+    {
+      "line": 110,
+      "kindHint": "warscroll",
+      "label": "Chaos Lord on Daemonic Mount"
+    },
+    {
+      "line": 111,
+      "kindHint": "warscroll",
+      "label": "Chaos Lord on Karkadrak"
+    },
+    {
+      "line": 112,
+      "kindHint": "warscroll",
+      "label": "Chaos Lord on Manticore",
+      "isLegends": true
+    },
+    {
+      "line": 114,
+      "kindHint": "warscroll",
+      "label": "Chaos Sorcerer Lord"
+    },
+    {
+      "line": 115,
+      "kindHint": "warscroll",
+      "label": "Chaos Sorcerer Lord on Manticore",
+      "isLegends": true
+    },
+    {
+      "line": 117,
+      "kindHint": "warscroll",
+      "label": "Chaos Spawn"
+    },
+    {
+      "line": 118,
+      "kindHint": "warscroll",
+      "label": "Chaos Warriors"
+    },
+    {
+      "line": 119,
+      "kindHint": "warscroll",
+      "label": "Chaos Warshrine",
+      "isLegends": true
+    },
+    {
+      "line": 121,
+      "kindHint": "warscroll",
+      "label": "Corvus Cabal",
+      "isLegends": true
+    },
+    {
+      "line": 123,
+      "kindHint": "warscroll",
+      "label": "Cypher Lords",
+      "isLegends": true
+    },
+    {
+      "line": 125,
+      "kindHint": "warscroll",
+      "label": "Daemon Prince"
+    },
+    {
+      "line": 126,
+      "kindHint": "warscroll",
+      "label": "Darkoath Chieftain"
+    },
+    {
+      "line": 127,
+      "kindHint": "warscroll",
+      "label": "Darkoath Chieftain on Warsteed"
+    },
+    {
+      "line": 128,
+      "kindHint": "warscroll",
+      "label": "Darkoath Fellriders"
+    },
+    {
+      "line": 129,
+      "kindHint": "warscroll",
+      "label": "Darkoath Marauders"
+    },
+    {
+      "line": 130,
+      "kindHint": "warscroll",
+      "label": "Darkoath Savagers"
+    },
+    {
+      "line": 131,
+      "kindHint": "warscroll",
+      "label": "Darkoath Warqueen"
+    },
+    {
+      "line": 132,
+      "kindHint": "warscroll",
+      "label": "Darkoath Warqueen"
+    },
+    {
+      "line": 133,
+      "kindHint": "warscroll",
+      "label": "Darkoath Wilderfiend"
+    },
+    {
+      "line": 134,
+      "kindHint": "warscroll",
+      "label": "Eternus, Blade of the First Prince"
+    },
+    {
+      "line": 135,
+      "kindHint": "warscroll",
+      "label": "Exalted Hero of Chaos"
+    },
+    {
+      "line": 136,
+      "kindHint": "warscroll",
+      "label": "Fomoroid Crusher"
+    },
+    {
+      "line": 137,
+      "kindHint": "warscroll",
+      "label": "Gaunt Summoner"
+    },
+    {
+      "line": 138,
+      "kindHint": "warscroll",
+      "label": "Gaunt Summoner on Disc of Tzeentch"
+    },
+    {
+      "line": 139,
+      "kindHint": "warscroll",
+      "label": "Godsworn Hunt",
+      "isLegends": true
+    },
+    {
+      "line": 141,
+      "kindHint": "warscroll",
+      "label": "Gorebeast Chariot"
+    },
+    {
+      "line": 142,
+      "kindHint": "warscroll",
+      "label": "Horns of Hashut",
+      "isLegends": true
+    },
+    {
+      "line": 144,
+      "kindHint": "warscroll",
+      "label": "Iron Golem",
+      "isLegends": true
+    },
+    {
+      "line": 146,
+      "kindHint": "warscroll",
+      "label": "Khagra's Ravagers",
+      "isLegends": true
+    },
+    {
+      "line": 148,
+      "kindHint": "warscroll",
+      "label": "Mindstealer Sphiranx"
+    },
+    {
+      "line": 149,
+      "kindHint": "warscroll",
+      "label": "Mutalith Vortex Beast"
+    },
+    {
+      "line": 150,
+      "kindHint": "warscroll",
+      "label": "Ogroid Myrmidon"
+    },
+    {
+      "line": 151,
+      "kindHint": "warscroll",
+      "label": "Ogroid Theridons"
+    },
+    {
+      "line": 152,
+      "kindHint": "warscroll",
+      "label": "Raptoryx"
+    },
+    {
+      "line": 153,
+      "kindHint": "warscroll",
+      "label": "Scions of the Flame",
+      "isLegends": true
+    },
+    {
+      "line": 155,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Chaos Lord on Karkadrak"
+    },
+    {
+      "line": 156,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Chaos Warriors"
+    },
+    {
+      "line": 157,
+      "kindHint": "warscroll",
+      "label": "Slaughterbrute"
+    },
+    {
+      "line": 158,
+      "kindHint": "warscroll",
+      "label": "Soul Grinder",
+      "isLegends": true
+    },
+    {
+      "line": 160,
+      "kindHint": "warscroll",
+      "label": "Spire Tyrants",
+      "isLegends": true
+    },
+    {
+      "line": 162,
+      "kindHint": "warscroll",
+      "label": "Splintered Fang",
+      "isLegends": true
+    },
+    {
+      "line": 164,
+      "kindHint": "warscroll",
+      "label": "Tarantulos Brood",
+      "isLegends": true
+    },
+    {
+      "line": 166,
+      "kindHint": "warscroll",
+      "label": "The Gnarlspirit Pack",
+      "isLegends": true
+    },
+    {
+      "line": 168,
+      "kindHint": "warscroll",
+      "label": "The Unmade",
+      "isLegends": true
+    },
+    {
+      "line": 170,
+      "kindHint": "warscroll",
+      "label": "Untamed Beasts",
+      "isLegends": true
+    },
+    {
+      "line": 172,
+      "kindHint": "warscroll",
+      "label": "Varanguard"
+    },
+    {
+      "line": 175,
+      "kindHint": "warscroll",
+      "label": "Nexus Chaotica"
+    },
+    {
+      "line": 176,
+      "kindHint": "warscroll",
+      "label": "Nexus Chaotica"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/std-001-duplicate-renown-bundles/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/std-001-duplicate-renown-bundles/list.txt
@@ -1,0 +1,179 @@
+Std1 49120/3000 pts
+-----
+Grand Alliance Chaos | Slaves to Darkness | Godswrath Warband
+General's Handbook 2026-27
+Auxiliaries: 57 (+31920 Points)
+Drops: 82
+Spell Lore - Lore of the Damned
+Manifestation Lore - Primal Energy (10 Points) and Manifestations of Malevolence
+Battle Tactics Cards: Blazing Onslaught
+-----
+Regiment 1
+Centaurion Marshal (120)
+-----
+Regiments of Renown
+Cogfort Raiders (450)
+Outlaw Conqueror Cogfort
+Diseased Revellers (310)
+Sloppity Bilepiper, Herald of Nurgle
+Beast of Nurgle
+Beast of Nurgle
+Exile Scavengers (410)
+Endrinmaster with Dirigible Suit
+Grundstok Gunhauler
+Skywardens
+Krittok's Clawpack (380)
+Krittok Foulblade
+Doom-Flayers
+Stormvermin
+Mask of the Deceiver (170)
+Mask of the Deceiver
+Mist-Clad Revellers (260)
+Shardspeaker of Slaanesh
+Blissbarb Archers
+Nurgle's Gift (180)
+Nurglings
+Nurglings
+One-eyed Grunnock (410)
+Warstomper Mega-Gargant
+Phulgoth's Shudderhood (530)
+Harbinger of Decay
+Pusgoyle Blightlords
+Putrid Blightkings
+Rogue Engine (470)
+Outlaw Cannonade Cogfort
+Seeker of the Dread Dirge (260)
+Ashen Elder
+Dominator Engine with Bane Maces
+Seekers of Silver (380)
+Magister on Disc of Tzeentch
+Gaunt Summoner on Disc of Tzeentch
+Screamers of Tzeentch
+Snerk's Trogg-Fer-Hire (220)
+Loonboss
+Dankhold Troggoth
+Squires of the Everchosen (280)
+Varghulf Courtier
+Morbheg Knights
+Stumblefoot Gargant (140)
+Mancrusher Gargant
+The Accursed Reflection (150)
+Contorted Epitome
+Dreadful Visage
+Mesmerising Mirror
+Wheels of Excruciation
+The Coven of Thryx (280)
+Magister
+Burning Sigil of Tzeentch
+Daemonic Simulacrum
+Pink Horrors
+Tome of Eyes
+The Curse-Steel Battery (380)
+Daemonsmith
+Deathshrieker Rocket Battery
+Tormentor Bombard
+The Exiled One (390)
+Skarbrand
+The Pustules (200)
+Spoilpox Scrivener, Herald of Nurgle
+Feculent Gnarlmaw
+Plaguebearers
+The Red Revelation (380)
+Slaughterpriest
+Bloodreavers
+Skullreapers
+The Scarlet Jury (300)
+Grand Justice Gormayne
+Cryptguard
+Royal Decapitator
+Volt-Klaw's Enginecoven (410)
+Warlock Galvaneer
+Ratling Warpblaster
+Warpvolt Scourgers
+Volt-Klaw's Enginecoven (410)
+Warlock Galvaneer
+Ratling Warpblaster
+Warpvolt Scourgers
+-----
+Auxiliary Units
+Abraxia, Spear of the Everchosen (250)
+Archaon, the Everchosen (810)
+Be'lakor, the Dark Master (450)
+Centaurion Marshal (120)
+Chaos Chariot (90)
+Chaos Chariot (90)
+Chaos Chosen (250)
+Chaos Furies (120)
+Chaos Knights (240)
+Chaos Legionnaires (80)
+Chaos Lord (100)
+Chaos Lord on Daemonic Mount (130)
+Chaos Lord on Karkadrak (190)
+Chaos Lord on Manticore (260)
+• Legends
+Chaos Sorcerer Lord (120)
+Chaos Sorcerer Lord on Manticore (280)
+• Legends
+Chaos Spawn (60)
+Chaos Warriors (180)
+Chaos Warshrine (250)
+• Legends
+Corvus Cabal (100)
+• Legends
+Cypher Lords (100)
+• Legends
+Daemon Prince (230)
+Darkoath Chieftain (80)
+Darkoath Chieftain on Warsteed (90)
+Darkoath Fellriders (130)
+Darkoath Marauders (80)
+Darkoath Savagers (90)
+Darkoath Warqueen (80)
+Darkoath Warqueen (80)
+Darkoath Wilderfiend (120)
+Eternus, Blade of the First Prince (160)
+Exalted Hero of Chaos (90)
+Fomoroid Crusher (120)
+Gaunt Summoner (160)
+Gaunt Summoner on Disc of Tzeentch (190)
+Godsworn Hunt (110)
+• Legends
+Gorebeast Chariot (100)
+Horns of Hashut (120)
+• Legends
+Iron Golem (100)
+• Legends
+Khagra's Ravagers (170)
+• Legends
+Mindstealer Sphiranx (140)
+Mutalith Vortex Beast (160)
+Ogroid Myrmidon (120)
+Ogroid Theridons (150)
+Raptoryx (100)
+Scions of the Flame (120)
+• Legends
+Scourge of Aqshy: Chaos Lord on Karkadrak (230)
+Scourge of Aqshy: Chaos Warriors (200)
+Slaughterbrute (200)
+Soul Grinder (330)
+• Legends
+Spire Tyrants (110)
+• Legends
+Splintered Fang (110)
+• Legends
+Tarantulos Brood (150)
+• Legends
+The Gnarlspirit Pack (110)
+• Legends
+The Unmade (110)
+• Legends
+Untamed Beasts (110)
+• Legends
+Varanguard (300)
+-----
+Faction Terrain
+Nexus Chaotica
+Nexus Chaotica
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466


### PR DESCRIPTION
Five more real Storm Forge exports across Death and Chaos. **None needed a parser change** — they pin behaviour rather than fix it.

## `fec-001-size-variants` — the first list to resolve completely

65 of 65 against the shipped catalog, and the one that leans hardest on exact-first label matching. It carries four `(2 models)` variants sitting beside their base warscrolls, and each lands on its own distinct entry:

```
"Crypt Flayers"            -> "Crypt Flayers"
"Crypt Flayers (2 models)" -> "Crypt Flayers (2 models)"
"Crypt Horrors"            -> "Crypt Horrors"
"Crypt Horrors (2 models)" -> "Crypt Horrors (2 models)"
```

The lenient fallback strips the count and would make every one of those pairs ambiguous — this is the case `normalizeImportLabelExact` was written for, now covered by a real roster.

## `std-001-duplicate-renown-bundles`

Buys the same renown bundle twice with identical members, and at 82 drops is the widest roster in the corpus. 118 of 122 resolve; the four misses are known #1783 gaps.

## `nh-001` and `obr-001` — a bundle named after its own member

Both contain:

```
Blades of the Hollow King (260)
Blades of the Hollow King
```

The pointed line is the container and is dropped; the unpointed line is the member and is kept — exactly once, from two different factions. `obr-001` adds single-member bundles (`Casket of Resurrections (200)` → `Black Coach`).

## Roster names are free text

`nh-001` has emoji embedded in its name and `sbg-001` is **nothing but emoji** (`😎🇺🇸🇺🇸😎`). Both survive NFKC normalisation intact, so the name still round-trips into `proposedName`.

`sbg-001` also carries `Blades of the Hollow King` as an ordinary auxiliary unit rather than a renown bundle, where it is correctly **not** flagged as renown content — the same name, classified by where it sits.

## Also

`.gitignore` now covers `vite.config.*.timestamp-*`. Vite writes those while loading an ESM config and one landed in a working tree mid-commit.

## Testing

- `yarn test --run` — 999 tests across 67 files, green on three consecutive full runs
- `yarn tsc --noEmit` and `yarn lint` clean