### PR TITLE
fix(import): resolve Armies of Renown and rosters from a lapsed season (#1783)

### DIFF
--- a/src/aos4/import/armiesOfRenown.ts
+++ b/src/aos4/import/armiesOfRenown.ts
@@ -1,0 +1,196 @@
+import type { Aos4Catalog, CanonicalId, ContentEntity, ContentGroup } from '../domain'
+
+/**
+ * Resolution support for Armies of Renown, which the catalog models by nesting rather than naming.
+ *
+ * Wahapedia renders an Army of Renown as a section of its parent faction: an `h2` carrying the
+ * army's name, then an `h3` per rules section beneath it. Generation reproduces that shape exactly
+ * — the container is a `content-group` named after the army, and each section is a child
+ * `content-group` named after the section, carrying the army's slug as its `groupType`:
+ *
+ * ```
+ * content-group "Da King’s Gitz"        groupType: da-kings-gitz
+ *   includes content-group "Spell Lore" groupType: da-kings-gitz
+ *   includes content-group "Battle Traits"
+ * ```
+ *
+ * Rosters name the same content flat, because a player picking a lore has to be told *whose* lore
+ * it is: the official app writes `Da King's Gitz Spell Lore`, and puts the army itself in the
+ * header's battle-formation slot (`Gloomspite Gitz | Da King's Gitz`). Neither form matches a
+ * catalog name on its own, so without this module every Army of Renown list silently loses its
+ * army rules — around 108 armies, and every list built on one.
+ *
+ * Nothing here invents data. The container and its sections are already in the catalog with their
+ * real names; this only reads the relationship graph to recover the qualified name the catalog
+ * never stores, and to make the container reachable from the faction that offers its sections.
+ */
+
+/**
+ * Section headings the generator normalizes every faction's rules onto.
+ *
+ * A group carrying one of these as its `groupType` is a rules *category* — the faction-level
+ * "Battle Formations" container and the individual formations beneath it both sit here — so it is
+ * never an army. `groupType` on an Army of Renown's sections is the army's slug instead, which is
+ * what makes the two distinguishable at all.
+ */
+const CATEGORY_GROUP_TYPES = new Set([
+  'artefact-of-power',
+  'battle-formation',
+  'battle-trait',
+  'heroic-trait',
+  'manifestation-lore',
+  'prayer-lore',
+  'spell-lore',
+])
+
+/**
+ * The section names an Army of Renown is built from.
+ *
+ * Needed because "self-named group with child groups" also describes a handful of enhancement
+ * tables — `Accursed Devices` over `Accursed Device`, `Marks of Vulcatrix` over `Mark of
+ * Vulcatrix`, `Monstrous Traits` over its beast lists. Those nest a *variant* under its own
+ * plural; an army nests the standard rules sections. Requiring at least one recognised section
+ * separates the two cleanly: it admits all 108 armies in the accepted corpus and none of the four
+ * enhancement tables.
+ */
+const ARMY_SECTION_NAMES = new Set([
+  'artefacts of power',
+  'battle traits',
+  'enhancements',
+  'heroic traits',
+  'manifestation lore',
+  'prayer lore',
+  'regiment abilities',
+  'spell lore',
+])
+
+/**
+ * The generator's `groupType` slug, minus its category aliases.
+ *
+ * Kept in step with `groupType` in `src/aos4/generate/corpus.ts` deliberately rather than shared:
+ * `src/aos4/generate/` is Node-side build tooling and must not be pulled into the browser bundle.
+ * The aliases are omitted because they are exactly what {@link CATEGORY_GROUP_TYPES} filters out
+ * first, so applying them here would only re-admit the categories.
+ */
+const groupTypeSlug = (value: string): string =>
+  value
+    .normalize('NFKD')
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-') || 'other'
+
+const isContentGroup = (entity: ContentEntity): entity is ContentGroup => entity.kind === 'content-group'
+
+export interface ArmyOfRenownSection {
+  /**
+   * The qualified name a roster uses for this section.
+   *
+   * `Da King’s Gitz Spell Lore` for the group the catalog simply calls `Spell Lore`.
+   */
+  qualifiedName: string
+  /**
+   * The rules category this section belongs to, read from its own heading.
+   *
+   * A section carries its *army's* slug as `groupType`, so the only thing left saying what kind of
+   * content it holds is the heading itself — and the generator derives category slugs from exactly
+   * those headings, which is what makes `Spell Lore` here line up with the `spell-lore` hint a
+   * roster's lore row produces.
+   */
+  categoryGroupType: string
+}
+
+export interface ArmyOfRenownIndex {
+  /** Every Army of Renown container, by canonical ID. */
+  containerIds: ReadonlySet<CanonicalId>
+  /** Every Army of Renown section, by canonical ID. */
+  sectionsById: ReadonlyMap<CanonicalId, ArmyOfRenownSection>
+  /** The sections each container holds, so a container can inherit their reachability. */
+  sectionIdsByContainerId: ReadonlyMap<CanonicalId, CanonicalId[]>
+}
+
+const EMPTY_INDEX: ArmyOfRenownIndex = {
+  containerIds: new Set(),
+  sectionsById: new Map(),
+  sectionIdsByContainerId: new Map(),
+}
+
+/**
+ * The generator's category aliases, which map a section heading onto its rules category.
+ *
+ * Mirrors the alias table in `groupType` (`src/aos4/generate/corpus.ts`) for the same reason
+ * {@link groupTypeSlug} does: build tooling must stay out of the browser bundle.
+ */
+const CATEGORY_ALIASES: Record<string, string> = {
+  'artefacts-of-power': 'artefact-of-power',
+  'battle-formations': 'battle-formation',
+  'battle-traits': 'battle-trait',
+  'heroic-traits': 'heroic-trait',
+}
+
+const categoryGroupType = (name: string): string => {
+  const slug = groupTypeSlug(name)
+  return CATEGORY_ALIASES[slug] ?? slug
+}
+
+/**
+ * Read the Armies of Renown out of a catalog's relationship graph.
+ *
+ * Structural rather than name-driven on purpose: there is no `armyOfRenown` flag in the catalog to
+ * read, and a hand-kept list of army names would go stale the day a new battletome lands, silently
+ * and with no test to catch it. The shape, by contrast, is a direct consequence of how the source
+ * pages are laid out, so a new army arrives already recognised.
+ */
+export const buildArmyOfRenownIndex = (catalog: Aos4Catalog): ArmyOfRenownIndex => {
+  const groupsById = new Map<CanonicalId, ContentGroup>(
+    catalog.entities.filter(isContentGroup).map(entity => [entity.id as CanonicalId, entity])
+  )
+  if (!groupsById.size) return EMPTY_INDEX
+
+  const childIdsById = new Map<CanonicalId, CanonicalId[]>()
+  catalog.relationships.forEach(relationship => {
+    if (relationship.kind !== 'includes') return
+    if (!groupsById.has(relationship.from) || !groupsById.has(relationship.to)) return
+    childIdsById.set(relationship.from, [...(childIdsById.get(relationship.from) ?? []), relationship.to])
+  })
+
+  const containerIds = new Set<CanonicalId>()
+  const sectionsById = new Map<CanonicalId, ArmyOfRenownSection>()
+  const sectionIdsByContainerId = new Map<CanonicalId, CanonicalId[]>()
+  const claimedSectionIds = new Set<CanonicalId>()
+
+  groupsById.forEach((container, containerId) => {
+    if (CATEGORY_GROUP_TYPES.has(container.groupType)) return
+    if (groupTypeSlug(container.name) !== container.groupType) return
+
+    const sectionIds = childIdsById.get(containerId) ?? []
+    const sections = sectionIds.flatMap(id => {
+      const section = groupsById.get(id)
+      return section ? [section] : []
+    })
+    if (!sections.some(section => ARMY_SECTION_NAMES.has(section.name.trim().toLowerCase()))) return
+
+    containerIds.add(containerId)
+    sectionIdsByContainerId.set(containerId, sectionIds)
+    sections.forEach(section => {
+      /**
+       * A section under two armies keeps neither qualified name.
+       *
+       * Not reachable in the accepted corpus — every section belongs to exactly one army — but
+       * guessing which army a shared section belonged to would be the kind of silent
+       * mis-resolution the importer refuses everywhere else.
+       */
+      if (claimedSectionIds.has(section.id)) {
+        sectionsById.delete(section.id)
+        return
+      }
+      claimedSectionIds.add(section.id)
+      sectionsById.set(section.id, {
+        qualifiedName: `${container.name} ${section.name}`,
+        categoryGroupType: categoryGroupType(section.name),
+      })
+    })
+  })
+
+  return { containerIds, sectionsById, sectionIdsByContainerId }
+}

--- a/src/aos4/import/index.ts
+++ b/src/aos4/import/index.ts
@@ -1,3 +1,4 @@
+export * from './armiesOfRenown'
 export * from './labelAliases'
 export * from './normalizeLabel'
 export * from './resolveRoster'

--- a/src/aos4/import/labelAliases.ts
+++ b/src/aos4/import/labelAliases.ts
@@ -41,6 +41,15 @@ export const IMPORT_LABEL_ALIASES: ImportLabelAlias[] = [
       'Rosters spell it correctly, so the correct spelling matches nothing. Remove once the ' +
       'upstream source is corrected.',
   },
+  {
+    from: 'Knives of the Crone',
+    to: 'The Knives of the Crone',
+    reason:
+      'Provider divergence: the official app drops this warband’s leading article, though it ' +
+      'keeps it on every other one in the same list ("The Shadeborn"). Not generalized to a ' +
+      'leading-article rule, because "The Roving Maw" and "Ironsunz" would then collide with ' +
+      'anything spelled either way.',
+  },
 ]
 
 const aliasIndex = new Map(IMPORT_LABEL_ALIASES.map(alias => [normalizeImportLabel(alias.from), alias.to]))

