### PR TITLE
fix(analytics): restore trustworthy GA4 reporting

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,113 @@
+# Analytics
+
+AoS Reminders uses the GA4 property `AoS Reminders - GA4`, web stream `5494190629`, and
+measurement ID `G-EM4GX294XG`. Analytics is directional product telemetry. It is never used to
+authorize an account, fulfill a payment, or provide canonical army or rules data.
+
+## Collection boundary
+
+`src/utils/analytics.ts` is the only GA4 adapter. Importing it has no side effects. Collection starts
+only when both conditions are true:
+
+- Vite built the application in production mode.
+- The browser hostname is exactly `aosreminders.com` or `www.aosreminders.com`.
+
+Development, test, preview, `localhost`, and `127.0.0.1` traffic do not initialize GA. Development
+actions may be written to the browser console for local diagnosis.
+
+The application owns page views. GA initializes with `send_page_view: false`, then
+`src/components/App.tsx` sends one initial page view and subscribes once to React Router history.
+Page paths contain only the pathname: query strings and fragments are never included. In the web
+stream's Enhanced Measurement settings, page loads remain enabled and browser-history page changes
+remain disabled. Enabling history-based measurement would create a second SPA page-view owner.
+
+## Event contract
+
+Event names are fixed. Categorical values belong in parameters and must never be interpolated into
+new event names.
+
+| Event | When | Parameters |
+|---|---|---|
+| `page_view` | Initial load and each SPA route change | Standard page path, location, and title; pathname only |
+| `ui_interaction` | Existing navigation or generic UI interaction | `interaction_name` |
+| `theme_change` | A visitor changes theme | `theme_name` |
+| `banner_view` | A notification banner is shown | `banner_name` |
+| `banner_close` | A notification banner is dismissed | `banner_name` |
+| `game_mode_change` | Edit/play mode changes | `game_mode` |
+| `select_content` | A faction is selected | Standard `content_type`, `item_id`; `faction_name` |
+| `file_download` | A reminders PDF is generated successfully | Standard `file_name`, `file_extension`; `print_layout`, `print_page_size` |
+| `roster_import` | An import preview succeeds or fails | `roster_source`, `import_outcome`, aggregate `selection_count`, `diagnostic_count` |
+| `account_action` | A coupon or gift is redeemed, or a subscription is cancelled | `account_action` |
+| `login_start` | Hosted login starts | `login_origin` |
+| `login_closed` | Hosted login closes without redirecting | `login_origin` |
+| `begin_checkout` | Stripe or PayPal checkout starts | Standard `currency`, `value`, `items`; `payment_provider` |
+| `purchase` | A recognized checkout return or PayPal approval completes | Standard `transaction_id`, `currency`, `value`, `items`; `payment_provider` |
+| `checkout_cancelled` | A recognized checkout is cancelled | `value`, `items`, `payment_provider` |
+
+The item catalog in `src/utils/plans.ts` owns stable analytics item IDs and numeric unit prices.
+Subscription and gift items use the categories `subscription` and `gift_subscription`.
+
+## Custom definitions
+
+The following event-scoped custom dimensions are registered in GA4 Admin. Names mirror their event
+parameters so the mapping stays obvious:
+
+| Dimension | Event parameter |
+|---|---|
+| Interaction name | `interaction_name` |
+| Theme name | `theme_name` |
+| Banner name | `banner_name` |
+| Game mode | `game_mode` |
+| Faction name | `faction_name` |
+| Print layout | `print_layout` |
+| Print page size | `print_page_size` |
+| Roster source | `roster_source` |
+| Import outcome | `import_outcome` |
+| Account action | `account_action` |
+| Login origin | `login_origin` |
+| Payment provider | `payment_provider` |
+
+The legacy `Event Category` and `Event Label` definitions remain for historical reports. No custom
+metrics are registered: ecommerce value and item quantity use GA4's standard fields, while import
+counts are diagnostic payloads rather than long-lived reporting dimensions. Custom definitions are
+not retroactive.
+
+## Privacy rules
+
+Analytics helpers accept only allowlisted, bounded metadata. Do not send:
+
+- email addresses, Auth0 identifiers, or other account identifiers;
+- army names, notes, roster contents, uploaded file names, or cloud-army identifiers;
+- share tokens, full URLs, query strings, fragments, or arbitrary error text;
+- rules text or user-authored content.
+
+The sole provider identifier is Stripe's Checkout Session ID or PayPal's subscription ID in the
+standard `purchase.transaction_id` field. Checkout query parameters are removed before the initial
+page view. Unknown plans, invalid gift quantities, and returns without a transaction ID do not
+produce a purchase event.
+
+## Ecommerce limitations
+
+Browser purchase events are useful for funnel and revenue analysis, but they are not payment proof.
+A return URL can be forged, a customer can close the browser before returning, and client-side
+collection can be blocked. Stripe, PayPal, and the subscription API remain authoritative.
+
+Authoritative server-side Measurement Protocol events should be added only with verified payment
+webhooks and a deliberate deduplication contract. That work belongs with the subscription
+authorization and Stripe modernization program.
+
+## Validation
+
+After a production deployment:
+
+1. In Realtime or DebugView, load production and navigate between two routes. Confirm one
+   pathname-only page view per route.
+2. Exercise one product action. Confirm its stable event name and the expected custom parameter.
+3. Confirm the hostname report accumulates `aosreminders.com` traffic but no new `localhost` or
+   `127.0.0.1` traffic from this application.
+4. For the next real purchase, confirm `purchase` has one item, numeric USD value, provider, and a
+   transaction ID, and that the checkout parameters disappear from the returned URL.
+5. Keep `purchase` marked as a key event and keep browser-history Enhanced Measurement disabled.
+
+The original failure diagnosis and implementation units are recorded in
+`docs/plans/2026-07-30-001-fix-google-analytics-reporting-plan.md`.

