### PR TITLE
fix(home): polish the homepage's grid, landmarks, and link names

### DIFF
--- a/src/components/helpers/link.tsx
+++ b/src/components/helpers/link.tsx
@@ -1,17 +1,27 @@
 import type { IconType } from 'react-icons'
 import { centerContentClass } from 'theme/helperClasses'
 import { logClick } from 'utils/analytics'
-import useWindowSize from 'utils/hooks/useWindowSize'
 
 interface LinkProps {
+  /*
+   * Only for links whose contents cannot name them — an icon-only control. Setting it on a link that
+   * already has visible text replaces that text as the accessible name, which is how the footer's
+   * release-notes link came to announce itself as "GithubLatestRelease" (WCAG 2.5.3 Label in Name).
+   */
+  ariaLabel?: string
   className?: string
   href: string
-  label: string
   onClick?: (...args: unknown[]) => void
 }
 
-export const LinkNewTab = ({ href, children, label, ...props }: React.PropsWithChildren<LinkProps>) => (
-  <a href={href} target="_blank" rel="noopener noreferrer" aria-label={label} {...props}>
+export const LinkNewTab = ({ href, children, ariaLabel, ...props }: React.PropsWithChildren<LinkProps>) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    {...(ariaLabel ? { 'aria-label': ariaLabel } : {})}
+    {...props}
+  >
     {children}
   </a>
 )
@@ -23,20 +33,17 @@ interface LinkButtonProps {
   text: string
 }
 
-export const LinkButton = ({ Icon, href, btnClass, text }: LinkButtonProps) => {
-  const { isMobile } = useWindowSize()
-
-  return (
-    <LinkNewTab
-      href={href}
-      className={`${btnClass} mb-1`}
-      onClick={() => logClick(`Contact-${text}`)}
-      label={text}
-    >
-      <div className={centerContentClass}>
-        <Icon className={isMobile ? 'mx-2 my-1' : 'me-2'} />
-        {isMobile ? '' : ` ${text}`}
-      </div>
-    </LinkNewTab>
-  )
-}
+/*
+ * The label stays at every width. Below 575.98px these dropped to icon-only, which left the footer
+ * showing three similar dark glyphs with nothing to tell them apart — a sighted-touch problem, since
+ * the accessible name survived either way. There are only three, so the row wraps rather than
+ * abbreviating.
+ */
+export const LinkButton = ({ Icon, href, btnClass, text }: LinkButtonProps) => (
+  <LinkNewTab href={href} className={`${btnClass} mb-1`} onClick={() => logClick(`Contact-${text}`)}>
+    <div className={centerContentClass}>
+      <Icon className="me-2" />
+      {text}
+    </div>
+  </LinkNewTab>
+)

--- a/src/components/info/banners/app_banner.tsx
+++ b/src/components/info/banners/app_banner.tsx
@@ -5,7 +5,7 @@ const AppBanner = () => {
     <NotificationBanner enableLog name="2026-aos4-welcome-back" variant="info">
       <span>
         <strong>Welcome back!</strong> AoS Reminders is being updated to the latest and greatest. Please
-        excuse any bugs as we get the kinks sorted out. We&apos;re so glad to see you back!
+        excuse any bugs as we get the kinks sorted out.
       </span>
     </NotificationBanner>
   )

--- a/src/components/info/reminders.tsx
+++ b/src/components/info/reminders.tsx
@@ -13,6 +13,9 @@ import { Dropdown } from 'react-bootstrap'
 import { FaEllipsisH } from 'react-icons/fa'
 import { MdVisibilityOff } from 'react-icons/md'
 