--- a/src/aos4/import/resolveRoster.ts
+++ b/src/aos4/import/resolveRoster.ts
@@ -9,6 +9,7 @@ import type {
 } from '../domain'
 import { resolveSelection } from '../select'
 import { createAos4ArmyDocument, deserializeAos4ArmyDocument, serializeAos4ArmyDocument } from '../state'
+import { buildArmyOfRenownIndex, type ArmyOfRenownIndex } from './armiesOfRenown'
 import { aliasedImportLabel } from './labelAliases'
 import { normalizeImportLabel, normalizeImportLabelExact } from './normalizeLabel'
 import type {
@@ -81,12 +82,26 @@ const relationshipIsApplicable = (
  */
 const ENHANCEMENT_KIND_HINTS = new Set<ParsedRosterSelectionKind>(['enhancement', 'artefact-of-power'])
 
-const kindMatches = (entity: ContentEntity, kindHint: ParsedRosterSelectionKind): boolean => {
+const kindMatches = (
+  entity: ContentEntity,
+  kindHint: ParsedRosterSelectionKind,
+  armiesOfRenown?: ArmyOfRenownIndex
+): boolean => {
   if (kindHint === 'faction') return entity.kind === 'faction'
   if (kindHint === 'warscroll') return entity.kind === 'warscroll'
   if (ENHANCEMENT_KIND_HINTS.has(kindHint)) {
     return entity.kind === 'ability' || entity.kind === 'content-group'
   }
+  /**
+   * An Army of Renown arrives under the battle-formation hint because that is the slot it occupies.
+   *
+   * The official app's header always ends `faction | battle formation`, and an Army of Renown takes
+   * that trailing slot (`Gloomspite Gitz | Da King's Gitz`) — the roster gives the parser nothing
+   * to tell the two apart with. The catalog does distinguish them: an army is a container group
+   * carrying its own slug as `groupType`, never `battle-formation`. So accept both here and let
+   * the name decide which one the roster meant.
+   */
+  if (kindHint === 'battle-formation' && armiesOfRenown?.containerIds.has(entity.id)) return true
   return entity.kind === 'content-group' && entity.groupType === kindHint
 }
 
@@ -116,14 +131,39 @@ export const findDeclaredRulesContext = (
   return matches[0]
 }
 
+/**
+ * The season a roster declared, as the year it began.
+ *
+ * Battlepacks are named by season — "General's Handbook 2025-26" — and that is the only part of
+ * the string worth reading once the name itself has failed to match a context we carry. Deliberately
+ * narrow: it recognises the four-digit-year form the handbooks use and nothing else, so an
+ * unfamiliar battlepack name yields nothing rather than a wrong year.
+ */
+const declaredSeasonStart = (declaredContext: string | undefined): number | undefined => {
+  const match = /\b(20\d{2})\s*[-–—/]\s*\d{2}\b/.exec(declaredContext ?? '')
+  return match ? Number(match[1]) : undefined
+}
+
+/** What the roster's declared ruleset resolved to, and whether it left content behind. */
+interface RulesContextResolution {
+  context: RulesContext
+  /**
+   * The roster named a season that has since lapsed, so its seasonal content is historical.
+   *
+   * Set here rather than inferred later because this is the only point that sees what the roster
+   * actually asked for.
+   */
+  allowsHistorical: boolean
+}
+
 const resolveRulesContext = (
   catalog: Aos4Catalog,
   parsedRoster: ParsedRoster,
   defaultRulesContextId: RulesContextId,
   diagnostics: Aos4ImportDiagnostic[]
-): RulesContext | undefined => {
+): RulesContextResolution | undefined => {
   const declared = findDeclaredRulesContext(catalog, parsedRoster.declaredContext)
-  if (declared) return declared
+  if (declared) return { context: declared, allowsHistorical: false }
 
   /**
    * A missing or unrecognised battlepack falls back rather than failing.
@@ -141,20 +181,40 @@ const resolveRulesContext = (
     })
     return undefined
   }
+
+  /**
+   * A lapsed season falls back to the current one *and* keeps what it lost.
+   *
+   * When a General's Handbook expires, everything it introduced — the `Scourge of Ghyran` unit
+   * variants, that season's battle formations — is catalogued as historical rather than deleted,
+   * while the army's warscrolls carry on into the new season unchanged. Falling back without the
+   * overlay therefore drops exactly the picks that made the list that season's list, and does it
+   * silently: the player sees a formation they chose simply missing. The overlay resolves those
+   * names where they actually live, without moving the document into a context that holds only
+   * 42 warscrolls and could not describe the rest of the army.
+   */
+  const seasonStart = declaredSeasonStart(parsedRoster.declaredContext)
+  const fallbackSeasonStart = declaredSeasonStart(fallback.season)
+  const allowsHistorical =
+    seasonStart !== undefined && fallbackSeasonStart !== undefined && seasonStart < fallbackSeasonStart
+
   diagnostics.push({
     code: 'unsupported-context',
     severity: 'warning',
     message: parsedRoster.declaredContext?.trim()
-      ? `The rules context "${parsedRoster.declaredContext}" is not one we carry; using ${fallback.name}. Change it above if that is wrong.`
+      ? allowsHistorical
+        ? `The rules context "${parsedRoster.declaredContext}" has been superseded; using ${fallback.name} with that season's content still available. Change it above if that is wrong.`
+        : `The rules context "${parsedRoster.declaredContext}" is not one we carry; using ${fallback.name}. Change it above if that is wrong.`
       : `No rules context was declared; using ${fallback.name}.`,
   })
-  return fallback
+  return { context: fallback, allowsHistorical }
 }
 
 const buildReachableIds = (
   catalog: Aos4Catalog,
   factionId: CanonicalId<'faction'>,
-  rulesContextId: RulesContextId
+  rulesContextId: RulesContextId,
+  armiesOfRenown: ArmyOfRenownIndex
 ): Set<CanonicalId> => {
   const entityById = new Map(catalog.entities.map(entity => [entity.id, entity]))
   const outgoing = new Map<CanonicalId, ContentRelationship[]>()
@@ -179,6 +239,24 @@ const buildReachableIds = (
       queue.push(target.id)
     })
   }
+
+  /**
+   * An Army of Renown container is reachable when the faction can reach its sections.
+   *
+   * The generator attaches an army's sections to the faction that offers them, but attaches
+   * nothing to the container itself — it exists only as the parent of those sections, with no
+   * inbound edge from anything. Traversal therefore never arrives at it, and a roster naming the
+   * army would be told it is unavailable to a faction that plainly offers its every rule. Deriving
+   * the container's availability from its sections says the same thing the graph already says,
+   * without inventing an edge the catalog does not have.
+   */
+  armiesOfRenown.sectionIdsByContainerId.forEach((sectionIds, containerId) => {
+    if (reachable.has(containerId)) return
+    const container = entityById.get(containerId)
+    if (!container || !isApplicable(container, rulesContextId)) return
+    if (sectionIds.some(sectionId => reachable.has(sectionId))) reachable.add(containerId)
+  })
+
   return reachable
 }
 
@@ -393,12 +471,14 @@ const resolveRosterSelection = (
    */
   resolutionContexts: ResolutionContext[],
   allowsLegends: boolean,
+  armiesOfRenown: ArmyOfRenownIndex,
   diagnostics: Aos4ImportDiagnostic[]
 ): Aos4ImportMatch | undefined => {
   const matchInContext = ({ context, reachableIds }: ResolutionContext) => {
     const rulesContextId = context.id
     const eligible = catalog.entities.filter(
-      entity => isApplicable(entity, rulesContextId) && kindMatches(entity, selection.kindHint)
+      entity =>
+        isApplicable(entity, rulesContextId) && kindMatches(entity, selection.kindHint, armiesOfRenown)
     )
 
     /**
@@ -419,6 +499,27 @@ const resolveRosterSelection = (
     }
 
     /**
+     * Match an Army of Renown's section by the qualified name the roster writes.
+     *
+     * The catalog calls it `Spell Lore` because it is nested under `Da King’s Gitz`; a flat roster
+     * line has to say `Da King's Gitz Spell Lore` or the player could not tell whose lore they
+     * picked. Searched separately from {@link matchLabel} rather than folded into `eligible`,
+     * because a section's `groupType` is its army's slug — admitting sections to the ordinary kind
+     * filter would make a bare `Spell Lore` match all 37 of them and fail as ambiguous. The
+     * section's own heading supplies the category instead.
+     */
+    const matchQualifiedLabel = (label: string): ContentEntity[] => {
+      const normalized = normalizeImportLabel(label)
+      return catalog.entities.filter(entity => {
+        const section = armiesOfRenown.sectionsById.get(entity.id)
+        if (!section || !isApplicable(entity, rulesContextId)) return false
+        const kindFits =
+          ENHANCEMENT_KIND_HINTS.has(selection.kindHint) || section.categoryGroupType === selection.kindHint
+        return kindFits && normalizeImportLabel(section.qualifiedName) === normalized
+      })
+    }
+
+    /**
      * Labels to try, in descending order of confidence.
      *
      * The roster's own wording always wins. A reviewed alias is consulted only when that finds
@@ -431,10 +532,10 @@ const resolveRosterSelection = (
       stripContextQualifier(selection.label, contextQualifiers(context)),
     ].filter((label): label is string => Boolean(label))
 
-    const contextCandidates = attempts.reduce<ContentEntity[]>(
-      (found, label) => (found.length ? found : matchLabel(label)),
-      []
-    )
+    const contextCandidates = [
+      ...attempts.map(label => () => matchLabel(label)),
+      ...attempts.map(label => () => matchQualifiedLabel(label)),
+    ].reduce<ContentEntity[]>((found, attempt) => (found.length ? found : attempt()), [])
     return { contextCandidates, candidates: contextCandidates.filter(entity => reachableIds.has(entity.id)) }
   }
 
@@ -514,14 +615,20 @@ export const resolveParsedRoster = (
   options: ResolveParsedRosterOptions
 ): Aos4ImportPreview => {
   const diagnostics: Aos4ImportDiagnostic[] = []
-  const context = resolveRulesContext(catalog, parsedRoster, options.defaultRulesContextId, diagnostics)
-  if (!context) {
+  const contextResolution = resolveRulesContext(
+    catalog,
+    parsedRoster,
+    options.defaultRulesContextId,
+    diagnostics
+  )
+  if (!contextResolution) {
     return {
       source: parsedRoster.source,
       matches: [],
       diagnostics: sortDiagnostics(diagnostics),
     }
   }
+  const context = contextResolution.context
 
   const factionResolution = resolveFaction(catalog, parsedRoster, context.id, diagnostics)
   const faction = factionResolution.faction
@@ -539,24 +646,39 @@ export const resolveParsedRoster = (
    */
   const effectiveContext = factionResolution.rulesContext ?? context
   const allowsLegends = Boolean(parsedRoster.allowsLegends)
+  /**
+   * Moving the document to another context abandons the superseded-season overlay.
+   *
+   * The overlay exists to keep a lapsed season's content reachable from the season that replaced
+   * it. A faction found only in Legends is a different situation entirely — the document is no
+   * longer in a seasonal context at all — so carrying the overlay across would be layering last
+   * season's standard-play content onto an army that is not playing standard.
+   */
+  const allowsHistorical = contextResolution.allowsHistorical && !factionResolution.rulesContext
+  const armiesOfRenown = buildArmyOfRenownIndex(catalog)
 
   /**
-   * A roster that opted into Legends resolves against its own context *and* the Legends overlay.
+   * A roster resolves against its own context *and* whichever overlays it earned.
    *
    * Legends warscrolls live in a context of their own, so without the overlay a list that mixes a
    * faction's current units with its retired ones — exactly what the opt-in is for — could only
-   * import half of itself. Reachability is computed per context, because the relationship edges
-   * that connect a faction to its units are context-scoped too.
+   * import half of itself. A lapsed season is the same problem with a different boundary. Both
+   * are additive: the document stays in the context that describes the bulk of the army, and the
+   * overlay only widens what a name may resolve to. Reachability is computed per context, because
+   * the relationship edges that connect a faction to its units are context-scoped too.
    */
-  const overlayContexts = allowsLegends
-    ? catalog.rulesContexts.filter(
-        rulesContext => rulesContext.status === 'legends' && rulesContext.id !== effectiveContext.id
-      )
-    : []
+  const overlayStatuses = new Set(
+    [allowsLegends ? 'legends' : undefined, allowsHistorical ? 'historical' : undefined].filter(
+      (status): status is RulesContext['status'] => Boolean(status)
+    )
+  )
+  const overlayContexts = catalog.rulesContexts.filter(
+    rulesContext => overlayStatuses.has(rulesContext.status) && rulesContext.id !== effectiveContext.id
+  )
   const reachableByContextId = new Map(
     [effectiveContext, ...overlayContexts].map(rulesContext => [
       rulesContext.id,
-      buildReachableIds(catalog, faction.id, rulesContext.id),
+      buildReachableIds(catalog, faction.id, rulesContext.id, armiesOfRenown),
     ])
   )
   const resolutionContexts = (preferLegends: boolean): ResolutionContext[] =>
@@ -577,6 +699,7 @@ export const resolveParsedRoster = (
           selection,
           resolutionContexts(Boolean(selection.isLegends)),
           allowsLegends,
+          armiesOfRenown,
           diagnostics
         )
         return match ? [match] : []
@@ -598,6 +721,7 @@ export const resolveParsedRoster = (
     explicitIds: explicitSelectionIds,
     rulesContextId: effectiveContext.id,
     ...(allowsLegends ? { allowsLegends: true } : {}),
+    ...(allowsHistorical ? { allowsHistorical: true } : {}),
   })
   const selectionErrors = selection.diagnostics.filter(diagnostic => diagnostic.severity === 'error')
   if (selectionErrors.length) {
@@ -623,6 +747,7 @@ export const resolveParsedRoster = (
     name: parsedRoster.proposedName.trim() || 'Imported Army',
     rulesContextId: effectiveContext.id,
     ...(allowsLegends ? { allowsLegends: true } : {}),
+    ...(allowsHistorical ? { allowsHistorical: true } : {}),
     explicitSelectionIds,
   })
   const roundTrip = deserializeAos4ArmyDocument(serializeAos4ArmyDocument(proposedDocument), catalog)

--- a/src/aos4/select/resolveSelection.ts
+++ b/src/aos4/select/resolveSelection.ts
@@ -23,6 +23,16 @@ export interface ResolveSelectionInput {
    * belongs to *either* context; diagnostics still report against the primary context.
    */
   allowsLegends?: boolean
+  /**
+   * Overlay the historical rules context(s) on top of `rulesContextId`.
+   *
+   * A General's Handbook lapses each summer, and the content it introduced moves to the historical
+   * context rather than disappearing. An army built during that season is a mixture: current
+   * warscrolls picked from a battletome that is still in print, alongside seasonal formations and
+   * unit variants that are not. With the overlay on, an entity or relationship is applicable when
+   * it belongs to *either* context; diagnostics still report against the primary context.
+   */
+  allowsHistorical?: boolean
 }
 
 export interface SelectionCause {
@@ -71,14 +81,23 @@ export const resolveSelection = (
 ): ResolvedSelection => {
   const index = createCatalogIndex(catalog)
   const contextIds = new Set(catalog.rulesContexts.map(context => context.id))
+  const overlayStatuses = new Set(
+    [input.allowsLegends ? 'legends' : undefined, input.allowsHistorical ? 'historical' : undefined].filter(
+      (status): status is string => Boolean(status)
+    )
+  )
   const applicableContextIds = new Set<RulesContextId>([
     input.rulesContextId,
-    ...(input.allowsLegends
-      ? catalog.rulesContexts.filter(context => context.status === 'legends').map(context => context.id)
-      : []),
+    ...catalog.rulesContexts
+      .filter(context => overlayStatuses.has(context.status))
+      .map(context => context.id),
   ])
-  const availabilityDescription = input.allowsLegends
-    ? `${input.rulesContextId} or Legends`
+  const overlayNames = [
+    input.allowsLegends ? 'Legends' : undefined,
+    input.allowsHistorical ? 'historical content' : undefined,
+  ].filter((name): name is string => Boolean(name))
+  const availabilityDescription = overlayNames.length
+    ? `${input.rulesContextId} or ${overlayNames.join(' or ')}`
     : input.rulesContextId
   const selectedIds = new Set<CanonicalId>()
   const availableIds = new Set<CanonicalId>()

--- a/src/aos4/state/armyDocument.ts
+++ b/src/aos4/state/armyDocument.ts
@@ -21,6 +21,17 @@ export interface Aos4ArmyDocument {
    * written before the field existed.
    */
   allowsLegends?: boolean
+  /**
+   * The army was built against a superseded season, so selection resolution overlays the
+   * historical rules context on top of `rulesContextId`.
+   *
+   * Last season's content — the `Scourge of Ghyran` unit variants, the battle formations the
+   * General's Handbook 2025-26 introduced — is catalogued as historical once its handbook lapses.
+   * An army imported from a roster of that vintage holds both: its units are current, its seasonal
+   * picks are not. Serialized only when true, so documents that never touched a past season
+   * round-trip byte-identically to schema 1 output written before the field existed.
+   */
+  allowsHistorical?: boolean
   explicitSelectionIds: CanonicalId[]
   reminderPreferences: Partial<Record<ReminderOccurrenceId, Aos4ReminderPreference>>
 }
@@ -67,6 +78,7 @@ export const createAos4ArmyDocument = (
   name: input.name.trim(),
   rulesContextId: input.rulesContextId,
   ...(input.allowsLegends ? { allowsLegends: true } : {}),
+  ...(input.allowsHistorical ? { allowsHistorical: true } : {}),
   explicitSelectionIds: sortedUnique(input.explicitSelectionIds),
   reminderPreferences: Object.fromEntries(
     Object.entries(input.reminderPreferences ?? {})
@@ -140,6 +152,7 @@ export const deserializeAos4ArmyDocument = (
     !value.name.trim() ||
     typeof value.rulesContextId !== 'string' ||
     (value.allowsLegends !== undefined && typeof value.allowsLegends !== 'boolean') ||
+    (value.allowsHistorical !== undefined && typeof value.allowsHistorical !== 'boolean') ||
     !Array.isArray(value.explicitSelectionIds) ||
     value.explicitSelectionIds.some(id => typeof id !== 'string') ||
     !isObject(value.reminderPreferences)
@@ -206,6 +219,7 @@ export const deserializeAos4ArmyDocument = (
       name: documentName,
       rulesContextId: rulesContext as RulesContextId,
       ...(value.allowsLegends === true ? { allowsLegends: true } : {}),
+      ...(value.allowsHistorical === true ? { allowsHistorical: true } : {}),
       explicitSelectionIds,
       reminderPreferences,
     }),

--- a/src/aos4/view/builder.ts
+++ b/src/aos4/view/builder.ts
@@ -27,6 +27,7 @@ export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4A
     explicitIds: document.explicitSelectionIds,
     rulesContextId: document.rulesContextId,
     ...(document.allowsLegends ? { allowsLegends: true } : {}),
+    ...(document.allowsHistorical ? { allowsHistorical: true } : {}),
   })
   const selected = new Set(selection.selectedIds)
   const available = new Set(selection.availableIds)

--- a/src/aos4/view/reminders.ts
+++ b/src/aos4/view/reminders.ts
@@ -226,6 +226,7 @@ export const createAos4ReminderViewModel = (
     explicitIds: document.explicitSelectionIds,
     rulesContextId: document.rulesContextId,
     ...(document.allowsLegends ? { allowsLegends: true } : {}),
+    ...(document.allowsHistorical ? { allowsHistorical: true } : {}),
   })
   const reminders = projectReminders(catalog, selection).map(reminder => withPreferences(reminder, document))
   const baseOrder = new Map(reminders.map((reminder, index) => [reminder.id, index]))

--- a/src/tests/aos4/importResolution.test.ts
+++ b/src/tests/aos4/importResolution.test.ts
@@ -129,9 +129,7 @@ describe('AoS 4 parsed-roster resolution', () => {
   it('resolves a regiment of renown member the faction cannot otherwise reach', () => {
     const preview = resolve(
       roster({
-        selections: [
-          { line: 12, label: 'Beta Only', kindHint: 'warscroll', isRegimentOfRenown: true },
-        ],
+        selections: [{ line: 12, label: 'Beta Only', kindHint: 'warscroll', isRegimentOfRenown: true }],
       })
     )
 
@@ -139,9 +137,7 @@ describe('AoS 4 parsed-roster resolution', () => {
       importFixtureIds.alphaFaction,
       importFixtureIds.betaOnly,
     ])
-    expect(
-      preview.diagnostics.filter(diagnostic => diagnostic.code === 'inapplicable-selection')
-    ).toEqual([])
+    expect(preview.diagnostics.filter(diagnostic => diagnostic.code === 'inapplicable-selection')).toEqual([])
   })
 
   it('still refuses to guess between two candidates for a regiment of renown member', () => {
@@ -158,14 +154,12 @@ describe('AoS 4 parsed-roster resolution', () => {
     )
   })
 
-  it('prefers the faction\'s own reachable version for a regiment of renown member', () => {
+  it("prefers the faction's own reachable version for a regiment of renown member", () => {
     // Reachability is tried first, so a name the faction *can* reach still resolves to its own
     // version rather than being decided by the relaxed pass.
     const preview = resolve(
       roster({
-        selections: [
-          { line: 13, label: 'Shared Guard', kindHint: 'warscroll', isRegimentOfRenown: true },
-        ],
+        selections: [{ line: 13, label: 'Shared Guard', kindHint: 'warscroll', isRegimentOfRenown: true }],
       })
     )
 
@@ -336,5 +330,158 @@ describe('AoS 4 Legends resolution', () => {
         message: expect.stringContaining('does not opt into Legends'),
       })
     )
+  })
+})
+
+/**
+ * Armies of Renown, which the catalog models by nesting instead of naming (issue #1783).
+ *
+ * The catalog holds an army as a container group with its sections beneath it; a roster names the
+ * army in the battle-formation slot and its sections as `<army> <section>`. Neither form matches a
+ * catalog name directly, so before this every Army of Renown list lost its army rules entirely.
+ */
+describe('AoS 4 Army of Renown resolution', () => {
+  it('resolves the army named in the battle-formation slot', () => {
+    const preview = resolve(
+      roster({
+        selections: [{ line: 3, label: 'Renowned Vanguard', kindHint: 'battle-formation' }],
+      })
+    )
+
+    expect(preview.diagnostics).toEqual([])
+    expect(preview.matches).toEqual([
+      { line: 3, label: 'Renowned Vanguard', canonicalId: importFixtureIds.renownedVanguard },
+    ])
+  })
+
+  it('selecting the army brings in the sections nested under it', () => {
+    const preview = resolve(
+      roster({
+        selections: [{ line: 3, label: 'Renowned Vanguard', kindHint: 'battle-formation' }],
+      })
+    )
+
+    expect(preview.proposedDocument?.explicitSelectionIds).toContain(importFixtureIds.renownedVanguard)
+    expect(preview.diagnostics.filter(diagnostic => diagnostic.severity === 'error')).toEqual([])
+  })
+
+  it('resolves a section by the army-qualified name a roster writes', () => {
+    const preview = resolve(
+      roster({
+        selections: [{ line: 8, label: 'Renowned Vanguard Spell Lore', kindHint: 'spell-lore' }],
+      })
+    )
+
+    expect(preview.diagnostics).toEqual([])
+    expect(preview.matches).toEqual([
+      {
+        line: 8,
+        label: 'Renowned Vanguard Spell Lore',
+        canonicalId: importFixtureIds.renownedVanguardSpellLore,
+      },
+    ])
+  })
+
+  it('refuses a qualified name whose section is the wrong kind of content', () => {
+    const preview = resolve(
+      roster({
+        selections: [{ line: 8, label: 'Renowned Vanguard Battle Traits', kindHint: 'spell-lore' }],
+      })
+    )
+
+    expect(preview.matches).toEqual([])
+    expect(preview.diagnostics).toContainEqual(
+      expect.objectContaining({ code: 'unknown-selection', line: 8 })
+    )
+  })
+
+  /**
+   * A bare section name stays unresolvable, because it does not identify anything.
+   *
+   * Thirty-seven armies in the accepted corpus have a section called "Spell Lore". Matching one of
+   * them on that name alone would be a coin flip dressed up as a resolution.
+   */
+  it('does not resolve a section by its unqualified name', () => {
+    const preview = resolve(
+      roster({
+        selections: [{ line: 8, label: 'Spell Lore', kindHint: 'spell-lore' }],
+      })
+    )
+
+    expect(preview.matches).toEqual([])
+  })
+})
+
+/**
+ * Rosters built against a lapsed General's Handbook (issue #1783).
+ *
+ * A season's content moves to the historical context when its handbook expires, while the army's
+ * warscrolls carry on unchanged. Falling back to the current season without an overlay therefore
+ * drops precisely the seasonal picks that defined the list.
+ */
+describe('AoS 4 superseded-season resolution', () => {
+  const supersededRoster = (selections: ParsedRoster['selections']): ParsedRoster =>
+    roster({ declaredContext: "General's Handbook 2024-25", selections })
+
+  it('keeps the lapsed season available while importing into the current one', () => {
+    const preview = resolve(supersededRoster([{ line: 9, label: 'Archive Guard', kindHint: 'warscroll' }]))
+
+    expect(preview.matches).toEqual([
+      { line: 9, label: 'Archive Guard', canonicalId: importFixtureIds.archiveGuard },
+    ])
+    expect(preview.proposedDocument?.rulesContextId).toBe(importFixtureContextIds.seasonal)
+    expect(preview.proposedDocument?.allowsHistorical).toBe(true)
+    expect(preview.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'unsupported-context',
+        severity: 'warning',
+        message: expect.stringContaining('has been superseded'),
+      })
+    )
+  })
+
+  it('resolves a formation the lapsed season introduced', () => {
+    const preview = resolve(
+      supersededRoster([{ line: 4, label: 'Archive Formation', kindHint: 'battle-formation' }])
+    )
+
+    expect(preview.matches).toEqual([
+      { line: 4, label: 'Archive Formation', canonicalId: importFixtureIds.archiveFormation },
+    ])
+  })
+
+  it('prefers the current season when a name exists on both sides', () => {
+    const preview = resolve(supersededRoster([{ line: 3, label: 'Shared Guard', kindHint: 'warscroll' }]))
+
+    expect(preview.matches).toEqual([
+      { line: 3, label: 'Shared Guard', canonicalId: importFixtureIds.alphaGuard },
+    ])
+  })
+
+  it('leaves a roster on the current season untouched', () => {
+    const preview = resolve(
+      roster({ selections: [{ line: 9, label: 'Archive Guard', kindHint: 'warscroll' }] })
+    )
+
+    expect(preview.matches).toEqual([])
+    expect(preview.proposedDocument?.allowsHistorical).toBeUndefined()
+  })
+
+  /**
+   * A season we have not published yet is not a lapsed one.
+   *
+   * Builders carry a new handbook before we do, and treating "ahead of us" as "behind us" would
+   * quietly resolve next season's picks against last season's content.
+   */
+  it('does not overlay history for a season newer than the one we carry', () => {
+    const preview = resolve(
+      roster({
+        declaredContext: "General's Handbook 2027-28",
+        selections: [{ line: 9, label: 'Archive Guard', kindHint: 'warscroll' }],
+      })
+    )
+
+    expect(preview.matches).toEqual([])
+    expect(preview.proposedDocument?.allowsHistorical).toBeUndefined()
   })
 })

--- a/src/tests/aos4/officialAppFixtures.test.ts
+++ b/src/tests/aos4/officialAppFixtures.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 
-import { AOS4_RUNTIME_PROJECTION } from '../../aos4/generated'
+import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID, AOS4_RUNTIME_PROJECTION } from '../../aos4/generated'
+import { buildArmyOfRenownIndex, resolveParsedRoster } from '../../aos4/import'
 import { decodeAos4TextRoster } from '../../importers/aos4'
 import {
   decodeOfficialAppFixture,
@@ -64,5 +65,114 @@ describe('official app list fixtures', () => {
     const text = readOfficialAppFixture(id)
     expect(decodeOfficialAppFixture(id)).toEqual(decodeOfficialAppFixture(id))
     expect(decodeAos4TextRoster(text.replace(/\n/g, '\r\n'))).toEqual(decodeAos4TextRoster(text))
+  })
+})
+
+/**
+ * What these rosters actually resolve to against the accepted corpus (issue #1783).
+ *
+ * The tests above stop at decoding, which is where the parser's job ends. Everything below is
+ * about the far larger loss that came after it: real lists resolving against real data and quietly
+ * dropping content the catalog was holding all along. Named labels rather than totals, because a
+ * count that drifts down by one tells you nothing about which player lost what.
+ */
+/** Memoized: resolving against the full catalog costs a fifth of a second, and ids repeat. */
+const resolutions = new Map<string, ReturnType<typeof resolveOnce>>()
+
+const resolveOnce = (id: string) => {
+  const { parsedRoster } = decodeOfficialAppFixture(id)
+  if (!parsedRoster) throw new Error(`Fixture ${id} did not decode`)
+  const preview = resolveParsedRoster(AOS4_CATALOG, parsedRoster, {
+    defaultRulesContextId: AOS4_DEFAULT_RULES_CONTEXT_ID,
+    createDocumentId: () => `army:${id}`,
+  })
+  return { parsedRoster, preview, matched: new Set(preview.matches.map(match => match.label)) }
+}
+
+const resolveFixture = (id: string) => {
+  const cached = resolutions.get(id) ?? resolveOnce(id)
+  resolutions.set(id, cached)
+  return cached
+}
+
+describe('official app list resolution', () => {
+  it('recognises the corpus Armies of Renown without sweeping in enhancement tables', () => {
+    const index = buildArmyOfRenownIndex(AOS4_CATALOG)
+    const named = (id: string) => AOS4_CATALOG.entities.find(entity => entity.id === id)?.name.trim() ?? ''
+    const containerNames = Array.from(index.containerIds, named)
+
+    expect(containerNames).toContain('Da King’s Gitz')
+    expect(containerNames).toContain('The First Phalanx of Ionrach')
+    expect(containerNames).toContain('Pioneer Outpost')
+
+    /**
+     * These nest a singular variant under its own plural — the one other shape in the corpus that
+     * looks like an army from a distance, and the reason a section heading has to be present.
+     */
+    expect(containerNames).not.toContain('Monstrous Traits')
+    expect(containerNames).not.toContain('Accursed Devices')
+    expect(containerNames).not.toContain('Marks of Vulcatrix')
+
+    // Every army the corpus carries, and no more; a data refresh that moves this should be read.
+    expect(index.containerIds.size).toBe(108)
+  })
+
+  it('resolves an Army of Renown and the lores nested under it', () => {
+    const { matched, preview } = resolveFixture('gg-001-army-of-renown')
+
+    expect(matched).toContain("Da King's Gitz")
+    expect(matched).toContain("Da King's Gitz Spell Lore")
+    expect(matched).toContain("Da King's Gitz Manifestation Lore")
+    expect(preview.proposedDocument).toBeDefined()
+  })
+
+  it.each([
+    ['idk-001-renown-army-no-lore', 'The First Phalanx of Ionrach'],
+    ['ko-001-renown-army-repeats', 'Pioneer Outpost'],
+  ])('%s resolves its Army of Renown (%s)', (id, army) => {
+    expect(resolveFixture(id).matched).toContain(army)
+  })
+
+  it('keeps a lapsed season’s content for a roster built during it', () => {
+    const { matched, preview } = resolveFixture('om-001-multi-terrain-auxiliaries')
+
+    // A General's Handbook 2025-26 formation, and two unit variants that season introduced.
+    expect(matched).toContain('Greedy Eaters')
+    expect(matched).toContain('Scourge of Ghyran Ironblaster')
+    expect(matched).toContain('Scourge of Ghyran Gnoblar Scraplauncher')
+    expect(preview.proposedDocument?.allowsHistorical).toBe(true)
+    // The document still imports into the season we carry, which holds the rest of the army.
+    expect(preview.proposedDocument?.rulesContextId).toBe(AOS4_DEFAULT_RULES_CONTEXT_ID)
+  })
+
+  it('leaves a current-season roster on the current season alone', () => {
+    const { preview } = resolveFixture('ser-001-current-format')
+
+    expect(preview.proposedDocument?.allowsHistorical).toBeUndefined()
+    expect(preview.diagnostics).toEqual([])
+  })
+
+  /**
+   * Names the corpus genuinely does not carry must keep failing closed.
+   *
+   * Each is a near-miss to something real — `Conqueror Cogfort` exists, two different Freeguild
+   * Marshals exist — and resolving to a neighbour would produce reminders for a unit the player
+   * never took. Tracked as corpus coverage instead; see the manifestation work in issue #1791.
+   */
+  it.each([
+    ['ij-001-renown-heavy', 'Outlaw Conqueror Cogfort'],
+    ['ij-001-renown-heavy', 'Mask of the Deceiver'],
+    ['sce-001-exported-version-format', 'Freeguild Marshal'],
+  ])('%s reports "%s" rather than guessing at a near-miss', (id, label) => {
+    const { matched, preview } = resolveFixture(id)
+
+    expect(matched).not.toContain(label)
+    expect(preview.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'unknown-selection',
+        severity: 'warning',
+        message: expect.stringContaining(label),
+      })
+    )
   })
 })