--- a/docs/plans/2026-07-30-001-fix-google-analytics-reporting-plan.md
+++ b/docs/plans/2026-07-30-001-fix-google-analytics-reporting-plan.md
@@ -1,0 +1,362 @@
+---
+title: Google Analytics Reporting Reliability - Plan
+type: fix
+date: 2026-07-30
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+issue: 1773
+---
+
+# Google Analytics Reporting Reliability - Plan
+
+## Goal Capsule
+
+- **Objective:** Make the GA4 property trustworthy enough to answer basic acquisition, product-usage, and subscription questions without development traffic, duplicate pageviews, event-name fragmentation, or sensitive query data.
+- **Authority order:** Repository constraints and issue #1773; current production behavior and GA4 property state; official Google Analytics and Stripe contracts; implementation details in this plan.
+- **Execution profile:** Preserve the current interface while changing the analytics adapter, existing call sites, tests, documentation, and additive GA4 property configuration.
+- **Stop conditions:** Do not deploy, merge, push `master`, delete historical GA4 data, alter account authorization, or make analytics the source of truth for payment fulfillment.
+- **Tail ownership:** Land the work in a migration sub-PR targeting `aos4-migration`, with the accepted AoS 4 beta gate and normal repository verification green.
+
+---
+
+## Product Contract
+
+### Summary
+
+Replace the legacy React GA adapter with a production-gated GA4 collection boundary, one explicit pageview stream, a small stable event taxonomy, privacy-safe parameters, and valid ecommerce events. Configure only the additive GA4 definitions needed to report those parameters.
+
+### Problem Frame
+
+The live GA4 property is not a reliable description of product use. On July 29, 2026, `localhost` generated the overwhelming majority of pageviews in the hostname report, which explains the reported spike. `src/utils/analytics.ts` initializes GA in every non-test build, including the Vite development server and locally served production builds.
+
+Pageviews also have two owners. GA4 Enhanced Measurement sends the initial page load while individual React routes call `logPageView`; Home has no manual call, and client-side transitions are not tracked centrally. Non-Home initial loads can be duplicated while some SPA transitions are missed.
+
+The event adapter still sends the Universal Analytics object shape. `react-ga4` maps the legacy `action` field to the GA4 event name, producing 345 distinct names in the last 28 days, including names that encode banner, faction, and mode values. Subscription completions no longer emit GA4 `purchase`, so the property reports zero revenue even though `purchase` is already configured as a key event.
+
+### Actors
+
+- A1. A visitor or subscriber uses the AoS 4 builder, reminders, printing, import, account, or checkout flows.
+- A2. A product maintainer uses GA4 reports to distinguish real production behavior from development activity and to analyze events by bounded dimensions.
+
+### Requirements
+
+**Collection integrity**
+
+- R1. Analytics must initialize and transmit only from a production build running on `aosreminders.com` or `www.aosreminders.com`.
+- R2. The app must emit exactly one explicit `page_view` for the initial sanitized URL and each subsequent SPA route transition.
+- R3. Pageviews must exclude query strings, fragments, share tokens, and checkout-session identifiers; other events must exclude emails, Auth0 identifiers, user-entered army names, roster contents, and cloud-army identifiers, with the provider transaction ID allowed only as the standard `purchase.transaction_id`.
+
+**Product reporting**
+
+- R4. Events must use a bounded GA4 taxonomy whose categorical differences are parameters rather than dynamically generated event names.
+- R5. Reporting must cover faction selection, edit/play mode changes, PDF generation, roster-import outcomes, account interactions, banners, theme changes, login attempts, and existing navigation interactions without changing their UI behavior.
+- R6. Subscription and gift checkout must emit GA4-recommended `begin_checkout` and `purchase` events with numeric value, USD currency, items, provider, and a provider transaction identifier; cancellation must remain a bounded custom event.
+
+**Operability**
+
+- R7. The GA4 property must expose the custom parameters needed for useful reports without deleting legacy definitions or changing historical data.
+- R8. Automated tests and documentation must make production gating, pageview ownership, taxonomy, privacy exclusions, ecommerce mapping, and the limits of client-side purchase telemetry explicit.
+- R9. The change must preserve the established interface, route behavior, account flows, and AoS 4 domain boundary.
+
+### Key Flows
+
+- F1. **Production pageview collection**
+  - **Trigger:** A1 loads the app or changes a React Router route.
+  - **Actors:** A1, A2
+  - **Steps:** The app initializes GA without an automatic pageview, removes recognized checkout state, sends a sanitized initial pageview, then observes route changes.
+  - **Outcome:** A2 sees one pageview per route and no development-host traffic after rollout.
+  - **Covered by:** R1, R2, R3
+- F2. **Product action collection**
+  - **Trigger:** A1 completes a tracked UI or AoS 4 action.
+  - **Actors:** A1, A2
+  - **Steps:** A typed analytics helper accepts only bounded, non-sensitive context and sends one stable event name.
+  - **Outcome:** A2 can analyze the action by registered parameters without event-name cardinality growth.
+  - **Covered by:** R3, R4, R5, R7
+- F3. **Checkout telemetry**
+  - **Trigger:** A1 starts, cancels, or returns from a Stripe or PayPal checkout.
+  - **Actors:** A1, A2
+  - **Steps:** The app maps the checked-in plan catalog to GA4 item/value fields, uses the provider identifier for deduplication, removes return parameters, and records the bounded event.
+  - **Outcome:** A2 gets directional checkout and revenue telemetry while the payment backend remains authoritative.
+  - **Covered by:** R3, R4, R6, R8
+
+### Acceptance Examples
+
+- AE1. **Development isolation**
+  - **Covers:** R1, R3
+  - **Given:** The Vite development server or a production bundle served from `localhost` or `127.0.0.1`.
+  - **When:** The app loads and tracked actions occur.
+  - **Then:** The Google tag is not initialized and no analytics request is sent.
+- AE2. **SPA pageview ownership**
+  - **Covers:** R2, R3
+  - **Given:** A production-host load at `/faq?army=<token>` followed by navigation to `/subscribe`.
+  - **When:** bootstrap and route navigation complete.
+  - **Then:** GA4 receives one pageview for `/faq` and one for `/subscribe`, with neither query string nor token.
+- AE3. **Stable action taxonomy**
+  - **Covers:** R4, R5
+  - **Given:** A1 selects two different factions and switches to play mode.
+  - **When:** the actions are tracked.
+  - **Then:** GA4 receives repeated stable event names with faction and mode values in parameters.
+- AE4. **Subscription purchase**
+  - **Covers:** R3, R6
+  - **Given:** A1 returns from a completed checkout for a checked-in plan with a provider transaction identifier.
+  - **When:** checkout query handling runs.
+  - **Then:** GA4 receives one `purchase` with the matching item, numeric USD value, quantity, provider, and transaction ID before the URL is sanitized.
+- AE5. **Untrusted checkout query**
+  - **Covers:** R3, R6, R8
+  - **Given:** A return URL names an unknown plan or lacks a usable provider transaction identifier.
+  - **When:** checkout query handling runs.
+  - **Then:** no revenue event is created, recognized query state is still removed, and the app continues normally.
+
+### Success Criteria
+
+- New GA4 traffic has no `localhost` or `127.0.0.1` pageviews attributable to this app.
+- A production navigation produces one sanitized pageview per route.
+- New custom product events use the bounded taxonomy in this plan; categorical values do not create new event names.
+- Valid Stripe and PayPal completions populate the existing `purchase` key event and monetization metrics.
+- Focused analytics tests and the full repository verification suite pass.
+
+### Scope Boundaries
+
+**In scope**
+
+- The web analytics adapter and existing analytics call sites.
+- Current AoS 4 builder, print, and import telemetry.
+- Current subscription and gift-checkout telemetry.
+- Additive GA4 custom dimensions and reporting documentation.
+
+#### Deferred to Follow-Up Work
+
+- Server-side GA4 Measurement Protocol events tied to verified Stripe/PayPal webhooks; this belongs with the subscription authorization and Stripe modernization work.
+- Replacing the deprecated client-only Stripe Checkout integration.
+- Consent-management or regional collection policy changes.
+- A historical-data annotation or BigQuery cleanup workflow.
+
+**Outside this product's identity**
+
+- Using analytics to authorize access, fulfill purchases, or store canonical army/rules data.
+- Sending user-authored rule, army, roster, account, or share content to GA4.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Analytics initialization is explicit and inert at module import.** `src/components/App.tsx` owns initialization so merely importing a helper cannot load Google code. Runtime enablement requires both Vite production mode and the production hostname. This implements R1 and makes locally served production bundles safe.
+- KTD2. **The app owns every pageview.** GA initializes with `send_page_view: false`; App sanitizes recognized checkout state, emits the initial pageview, and subscribes once to `src/utils/history.ts`. Route components lose their mount-time pageview effects. The GA4 stream keeps history-based Enhanced Measurement off, preventing a second SPA pageview owner. This implements R2 and R3.
+- KTD3. **Typed domain helpers own a bounded event vocabulary.** Recommended events are used where their semantics fit (`select_content`, `file_download`, `begin_checkout`, `purchase`); custom events use stable snake_case names. Existing generic click sites map to one `ui_interaction` event. Helpers accept allowlisted parameters rather than arbitrary payloads. This implements R3-R5.
+- KTD4. **The checked-in plan catalog supplies ecommerce facts.** Subscription and gift plans provide the item name, provider product/plan identifier, unit price, and quantity. Stripe includes its Checkout Session ID in the return URL and PayPal uses its subscription ID, both as GA4 `transaction_id`. Unknown or incomplete returns do not emit revenue. This implements R6 while treating client-side purchase telemetry as directional, not payment proof.
+- KTD5. **GA4 property changes are additive.** Keep the existing `purchase` key event and legacy custom definitions; add only event-scoped custom dimensions used by the new taxonomy. Avoid custom metrics because value, quantity, and item fields are standard ecommerce fields. This implements R7 and limits irreversible external-state changes.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  Boot[Application bootstrap] --> Gate{Production build and hostname?}
+  Gate -->|No| Local[Console diagnostics only]
+  Gate -->|Yes| Init[Initialize GA4 without auto pageview]
+  Init --> Clean[Handle and remove checkout query state]
+  Clean --> Initial[Send sanitized initial pageview]
+  Initial --> History[Observe React Router history]
+  History --> Page[Send one sanitized pageview per route]
+  UI[Existing UI and AoS 4 actions] --> Typed[Typed analytics helpers]
+  Checkout[Stripe and PayPal callbacks] --> Typed
+  Typed --> Gate
+  Gate --> GA4[GA4 property]
+  GA4 --> Reports[Standard reports and custom dimensions]
+```
+
+```mermaid
+sequenceDiagram
+  participant Browser
+  participant App
+  participant Checkout
+  participant GA4
+  Browser->>App: Load return URL
+  App->>GA4: Initialize with automatic pageview disabled
+  App->>Checkout: Parse checked-in plan and provider transaction ID
+  Checkout->>GA4: purchase or checkout_cancelled
+  App->>Browser: Remove recognized query state
+  App->>GA4: page_view with pathname only
+  App->>App: Subscribe to route history
+```
+
+### Assumptions
+
+- The user-authorized GA4 session permits additive changes to property 386405185; no destructive property changes are needed.
+- The property keeps Enhanced Measurement page-load tracking on and browser-history tracking off; application initialization disables the automatic page-load event for this tag.
+- `purchase` remains configured as a key event.
+- The production hostnames are `aosreminders.com` and `www.aosreminders.com`; other deployment or preview hosts are intentionally excluded.
+- Stripe Checkout substitutes its documented `{CHECKOUT_SESSION_ID}` return-URL template. Existing in-flight checkouts without that identifier may finish without a GA4 purchase event.
+
+### System-Wide Impact
+
+- **Bootstrap and routing:** Analytics sequencing moves into `App` so checkout parameters are removed before the initial pageview and route components no longer compete for ownership.
+- **Privacy:** The adapter sends only fixed categorical metadata and sanitized pathnames. It never accepts free-form roster, army, account, share, or query data.
+- **Payments:** GA4 receives client-side telemetry only. Stripe/PayPal and the subscription API continue to determine payment and entitlement state.
+- **AoS 4 boundary:** Home and the import UI report accepted canonical IDs or source enums outward; `src/aos4/` remains independent of application analytics.
+- **Operations:** Custom dimensions begin collecting only after creation and are not retroactive. The live hostname report is the rollout sentinel for renewed contamination.
+
+### Risks and Dependencies
+
+- **Client-side purchase spoofing or drop-off:** Return URLs can be forged and a successful customer may never return. Treat GA4 revenue as directional and defer authoritative server-side events to webhook modernization.
+- **Duplicate pageviews:** A future stream setting or second route listener could reintroduce duplication. Keep the single-owner decision documented and cover App startup/history behavior.
+- **High-cardinality or private parameters:** Generic payload APIs make accidental leaks easy. Typed wrappers, pathname-only pageviews, and focused payload tests mitigate this.
+- **Provider contract drift:** Stripe has deprecated the client-only `redirectToCheckout` surface in newer Stripe.js. Do not upgrade it in this issue; preserve the current pinned integration and track replacement separately.
+- **Non-retroactive definitions:** Custom dimensions cannot repair the existing 345-event history. Validate new traffic after rollout instead of rewriting history.
+
+### Sequencing
+
+U1 establishes the safe adapter and pageview owner. U2 and U3 migrate product and ecommerce call sites onto that contract. U4 makes the parameters reportable and records the operating model. U5 validates the complete change and prepares the migration PR.
+
+---
+
+## Implementation Units
+
+### U1. Establish the production-only analytics boundary
+
+- **Goal:** Replace import-time initialization and route-local pageviews with one testable collection boundary.
+- **Requirements:** R1-R4, R8, R9; F1; AE1, AE2
+- **Dependencies:** None
+- **Files:** `src/utils/analytics.ts`, `src/components/App.tsx`, `src/components/routes/Faq.tsx`, `src/components/routes/Join.tsx`, `src/components/routes/Profile.tsx`, `src/components/routes/Redeem.tsx`, `src/components/routes/Subscribe.tsx`, `src/tests/analytics.test.ts`
+- **Approach:**
+  1. Make module import inert and gate initialization on build mode plus an exact production-host allowlist.
+  2. Disable GA4's automatic pageview and expose sanitized pathname-only page tracking.
+  3. Initialize, process checkout returns, send the initial pageview, and install one history listener from App.
+  4. Remove route-local pageview effects.
+- **Execution note:** Start with adapter characterization tests for import side effects, host gating, and sanitized pageview payloads.
+- **Patterns to follow:** `src/utils/history.ts`; query sanitization in `src/utils/shareLink.ts`; focused jsdom utility tests under `src/tests/aos4/`.
+- **Test scenarios:**
+  1. Covers AE1. Importing the module and initializing on a test, development, localhost, or loopback context does not call `ReactGA.initialize`.
+  2. A production build on either accepted hostname initializes once with automatic pageviews disabled.
+  3. Covers AE2. Initial load and a subsequent history transition each emit one pageview.
+  4. A URL containing query and fragment data emits only origin plus pathname fields.
+  5. Repeated initialization does not register duplicate listeners or initialize GA twice.
+- **Verification:** Focused tests prove gating, initialization options, pageview payloads, and listener cleanup; route components contain no pageview side effects.
+
+### U2. Restore bounded product-usage events
+
+- **Goal:** Replace dynamic UA-shaped events and restore AoS 4 action coverage with stable GA4 names and safe parameters.
+- **Requirements:** R3-R5, R8, R9; F2; AE3
+- **Dependencies:** U1
+- **Files:** `src/utils/analytics.ts`, `src/components/routes/Home.tsx`, `src/components/input/importArmy/importArmyModal.tsx`, `src/context/useAppStatus.tsx`, `src/context/useTheme.tsx`, `src/components/info/banners/notification_banner.tsx`, `src/components/routes/Join.tsx`, `src/components/routes/Redeem.tsx`, `src/utils/hooks/useLogin.tsx`, `src/tests/analytics.test.ts`, `src/tests/aos4/importUi.test.tsx`
+- **Approach:**
+  1. Define typed helpers for the bounded taxonomy and keep generic interaction tracking on one event name.
+  2. Track faction choice, game-mode changes, successful PDF generation, and import success/failure using canonical IDs, source enums, and aggregate counts only; move game-mode ownership to Home and remove the stale context-side analytics call.
+  3. Migrate theme, banner, account, and login call sites away from arbitrary event-name construction.
+  4. Remove obsolete generic event and subscription helpers after every caller is migrated.
+- **Patterns to follow:** Canonical faction IDs in `src/components/routes/Home.tsx`; `Aos4ImportSource` in `src/aos4/import/types.ts`; existing UI tests in `src/tests/aos4/importUi.test.tsx`.
+- **Test scenarios:**
+  1. Covers AE3. Different faction values emit the same event name and differ only by `item_id` and bounded faction display metadata.
+  2. Edit and play transitions emit one stable event with the resulting mode.
+  3. Successful PDF generation emits a `file_download` with a synthetic file name, extension, layout, and page-size metadata but not the user's army/file name.
+  4. Successful imports emit source, success outcome, selection count, and diagnostic count without roster text or proposed army name.
+  5. Failed preview attempts emit source when known, error outcome, and diagnostic count without file name or input body.
+  6. Theme, banner, account, login, and interaction helpers never use their categorical value as the GA4 event name.
+- **Verification:** Repository search finds no legacy `logEvent`, `logSubscription`, or `logGiftedSubscription` call sites; focused tests assert stable names and allowlisted payloads.
+
+### U3. Emit valid subscription ecommerce telemetry
+
+- **Goal:** Restore checkout funnel and revenue reporting without making browser telemetry authoritative.
+- **Requirements:** R3, R4, R6, R8, R9; F3; AE4, AE5
+- **Dependencies:** U1
+- **Files:** `src/utils/analytics.ts`, `src/utils/handleQueryParams.ts`, `src/utils/plans.ts`, `src/components/payment/pricingPlans.tsx`, `src/components/payment/giftSubscriptions.tsx`, `src/components/payment/paypal/paypalButton.tsx`, `src/tests/handleQueryParams.test.ts`, `src/tests/analytics.test.ts`
+- **Approach:**
+  1. Map checked-in subscription and gift plans to standard ecommerce items and numeric USD values.
+  2. Emit `begin_checkout` before Stripe/PayPal handoff, extending the PayPal button callback boundary to expose the authenticated click, and emit a bounded cancellation event on callback.
+  3. Add the Stripe Checkout Session template to success URLs and use the PayPal subscription ID for purchase deduplication.
+  4. Validate return-query plan, quantity, and transaction identifier before emitting `purchase`, then sanitize the URL regardless of validity.
+- **Execution note:** Write return-query and ecommerce-payload tests before modifying checkout callbacks because these paths touch payment reporting.
+- **Patterns to follow:** Plan ownership in `src/utils/plans.ts`; query parsing and cleanup in `src/utils/handleQueryParams.ts`; provider callbacks in the current payment components.
+- **Test scenarios:**
+  1. A subscription checkout emits `begin_checkout` with one plan item and the plan's billed interval value.
+  2. A gift checkout multiplies unit value by a bounded positive quantity and preserves that quantity on the item.
+  3. Covers AE4. A recognized Stripe subscription return with a session ID emits one purchase whose transaction ID is that session ID.
+  4. A PayPal success uses the subscription ID as the purchase transaction ID and identifies PayPal as provider.
+  5. Covers AE5. Unknown plan, missing transaction ID, invalid quantity, or non-string query values do not emit purchase.
+  6. Subscription, gift, and cancellation return parameters are removed before the initial pageview.
+- **Verification:** Focused tests assert recommended event shapes, numeric totals, transaction IDs, invalid-return suppression, and URL cleanup.
+
+### U4. Configure and document reportable GA4 parameters
+
+- **Goal:** Make the new event parameters usable in GA4 and leave a durable reporting contract for future changes.
+- **Requirements:** R7, R8
+- **Dependencies:** U2, U3
+- **Files:** `docs/analytics.md`
+- **Approach:**
+  1. Add event-scoped custom dimensions only for non-standard parameters used by the taxonomy, including interaction, faction, mode, import, banner, theme, login-origin, account-action, and payment-provider context.
+  2. Preserve the existing `purchase` key event and legacy definitions; do not delete or rewrite historical data.
+  3. Document event names, parameters, privacy exclusions, pageview ownership, environment gating, GA4 property settings, validation reports, and client-side purchase limitations.
+- **Patterns to follow:** Operational documentation in `docs/printing.md`; official GA4 recommended-event and custom-definition contracts.
+- **Test scenarios:** Test expectation: none -- this unit is additive external configuration and documentation; U1-U3 test every emitted parameter contract.
+- **Verification:** The GA4 Admin custom-definitions table shows the new event-scoped dimensions, `purchase` remains a key event, browser-history Enhanced Measurement remains off, and `docs/analytics.md` matches the implemented taxonomy.
+
+### U5. Validate and ship the reporting fix
+
+- **Goal:** Prove the change preserves application behavior and prepare a reviewable migration sub-PR.
+- **Requirements:** R1-R9
+- **Dependencies:** U1-U4
+- **Files:** All files changed by U1-U4 and the PR description
+- **Approach:**
+  1. Run focused analytics/import/payment tests and the repository's full lint, type, unit, build, and AoS 4 beta gates.
+  2. Review the diff for correctness, privacy, payment-reporting risk, project standards, and unnecessary complexity.
+  3. Commit and push the feature branch, then open a PR targeting `aos4-migration` that links issue #1773 and includes post-deploy GA4 validation steps.
+- **Patterns to follow:** Migration branch and verification policy in the repository instructions; existing migration sub-PR conventions.
+- **Test scenarios:** Test expectation: none -- this unit verifies and packages behavior implemented and tested in U1-U3.
+- **Verification:** All required gates pass, review findings are resolved or documented, and the PR targets `aos4-migration` without deployment or merge.
+
+---
+
+## Verification Contract
+
+| Gate | Applies to | Done signal |
+|---|---|---|
+| Focused analytics and checkout tests | U1-U3 | Host, payload, taxonomy, pageview, import, and ecommerce scenarios pass |
+| `yarn lint` | U1-U5 | Zero lint warnings or errors |
+| `yarn tsc --noEmit` | U1-U5 | Strict TypeScript check passes |
+| `yarn test --run` | U1-U5 | Full Vitest suite passes |
+| `yarn build` | U1-U5 | Production bundle builds within the entry-chunk budget |
+| `yarn data:aos4:verify:beta` | U1-U5 | Accepted corpus certification remains valid |
+| GA4 Admin inspection | U4 | New custom dimensions exist, `purchase` remains a key event, and history-based pageview tracking remains off |
+| Diff and PR review | U5 | No P0/P1 correctness, privacy, reliability, testing, or project-standard finding remains |
+
+Post-deploy validation is operational, not part of this branch's authorization: Realtime/DebugView should show one sanitized pageview and stable event names from the production host, then the hostname report should stop accumulating development traffic.
+
+---
+
+## Definition of Done
+
+- R1-R9 are implemented without visible UI changes or AoS 4 domain dependencies.
+- U1-U3 test scenarios pass and no legacy UA-shaped analytics helper remains.
+- The GA4 property has the additive definitions needed by the implemented parameter contract.
+- `docs/analytics.md` documents collection ownership, taxonomy, privacy rules, ecommerce caveats, and validation.
+- Every Verification Contract gate available before deployment passes.
+- Abandoned experiments, unused helpers, duplicate pageview effects, and dead analytics code are removed from the diff.
+- The branch is committed, pushed, and represented by a migration sub-PR targeting `aos4-migration`; production remains untouched.
+
+---
+
+## Appendix
+
+### Sources and Research
+
+- Issue #1773: `https://github.com/daviseford/aos-reminders/issues/1773`
+- Current collection boundary: `src/utils/analytics.ts`
+- Current routing boundary: `src/components/App.tsx` and `src/utils/history.ts`
+- Current plan catalog and callbacks: `src/utils/plans.ts`, `src/components/payment/pricingPlans.tsx`, `src/components/payment/giftSubscriptions.tsx`
+- GA4 pageview measurement: `https://developers.google.com/analytics/devguides/collection/ga4/views`
+- GA4 recommended events: `https://developers.google.com/analytics/devguides/collection/ga4/reference/events`
+- GA4 event parameter guidance: `https://support.google.com/analytics/answer/13675006`
+- GA4 event collection limits: `https://support.google.com/analytics/answer/9267744`
+- GA4 custom-dimension limits: `https://support.google.com/analytics/answer/12229528`
+- Stripe Checkout success-page session identifier: `https://docs.stripe.com/payments/checkout/custom-success-page`
+
+### Live GA4 Evidence
+
+- Property `AoS Reminders - GA4`, stream ID `5494190629`, measurement ID `G-EM4GX294XG`.
+- In the last 28 days, the property showed 345 distinct event names, 3,610 events, and 392 users; top custom names included banner, mode, and selection values.
+- The July 29 hostname breakdown was dominated by `localhost`, with small amounts from `aosreminders.com`, another host, and `127.0.0.1`.
+- Enhanced Measurement had page loads enabled and browser-history changes disabled.
+- `purchase` was already marked as a key event, but monetization revenue was zero.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2,6 +2,7 @@ import { LoadingBody } from 'components/helpers/suspenseFallbacks'
 import ProtectedRoute from 'components/page/privateRoute'
 import { lazy, Suspense, useEffect } from 'react'
 import { Route, Router, Switch } from 'react-router-dom'