+/** The skip link's destination. Exported so the anchor and its target cannot drift apart. */
+export const REMINDERS_ANCHOR_ID = 'aos4-reminders'
+
 export interface ReminderSourceLink {
   id: string
   label: string
@@ -298,7 +301,12 @@ const Reminders = (props: RemindersProps) => {
 
   return (
     <div className={`row mx-auto ${props.isGameMode ? 'mt-0' : 'mt-3'} d-flex justify-content-center`}>
-      <div className="col col-sm-11 col-md-10 col-lg-10 col-xl-8 ReminderContainer">
+      {/* tabIndex -1 so the skip link can move focus here; it stays out of the tab order. */}
+      <div
+        className="col col-sm-11 col-md-10 col-lg-10 col-xl-8 ReminderContainer"
+        id={REMINDERS_ANCHOR_ID}
+        tabIndex={-1}
+      >
         {groups.map(group => (
           <ReminderCard key={group.key} {...props} group={group} />
         ))}

--- a/src/components/input/army_builder.tsx
+++ b/src/components/input/army_builder.tsx
@@ -94,7 +94,13 @@ const SelectionCard = ({
   const title = isMobile && group.mobileTitle ? group.mobileTitle : group.title
   const selectionCount = selectedValues.length
   const bodyClass = `${theme.cardBody} ${isExpanded ? '' : 'd-none'} ${isMobile ? 'py-3' : ''}`
-  const colMobile = isMobile && !isExpanded ? 'col w-50 px-1' : 'col-12 px-1'
+  /*
+   * col-6, not the `col w-50` this carried before: `.col` sets `flex: 1 0 0%`, and a flex-basis of 0
+   * wins over `width`, so `w-50` never applied. Collapsed cards sized to their own title text instead
+   * — on a 390px phone the row tiled three-up, then two-up, then three-up, and a trailing card grew
+   * to fill its row. col-6 is the two-up tiling DESIGN.md specifies, at one width for every card.
+   */
+  const colMobile = isMobile && !isExpanded ? 'col-6 px-1' : 'col-12 px-1'
   const colDesktop = `col-sm-12 col-md-6 col-lg-4 col-xl-4 ${isMobile ? '' : 'mb-2'}`
   const bodyId = `aos4-builder-${group.key}`
 

--- a/src/components/page/footer.tsx
+++ b/src/components/page/footer.tsx
@@ -5,8 +5,13 @@ import Contact from 'components/page/contact'
 import { useTheme } from 'context/useTheme'
 import pkgJson from '../../../package.json'
 
+/*
+ * <footer>, not <div>: this block holds the Games Workshop disclaimer and the contact links, and a
+ * bare div left them unreachable by landmark navigation. `footer` is display: block, so the box is
+ * unchanged.
+ */
 const Footer = () => (
-  <div className="container d-print-none">
+  <footer className="container d-print-none">
     <DonateComponent />
     <OfflineComponent />
     <Disclaimer />
@@ -16,7 +21,7 @@ const Footer = () => (
       </div>
     </div>
     <ReleaseNotes />
-  </div>
+  </footer>
 )
 
 const Disclaimer = () => {
@@ -41,10 +46,7 @@ const ReleaseNotes = () => {
   return (
     <div className={`row text-center ${theme.bgColor} pt-1 pb-2`}>
       <div className="col">
-        <LinkNewTab
-          href="https://github.com/daviseford/aos-reminders/releases/latest"
-          label="GithubLatestRelease"
-        >
+        <LinkNewTab href="https://github.com/daviseford/aos-reminders/releases/latest">
           <small className={theme.text}>AoS Reminders v{pkgJson.version} - Release Notes</small>
         </LinkNewTab>
       </div>

--- a/src/components/routes/Faq.tsx
+++ b/src/components/routes/Faq.tsx
@@ -49,13 +49,13 @@ interface IFaqSection {
 }
 
 const GithubIssuesLink = () => (
-  <LinkNewTab className="FaqLink" href={`${GITHUB_URL}/issues`} label="Faq-GithubIssues">
+  <LinkNewTab className="FaqLink" href={`${GITHUB_URL}/issues`}>
     open an issue on Github
   </LinkNewTab>
 )
 
 const WahapediaLink = () => (
-  <LinkNewTab className="FaqLink" href="//wahapedia.ru/aos4/the-rules/" label="Faq-Wahapedia">
+  <LinkNewTab className="FaqLink" href="//wahapedia.ru/aos4/the-rules/">
     Wahapedia
   </LinkNewTab>
 )

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -10,7 +10,7 @@ import {
   type Aos4ReminderViewModel,
 } from '../../aos4/view'
 import AppBanner from 'components/info/banners/app_banner'
-import Reminders, { type ReminderSourceLink } from 'components/info/reminders'
+import Reminders, { REMINDERS_ANCHOR_ID, type ReminderSourceLink } from 'components/info/reminders'
 import ArmyBuilder from 'components/input/army_builder'
 import { useSubscriberAction } from 'components/input/importArmy/subscriberAction'
 import Toolbar from 'components/input/toolbar/toolbar'
@@ -81,6 +81,27 @@ const factionById = new Map(
 const selectableFactions = armyFactions(AOS4_CATALOG)
 
 const toFileName = (name: string) => `${name.trim().split(/\s+/).join('_') || 'AoS'}_Reminders`
+
+/*
+ * The masthead, mode switch, faction select, builder cards, and the seven toolbar buttons all sit
+ * between the top of the document and the reminders, so reaching the content by keyboard means
+ * tabbing past roughly a dozen controls. The link targets the reminders rather than <main>, because
+ * <main> wraps the routed tree from the navbar down and skipping to it would move nothing.
+ */
+const SkipToReminders = () => (
+  /*
+   * A light chip in both themes rather than a theme slot. The link reveals itself over the masthead,
+   * and the masthead is dark in each theme — Deep Harbour Teal in light, Midnight Slate in dark — so
+   * `theme.bgColor` would paint it Midnight Slate on Midnight Slate and hide it exactly when a
+   * keyboard user needs to see it.
+   */
+  <a
+    className="SkipLink visually-hidden-focusable bg-light text-dark d-print-none"
+    href={`#${REMINDERS_ANCHOR_ID}`}
+  >
+    Skip to reminders
+  </a>
+)
 
 const HomeContent = () => {
   const [document, setDocument] = useState(loadDocument)
@@ -238,6 +259,8 @@ const HomeContent = () => {
 
   return (
     <div>
+      <SkipToReminders />
+
       <Header
         armyName={document.name}
         factionId={factionId}

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -130,14 +130,38 @@ small {
     }
 }
 
+/*
+ * Skip link. Bootstrap's `.visually-hidden-focusable` clips the link while it is unfocused and then
+ * returns it to the normal flow on focus — which would push the masthead down the moment a keyboard
+ * user hits Tab. Holding it absolute keeps the reveal from moving anything else. The colours are
+ * utility classes on the element itself (see Home.tsx); `$border-radius` is the parity-pinned 4.6
+ * value, so the chip matches every other control on the page.
+ */
+.SkipLink:focus {
+    position: absolute;
+    z-index: 1030;
+    top: 0;
+    left: 0;
+    margin: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid currentcolor;
+    border-radius: $border-radius;
+    text-decoration: none;
+}
+
 /* Reboot sizes <legend> at 1.5rem; these group labels replaced 1rem <label>s. */
 .FieldsetLegend {
     margin-bottom: 0.25rem;
     font-size: 1rem;
 }
 
+/*
+ * 12px to match `small`, which is the smallest type anywhere else in the product. The disclaimer is a
+ * brand commitment that has to appear on every page, so it should not also be the one thing set below
+ * the floor; position and colour already make it subordinate.
+ */
 .DisclaimerText {
-    font-size: 11px;
+    font-size: 12px;
 }
 
 /*

--- a/src/tests/aos4/homePresentation.test.tsx
+++ b/src/tests/aos4/homePresentation.test.tsx
@@ -221,6 +221,69 @@ describe('AoS 4 home presentation', () => {
     expect(offered).not.toContain('Endless Spells')
   })
 
+  it('opens on a skip link that reaches the reminders, and a real footer landmark', () => {
+    const skip = container.querySelector('a.SkipLink')
+    expect(skip).not.toBeNull()
+    expect(skip?.textContent).toBe('Skip to reminders')
+    // First focusable in the document, or it is not a skip link.
+    expect(container.querySelector('a, button, input, select, textarea')).toBe(skip)
+
+    // The target has to exist and be focusable, otherwise the link moves focus nowhere.
+    const target = container.querySelector('#aos4-reminders')
+    expect(target).not.toBeNull()
+    expect(skip?.getAttribute('href')).toBe(`#${target?.id}`)
+    expect(target?.getAttribute('tabindex')).toBe('-1')
+
+    // The masthead is dark in both themes, so the chip stays light in both.
+    expect(skip?.className).toContain('bg-light')
+    expect(skip?.className).toContain('d-print-none')
+
+    expect(container.querySelector('footer')).not.toBeNull()
+  })
+
+  it('lets link contents supply the accessible name instead of an analytics slug', () => {
+    const release = Array.from(container.querySelectorAll('a')).find(link =>
+      link.textContent?.includes('Release Notes')
+    )
+    expect(release).not.toBeUndefined()
+    // WCAG 2.5.3: this announced itself as "GithubLatestRelease" while reading "…Release Notes".
+    expect(release?.getAttribute('aria-label')).toBeNull()
+
+    // The contact links keep their text at every width, so they name themselves too.
+    const contacts = Array.from(container.querySelectorAll('footer a')).map(link => link.textContent?.trim())
+    expect(contacts).toEqual(expect.arrayContaining(['Github', 'Email', 'Discord']))
+  })
+
+  it('tiles collapsed builder cards two-up on mobile rather than sizing them to their titles', () => {
+    act(() => {
+      unmountComponentAtNode(container)
+    })
+    // jsdom has no matchMedia, so breakpoints.ts falls back to innerWidth. 1024 is the default, and
+    // the mobile branch never renders without this.
+    const width = window.innerWidth
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 })
+
+    try {
+      act(() => {
+        renderHome()
+      })
+
+      const collapsed = Array.from(container.querySelectorAll('.card'))
+        .map(card => card.parentElement)
+        .filter((col): col is HTMLElement => !!col && col.className.includes('col-6'))
+
+      // More than the one expanded card, so this is exercising the collapsed branch.
+      expect(collapsed.length).toBeGreaterThan(1)
+      /*
+       * `col w-50` was the intent and never applied: `.col` sets `flex: 1 0 0%`, and a flex-basis of
+       * 0 beats `width`, so the cards sized to their own titles and tiled three-up then two-up.
+       */
+      expect(container.querySelector('.col.w-50')).toBeNull()
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: width })
+    }
+  })
+
   it('does not render the migration-workbench reskin', () => {
     expect(container.querySelector('.aos4-hero')).toBeNull()
     expect(container.querySelector('.aos4-layout')).toBeNull()


### PR DESCRIPTION
A polish pass over `/`, measured live at 320 / 390 / 535 / 900 / 1440px in both themes. Five defects,
none of them a redesign. This is the `/impeccable polish` step the
[2026-07-30 audit](../blob/aos4-migration/docs/design/2026-07-30-mobile-accessibility-audit.md)
left open, and it closes four of its remaining findings.

## What was wrong

**The builder's mobile two-up tiling never shipped.** DESIGN.md records that collapsed cards "drop to
`col w-50` and tile two-up so the whole builder is visible without scrolling". `.col` sets
`flex: 1 0 0%`, and a flex-basis of 0 beats `width`, so `w-50` never applied — cards sized to their
own title text. At 390px the row tiled three-up, then two-up, then three-up, and a trailing card grew
to fill its row. `col-6` gives the specified two-up at one width for every card. Desktop is untouched.

| | 390px | 320px |
|---|---|---|
| Before | 132 / 115 / 96 / 176 / 176 / 121 / 111 / 111 … | ragged |
| After | 176 for every card | 141 for every card |

**No `<footer>` landmark** (WCAG 1.3.1) — the Games Workshop disclaimer and contact links were
unreachable by landmark navigation. `footer` is `display: block`, so the box is unchanged.

**No way past the chrome by keyboard** (WCAG 2.4.1). A skip link now opens the document. It targets
the reminders rather than `<main>`, because `<main>` wraps the routed tree from the navbar down and
skipping to it would move nothing — the audit's suggestion would have been a no-op.

**`LinkNewTab` always set `aria-label` from `label`, the analytics slug.** The footer's release-notes
link read "AoS Reminders v5.2.9 - Release Notes" and announced itself as `GithubLatestRelease`
(WCAG 2.5.3 Label in Name). `aria-label` is opt-in now; no call site needed it.

**Contact buttons dropped their labels below 575.98px**, leaving three similar dark glyphs. The
accessible name survived, so this was a sighted-touch defect.

**`.DisclaimerText` was 11px** — the only type in the product below `small`. Now 12px.

## Testing instructions

Run `yarn start` and open `/`.

**1. Builder tiles two-up on a phone.** Open DevTools device toolbar at 390px wide (and again at
320px). The collapsed builder cards — Formations, Artefacts, Spell Lores, Prayer Lores,
Manifestations, and the faction's content groups — should sit in a clean two-column grid, every card
the same width, no card stretched across a row on its own. Before this change they tiled three-up
then two-up then three-up. Resize above 576px and confirm desktop is unchanged: three-up at `lg`,
two-up at `md`.

**2. Skip link.** Load `/` and press <kbd>Tab</kbd> once, before clicking anything. A "Skip to
reminders" chip should appear at the top-left over the masthead — and nothing else on the page should
move when it appears. Press <kbd>Enter</kbd>: the page jumps to the Deployment card and focus lands on
the reminders column. Tab again and focus should continue from there, not from the top.

**3. Skip link in dark theme.** The masthead is Midnight Slate in dark, so the chip must not vanish
into it. With a subscriber account switch to dark on `/profile`, or set `localStorage.theme = 'dark'`
and reload. Tab once — the chip should still read as a light box on the dark masthead.

**4. Accessible names.** In DevTools, inspect the footer's "AoS Reminders v5.2.9 - Release Notes"
link and check the Accessibility pane: the computed name should be the visible text, not
`GithubLatestRelease`. Same for the FAQ's "open an issue on Github" and "Wahapedia" links.

**5. Footer landmark and labels.** `document.querySelectorAll('footer').length` should be `1`. At
320px wide, the Github / Email / Discord buttons should each show their word next to the icon and
still fit on one row without the page scrolling sideways.

**6. Print is unaffected.** <kbd>Ctrl/Cmd</kbd>+<kbd>P</kbd> on `/`: the skip link must not appear in
the preview (it carries `d-print-none`, as the footer already did).

## Verification

- `yarn lint`, `tsc --noEmit`, full `vitest` run — **1027 tests across 67 files, all passing**
- `vite build` passes the 850 kB entry-chunk budget at **814.05 kB**, which is byte-identical to base
  built in the same worktree — this adds nothing to the entry
- Impeccable design detector clean over all changed files
- Four new assertions in `homePresentation.test.tsx`. The two-up one was checked against the old code
  and fails there, so it is a real regression pin rather than a vacuous one; it sets `innerWidth` to
  390 because jsdom has no `matchMedia` and `breakpoints.ts` falls back to `innerWidth`.

## Deliberately not changed

Builder card headers wrap to two lines for longer data-derived group names ("Manifestation Lores",
"Heroes Of The First Forged"), so collapsed cards in a row can differ by 29px and their bottoms do not
align. Every available fix costs something DESIGN.md protects: a `min-height` spends density, a
smaller title changes the shared `.CardHeaderTitle` ramp, and the names come from the corpus and
cannot be abbreviated without inventing them. Recorded here rather than guessed at.

The skip link leaves the browser's default focus ring on the reminders column, which draws a border
down that column until focus moves on. That is the visible-focus indicator and DESIGN.md forbids
suppressing it, so it stays.