--- a/src/tests/aos4/representativeSlice.test.ts
+++ b/src/tests/aos4/representativeSlice.test.ts
@@ -219,6 +219,29 @@ describe('AoS 4 representative vertical slice', () => {
     ).not.toContain(finestHour.id)
   })
 
+  /**
+   * `allowsHistorical` round-trips, and its absence still writes schema 1's original bytes.
+   *
+   * Documents saved before the field existed have to keep deserializing, and documents that never
+   * touch a past season have to keep serializing to the same bytes — otherwise every stored army
+   * in every browser rewrites itself the first time it loads (issue #1783).
+   */
+  it('round-trips the superseded-season opt-in without disturbing documents that lack it', () => {
+    const plain = createDocument()
+    const serializedPlain = serializeAos4ArmyDocument(plain)
+    expect(serializedPlain).not.toContain('allowsHistorical')
+
+    const lapsed = createAos4ArmyDocument({ ...plain, allowsHistorical: true })
+    const restored = deserializeAos4ArmyDocument(serializeAos4ArmyDocument(lapsed), AOS4_CATALOG)
+
+    expect(restored.diagnostics).toEqual([])
+    expect(restored.document?.allowsHistorical).toBe(true)
+    expect(serializeAos4ArmyDocument(restored.document!)).toBe(serializeAos4ArmyDocument(lapsed))
+    expect(
+      deserializeAos4ArmyDocument(serializedPlain, AOS4_CATALOG).document?.allowsHistorical
+    ).toBeUndefined()
+  })
+
   it('loads entirely from generated data without source network access', () => {
     const originalFetch = globalThis.fetch
     const network = vi.fn(() => {

--- a/src/tests/aos4/selectionGraph.test.ts
+++ b/src/tests/aos4/selectionGraph.test.ts
@@ -269,6 +269,54 @@ describe('AoS 4 selection resolution', () => {
     expect(withOptIn.diagnostics).toEqual([])
   })
 
+  /**
+   * Historical content overlays the same way Legends does (issue #1783).
+   *
+   * A General's Handbook lapses every summer and what it introduced becomes historical, while the
+   * army's warscrolls carry on. An army built during that season is a mixture of the two, so it
+   * needs both contexts applicable at once — moving it wholesale into a context holding only that
+   * season's additions would strip the rest of the army instead.
+   */
+  it('overlays historical content only when the document opts in', () => {
+    const catalog = createCatalog()
+    const historicalContext = rulesContextId('30000000-0000-4000-8000-000000000015')
+    const lapsedFormation = contentGroupId('30000000-0000-4000-8000-000000000016')
+    catalog.rulesContexts.push({
+      id: historicalContext,
+      name: 'Historical',
+      mode: 'standard',
+      status: 'historical',
+      publicationIds: [],
+    })
+    catalog.entities.push(entity(lapsedFormation, 'Lapsed Formation', [historicalContext]))
+    catalog.relationships.push({
+      id: 'relationship:unit-includes-lapsed',
+      kind: 'includes',
+      from: ids.unit,
+      to: lapsedFormation,
+      rulesContextIds: [historicalContext],
+    })
+
+    const withoutOptIn = resolveSelection(catalog, {
+      explicitIds: [ids.unit, lapsedFormation],
+      rulesContextId: contextIds.standard,
+    })
+    const withOptIn = resolveSelection(catalog, {
+      explicitIds: [ids.unit, lapsedFormation],
+      rulesContextId: contextIds.standard,
+      allowsHistorical: true,
+    })
+
+    expect(withoutOptIn.selectedIds).not.toContain(lapsedFormation)
+    expect(withoutOptIn.diagnostics.map(diagnostic => diagnostic.code)).toEqual(
+      expect.arrayContaining(['inapplicable-explicit-selection'])
+    )
+    expect(withOptIn.selectedIds).toContain(lapsedFormation)
+    expect(withOptIn.diagnostics).toEqual([])
+    // The unit the army is actually made of is still there; the overlay adds, it does not replace.
+    expect(withOptIn.selectedIds).toContain(ids.unit)
+  })
+
   it('is deterministic when entity, relationship, and input order changes', () => {
     const catalog = createCatalog()
     const reorderedCatalog: Aos4Catalog = {

--- a/src/tests/fixtures/aos4/import/catalog.ts
+++ b/src/tests/fixtures/aos4/import/catalog.ts
@@ -35,6 +35,20 @@ export const importFixtureIds = {
   sameNameLore: contentGroupId('81000000-0000-4000-8000-000000000033'),
   excludedA: contentGroupId('81000000-0000-4000-8000-000000000034'),
   excludedB: contentGroupId('81000000-0000-4000-8000-000000000035'),
+  /**
+   * An Army of Renown, shaped the way generation emits one.
+   *
+   * The container carries its own slug as `groupType` and has no inbound edge from anything; its
+   * sections are named after the rules section, carry the *army's* slug, and are what the faction
+   * actually offers. Reproduced faithfully because the importer recovers the army from that shape
+   * alone — a tidier fixture would test a graph the generator never produces.
+   */
+  renownedVanguard: contentGroupId('81000000-0000-4000-8000-000000000040'),
+  renownedVanguardBattleTraits: contentGroupId('81000000-0000-4000-8000-000000000041'),
+  renownedVanguardSpellLore: contentGroupId('81000000-0000-4000-8000-000000000042'),
+  /** Last season's content, catalogued as historical once its handbook lapsed. */
+  archiveGuard: warscrollId('81000000-0000-4000-8000-000000000050'),
+  archiveFormation: contentGroupId('81000000-0000-4000-8000-000000000051'),
 }
 
 const sourceRefs: ContentEntity['sourceRefs'] = []
@@ -63,6 +77,8 @@ export const createImportFixtureCatalog = (): Aos4Catalog => {
     importFixtureIds.sameNameLore,
     importFixtureIds.excludedA,
     importFixtureIds.excludedB,
+    importFixtureIds.renownedVanguardBattleTraits,
+    importFixtureIds.renownedVanguardSpellLore,
   ].map((to, index) => ({
     id: `relationship:alpha-offers-${index}`,
     kind: 'offers',
@@ -113,6 +129,34 @@ export const createImportFixtureCatalog = (): Aos4Catalog => {
       from: importFixtureIds.excludedA,
       to: importFixtureIds.excludedB,
       rulesContextIds: [importFixtureContextIds.seasonal],
+    },
+    {
+      id: 'relationship:renowned-vanguard-includes-battle-traits',
+      kind: 'includes',
+      from: importFixtureIds.renownedVanguard,
+      to: importFixtureIds.renownedVanguardBattleTraits,
+      rulesContextIds: [importFixtureContextIds.seasonal],
+    },
+    {
+      id: 'relationship:renowned-vanguard-includes-spell-lore',
+      kind: 'includes',
+      from: importFixtureIds.renownedVanguard,
+      to: importFixtureIds.renownedVanguardSpellLore,
+      rulesContextIds: [importFixtureContextIds.seasonal],
+    },
+    {
+      id: 'relationship:alpha-offers-archive-guard',
+      kind: 'offers',
+      from: importFixtureIds.alphaFaction,
+      to: importFixtureIds.archiveGuard,
+      rulesContextIds: [importFixtureContextIds.historical],
+    },
+    {
+      id: 'relationship:alpha-offers-archive-formation',
+      kind: 'offers',
+      from: importFixtureIds.alphaFaction,
+      to: importFixtureIds.archiveFormation,
+      rulesContextIds: [importFixtureContextIds.historical],
     }
   )
 
@@ -163,6 +207,7 @@ export const createImportFixtureCatalog = (): Aos4Catalog => {
           importFixtureContextIds.current,
           importFixtureContextIds.seasonal,
           importFixtureContextIds.legends,
+          importFixtureContextIds.historical,
         ],
         sourceRefs,
       },
@@ -246,6 +291,23 @@ export const createImportFixtureCatalog = (): Aos4Catalog => {
       contentGroup(importFixtureIds.sameNameLore, 'Shared Guard', 'spell-lore'),
       contentGroup(importFixtureIds.excludedA, 'Choice A', 'artefact-of-power'),
       contentGroup(importFixtureIds.excludedB, 'Choice B', 'artefact-of-power'),
+      contentGroup(importFixtureIds.renownedVanguard, 'Renowned Vanguard', 'renowned-vanguard'),
+      contentGroup(importFixtureIds.renownedVanguardBattleTraits, 'Battle Traits', 'renowned-vanguard'),
+      contentGroup(importFixtureIds.renownedVanguardSpellLore, 'Spell Lore', 'renowned-vanguard'),
+      contentGroup(importFixtureIds.archiveFormation, 'Archive Formation', 'battle-formation', [
+        importFixtureContextIds.historical,
+      ]),
+      {
+        id: importFixtureIds.archiveGuard,
+        kind: 'warscroll',
+        revision: 'import-fixture',
+        name: 'Archive Guard',
+        factionIds: [importFixtureIds.alphaFaction],
+        keywords: [],
+        characteristics: { move: '5"', save: '4+', control: '1', health: '2' },
+        rulesContextIds: [importFixtureContextIds.historical],
+        sourceRefs,
+      },
     ],
     relationships,
   }


### PR DESCRIPTION
Fixes the three resolver-side defects in #1783. The data-sourcing defect is split out to #1791.

Investigating them changed the diagnosis in two places, so the headline first: **defect 1 was not a
data loss**, and it is the same defect as defect 2. **Defect 3 is much larger than one formation**,
and the corpus was right about it all along.

## Armies of Renown (#1783 defects 1 and 2)

The catalog models an army by nesting rather than naming, reproducing the source page's shape:

```
content-group "Da King’s Gitz"          groupType: da-kings-gitz
  includes content-group "Spell Lore"   groupType: da-kings-gitz
  includes content-group "Battle Traits"
```

Rosters name the same content flat, because a player picking a lore has to be told whose lore it is.
The official app writes `Da King's Gitz Spell Lore`, and puts the army itself in the header's battle
formation slot (`Gloomspite Gitz | Da King's Gitz`). Neither form matched a catalog name, so all 108
armies — and every list built on one — silently lost their army rules.

`src/aos4/import/armiesOfRenown.ts` recovers both from the relationship graph. It is structural
rather than a list of army names, which would go stale on the next battletome with no test to catch
it; the shape is a direct consequence of how the source pages are laid out, so a new army arrives
already recognised. Three pieces:

- `kindMatches` accepts an army container under the `battle-formation` hint, since that is the slot
  the roster puts it in and the parser has nothing to tell them apart with.
- `buildReachableIds` derives a container's availability from its sections. Generation attaches the
  sections to the faction that offers them and attaches nothing to the container, so traversal never
  arrives at it — a roster naming the army was told it was unavailable to a faction that plainly
  offers its every rule.
- A qualified-name pass matches `<army> <section>`, tried only after the plain name finds nothing,
  and kept out of the ordinary kind filter so a bare `Spell Lore` still matches nothing rather than
  colliding with all 37 of them.

### On defect 1

#1783 counted 348 content-groups "named after their section heading instead of themselves" and read
it as the largest gap in the corpus. It is not a gap. Of the 348:

- **137** have no content-group parent. These are the per-faction category containers — 28 factions
  by ~5 categories — and `Battle Formations` is their correct name. Their children carry the real
  names (`Lore of Change`, `Fated Artefacts`, `Denizens of the Silver Towers`).
- **211** are the Army of Renown sections above, whose army is recoverable from the graph.

Nothing was lost, and restoring "real names" would not have produced the universal manifestation
lores the issue attributed to this — those are a source coverage gap, now in #1791.

## Rosters built during a lapsed season (#1783 defect 3)

`Greedy Eaters` sits in Historical because it is a General's Handbook 2025-26 formation and that
handbook expired on 2026-07-05. That is correct. So do all 42 `Scourge of Ghyran` unit variants,
which is why this defect is not one formation — it is every list built during last season.

The bug is on the import side: a roster declaring 2025-26 fell back to 2026-27 and dropped exactly
the picks that made it that season's list. It now overlays the historical context, the way
`allowsLegends` already overlays Legends. An overlay rather than a move, because Historical holds
only 42 warscrolls and 145 content groups — moving the document there would strip the other 805
warscrolls the army is actually made of.

- `Aos4ArmyDocument.allowsHistorical`, serialized only when true, so documents that never touched a
  past season keep round-tripping to schema 1's original bytes.
- `resolveSelection` treats it exactly like the Legends overlay.
- Detection reads the season year out of the declared battlepack. A season *newer* than the one we
  carry is deliberately not treated as lapsed.
- The current context is still tried first, so a formation that exists in both seasons resolves to
  the version the player will actually be playing under.

## Name gaps

One reviewed alias added: `Knives of the Crone` to `The Knives of the Crone`. The official app drops
this warband's leading article although it keeps it on every other one in the same list
(`The Shadeborn`), so it is provider divergence, not a rule. Not generalized to article-stripping,
which would put `The Roving Maw` and `Ironsunz` in reach of anything spelled either way.

The rest keep failing closed and moved to #1791, because each is a near-miss to something real and
`labelAliases` cannot invent an entity:

- `Outlaw Conqueror Cogfort` / `Outlaw Cannonade Cogfort` — the base `Conqueror Cogfort` exists, but
  so do `The Iron March Linebreaker Cogfort` and `The Iron March Immolator Cogfort`, so `Outlaw`
  looks like a real variant we do not carry rather than a spelling.
- `Freeguild Marshal` — ambiguous between `Freeguild Marshal and Relic Envoy` and the Griffon one.
- `Mask of the Deceiver` — genuinely absent.

## Result

Across the twelve official-app fixtures:

| fixture | before | after | what it recovered |
| --- | --- | --- | --- |
| `gg-001-army-of-renown` | 28/33 | **31/33** | the army and both its lores |
| `om-001-multi-terrain-auxiliaries` | 20/24 | **23/24** | `Greedy Eaters`, two Scourge of Ghyran |
| `lrl-001-multi-lore` | 53/64 | **58/64** | four Scourge of Ghyran |
| `idk-001-renown-army-no-lore` | 21/23 | **23/23** | the army, one Scourge of Ghyran |
| `ko-001-renown-army-repeats` | 20/22 | **21/22** | `Pioneer Outpost` |
| `dok-001-legends-repeats` | 42/43 | **43/43** | `Knives of the Crone` |
| `ser`, `sob` | full | full | — |
| `cos`, `fs`, `ij`, `sce` | — | unchanged | blocked on #1791 |

Every remaining failure across all twelve is missing corpus data.

## Testing

- `src/tests/aos4/importResolution.test.ts` — army container, qualified section name, wrong-kind
  refusal, bare section name refusal; lapsed-season overlay, current-season preference on a name in
  both, and a newer-than-ours season not treated as lapsed. Fixture catalog gained an army shaped
  the way generation emits one, rather than a tidier graph the generator never produces.
- `src/tests/aos4/officialAppFixtures.test.ts` — the same behaviour against the accepted corpus,
  asserted on named labels rather than totals. Pins the army count at 108 and pins the four
  enhancement tables (`Monstrous Traits`, `Accursed Devices`, `Marks of Vulcatrix`) *out*, since
  those are the one other shape that looks like an army from a distance. Also pins the #1791 names
  as deliberate failures, to be flipped when the data lands.
- `src/tests/aos4/selectionGraph.test.ts` — the historical overlay adds without replacing.
- `src/tests/aos4/representativeSlice.test.ts` — `allowsHistorical` round-trips, and its absence
  still writes byte-identical schema 1 output.

`yarn lint`, `yarn tsc --noEmit`, `yarn test --run` (947 passing), and `yarn build` all pass. No
generated data changed, so the beta certification is untouched.

### To verify by hand

Import `src/tests/fixtures/aos4/import/official-app/lists/gg-001-army-of-renown/list.txt` and check
that `Da King's Gitz` and both its lores arrive, then import `om-001-multi-terrain-auxiliaries` and
check that `Greedy Eaters` and the two `Scourge of Ghyran` units arrive with the warning now saying
the ruleset "has been superseded" rather than "is not one we carry".