+import { initializeAnalytics, startPageViewTracking } from 'utils/analytics'
 import { ROUTES } from 'utils/env'
 import { handleStripeCheckout } from 'utils/handleQueryParams'
 import history from 'utils/history'
@@ -15,7 +16,9 @@ const Subscribe = lazy(() => import('components/routes/Subscribe'))
 
 const App = () => {
   useEffect(() => {
+    initializeAnalytics()
     handleStripeCheckout()
+    return startPageViewTracking(history)
   }, [])
 
   return (

--- a/src/components/info/banners/notification_banner.tsx
+++ b/src/components/info/banners/notification_banner.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { centerContentClass } from 'theme/helperClasses'
 import { TBootstrapTypes } from 'types/theme'
-import { logClick, logEvent } from 'utils/analytics'
+import { logBannerClose, logBannerView } from 'utils/analytics'
 
 const storageKey = (name: string) => `aos-reminders:aos4:banner:${name}`
 
@@ -43,13 +43,13 @@ export const NotificationBanner = ({
   const [isOn, setIsOn] = useState(() => !(persistClose && isDismissed(name)))
 
   useEffect(() => {
-    if (enableLog && isOn) logEvent(`Display-${name}`)
+    if (enableLog && isOn) logBannerView(name)
   }, [enableLog, isOn, name])
 
   const handleClose = () => {
     setIsOn(false)
     if (persistClose) rememberDismissal(name)
-    if (enableLog) logClick(`Close-${name}`)
+    if (enableLog) logBannerClose(name)
   }
 
   if (!isOn) return null

--- a/src/components/input/importArmy/importArmyModal.tsx
+++ b/src/components/input/importArmy/importArmyModal.tsx
@@ -7,13 +7,14 @@ import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID } from '../../../aos4/gener
 import type { Aos4ArmyDocument } from '../../../aos4/state'
 import GenericModal from 'components/modals/generic/generic_modal'
 import { useTheme } from 'context/useTheme'
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   createRosterFileTooLargeResult,
   decodeAos4RosterFile,
   decodeAos4TextRoster,
   MAX_ROSTER_FILE_BYTES,
 } from '../../../importers/aos4'
+import { logRosterImport } from 'utils/analytics'
 import { createAos4DocumentId } from 'utils/createAos4DocumentId'
 import { sendFailedImportReport } from './failedImportReport'
 import ImportPreview from './importPreview'
@@ -53,6 +54,7 @@ const ImportArmyModal = ({
   const [droppedFile, setDroppedFile] = useState<File>()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const filePreviewRequestRef = useRef(0)
+  const trackedErrorRef = useRef<Aos4ParsedRosterResult | undefined>(undefined)
 
   const preview = useMemo(() => {
     if (!decoded?.parsedRoster) return undefined
@@ -75,6 +77,17 @@ const ImportArmyModal = ({
   const hasErrors = diagnostics.some(diagnostic => diagnostic.severity === 'error')
   const canApply = Boolean(preview?.proposedDocument) && !hasErrors
   const canReport = Boolean(decoded && hasErrors && (mode === 'paste' ? text : droppedFile))
+
+  useEffect(() => {
+    if (!decoded || !hasErrors || trackedErrorRef.current === decoded) return
+    trackedErrorRef.current = decoded
+    logRosterImport({
+      diagnosticCount: diagnostics.length,
+      outcome: 'error',
+      selectionCount: decoded.parsedRoster?.selections.length ?? 0,
+      source: decoded.parsedRoster?.source ?? 'unknown',
+    })
+  }, [decoded, diagnostics.length, hasErrors])
 
   const chooseMode = (nextMode: ImportMode) => {
     filePreviewRequestRef.current += 1
@@ -136,6 +149,12 @@ const ImportArmyModal = ({
 
   const apply = () => {
     if (!canApply || !preview?.proposedDocument) return
+    logRosterImport({
+      diagnosticCount: diagnostics.length,
+      outcome: 'success',
+      selectionCount: decoded?.parsedRoster?.selections.length ?? 0,
+      source: decoded?.parsedRoster?.source ?? 'unknown',
+    })
     onApply(preview.proposedDocument)
   }
 

--- a/src/components/payment/giftSubscriptions.tsx
+++ b/src/components/payment/giftSubscriptions.tsx
@@ -11,15 +11,18 @@ import CopyToClipboard from 'react-copy-to-clipboard'
 import { FaCheck, FaGift, FaRegSmileBeam } from 'react-icons/fa'
 import { centerContentClass } from 'theme/helperClasses'
 import { IGiftSubscription } from 'types/subscription'
-import { logClick } from 'utils/analytics'
+import { logBeginCheckout, logClick } from 'utils/analytics'
 import { isDev, STRIPE_KEY } from 'utils/env'
 import useLogin from 'utils/hooks/useLogin'
 import useWindowSize from 'utils/hooks/useWindowSize'
-import { GiftedSubscriptionPlans, IGiftedSubscriptionPlans } from 'utils/plans'
+import {
+  GiftedSubscriptionPlans,
+  IGiftedSubscriptionPlans,
+  MAX_GIFT_QUANTITY,
+  toGiftSubscriptionAnalyticsItem,
+} from 'utils/plans'
 
 const COL_SIZE = 'col-12 col-sm-12 col-md-10 col-xl-8 col-xxl-6'
-const MAX_GIFT_QUANTITY = 99
-
 const GiftSubscriptionsComponent = () => {
   const stripe = useStripe()
   const { isActive } = useSubscription()
@@ -205,21 +208,29 @@ const PlanComponent = ({ supportPlan }: { supportPlan: IGiftedSubscriptionPlans 
     if (quantity < 1) return
 
     logClick(origin)
+    logBeginCheckout({
+      items: [toGiftSubscriptionAnalyticsItem(supportPlan, quantity)],
+      provider: 'stripe',
+    })
     const price = isDev ? supportPlan.stripe_dev : supportPlan.stripe_prod
     const url = isDev ? 'localhost:3000' : 'aosreminders.com'
+    const successQuery = qs.stringify({
+      gifted: true,
+      checkout_kind: 'gift_subscription',
+      quantity,
+      plan: supportPlan.title,
+    })
     const result = await stripe.redirectToCheckout({
       mode: 'payment',
       lineItems: [{ price, quantity }],
       customerEmail: user.email,
       clientReferenceId: user.email,
-      successUrl: `${window.location.protocol}//${url}/profile?${qs.stringify({
-        gifted: true,
-        quantity,
-        plan: supportPlan.title,
-      })}`,
+      successUrl: `${window.location.protocol}//${url}/profile?${successQuery}&checkout_session_id={CHECKOUT_SESSION_ID}`,
       cancelUrl: `${window.location.protocol}//${url}?${qs.stringify({
         canceled: true,
+        checkout_kind: 'gift_subscription',
         plan: supportPlan.title,
+        quantity,
       })}`,
     })
 

--- a/src/components/payment/paypal/paypalButton.tsx
+++ b/src/components/payment/paypal/paypalButton.tsx
@@ -37,6 +37,7 @@ declare global {
 interface IPayPalButtonProps {
   planId: string
   planTitle: string
+  onClick?: () => unknown
   onSuccess?: (data: IApprovalResponse) => unknown
   onCancel?: (data: unknown) => unknown
   style?: IStyle
@@ -67,15 +68,15 @@ const PaypalButton = (props: IPayPalButtonProps) => {
   const { user, isAuthenticated } = useAuth0()
   const { login } = useLogin({ origin: props.planTitle })
   const { paypalIsReady } = usePaypal()
-  const { onSuccess, onCancel, planId, style } = props
+  const { onClick, onSuccess, onCancel, planId, style } = props
 
   const containerRef = useRef<HTMLDivElement>(null)
-  const handlersRef = useRef({ onSuccess, onCancel, login })
+  const handlersRef = useRef({ onClick, onSuccess, onCancel, login })
   const email = user?.email
 
   // Keep the latest callbacks reachable without making them effect dependencies.
   useEffect(() => {
-    handlersRef.current = { onSuccess, onCancel, login }
+    handlersRef.current = { onClick, onSuccess, onCancel, login }
   })
 
   // Serialised so a fresh style object literal on every render does not re-mount the button.
@@ -101,7 +102,8 @@ const PaypalButton = (props: IPayPalButtonProps) => {
         : undefined,
       onApprove: (data: IApprovalResponse) => handlersRef.current.onSuccess?.(data),
       onCancel: (data: unknown) => handlersRef.current.onCancel?.(data),
-      onClick: isAuthenticated ? undefined : () => handlersRef.current.login(),
+      onClick: () =>
+        isAuthenticated ? handlersRef.current.onClick?.() : handlersRef.current.login(),
     })
 
     if (buttons.isEligible && !buttons.isEligible()) return

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -10,10 +10,19 @@ import { useTheme } from 'context/useTheme'
 import qs from 'qs'
 import React, { useState } from 'react'
 import { IconContext } from 'react-icons'
-import { logClick, logEvent, logSubscription } from 'utils/analytics'
+import {
+  logBeginCheckout,
+  logCheckoutCancelled,
+  logClick,
+  logPurchase,
+} from 'utils/analytics'
 import { isDev, STRIPE_KEY } from 'utils/env'
 import useLogin from 'utils/hooks/useLogin'
-import { ISubscriptionPlan, SubscriptionPlans } from 'utils/plans'
+import {
+  ISubscriptionPlan,
+  SubscriptionPlans,
+  toSubscriptionAnalyticsItem,
+} from 'utils/plans'
 import { SubscriptionApi } from '../../api/subscriptionApi'
 
 const PricingPlansComponent = () => {
@@ -87,19 +96,26 @@ export const PlanComponent = (props: IPlanProps) => {
     if (!user) return
 
     logClick(supportPlan.title)
+    logBeginCheckout({
+      items: [toSubscriptionAnalyticsItem(supportPlan)],
+      provider: 'stripe',
+    })
     const plan = isDev ? supportPlan.stripe_dev : supportPlan.stripe_prod
     const origin = window.location.origin
+    const successQuery = qs.stringify({
+      subscribed: true,
+      checkout_kind: 'subscription',
+      plan: supportPlan.title,
+    })
 
     const result = await stripe.redirectToCheckout({
       items: [{ plan, quantity: 1 }],
       customerEmail: user.email,
       clientReferenceId: user.email,
-      successUrl: `${origin}/?${qs.stringify({
-        subscribed: true,
-        plan: supportPlan.title,
-      })}`,
+      successUrl: `${origin}/?${successQuery}&checkout_session_id={CHECKOUT_SESSION_ID}`,
       cancelUrl: `${origin}/?${qs.stringify({
         canceled: true,
+        checkout_kind: 'subscription',
         plan: supportPlan.title,
       })}`,
     })
@@ -163,6 +179,7 @@ const PayPalComponent = (props: IPlanProps) => {
 
   const { paypal_dev, paypal_prod, title } = props.supportPlan
   const planId = isDev ? paypal_dev : paypal_prod
+  const analyticsItem = toSubscriptionAnalyticsItem(props.supportPlan)
 
   // The approval response is proof of payment — passing its subscriptionID
   // lets the API grant access even before PayPal's webhooks arrive. The modal
@@ -180,8 +197,11 @@ const PayPalComponent = (props: IPlanProps) => {
     setApproval(data)
     setModalIsOpen(true)
     props.setPaypalModalIsOpen(true)
-    logEvent(`Checkout-Subscribed-${title}`)
-    logSubscription(title, 'paypal')
+    logPurchase({
+      items: [analyticsItem],
+      provider: 'paypal',
+      transactionId: data.subscriptionID,
+    })
 
     try {
       await requestGrant(data)
@@ -199,7 +219,8 @@ const PayPalComponent = (props: IPlanProps) => {
     <div className="col mt-2">
       {!props.paypalModalIsOpen && (
         <PayPalButton
-          onCancel={() => logEvent(`Checkout-Canceled-${title}`)}
+          onClick={() => logBeginCheckout({ items: [analyticsItem], provider: 'paypal' })}
+          onCancel={() => logCheckoutCancelled({ items: [analyticsItem], provider: 'paypal' })}
           onSuccess={handleSuccess}
           planId={planId}
           planTitle={title}

--- a/src/components/routes/Faq.tsx
+++ b/src/components/routes/Faq.tsx
@@ -5,7 +5,6 @@ import Footer from 'components/page/footer'
 import { useTheme } from 'context/useTheme'
 import { lazy, Suspense, useEffect } from 'react'
 import { Link } from 'react-router-dom'
-import { logPageView } from 'utils/analytics'
 import { GITHUB_URL, ROUTES } from 'utils/env'
 
 const Navbar = lazy(() => import('components/page/navbar'))
@@ -307,7 +306,6 @@ const Faq = () => {
   const { theme } = useTheme()
 
   useEffect(() => {
-    logPageView()
     /*
      * Questions carry anchors now, so /faq#unsubscribe has to survive arrival. Scrolling to the top
      * unconditionally would land the reader back at the masthead every time.

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -18,6 +18,7 @@ import Footer from 'components/page/footer'
 import { Header } from 'components/page/homeHeader'
 import { ArmyCollectionProvider } from 'context/useArmyCollection'
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
+import { logFactionSelection, logGameModeChange, logPdfDownload } from 'utils/analytics'
 import { consumePendingShareId } from 'utils/shareLink'
 
 const ImportArmyModal = lazy(() => import('components/input/importArmy/importArmyModal'))
@@ -130,6 +131,7 @@ const HomeContent = () => {
     const preset = withPageSize(selectedPreset, pageSize)
     const plan = planPrintLayout(printDocument, preset, createJsPdfMeasurer())
     renderPrintPlanToPdf(plan, { title: printDocument.title }).save(`${fileName}.pdf`)
+    logPdfDownload(presetId, pageSize)
   }
 
   useEffect(() => {
@@ -162,6 +164,7 @@ const HomeContent = () => {
 
   const selectFaction = (nextFactionId: CanonicalId<'faction'>) => {
     const faction = factionById.get(nextFactionId)
+    logFactionSelection(nextFactionId, faction?.name ?? 'Unknown faction')
     setDocument(current =>
       createAos4ArmyDocument({
         ...current,
@@ -170,6 +173,12 @@ const HomeContent = () => {
         reminderPreferences: {},
       })
     )
+  }
+
+  const toggleGameMode = () => {
+    const nextMode = !isGameMode
+    setIsGameMode(nextMode)
+    logGameModeChange(nextMode)
   }
 
   const showAll = () => {
@@ -228,7 +237,7 @@ const HomeContent = () => {
         factions={factions}
         isGameMode={isGameMode}
         onFactionChange={selectFaction}
-        onToggleGameMode={() => setIsGameMode(current => !current)}
+        onToggleGameMode={toggleGameMode}
       />
 
       <AppBanner />

--- a/src/components/routes/Join.tsx
+++ b/src/components/routes/Join.tsx
@@ -6,7 +6,7 @@ import { RedemptionError, RedemptionLogin, RedemptionSuccess } from 'components/
 import { useSubscription } from 'context/useSubscription'
 import { useTheme } from 'context/useTheme'
 import React, { lazy, Suspense, useEffect, useState } from 'react'
-import { logEvent, logPageView } from 'utils/analytics'
+import { logAccountAction } from 'utils/analytics'
 import useLogin from 'utils/hooks/useLogin'
 import { SubscriptionApi } from '../../api/subscriptionApi'
 
@@ -23,10 +23,6 @@ const Join = () => {
   const { isLoading, user } = useAuth0()
   const { getSubscription, isActive } = useSubscription()
   const { theme, isDark, setLightTheme } = useTheme()
-
-  useEffect(() => {
-    logPageView()
-  }, [])
 
   useEffect(() => {
     void getSubscription()
@@ -95,7 +91,7 @@ const RedeemSection = () => {
       if (body.error) {
         setError(body.error)
       } else {
-        logEvent('Redeemed-Coupon')
+        logAccountAction('coupon_redeemed')
         setError('')
         setSuccess(true)
       }

--- a/src/components/routes/Profile.tsx
+++ b/src/components/routes/Profile.tsx
@@ -14,7 +14,7 @@ import { MdCheckCircle, MdNotInterested } from 'react-icons/md'
 import { Link } from 'react-router-dom'
 import Switch from 'react-switch'
 import { centerContentClass } from 'theme/helperClasses'
-import { logClick, logPageView } from 'utils/analytics'
+import { logClick } from 'utils/analytics'
 import { ROUTES } from 'utils/env'
 import { titleCase } from 'utils/textUtils'
 
@@ -24,10 +24,6 @@ const Profile = () => {
   const { isLoading, user } = useAuth0()
   const { getSubscription } = useSubscription()
   const { theme } = useTheme()
-
-  useEffect(() => {
-    logPageView()
-  }, [])
 
   useEffect(() => {
     void getSubscription()

--- a/src/components/routes/Redeem.tsx
+++ b/src/components/routes/Redeem.tsx
@@ -9,7 +9,7 @@ import { useTheme } from 'context/useTheme'
 import { isString } from 'lodash'
 import qs from 'qs'
 import React, { lazy, Suspense, useEffect, useState } from 'react'
-import { logEvent, logPageView } from 'utils/analytics'
+import { logAccountAction } from 'utils/analytics'
 import useLogin from 'utils/hooks/useLogin'
 import { RedemptionStorage } from 'utils/redemptionStorage'
 import { SubscriptionApi } from '../../api/subscriptionApi'
@@ -35,7 +35,6 @@ const Redeem = () => {
   const { theme, isDark, setLightTheme } = useTheme()
 
   useEffect(() => {
-    logPageView()
     cacheQueryRedemption()
   }, [])
 
@@ -135,7 +134,7 @@ const RedeemSection = () => {
         // Cleared only once the gift is actually spent. Clearing on failure too used to throw away
         // the one copy of the id whenever the link's query string was no longer in the address bar.
         RedemptionStorage.clear()
-        logEvent('Redeemed-Gift')
+        logAccountAction('gift_redeemed')
         setSuccess(true)
       } else {
         // A response that confirms nothing is a failure, not a silent no-op.

--- a/src/components/routes/Subscribe.tsx
+++ b/src/components/routes/Subscribe.tsx
@@ -6,7 +6,7 @@ import { PricingPlans } from 'components/payment/pricingPlans'
 import { useSubscription } from 'context/useSubscription'
 import { useTheme } from 'context/useTheme'
 import React, { lazy, Suspense, useEffect } from 'react'
-import { logClick, logPageView } from 'utils/analytics'
+import { logClick } from 'utils/analytics'
 import useWindowSize from 'utils/hooks/useWindowSize'
 
 const Navbar = lazy(() => import('components/page/navbar'))
@@ -25,7 +25,6 @@ const Subscribe = () => {
   const { theme } = useTheme()
 
   useEffect(() => {
-    logPageView()
     window.scrollTo(0, 0)
   }, [])
 

--- a/src/context/useAppStatus.tsx
+++ b/src/context/useAppStatus.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { logEvent } from 'utils/analytics'
 
 interface AppStatusValue {
   hasNewContent: boolean
@@ -17,10 +16,7 @@ const AppStatusProvider = ({ children }: React.PropsWithChildren<object>) => {
   const [hasNewContent, setHasNewContent] = useState(false)
 
   const toggleGameMode = useCallback(() => {
-    setIsGameMode(current => {
-      logEvent(`ToggleGameMode-${current ? 'Off' : 'On'}`)
-      return !current
-    })
+    setIsGameMode(current => !current)
   }, [])
 
   useEffect(() => {

--- a/src/context/useTheme.tsx
+++ b/src/context/useTheme.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import DarkTheme from 'theme/dark'
 import LightTheme from 'theme/light'
 import { ITheme, TThemeType } from 'types/theme'
-import { logEvent } from 'utils/analytics'
+import { logThemeChange } from 'utils/analytics'
 import { SubscriptionApi } from '../api/subscriptionApi'
 
 const LOCAL_THEME_KEY = 'theme'
@@ -46,7 +46,7 @@ const ThemeProvider = ({ children }: React.PropsWithChildren<object>) => {
         console.error('Unable to save subscriber theme', error)
       })
     }
-    logEvent(`SetTheme-${theme}`)
+    logThemeChange(theme)
     return isDark ? setLightTheme() : setDarkTheme()
   }, [isActive, isDark, setDarkTheme, setLightTheme, subscription])
 

--- a/src/tests/analytics.test.ts
+++ b/src/tests/analytics.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ga = vi.hoisted(() => ({
+  event: vi.fn(),
+  initialize: vi.fn(),
+  send: vi.fn(),
+}))
+
+vi.mock('react-ga4', () => ({ default: ga }))
+
+const loadAnalytics = async () => {
+  vi.resetModules()
+  return import('utils/analytics')
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('analytics collection boundary', () => {
+  it('is inert on import and rejects non-production hosts', async () => {
+    const analytics = await loadAnalytics()
+    const history = {
+      location: { pathname: '/' },
+      listen: vi.fn(() => vi.fn()),
+    }
+
+    expect(ga.initialize).not.toHaveBeenCalled()
+    expect(analytics.canCollectAnalytics({ hostname: 'aosreminders.com', isProduction: false })).toBe(false)
+    expect(analytics.canCollectAnalytics({ hostname: 'localhost', isProduction: true })).toBe(false)
+    expect(analytics.canCollectAnalytics({ hostname: '127.0.0.1', isProduction: true })).toBe(false)
+    expect(analytics.canCollectAnalytics({ hostname: 'preview.aosreminders.com', isProduction: true })).toBe(
+      false
+    )
+    expect(analytics.startPageViewTracking(history)).toEqual(expect.any(Function))
+    expect(history.listen).not.toHaveBeenCalled()
+  })
+
+  it.each(['aosreminders.com', 'www.aosreminders.com'])(
+    'initializes once on the production hostname %s with automatic pageviews disabled',
+    async hostname => {
+      const analytics = await loadAnalytics()
+
+      expect(analytics.initializeAnalytics({ hostname, isProduction: true })).toBe(true)
+      expect(analytics.initializeAnalytics({ hostname, isProduction: true })).toBe(false)
+      expect(ga.initialize).toHaveBeenCalledTimes(1)
+      expect(ga.initialize).toHaveBeenCalledWith('G-EM4GX294XG', {
+        gaOptions: { siteSpeedSampleRate: 100 },
+        gtagOptions: { send_page_view: false },
+      })
+    }
+  )
+
+  it('tracks the initial path and subsequent history paths without query or fragment data', async () => {
+    const analytics = await loadAnalytics()
+    analytics.initializeAnalytics({ hostname: 'aosreminders.com', isProduction: true })
+
+    let listener: ((location: { pathname: string }) => void) | undefined
+    const unlisten = vi.fn()
+    const history = {
+      location: { pathname: '/faq', search: '?army=secret', hash: '#private' },
+      listen: vi.fn((nextListener: (location: { pathname: string }) => void) => {
+        listener = nextListener
+        return unlisten
+      }),
+    }
+
+    expect(analytics.startPageViewTracking(history)).toBe(unlisten)
+    listener?.({ pathname: '/subscribe' })
+
+    expect(ga.send).toHaveBeenNthCalledWith(1, {
+      hitType: 'pageview',
+      location: 'http://localhost:3000/faq',
+      page: '/faq',
+      title: document.title,
+    })
+    expect(ga.send).toHaveBeenNthCalledWith(2, {
+      hitType: 'pageview',
+      location: 'http://localhost:3000/subscribe',
+      page: '/subscribe',
+      title: document.title,
+    })
+    expect(JSON.stringify(ga.send.mock.calls)).not.toContain('secret')
+    expect(history.listen).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('analytics event taxonomy', () => {
+  it('uses stable event names and bounded parameters for product actions', async () => {
+    const analytics = await loadAnalytics()
+    analytics.initializeAnalytics({ hostname: 'aosreminders.com', isProduction: true })
+
+    analytics.logFactionSelection('faction:stormcast-eternals', 'Stormcast Eternals')
+    analytics.logFactionSelection('faction:skaven', 'Skaven')
+    analytics.logGameModeChange(true)
+    analytics.logPdfDownload('compact', 'a4')
+    analytics.logRosterImport({
+      diagnosticCount: 2,
+      outcome: 'success',
+      selectionCount: 12,
+      source: 'official-app-text',
+    })
+
+    expect(ga.event.mock.calls.map(([name]) => name)).toEqual([
+      'select_content',
+      'select_content',
+      'game_mode_change',
+      'file_download',
+      'roster_import',
+    ])
+    expect(ga.event).toHaveBeenNthCalledWith(1, 'select_content', {
+      content_type: 'faction',
+      faction_name: 'Stormcast Eternals',
+      item_id: 'faction:stormcast-eternals',
+    })
+    expect(ga.event).toHaveBeenCalledWith('file_download', {
+      file_extension: 'pdf',
+      file_name: 'reminders-compact-a4.pdf',
+      print_layout: 'compact',
+      print_page_size: 'a4',
+    })
+    expect(JSON.stringify(ga.event.mock.calls)).not.toContain('army=')
+  })
+
+  it('emits valid ecommerce events with numeric totals and a provider transaction id', async () => {
+    const analytics = await loadAnalytics()
+    analytics.initializeAnalytics({ hostname: 'aosreminders.com', isProduction: true })
+    const item = {
+      item_category: 'gift_subscription',
+      item_id: 'gift-subscription-3-months',
+      item_name: '3 Months',
+      price: 2.67,
+      quantity: 3,
+    } as const
+
+    analytics.logBeginCheckout({ items: [item], provider: 'stripe' })
+    analytics.logPurchase({
+      items: [item],
+      provider: 'stripe',
+      transactionId: 'cs_live_123',
+    })
+
+    expect(ga.event).toHaveBeenNthCalledWith(1, 'begin_checkout', {
+      currency: 'USD',
+      items: [item],
+      payment_provider: 'stripe',
+      value: 8.01,
+    })
+    expect(ga.event).toHaveBeenNthCalledWith(2, 'purchase', {
+      currency: 'USD',
+      items: [item],
+      payment_provider: 'stripe',
+      transaction_id: 'cs_live_123',
+      value: 8.01,
+    })
+  })
+})

--- a/src/tests/aos4/giftSubscriptions.test.tsx
+++ b/src/tests/aos4/giftSubscriptions.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+// @vitest-environment-options {"url":"https://preview.example.test/profile"}
+
+import { GiftSubscriptions } from 'components/payment/giftSubscriptions'
+import { act } from 'react'
+import { render, Simulate, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
+import { GiftedSubscriptionPlans } from 'utils/plans'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const stripe = vi.hoisted(() => ({
+  redirectToCheckout: vi.fn(),
+}))
+
+const analytics = vi.hoisted(() => ({
+  logBeginCheckout: vi.fn(),
+  logClick: vi.fn(),
+}))
+
+vi.mock('utils/analytics', () => analytics)
+
+vi.mock('@auth0/auth0-react', () => ({
+  useAuth0: () => ({
+    isAuthenticated: true,
+    user: { email: 'gifter@example.com' },
+  }),
+}))
+
+vi.mock('@stripe/react-stripe-js', () => ({
+  Elements: ({ children }: React.PropsWithChildren<object>) => children,
+  useStripe: () => stripe,
+}))
+
+vi.mock('@stripe/stripe-js', () => ({
+  loadStripe: vi.fn(() => Promise.resolve(null)),
+}))
+
+vi.mock('context/useSubscription', () => ({
+  useSubscription: () => ({
+    isActive: true,
+    subscription: { giftSubscriptions: [] },
+  }),
+}))
+
+vi.mock('context/useTheme', () => ({
+  useTheme: () => ({
+    isDark: false,
+    theme: {
+      genericButtonBlock: '',
+      text: '',
+    },
+  }),
+}))
+
+vi.mock('utils/hooks/useLogin', () => ({
+  default: () => ({ login: vi.fn() }),
+}))
+
+vi.mock('utils/hooks/useWindowSize', () => ({
+  default: () => ({ isMobile: false }),
+}))
+
+describe('gift subscription checkout', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stripe.redirectToCheckout.mockResolvedValue({})
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  it('reports the selected quantity and keeps it in Stripe return URLs', async () => {
+    await act(async () => {
+      render(<GiftSubscriptions />, container)
+    })
+
+    const quantity = container.querySelector<HTMLInputElement>(
+      'input[aria-label="Quantity of 1 Month gifts"]'
+    )
+    const purchase = container.querySelector<HTMLButtonElement>('tbody button')
+    expect(quantity).not.toBeNull()
+    expect(purchase).not.toBeNull()
+
+    await act(async () => {
+      quantity!.value = '3'
+      Simulate.change(quantity!)
+    })
+    await act(async () => {
+      purchase!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(analytics.logBeginCheckout).toHaveBeenCalledWith({
+      items: [
+        {
+          item_category: 'gift_subscription',
+          item_id: 'gift-subscription-1-month',
+          item_name: '1 Month',
+          price: 0.99,
+          quantity: 3,
+        },
+      ],
+      provider: 'stripe',
+    })
+    expect(stripe.redirectToCheckout).toHaveBeenCalledWith({
+      cancelUrl:
+        'https://aosreminders.com?canceled=true&checkout_kind=gift_subscription&plan=1%20Month&quantity=3',
+      clientReferenceId: 'gifter@example.com',
+      customerEmail: 'gifter@example.com',
+      lineItems: [{ price: GiftedSubscriptionPlans[0].stripe_prod, quantity: 3 }],
+      mode: 'payment',
+      successUrl:
+        'https://aosreminders.com/profile?gifted=true&checkout_kind=gift_subscription&quantity=3&plan=1%20Month&checkout_session_id={CHECKOUT_SESSION_ID}',
+    })
+  })
+})

--- a/src/tests/aos4/importUi.test.tsx
+++ b/src/tests/aos4/importUi.test.tsx
@@ -11,6 +11,7 @@ import { Simulate } from 'tests/support/reactTestHelpers'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const logRosterImport = vi.hoisted(() => vi.fn())
 const auth = vi.hoisted(() => ({
   isAuthenticated: false,
   isLoading: false,
@@ -20,6 +21,8 @@ const subscription = vi.hoisted(() => ({
   subscriptionLoading: false,
 }))
 const login = vi.hoisted(() => vi.fn())
+
+vi.mock('utils/analytics', () => ({ logRosterImport }))
 
 vi.mock('@auth0/auth0-react', () => ({
   useAuth0: () => auth,
@@ -239,6 +242,7 @@ describe('AoS 4 import modal', () => {
   beforeEach(() => {
     onApply = vi.fn()
     closeModal = vi.fn()
+    logRosterImport.mockReset()
     container = document.createElement('div')
     document.body.appendChild(container)
     act(() => {
@@ -275,6 +279,12 @@ describe('AoS 4 import modal', () => {
       reminderPreferences: {},
     })
     expect(onApply.mock.calls[0][0].explicitSelectionIds.length).toBeGreaterThan(1)
+    expect(logRosterImport).toHaveBeenCalledWith({
+      diagnosticCount: 0,
+      outcome: 'success',
+      selectionCount: 3,
+      source: 'official-app-text',
+    })
   })
 
   it('opens a reproducible GitHub report and downloads the exact failed pasted roster', async () => {
@@ -296,6 +306,12 @@ describe('AoS 4 import modal', () => {
     pasteAndPreview(pastedRoster)
 
     expect(container.textContent).toContain('GitHub issues are public')
+    expect(logRosterImport).toHaveBeenCalledWith({
+      diagnosticCount: expect.any(Number),
+      outcome: 'error',
+      selectionCount: 3,
+      source: 'official-app-text',
+    })
     const report = findButton(container, 'Send to devs')
     act(() => {
       Simulate.click(report)

--- a/src/tests/aos4/pricingPlans.test.tsx
+++ b/src/tests/aos4/pricingPlans.test.tsx
@@ -2,14 +2,35 @@
 // @vitest-environment-options {"url":"https://preview.example.test/subscribe"}
 
 import { PlanComponent } from 'components/payment/pricingPlans'
+import type { IApprovalResponse } from 'components/payment/paypal/paypalTypes'
 import { render, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
 import { act } from 'react'
 import { SUBSCRIPTION_PLANS } from 'utils/plans'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SubscriptionApi } from '../../api/subscriptionApi'
+
+interface PaypalButtonCallbacks {
+  onCancel: () => void
+  onClick: () => void
+  onSuccess: (data: IApprovalResponse) => Promise<void>
+}
 
 const stripe = vi.hoisted(() => ({
   redirectToCheckout: vi.fn(),
 }))
+
+const paypal = vi.hoisted(() => ({
+  callbacks: null as PaypalButtonCallbacks | null,
+}))
+
+const analytics = vi.hoisted(() => ({
+  logBeginCheckout: vi.fn(),
+  logCheckoutCancelled: vi.fn(),
+  logClick: vi.fn(),
+  logPurchase: vi.fn(),
+}))
+
+vi.mock('utils/analytics', () => analytics)
 
 vi.mock('@auth0/auth0-react', () => ({
   useAuth0: () => ({
@@ -28,7 +49,14 @@ vi.mock('@stripe/stripe-js', () => ({
 }))
 
 vi.mock('components/payment/paypal/paypalButton', () => ({
-  default: () => <div>PayPal</div>,
+  default: (callbacks: PaypalButtonCallbacks) => {
+    paypal.callbacks = callbacks
+    return <div>PayPal</div>
+  },
+}))
+
+vi.mock('components/modals/paypal_post_subscribe_modal', () => ({
+  PaypalPostSubscribeModal: () => null,
 }))
 
 vi.mock('context/useTheme', () => ({
@@ -46,6 +74,8 @@ describe('subscription pricing plans', () => {
 
   beforeEach(() => {
     stripe.redirectToCheckout.mockReset()
+    paypal.callbacks = null
+    vi.clearAllMocks()
     container = document.createElement('div')
     document.body.appendChild(container)
   })
@@ -89,14 +119,77 @@ describe('subscription pricing plans', () => {
     expect(stripe.redirectToCheckout).toHaveBeenCalledTimes(1)
     expect(stripe.redirectToCheckout).toHaveBeenCalledWith(
       expect.objectContaining({
-        cancelUrl: 'https://preview.example.test/?canceled=true&plan=1%20Month',
+        cancelUrl: 'https://preview.example.test/?canceled=true&checkout_kind=subscription&plan=1%20Month',
         clientReferenceId: 'general@example.com',
         customerEmail: 'general@example.com',
         items: [{ plan: SUBSCRIPTION_PLANS[0].stripe_prod, quantity: 1 }],
-        successUrl: 'https://preview.example.test/?subscribed=true&plan=1%20Month',
+        successUrl:
+          'https://preview.example.test/?subscribed=true&checkout_kind=subscription&plan=1%20Month&checkout_session_id={CHECKOUT_SESSION_ID}',
       })
     )
+    expect(analytics.logBeginCheckout).toHaveBeenCalledWith({
+      items: [
+        {
+          item_category: 'subscription',
+          item_id: 'subscription-1-month',
+          item_name: '1 Month',
+          price: 1.99,
+          quantity: 1,
+        },
+      ],
+      provider: 'stripe',
+    })
     expect(container.querySelector('button')?.textContent).toBe('Subscribe for 1 Month')
     expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('reports the PayPal checkout lifecycle with the same stable commerce item', async () => {
+    vi.spyOn(SubscriptionApi, 'requestGrant').mockImplementation(() => Promise.resolve() as never)
+
+    await act(async () => {
+      render(
+        <PlanComponent
+          supportPlan={SUBSCRIPTION_PLANS[0]}
+          paypalModalIsOpen={false}
+          setPaypalModalIsOpen={vi.fn()}
+        />,
+        container
+      )
+    })
+
+    expect(paypal.callbacks).not.toBeNull()
+    paypal.callbacks!.onClick()
+    paypal.callbacks!.onCancel()
+
+    await act(async () => {
+      await paypal.callbacks!.onSuccess({
+        billingToken: null,
+        facilitatorAccessToken: 'access-token',
+        orderID: 'order-id',
+        paymentID: null,
+        subscriptionID: 'subscription-id',
+      })
+    })
+
+    const expectedItem = {
+      item_category: 'subscription',
+      item_id: 'subscription-1-month',
+      item_name: '1 Month',
+      price: 1.99,
+      quantity: 1,
+    }
+    expect(analytics.logBeginCheckout).toHaveBeenCalledWith({
+      items: [expectedItem],
+      provider: 'paypal',
+    })
+    expect(analytics.logCheckoutCancelled).toHaveBeenCalledWith({
+      items: [expectedItem],
+      provider: 'paypal',
+    })
+    expect(analytics.logPurchase).toHaveBeenCalledWith({
+      items: [expectedItem],
+      provider: 'paypal',
+      transactionId: 'subscription-id',
+    })
   })
 })

--- a/src/tests/handleQueryParams.test.ts
+++ b/src/tests/handleQueryParams.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { handleStripeCheckout } from 'utils/handleQueryParams'
+
+const analytics = vi.hoisted(() => ({
+  logCheckoutCancelled: vi.fn(),
+  logPurchase: vi.fn(),
+}))
+
+vi.mock('utils/analytics', () => analytics)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  window.history.replaceState({}, '', '/')
+})
+
+describe('Stripe checkout return handling', () => {
+  it('logs a recognized subscription purchase and preserves unrelated URL state', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/?subscribed=true&checkout_kind=subscription&plan=1%20Month&checkout_session_id=cs_live_123&campaign=summer#top'
+    )
+
+    handleStripeCheckout()
+
+    expect(analytics.logPurchase).toHaveBeenCalledWith({
+      items: [
+        {
+          item_category: 'subscription',
+          item_id: 'subscription-1-month',
+          item_name: '1 Month',
+          price: 1.99,
+          quantity: 1,
+        },
+      ],
+      provider: 'stripe',
+      transactionId: 'cs_live_123',
+    })
+    expect(window.location.pathname + window.location.search + window.location.hash).toBe(
+      '/?campaign=summer#top'
+    )
+  })
+
+  it('logs a recognized gift purchase with a bounded numeric quantity', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/profile?gifted=true&checkout_kind=gift_subscription&plan=3%20Months&quantity=3&checkout_session_id=cs_live_gift'
+    )
+
+    handleStripeCheckout()
+
+    expect(analytics.logPurchase).toHaveBeenCalledWith({
+      items: [
+        {
+          item_category: 'gift_subscription',
+          item_id: 'gift-subscription-3-months',
+          item_name: '3 Months',
+          price: 2.67,
+          quantity: 3,
+        },
+      ],
+      provider: 'stripe',
+      transactionId: 'cs_live_gift',
+    })
+    expect(window.location.pathname + window.location.search).toBe('/profile')
+  })
+
+  it.each([
+    '?subscribed=true&checkout_kind=subscription&plan=Unknown&checkout_session_id=cs_live_bad',
+    '?subscribed=true&checkout_kind=subscription&plan=1%20Month',
+    '?gifted=true&checkout_kind=gift_subscription&plan=1%20Month&quantity=0&checkout_session_id=cs_live_bad',
+    '?gifted=true&checkout_kind=gift_subscription&plan=1%20Month&quantity=100&checkout_session_id=cs_live_bad',
+    '?subscribed=true&canceled=true&checkout_kind=subscription&plan=1%20Month&checkout_session_id=cs_live_bad',
+  ])('does not log forged or incomplete purchase state: %s', search => {
+    window.history.replaceState({}, '', `/${search}`)
+
+    handleStripeCheckout()
+
+    expect(analytics.logPurchase).not.toHaveBeenCalled()
+    expect(analytics.logCheckoutCancelled).not.toHaveBeenCalled()
+    expect(window.location.pathname + window.location.search).toBe('/')
+  })
+
+  it('logs a bounded cancellation event for a recognized plan', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/?canceled=true&checkout_kind=gift_subscription&plan=1%20Year&quantity=3'
+    )
+
+    handleStripeCheckout()
+
+    expect(analytics.logCheckoutCancelled).toHaveBeenCalledWith({
+      items: [
+        {
+          item_category: 'gift_subscription',
+          item_id: 'gift-subscription-1-year',
+          item_name: '1 Year',
+          price: 9.49,
+          quantity: 3,
+        },
+      ],
+      provider: 'stripe',
+    })
+    expect(window.location.pathname + window.location.search).toBe('/')
+  })
+})

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,50 +1,183 @@
 import ReactGA from 'react-ga4'
+import type { Aos4ImportSource } from '../aos4/import'
+import type { PrintPageSize } from '../aos4/print/presets'
+import type { PrintPreset } from '../aos4/print/types'
 
-const isDevelopment = import.meta.env.DEV
-const isProduction = import.meta.env.PROD
+const MEASUREMENT_ID = 'G-EM4GX294XG'
+const PRODUCTION_HOSTS = new Set(['aosreminders.com', 'www.aosreminders.com'])
 const isTest = import.meta.env.MODE === 'test'
 
-if (!isTest) {
-  ReactGA.initialize('G-EM4GX294XG', {
+let initialized = false
+
+export interface AnalyticsEnvironment {
+  hostname: string
+  isProduction: boolean
+}
+
+interface PageLocation {
+  pathname: string
+}
+
+interface PageViewHistory {
+  location: PageLocation
+  listen: (listener: (location: PageLocation) => void) => () => void
+}
+
+export interface AnalyticsCommerceItem {
+  item_category: 'subscription' | 'gift_subscription'
+  item_id: string
+  item_name: string
+  price: number
+  quantity: number
+}
+
+interface CheckoutEvent {
+  items: AnalyticsCommerceItem[]
+  provider: 'paypal' | 'stripe'
+}
+
+interface PurchaseEvent extends CheckoutEvent {
+  transactionId: string
+}
+
+type AnalyticsParameters = Record<string, unknown>
+
+const currentEnvironment = (): AnalyticsEnvironment => ({
+  hostname: typeof window === 'undefined' ? '' : window.location.hostname,
+  isProduction: import.meta.env.PROD,
+})
+
+export const canCollectAnalytics = ({ hostname, isProduction }: AnalyticsEnvironment): boolean =>
+  isProduction && PRODUCTION_HOSTS.has(hostname.toLowerCase())
+
+export const initializeAnalytics = (environment = currentEnvironment()): boolean => {
+  if (initialized || !canCollectAnalytics(environment)) return false
+
+  ReactGA.initialize(MEASUREMENT_ID, {
     gaOptions: { siteSpeedSampleRate: 100 },
+    gtagOptions: { send_page_view: false },
+  })
+  initialized = true
+  return true
+}
+
+const logToGA = (name: string, parameters: AnalyticsParameters = {}): void => {
+  if (!isTest && import.meta.env.DEV) console.debug('GA4 Event:', name, parameters)
+  if (initialized) ReactGA.event(name, parameters)
+}
+
+const sanitizedPath = (pathname: string): string => (pathname.startsWith('/') ? pathname : '/')
+
+export const logPageView = ({ pathname }: PageLocation): void => {
+  if (!initialized || typeof window === 'undefined' || typeof document === 'undefined') return
+  const page = sanitizedPath(pathname)
+  ReactGA.send({
+    hitType: 'pageview',
+    location: `${window.location.origin}${page}`,
+    page,
+    title: document.title,
   })
 }
 
-const logToGA = (payload: { action: string; category: string; label: string }) => {
-  if (isDevelopment) {
-    console.log('GA Event: ', payload)
-  } else if (isProduction) {
-    ReactGA.event(payload)
-  }
+export const startPageViewTracking = (routerHistory: PageViewHistory): (() => void) => {
+  if (!initialized) return () => undefined
+  logPageView(routerHistory.location)
+  return routerHistory.listen(location => logPageView(location))
 }
 
-export const logClick = (label: string): void => {
-  if (!label) return
-  logToGA({
-    category: 'Click',
-    action: `Click-${label}`,
-    label: 'AoS Reminders',
+export const logClick = (interactionName: string): void => {
+  logToGA('ui_interaction', { interaction_name: interactionName })
+}
+
+export const logThemeChange = (themeName: string): void => {
+  logToGA('theme_change', { theme_name: themeName })
+}
+
+export const logBannerView = (bannerName: string): void => {
+  logToGA('banner_view', { banner_name: bannerName })
+}
+
+export const logBannerClose = (bannerName: string): void => {
+  logToGA('banner_close', { banner_name: bannerName })
+}
+
+export const logGameModeChange = (isGameMode: boolean): void => {
+  logToGA('game_mode_change', { game_mode: isGameMode ? 'play' : 'edit' })
+}
+
+export const logFactionSelection = (factionId: string, factionName: string): void => {
+  logToGA('select_content', {
+    content_type: 'faction',
+    faction_name: factionName,
+    item_id: factionId,
   })
 }
 
-export const logEvent = (event: string): void => {
-  if (!event) return
-  logToGA({
-    category: 'Event',
-    action: `Event-${event}`,
-    label: 'AoS Reminders',
+export const logPdfDownload = (layout: PrintPreset['id'], pageSize: PrintPageSize): void => {
+  logToGA('file_download', {
+    file_extension: 'pdf',
+    file_name: `reminders-${layout}-${pageSize}.pdf`,
+    print_layout: layout,
+    print_page_size: pageSize,
   })
 }
 
-export const logPageView = (): void => {
-  if (!isProduction) return
-  ReactGA.send({ hitType: 'pageview', page: window.location.pathname + window.location.search })
+export const logRosterImport = ({
+  diagnosticCount,
+  outcome,
+  selectionCount,
+  source,
+}: {
+  diagnosticCount: number
+  outcome: 'error' | 'success'
+  selectionCount: number
+  source: Aos4ImportSource | 'unknown'
+}): void => {
+  logToGA('roster_import', {
+    diagnostic_count: diagnosticCount,
+    import_outcome: outcome,
+    roster_source: source,
+    selection_count: selectionCount,
+  })
 }
 
-export const logSubscription = (plan: string, provider: 'paypal' | 'stripe'): void => {
-  logEvent(`Subscription-${provider}-${plan}`)
+export const logAccountAction = (
+  accountAction: 'coupon_redeemed' | 'gift_redeemed' | 'subscription_cancelled'
+): void => {
+  logToGA('account_action', { account_action: accountAction })
 }
 
-export const logGiftedSubscription = (plan: string, quantity: string): void => {
-  logEvent(`Gifted-Subscription-${plan}-x-${quantity}`)
+export const logLoginAttempt = (loginOrigin: string, outcome: 'closed' | 'started'): void => {
+  logToGA(outcome === 'started' ? 'login_start' : 'login_closed', { login_origin: loginOrigin })
 }
+
+export const logBeginCheckout = ({ items, provider }: CheckoutEvent): void => {
+  logToGA('begin_checkout', {
+    currency: 'USD',
+    items,
+    payment_provider: provider,
+    value: commerceValue(items),
+  })
+}
+
+export const logPurchase = ({ items, provider, transactionId }: PurchaseEvent): void => {
+  if (!transactionId.trim()) return
+  logToGA('purchase', {
+    currency: 'USD',
+    items,
+    payment_provider: provider,
+    transaction_id: transactionId,
+    value: commerceValue(items),
+  })
+}
+
+export const logCheckoutCancelled = ({ items, provider }: CheckoutEvent): void => {
+  logToGA('checkout_cancelled', {
+    items,
+    payment_provider: provider,
+    value: commerceValue(items),
+  })
+}
+
+const commerceValue = (items: AnalyticsCommerceItem[]): number =>
+  Number(items.reduce((total, item) => total + item.price * item.quantity, 0).toFixed(2))

--- a/src/utils/handleQueryParams.ts
+++ b/src/utils/handleQueryParams.ts
@@ -1,29 +1,88 @@
-import { isString } from 'lodash'
-import qs from 'qs'
-import { logEvent, logGiftedSubscription, logSubscription } from 'utils/analytics'
+import { logCheckoutCancelled, logPurchase } from 'utils/analytics'
+import {
+  findGiftedSubscriptionPlan,
+  findSubscriptionPlan,
+  MAX_GIFT_QUANTITY,
+  toGiftSubscriptionAnalyticsItem,
+  toSubscriptionAnalyticsItem,
+} from 'utils/plans'
+
+const checkoutKeys = [
+  'subscribed',
+  'canceled',
+  'gifted',
+  'checkout_kind',
+  'plan',
+  'quantity',
+  'checkout_session_id',
+] as const
+
+const cleanCheckoutState = (url: URL): void => {
+  checkoutKeys.forEach(key => url.searchParams.delete(key))
+  window.history.replaceState({}, document.title, `${url.pathname}${url.search}${url.hash}`)
+}
 
 export const handleStripeCheckout = () => {
-  const {
-    subscribed = false,
-    canceled = false,
-    plan = '',
-    gifted = false,
-    quantity = '',
-  } = qs.parse(window.location.search, {
-    ignoreQueryPrefix: true,
-  })
+  const url = new URL(window.location.href)
+  const { searchParams } = url
+  const hasCheckoutState = ['subscribed', 'canceled', 'gifted'].some(key => searchParams.has(key))
+  if (!hasCheckoutState) return
 
-  if (subscribed && isString(plan)) {
-    logEvent(`Checkout-Subscribed-${plan}`)
-    logSubscription(plan, 'stripe')
+  const subscribed = searchParams.get('subscribed') === 'true'
+  const canceled = searchParams.get('canceled') === 'true'
+  const gifted = searchParams.get('gifted') === 'true'
+  if (Number(subscribed) + Number(canceled) + Number(gifted) !== 1) {
+    cleanCheckoutState(url)
+    return
   }
-  if (gifted && isString(plan) && isString(quantity)) {
-    logEvent(`Checkout-Gifted-Subscription-${plan}-x-${quantity}`)
-    logGiftedSubscription(plan, quantity)
-  }
-  if (canceled) logEvent(`Checkout-Canceled-${plan}`)
 
-  if (subscribed || canceled || gifted) {
-    window.history.replaceState({}, document.title, window.location.pathname)
+  const planTitle = searchParams.get('plan') ?? ''
+  const transactionId = searchParams.get('checkout_session_id')?.trim() ?? ''
+  const checkoutKind = searchParams.get('checkout_kind')
+
+  if (subscribed && checkoutKind === 'subscription' && transactionId) {
+    const plan = findSubscriptionPlan(planTitle)
+    if (plan) {
+      logPurchase({
+        items: [toSubscriptionAnalyticsItem(plan)],
+        provider: 'stripe',
+        transactionId,
+      })
+    }
   }
+
+  const quantity = Number(searchParams.get('quantity'))
+  const validGiftQuantity = Number.isInteger(quantity) && quantity >= 1 && quantity <= MAX_GIFT_QUANTITY
+  if (gifted && checkoutKind === 'gift_subscription' && transactionId && validGiftQuantity) {
+    const plan = findGiftedSubscriptionPlan(planTitle)
+    if (plan) {
+      logPurchase({
+        items: [toGiftSubscriptionAnalyticsItem(plan, quantity)],
+        provider: 'stripe',
+        transactionId,
+      })
+    }
+  }
+
+  if (canceled) {
+    if (checkoutKind === 'gift_subscription') {
+      const plan = findGiftedSubscriptionPlan(planTitle)
+      if (plan) {
+        logCheckoutCancelled({
+          items: [toGiftSubscriptionAnalyticsItem(plan, validGiftQuantity ? quantity : 1)],
+          provider: 'stripe',
+        })
+      }
+    } else if (checkoutKind === 'subscription') {
+      const plan = findSubscriptionPlan(planTitle)
+      if (plan) {
+        logCheckoutCancelled({
+          items: [toSubscriptionAnalyticsItem(plan)],
+          provider: 'stripe',
+        })
+      }
+    }
+  }
+
+  cleanCheckoutState(url)
 }

--- a/src/utils/hooks/useLogin.tsx
+++ b/src/utils/hooks/useLogin.tsx
@@ -1,6 +1,6 @@
 import { useAuth0 } from '@auth0/auth0-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { logEvent } from 'utils/analytics'
+import { logLoginAttempt } from 'utils/analytics'
 import openPopup from 'utils/openPopup'
 
 interface UseLoginProps {
@@ -25,7 +25,7 @@ const useLogin = ({ origin, onPopupClose }: UseLoginProps) => {
   const login = useCallback(
     (event?: React.MouseEvent) => {
       event?.preventDefault()
-      logEvent(`Click-${origin}-Login`)
+      logLoginAttempt(origin, 'started')
 
       const popup = openPopup()
       setPopupIsClosed(false)
@@ -39,7 +39,7 @@ const useLogin = ({ origin, onPopupClose }: UseLoginProps) => {
         if (!popup.closed) return
         clearPopupTimer()
         setPopupIsClosed(true)
-        logEvent(`${origin}-Login-Closed`)
+        logLoginAttempt(origin, 'closed')
         onPopupClose?.()
       }, 1000)
 

--- a/src/utils/plans.ts
+++ b/src/utils/plans.ts
@@ -1,4 +1,7 @@
+import type { AnalyticsCommerceItem } from 'utils/analytics'
+
 export interface IGiftedSubscriptionPlans {
+  analyticsId: string
   cost: string
   stripe_dev: string
   stripe_prod: string
@@ -15,18 +18,21 @@ export interface ISubscriptionPlan extends IGiftedSubscriptionPlans {
 
 export const GiftedSubscriptionPlans: IGiftedSubscriptionPlans[] = [
   {
+    analyticsId: 'gift-subscription-1-month',
     cost: '0.99',
     stripe_dev: 'price_1HmJnuCx8OcHZ9hn9y2JGcDo',
     stripe_prod: 'price_1HmKTgCx8OcHZ9hnRLRJrBPc',
     title: '1 Month',
   },
   {
+    analyticsId: 'gift-subscription-3-months',
     cost: '2.67',
     stripe_dev: 'price_1HmKRCCx8OcHZ9hn6vTZs16V',
     stripe_prod: 'price_1HmKTgCx8OcHZ9hnfUPSwgvw',
     title: '3 Months',
   },
   {
+    analyticsId: 'gift-subscription-1-year',
     cost: '9.49',
     stripe_dev: 'price_1HmKRCCx8OcHZ9hnHd9mOh0Z',
     stripe_prod: 'price_1HmKTfCx8OcHZ9hn8tunKnFb',
@@ -36,6 +42,7 @@ export const GiftedSubscriptionPlans: IGiftedSubscriptionPlans[] = [
 
 export const SubscriptionPlans: ISubscriptionPlan[] = [
   {
+    analyticsId: 'subscription-1-month',
     cost: '1.99',
     monthly_cost: '1.99',
     paypal_dev: 'P-54G67667NT497912UL5TBTBQ',
@@ -45,6 +52,7 @@ export const SubscriptionPlans: ISubscriptionPlan[] = [
     title: '1 Month',
   },
   {
+    analyticsId: 'subscription-3-months',
     cost: '4.47',
     monthly_cost: '1.49',
     paypal_dev: 'P-8HN142814F897112NL5TBTVA',
@@ -54,6 +62,7 @@ export const SubscriptionPlans: ISubscriptionPlan[] = [
     title: '3 Months',
   },
   {
+    analyticsId: 'subscription-1-year',
     cost: '11.88',
     monthly_cost: '0.99',
     paypal_dev: 'P-7YT370523H1387633L5TCFHI',
@@ -66,3 +75,33 @@ export const SubscriptionPlans: ISubscriptionPlan[] = [
 
 export const SUBSCRIPTION_PLANS = SubscriptionPlans
 export type SubscriptionPlan = ISubscriptionPlan
+
+export const MAX_GIFT_QUANTITY = 99
+
+export const findSubscriptionPlan = (title: string): ISubscriptionPlan | undefined =>
+  SubscriptionPlans.find(plan => plan.title === title)
+
+export const findGiftedSubscriptionPlan = (title: string): IGiftedSubscriptionPlans | undefined =>
+  GiftedSubscriptionPlans.find(plan => plan.title === title)
+
+export const toSubscriptionAnalyticsItem = (
+  plan: ISubscriptionPlan,
+  quantity = 1
+): AnalyticsCommerceItem => ({
+  item_category: 'subscription',
+  item_id: plan.analyticsId,
+  item_name: plan.title,
+  price: parseFloat(plan.cost),
+  quantity,
+})
+
+export const toGiftSubscriptionAnalyticsItem = (
+  plan: IGiftedSubscriptionPlans,
+  quantity = 1
+): AnalyticsCommerceItem => ({
+  item_category: 'gift_subscription',
+  item_id: plan.analyticsId,
+  item_name: plan.title,
+  price: parseFloat(plan.cost),
+  quantity,
+})


### PR DESCRIPTION
## Summary

Google Analytics was describing development activity more than product use: `localhost` dominated the hostname report, route-level pageview calls duplicated some loads while missing other SPA transitions, legacy Universal Analytics payloads created 345 event names in 28 days, and subscription completions did not populate GA4 revenue.

This restores a reporting contract that is safe to trust going forward:

- collection is inert unless a production build runs on `aosreminders.com` or `www.aosreminders.com`;
- the application owns one pathname-only pageview stream after checkout parameters are removed;
- product behavior uses stable GA4 event names with bounded, privacy-safe parameters;
- Stripe and PayPal checkout lifecycles use `begin_checkout`, `purchase`, and one bounded cancellation event with checked-in plan facts.

The existing GA4 property was configured additively with 12 event-scoped custom dimensions. The `purchase` key event and two legacy definitions were preserved, and Enhanced Measurement keeps page loads enabled with browser-history page changes disabled. No product UI, rules source, accepted corpus, or generated file changed.

Browser purchase events remain directional telemetry, not payment proof. Verified Stripe/PayPal webhooks and the subscription API remain authoritative; existing in-flight Stripe checkouts that lack a Checkout Session ID may finish without a new `purchase` event.

## Validation

Run with Node `v22.23.2`:

- `yarn lint`
- `yarn tsc --noEmit`
- `yarn test --run` - 70 files, 1,076 tests passed
- `yarn build`
- `yarn data:aos4:verify:beta` - 79,294 checks passed, 0 findings

Focused coverage exercises production-host gating, import-time inertness, sanitized SPA pageviews, stable event payloads, Stripe return validation, PayPal lifecycle callbacks, gift quantities, and checkout URLs. The GA4 browser session also confirmed all 14 custom definitions, `purchase` as a key event, and the intended Enhanced Measurement settings.

Related: #1773

## Post-Deploy Monitoring & Validation

- **Queries and dashboards:** In GA4 Realtime/DebugView, inspect `page_view`, one product event, `begin_checkout`, and `purchase`. In Reports or Explore, filter Hostname for `localhost` and `127.0.0.1`, and inspect new event names and `payment_provider` from the deployment timestamp forward.
- **Healthy signals:** One pathname-only pageview appears for the initial route and each SPA navigation; new product events use the documented bounded taxonomy; production hostnames accumulate traffic while development hostnames do not; the next real purchase has one item, numeric USD value, provider, and transaction ID.
- **Failure signals:** Any new development-host traffic, duplicate pageviews for one navigation, newly generated event-name variants, checkout parameters in page locations, or a completed real checkout with malformed ecommerce fields.
- **Mitigation trigger:** If development traffic or duplicate pageviews appears, revert the analytics commit before further rollout. If only a product or ecommerce event is malformed, disable or revert that call site while preserving the production collection gate. Do not change payment fulfillment based on GA4.
- **Window and owner:** Repository maintainer checks Realtime immediately after deployment, the hostname/event reports after 48 hours, and purchase fields after the next real transaction; recheck the seven-day trend before considering the issue closed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
