### PR TITLE
fix(home): stop offering Endless Spells as an army (#1796)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,10 @@ The migration branch is now an Age of Sigmar fourth-edition-only workbench:
   the document's rules context during selection resolution
 - old browser state is deleted and replaced with a schema-valid AoS 4 document; it is never
   translated
-- all 28 decoded factions are selectable through one source-complete relationship graph
+- the 27 decoded factions that field units are selectable through one source-complete relationship
+  graph; the 28th row, `Endless Spells`, is a Wahapedia container for universal manifestations
+  rather than an army, and `armyFactions` keeps it out of the selector and the import search space
+  until #1791 settles where that content belongs
 - the accepted corpus contains 1,268 warscrolls, 1,002 battle profiles, 4,850 abilities,
   2,247 weapons, 1,402 content groups, and 18,974 live source records
 - current standard, General's Handbook 2026-27 (`Scourge of Aqshy`), Spearhead, Legends, and

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -81,9 +81,10 @@ rules authorities.
 
 ### Confirmed capabilities
 
-- Faction selection across all 28 decoded factions, and a builder covering warscrolls and content
-  groups (battle formations, artefacts of power, spell/prayer/manifestation lores, regiments of
-  renown).
+- Faction selection across the 27 armies a player can field — the 28th decoded faction row,
+  `Endless Spells`, is a source container for universal manifestations rather than a force — and a
+  builder covering warscrolls and content groups (battle formations, artefacts of power,
+  spell/prayer/manifestation lores, regiments of renown).
 - Reminder projection grouped by timing window, with per-reminder hide/show, free-text notes, and
   drag reordering within a group.
 - Source attribution per reminder, badged `Official` for Games Workshop records and linked where a

--- a/src/aos4/domain/armies.ts
+++ b/src/aos4/domain/armies.ts
@@ -1,0 +1,30 @@
+import type { Aos4Catalog, Faction } from './content'
+import type { CanonicalId } from './identity'
+
+/**
+ * The factions a player can field as an army, as opposed to every faction row the sources decode.
+ *
+ * Wahapedia's `Factions.csv` uses faction rows as containers as well as armies. `Endless Spells`
+ * is a row so that manifestations — a category of units and spells any army may take — have
+ * somewhere to hang, and generation turns it into a `faction` entity like every other row. Offering
+ * it in the army selector hands the player an army with no units (#1796).
+ *
+ * The relationship graph separates the two without pinning a name or an ID: a container offers no
+ * warscrolls at all, while the smallest real army offers eleven. Restoring the manifestation
+ * warscrolls (#1791) is expected to settle where that content belongs and retire the container row
+ * at generation time, at which point this has nothing left to exclude.
+ */
+export const armyFactions = (catalog: Aos4Catalog): Faction[] => {
+  const warscrollIds = new Set<CanonicalId>(
+    catalog.entities.flatMap(entity => (entity.kind === 'warscroll' ? [entity.id] : []))
+  )
+  const offersWarscrolls = new Set<CanonicalId>(
+    catalog.relationships.flatMap(relationship =>
+      warscrollIds.has(relationship.to) ? [relationship.from] : []
+    )
+  )
+
+  return catalog.entities.filter(
+    (entity): entity is Faction => entity.kind === 'faction' && offersWarscrolls.has(entity.id)
+  )
+}

--- a/src/aos4/domain/index.ts
+++ b/src/aos4/domain/index.ts
@@ -1,4 +1,5 @@
 export * from './ability'
+export * from './armies'
 export * from './content'
 export * from './entity'
 export * from './game'

--- a/src/aos4/import/resolveRoster.ts
+++ b/src/aos4/import/resolveRoster.ts
@@ -1,11 +1,12 @@
-import type {
-  Aos4Catalog,
-  CanonicalId,
-  ContentEntity,
-  ContentRelationship,
-  Faction,
-  RulesContext,
-  RulesContextId,
+import {
+  armyFactions,
+  type Aos4Catalog,
+  type CanonicalId,
+  type ContentEntity,
+  type ContentRelationship,
+  type Faction,
+  type RulesContext,
+  type RulesContextId,
 } from '../domain'
 import { resolveSelection } from '../select'
 import { createAos4ArmyDocument, deserializeAos4ArmyDocument, serializeAos4ArmyDocument } from '../state'
@@ -281,14 +282,18 @@ const factionNameCandidates = (label: string): string[] => {
   return stripped && stripped !== label.trim() ? [label, stripped] : [label]
 }
 
-const findFactions = (catalog: Aos4Catalog, label: string, rulesContextId: RulesContextId): Faction[] => {
+/**
+ * Match a roster's faction label against the armies a player can actually field.
+ *
+ * The search space is `armyFactions`, not every decoded faction row: `Endless Spells` is a
+ * container for universal manifestations rather than an army (#1796), and a roster naming it would
+ * resolve to a force with no units instead of failing where the player can see it.
+ */
+const findFactions = (armies: Faction[], label: string, rulesContextId: RulesContextId): Faction[] => {
   for (const candidate of factionNameCandidates(label)) {
     const normalized = normalizeImportLabel(candidate)
-    const matches = catalog.entities.filter(
-      (entity): entity is Faction =>
-        entity.kind === 'faction' &&
-        isApplicable(entity, rulesContextId) &&
-        normalizeImportLabel(entity.name) === normalized
+    const matches = armies.filter(
+      faction => isApplicable(faction, rulesContextId) && normalizeImportLabel(faction.name) === normalized
     )
     if (matches.length) return matches
   }
@@ -306,6 +311,7 @@ const findFactions = (catalog: Aos4Catalog, label: string, rulesContextId: Rules
  */
 const alternativeContextForFaction = (
   catalog: Aos4Catalog,
+  armies: Faction[],
   label: string,
   currentContextId: RulesContextId
 ): RulesContext | undefined => {
@@ -313,7 +319,7 @@ const alternativeContextForFaction = (
     context =>
       context.id !== currentContextId &&
       IMPORTABLE_CONTEXT_STATUSES.has(context.status) &&
-      findFactions(catalog, label, context.id).length === 1
+      findFactions(armies, label, context.id).length === 1
   )
   return candidates.length === 1 ? candidates[0] : undefined
 }
@@ -338,15 +344,16 @@ const resolveFaction = (
     return { matches: [] }
   }
 
+  const armies = armyFactions(catalog)
   let switchedContext: RulesContext | undefined
   const resolved = labels.map(({ label, line }) => {
-    let candidates = findFactions(catalog, label, rulesContextId)
+    let candidates = findFactions(armies, label, rulesContextId)
 
     if (!candidates.length) {
-      const alternative = alternativeContextForFaction(catalog, label, rulesContextId)
+      const alternative = alternativeContextForFaction(catalog, armies, label, rulesContextId)
       if (alternative) {
         switchedContext = alternative
-        candidates = findFactions(catalog, label, alternative.id)
+        candidates = findFactions(armies, label, alternative.id)
         diagnostics.push({
           code: 'unsupported-context',
           severity: 'warning',

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -1,4 +1,4 @@
-import type { CanonicalId, Faction, SourceArtifact } from '../../aos4/domain'
+import { armyFactions, type CanonicalId, type SourceArtifact } from '../../aos4/domain'
 import { AOS4_CATALOG, AOS4_DEFAULT_FACTION_ID } from '../../aos4/generated'
 import type { PrintPageSize } from '../../aos4/print/presets'
 import type { PrintPreset } from '../../aos4/print/types'
@@ -69,8 +69,15 @@ const reminderSources = (reminder: Aos4ReminderViewModel): ReminderSourceLink[] 
     ).values()
   )
 
-const factionEntities = AOS4_CATALOG.entities.filter((entity): entity is Faction => entity.kind === 'faction')
-const factionById = new Map(factionEntities.map(faction => [faction.id, faction]))
+/*
+ * Every decoded faction can name itself, but only the ones that field units are offered. A stored
+ * document naming a faction that is no longer on offer keeps its own name and leaves the selector
+ * empty, the same way one from another rules context already does.
+ */
+const factionById = new Map(
+  AOS4_CATALOG.entities.flatMap(entity => (entity.kind === 'faction' ? [[entity.id, entity] as const] : []))
+)
+const selectableFactions = armyFactions(AOS4_CATALOG)
 
 const toFileName = (name: string) => `${name.trim().split(/\s+/).join('_') || 'AoS'}_Reminders`
 
@@ -92,7 +99,7 @@ const HomeContent = () => {
   })
   const factions = useMemo(
     () =>
-      factionEntities
+      selectableFactions
         .filter(faction => faction.rulesContextIds.includes(document.rulesContextId))
         .map(faction => ({ label: faction.name, value: faction.id }))
         .sort((left, right) => left.label.localeCompare(right.label)),

--- a/src/tests/aos4/catalogIntegrity.test.ts
+++ b/src/tests/aos4/catalogIntegrity.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import {
+  armyFactions,
   sourceRecordId,
   validateCatalog,
   type Ability,
@@ -305,6 +306,23 @@ describe('AoS 4 catalog generation integrity', () => {
       (entity): entity is Faction => entity.kind === 'faction' && entity.rulesContextIds.includes(standard.id)
     )
     expect(factions).toHaveLength(27)
+
+    /*
+     * Not every decoded faction row is an army. `Endless Spells` is a container for universal
+     * manifestations (#1796), and it is the only row of that shape: every real army offers at least
+     * eleven warscrolls, this one offers none. Restoring the manifestation warscrolls (#1791) is
+     * expected to retire the row, and this assertion should fail loudly when a second container
+     * appears or this one gains units, rather than letting either back into the army selector.
+     */
+    const armies = armyFactions(AOS4_CATALOG)
+    const allFactions = AOS4_CATALOG.entities.filter((entity): entity is Faction => entity.kind === 'faction')
+    expect(allFactions).toHaveLength(28)
+    expect(armies).toHaveLength(27)
+    expect(allFactions.filter(faction => !armies.includes(faction)).map(faction => faction.name)).toEqual([
+      'Endless Spells',
+    ])
+    expect(armies.filter(army => army.rulesContextIds.includes(seasonal.id))).toHaveLength(26)
+
     AOS4_CATALOG.rulesContexts.forEach(context => {
       const applicableFactions = AOS4_CATALOG.entities.filter(
         (entity): entity is Faction =>

--- a/src/tests/aos4/domain.test.ts
+++ b/src/tests/aos4/domain.test.ts
@@ -2,6 +2,7 @@ import {
   AOS4_CATALOG_SCHEMA_VERSION,
   TURN_PHASES,
   abilityId,
+  armyFactions,
   artifactId,
   battleProfileId,
   contentGroupId,
@@ -429,6 +430,21 @@ describe('AoS 4 domain', () => {
         subject: incomplete.id,
       })
     )
+  })
+
+  it('counts only factions that offer warscrolls as armies a player can field', () => {
+    const catalog = createCatalog()
+    const container = factionId('10000000-0000-4000-8000-000000000018')
+    catalog.entities.push({ ...faction, id: container, name: 'Endless Spells' })
+    catalog.relationships.push({
+      id: 'relationship:container-content-group',
+      kind: 'offers',
+      from: container,
+      to: ids.contentGroup,
+    })
+
+    expect(catalog.entities.filter(entity => entity.kind === 'faction')).toHaveLength(2)
+    expect(armyFactions(catalog).map(army => army.name)).toEqual(['Fixture Faction'])
   })
 
   it('rejects malformed canonical, artifact, and rules-context IDs', () => {

--- a/src/tests/aos4/homePresentation.test.tsx
+++ b/src/tests/aos4/homePresentation.test.tsx
@@ -197,6 +197,30 @@ describe('AoS 4 home presentation', () => {
     expect(container.querySelector('[role="dialog"][aria-label="Import Army"]')).not.toBeNull()
   })
 
+  /**
+   * `Endless Spells` is a `Factions.csv` container for universal manifestations, not an army
+   * (#1796). Offering it handed the player a force with no units and no explanation.
+   */
+  it('offers only factions that field units in the army selector', async () => {
+    const factionInput = container.querySelector<HTMLInputElement>('input[aria-label="Faction"]')
+    expect(factionInput).not.toBeNull()
+
+    await act(async () => {
+      factionInput!.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
+      )
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    const offered = Array.from(container.querySelectorAll('[role="option"]')).map(option =>
+      option.textContent?.trim()
+    )
+    expect(offered).toContain('Stormcast Eternals')
+    expect(offered).toContain('Flesh-eater Courts')
+    expect(offered).toContain('Disciples of Tzeentch')
+    expect(offered).not.toContain('Endless Spells')
+  })
+
   it('does not render the migration-workbench reskin', () => {
     expect(container.querySelector('.aos4-hero')).toBeNull()
     expect(container.querySelector('.aos4-layout')).toBeNull()

--- a/src/tests/aos4/importResolution.test.ts
+++ b/src/tests/aos4/importResolution.test.ts
@@ -231,6 +231,20 @@ describe('AoS 4 parsed-roster resolution', () => {
     )
   })
 
+  /**
+   * A container row is not an army (#1796). Resolving one would hand back a force with no units
+   * and no way for the player to tell why, so it is absent from the search space entirely and the
+   * roster fails where they can see it.
+   */
+  it('does not resolve a faction row that offers no warscrolls', () => {
+    const container = resolve(roster({ declaredFaction: 'Endless Spells', selections: [] }))
+
+    expect(container.proposedDocument).toBeUndefined()
+    expect(container.diagnostics).toContainEqual(
+      expect.objectContaining({ code: 'missing-faction', severity: 'error' })
+    )
+  })
+
   it('rejects a roster without a faction and round-trips the proposed document', () => {
     const missingFaction = resolve(roster({ declaredFaction: undefined }))
 

--- a/src/tests/fixtures/aos4/import/catalog.ts
+++ b/src/tests/fixtures/aos4/import/catalog.ts
@@ -21,6 +21,11 @@ export const importFixtureContextIds = {
 export const importFixtureIds = {
   alphaFaction: factionId('81000000-0000-4000-8000-000000000010'),
   betaFaction: factionId('81000000-0000-4000-8000-000000000011'),
+  /**
+   * A `Factions.csv` container row rather than an army, shaped the way `Endless Spells` is: it
+   * offers universal rules content to hang manifestations off, and no warscrolls at all.
+   */
+  containerFaction: factionId('81000000-0000-4000-8000-000000000012'),
   alphaGuard: warscrollId('81000000-0000-4000-8000-000000000020'),
   betaGuard: warscrollId('81000000-0000-4000-8000-000000000021'),
   betaOnly: warscrollId('81000000-0000-4000-8000-000000000022'),
@@ -145,6 +150,13 @@ export const createImportFixtureCatalog = (): Aos4Catalog => {
       rulesContextIds: [importFixtureContextIds.seasonal],
     },
     {
+      id: 'relationship:container-offers-same-name-lore',
+      kind: 'offers',
+      from: importFixtureIds.containerFaction,
+      to: importFixtureIds.sameNameLore,
+      rulesContextIds: [importFixtureContextIds.seasonal],
+    },
+    {
       id: 'relationship:alpha-offers-archive-guard',
       kind: 'offers',
       from: importFixtureIds.alphaFaction,
@@ -217,6 +229,14 @@ export const createImportFixtureCatalog = (): Aos4Catalog => {
         revision: 'import-fixture',
         name: 'Beta Hosts',
         rulesContextIds: [importFixtureContextIds.seasonal],
+        sourceRefs,
+      },
+      {
+        id: importFixtureIds.containerFaction,
+        kind: 'faction',
+        revision: 'import-fixture',
+        name: 'Endless Spells',
+        rulesContextIds: [importFixtureContextIds.current, importFixtureContextIds.seasonal],
         sourceRefs,
       },
       {

--- a/src/tests/support/listbotCorpusCommand.ts
+++ b/src/tests/support/listbotCorpusCommand.ts
@@ -10,7 +10,7 @@ import {
   createPinnedHttpsTransport,
   resolveDnsAddresses,
 } from '../../aos4/data'
-import type { RulesContextId } from '../../aos4/domain'
+import { armyFactions, type RulesContextId } from '../../aos4/domain'
 import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID } from '../../aos4/generated'
 import { stableJson } from '../../aos4/generate/serialization'
 import { resolveParsedRoster } from '../../aos4/import'
@@ -36,7 +36,6 @@ const MAX_VERSION_BYTES = 64 * 1024
 const OUTPUT_ROOT = path.resolve('data', 'aos4', 'import-corpus')
 const DEFAULT_OUTPUT = path.join(OUTPUT_ROOT, 'listbot')
 const CACHE_ROOT = path.resolve('.cache', 'aos4', 'import', 'listbot')
-const NON_ARMY_FACTION_IDS = new Set(['faction:e668f75e-fd2f-513d-8ebb-e24696ceacb6'])
 const IMPORTABLE_CONTEXT_STATUSES = new Set(['current', 'seasonal', 'legends'])
 
 interface CommandOptions {
@@ -108,9 +107,7 @@ const catalogArmyContexts = (): ArmyContext[] => {
   const bindingsByCatalogFactionId = new Map(
     LISTBOT_ARMY_BINDINGS.map(binding => [binding.catalogFactionId, binding])
   )
-  const factions = AOS4_CATALOG.entities.flatMap(entity =>
-    entity.kind === 'faction' && !NON_ARMY_FACTION_IDS.has(entity.id) ? [entity] : []
-  )
+  const factions = armyFactions(AOS4_CATALOG)
   const factionIds = new Set(factions.map(faction => faction.id))
   LISTBOT_ARMY_BINDINGS.forEach(binding => {
     if (!factionIds.has(binding.catalogFactionId as (typeof factions)[number]['id'])) {


### PR DESCRIPTION
Closes #1796.

## The bug

`Endless Spells` appeared in the army selector on `/` as a choosable army. Picking it gave an army
with no units, because it is not an army — manifestations are a category of units and spells any
army can take. Wahapedia files them under an `Endless Spells` row in `Factions.csv` purely as a
container, and generation turns that row into a `faction` entity like any other. It carries the
default 2026-27 seasonal context, so every user saw it.

## The fix

`armyFactions` (`src/aos4/domain/armies.ts`) derives the distinction from the relationship graph
rather than pinning a name or an ID: a container offers no warscrolls, while the smallest real
army offers eleven. Measured across the accepted corpus, the gap is 0 vs 11–97 — there is no
ambiguous middle.

Three call sites go through it:

- `Home.tsx` — the army selector offers armies only. Name lookup still covers all 28 rows, so a
  stored document naming an unoffered faction keeps its own name and leaves the selector empty,
  the way one from another rules context already behaves.
- `resolveRoster.ts` — the importer's `findFactions` search space. No roster declares it today, so
  this is prevention rather than a live defect.
- `listbotCorpusCommand.ts` — replaces `NON_ARMY_FACTION_IDS`, a hardcoded Endless Spells UUID
  that already existed for exactly this reason.

Docs corrected: `AGENTS.md` and `PRODUCT.md` claimed all 28 decoded factions are selectable. The
real number is 27. Pure corpus statistics (README, maintenance report counts) still say 28 and are
untouched — 28 rows *are* decoded.

## Scope

This is the render-side half. #1791 restores the manifestation warscrolls and decides where that
content belongs; it is expected to retire the container row at generation time, at which point
`armyFactions` has nothing left to exclude. Regenerating the corpus is not possible from this
branch (no `.cache/aos4/`), and hand-editing generated products is forbidden.

The catalog assertion added here fails loudly if a second container appears or this one gains
units, rather than letting either back into the selector.

## Testing

- New: `domain.test.ts` (helper against a synthetic catalog), `catalogIntegrity.test.ts`
  (28 rows / 27 armies / `Endless Spells` is the only exclusion / 26 in the seasonal context),
  `importResolution.test.ts` (a roster declaring a container row fails `missing-faction` — verified
  to fail without the fix), `homePresentation.test.tsx` (opens the real selector and asserts the
  offered options).
- `yarn lint`, `yarn tsc --noEmit`, `yarn test --run` (67 files, 1063 tests), `yarn build`, and
  `yarn data:aos4:verify:beta` (79,294 pass, 0 findings) all green.

## Reproduce

Load `/`, open the army selector, look between `Disciples of Tzeentch` and `Flesh-eater Courts`.
`Endless Spells` is gone; the other 26 seasonal armies are unchanged.

https://claude.ai/code/session_01VBi45V9jhNrgcDJohBdDNW