### PR TITLE
chore: apply prettier to the 23 files with formatting drift

### DIFF
--- a/src/aos4/data/gamesWorkshop/battleProfiles.ts
+++ b/src/aos4/data/gamesWorkshop/battleProfiles.ts
@@ -177,16 +177,10 @@ const cleanExtractedText = (value: string): string =>
     )
     .replace(/\bS\s+y\s+lva\s+n\s+e\s+t\s+h\b/gi, 'Sylvaneth')
     .replace(/\bSpider\s+fa\s+ng\b/gi, 'Spiderfang')
-    .replace(
-      /\bVa\s+n\s+a\s+r\s+i\s+Au\s+r\s+a\s+la\s+n\s+Wa\s+rdens\b/gi,
-      'Vanari Auralan Wardens'
-    )
+    .replace(/\bVa\s+n\s+a\s+r\s+i\s+Au\s+r\s+a\s+la\s+n\s+Wa\s+rdens\b/gi, 'Vanari Auralan Wardens')
     .replace(/\bI\s+ron\s+jaw\s+z\b/gi, 'Ironjawz')
     .replace(/\bB\s+o\s+s\s+s\s+r\s+o\s+k\s+k\s+Tow\s+e\s+r\b/gi, 'Bossrokk Tower')
-    .replace(
-      /\bC\s+h\s+a\s+r\s+n\s+e\s+l\s+Ve\s+s\s+t\s+m\s+e\s+nt\s+s\b/gi,
-      'Charnel Vestments'
-    )
+    .replace(/\bC\s+h\s+a\s+r\s+n\s+e\s+l\s+Ve\s+s\s+t\s+m\s+e\s+nt\s+s\b/gi, 'Charnel Vestments')
     .replace(/\bD\s+ua\s+r\s+d\s+i\s+n\b/gi, 'Duardin')
     .replace(/\bDa\s+e\s+m\s+o\s+n\b/gi, 'Daemon')
     .replace(/\bK\s+n\s+i\s+g\s+h\s+t\s+s\b/gi, 'Knights')
@@ -479,7 +473,11 @@ const sectionForRow = (items: PositionedItem[], row: NumericRow): string => {
     )
     .sort((left, right) => left.y - right.y)
   return (
-    headers[0]?.str.replace(/\s+/g, ' ').trim().toUpperCase().replace(/^LEGENDS\s+/, '') ?? 'UNITS'
+    headers[0]?.str
+      .replace(/\s+/g, ' ')
+      .trim()
+      .toUpperCase()
+      .replace(/^LEGENDS\s+/, '') ?? 'UNITS'
   )
 }
 
@@ -515,8 +513,7 @@ const extractUnitFacts = (
       withoutColumnHeader(textValue(baseSizeItemsForRow(items, rows, rowIndex)), /^BASE SIZE\s*/i)
     )
     const seasonal =
-      /^Scourge of Aqshy\b/i.test(name) ||
-      /\bGeneral.s Handbook 20\d{2}[–-]\d{2}\b/i.test(splitColumns.notes)
+      /^Scourge of Aqshy\b/i.test(name) || /\bGeneral.s Handbook 20\d{2}[–-]\d{2}\b/i.test(splitColumns.notes)
     const fact = {
       kind: 'unit' as const,
       key: `page:${page}:unit:${rowIndex + 1}`,

--- a/src/aos4/generate/corpus.ts
+++ b/src/aos4/generate/corpus.ts
@@ -1649,9 +1649,7 @@ export const buildAos4Corpus = (
       rulesContextIds: contextsFor(record.meta),
       sourceRefs: [sourceReference(record.meta.sourceRecordId, 'selection wrapper')],
     } satisfies ContentGroup)
-    offeringFactionIds(record.factionId).forEach(factionId =>
-      addRelationship('offers', factionId, choiceId)
-    )
+    offeringFactionIds(record.factionId).forEach(factionId => addRelationship('offers', factionId, choiceId))
     addRelationship('includes', choiceId, abilityId)
   })
   ;(dataset.generalRuleAbilities ?? []).forEach(record =>

--- a/src/aos4/generate/corpusCommand.ts
+++ b/src/aos4/generate/corpusCommand.ts
@@ -425,8 +425,7 @@ const loadWahapediaHtmlPages = async (
     if (isFactionPage) {
       factions.push(factionPage!.page!)
       pages.push(...(factionRoot?.pages ?? []))
-      factionRootWarscrolls +=
-        factionRoot?.pages.filter(page => page.recordKind === 'warscroll').length ?? 0
+      factionRootWarscrolls += factionRoot?.pages.filter(page => page.recordKind === 'warscroll').length ?? 0
     } else if (isRulesPage) {
       rules.push(rulesPage!.page!)
     } else if (isCollectionPage) {

--- a/src/aos4/reminders/projectReminders.ts
+++ b/src/aos4/reminders/projectReminders.ts
@@ -1,10 +1,4 @@
-import type {
-  Ability,
-  AbilityText,
-  Aos4Catalog,
-  CanonicalId,
-  SourceReference,
-} from '../domain'
+import type { Ability, AbilityText, Aos4Catalog, CanonicalId, SourceReference } from '../domain'
 import type { ResolvedSelection, SelectionCause } from '../select'
 import { reminderOccurrenceId, semanticTimingKey } from './reminderIdentity'
 import { orderReminders } from './orderReminders'
@@ -13,18 +7,10 @@ import type { ProjectedReminder, ReminderOccurrenceId } from './types'
 const compareIds = (left: string, right: string): number => left.localeCompare(right)
 
 const sourceReferenceKey = (reference: SourceReference): string =>
-  [
-    reference.sourceRecordId,
-    reference.field ?? '',
-    reference.transformation ?? '',
-  ].join('|')
+  [reference.sourceRecordId, reference.field ?? '', reference.transformation ?? ''].join('|')
 
 const causeKey = (cause: SelectionCause): string =>
-  [
-    cause.rootId,
-    cause.entityPath.join('>'),
-    cause.relationshipPath.join('>'),
-  ].join('|')
+  [cause.rootId, cause.entityPath.join('>'), cause.relationshipPath.join('>')].join('|')
 
 const uniqueBy = <T>(values: Iterable<T>, key: (value: T) => string): T[] => {
   const unique = new Map<string, T>()
@@ -44,12 +30,7 @@ const displayKey = (ability: Ability, timingKey: string): string =>
   JSON.stringify([ability.name, textKey(ability.text), timingKey])
 
 const contributingIds = (causes: SelectionCause[], abilityIds: CanonicalId[]): CanonicalId[] =>
-  Array.from(
-    new Set([
-      ...abilityIds,
-      ...causes.flatMap(cause => cause.entityPath),
-    ])
-  ).sort(compareIds)
+  Array.from(new Set([...abilityIds, ...causes.flatMap(cause => cause.entityPath)])).sort(compareIds)
 
 const mergeReminder = (
   reminder: ProjectedReminder,
@@ -57,9 +38,7 @@ const mergeReminder = (
   ability: Ability,
   causes: SelectionCause[]
 ): void => {
-  reminder.occurrenceIds = Array.from(
-    new Set([...reminder.occurrenceIds, occurrenceId])
-  ).sort(compareIds)
+  reminder.occurrenceIds = Array.from(new Set([...reminder.occurrenceIds, occurrenceId])).sort(compareIds)
   reminder.abilityIds = Array.from(new Set([...reminder.abilityIds, ability.id])).sort(compareIds)
   reminder.causes = uniqueBy([...reminder.causes, ...causes], causeKey)
   reminder.contributingEntityIds = contributingIds(reminder.causes, reminder.abilityIds)
@@ -67,10 +46,7 @@ const mergeReminder = (
   reminder.id = reminder.occurrenceIds[0]
 }
 
-export const projectReminders = (
-  catalog: Aos4Catalog,
-  selection: ResolvedSelection
-): ProjectedReminder[] => {
+export const projectReminders = (catalog: Aos4Catalog, selection: ResolvedSelection): ProjectedReminder[] => {
   const selectedIds = new Set(selection.selectedIds)
   const causesByEntityId = new Map<CanonicalId, SelectionCause[]>()
   selection.causes.forEach(cause => {

--- a/src/aos4/reminders/reminderIdentity.ts
+++ b/src/aos4/reminders/reminderIdentity.ts
@@ -29,5 +29,4 @@ export const semanticTimingKey = (timing: AbilityTiming): string => {
 export const reminderOccurrenceId = (
   abilityId: CanonicalId<'ability'>,
   timing: AbilityTiming
-): ReminderOccurrenceId =>
-  `reminder:${abilityId}@${semanticTimingKey(timing)}` as ReminderOccurrenceId
+): ReminderOccurrenceId => `reminder:${abilityId}@${semanticTimingKey(timing)}` as ReminderOccurrenceId

--- a/src/aos4/reminders/types.ts
+++ b/src/aos4/reminders/types.ts
@@ -1,10 +1,4 @@
-import type {
-  AbilityText,
-  AbilityTiming,
-  CanonicalId,
-  SourceReference,
-  TimingKind,
-} from '../domain'
+import type { AbilityText, AbilityTiming, CanonicalId, SourceReference, TimingKind } from '../domain'
 import type { SelectionCause } from '../select'
 
 declare const reminderOccurrenceIdBrand: unique symbol

--- a/src/aos4/review/adversarialReviewCommand.ts
+++ b/src/aos4/review/adversarialReviewCommand.ts
@@ -253,11 +253,7 @@ const run = async (): Promise<void> => {
         livePacketIds.push(pair.blindPacket.id, pair.comparisonPacket.id)
       })
   }
-  assertInterspersedCalibrationControls(
-    manifest.batches,
-    liveBlindPacketIds,
-    calibrationBlindPacketIds
-  )
+  assertInterspersedCalibrationControls(manifest.batches, liveBlindPacketIds, calibrationBlindPacketIds)
   const calibrationPacketIds = calibrationPairs.flatMap(pair => [
     pair.blindPacket.id,
     pair.comparisonPacket.id,
@@ -272,12 +268,7 @@ const run = async (): Promise<void> => {
     if (!pair.calibrationKind) {
       throw new Error(`Calibration pair is missing its control kind: ${pair.pairKey}`)
     }
-    const blind = createAdversarialBlindResult(
-      pair,
-      assignment.id,
-      reviewer,
-      campaignTimes.calibrationBlind
-    )
+    const blind = createAdversarialBlindResult(pair, assignment.id, reviewer, campaignTimes.calibrationBlind)
     const comparison = createAdversarialComparisonResult(
       pair,
       blind,
@@ -382,11 +373,7 @@ const run = async (): Promise<void> => {
     await Promise.all([
       writeFile(path.join(staging, 'assignment.json'), stableJson(assignment), 'utf8'),
       writeFile(path.join(staging, 'calibration.json'), stableJson(calibration), 'utf8'),
-      writeFile(
-        path.join(staging, 'calibration-results.json'),
-        stableJson(calibrationResults),
-        'utf8'
-      ),
+      writeFile(path.join(staging, 'calibration-results.json'), stableJson(calibrationResults), 'utf8'),
       writeFile(path.join(staging, 'findings.json'), stableJson(allFindings), 'utf8'),
       writeFile(
         path.join(staging, 'results-index.json'),

--- a/src/aos4/review/certification.ts
+++ b/src/aos4/review/certification.ts
@@ -270,7 +270,9 @@ const sortedResults = (results: ReviewerResult[]): ReviewerResult[] =>
   )
 
 const calibrationControlEntries = (index: ReviewPacketSafeIndex): ReviewPacketIndexEntry[] =>
-  index.entries.filter(entry => entry.calibration).sort((left, right) => compareText(left.pairKey, right.pairKey))
+  index.entries
+    .filter(entry => entry.calibration)
+    .sort((left, right) => compareText(left.pairKey, right.pairKey))
 
 export const createCalibrationEvidenceReceipt = (
   assignmentId: ReviewAssignment['id'],
@@ -298,10 +300,7 @@ export const createCalibrationEvidenceReceipt = (
   return { ...receipt, receiptChecksum: checksumReviewRecord(receipt) }
 }
 
-export const reviewLedgerWithResults = (
-  ledger: ReviewLedger,
-  results: ReviewerResult[]
-): ReviewLedger => ({
+export const reviewLedgerWithResults = (ledger: ReviewLedger, results: ReviewerResult[]): ReviewLedger => ({
   ...ledger,
   results: [...ledger.results, ...results],
   findings: [...ledger.findings, ...results.flatMap(result => result.findings)],
@@ -332,13 +331,7 @@ export const calibrationEvidenceIssues = (
     verifications: [],
   })
   calibrationLedgerIssues.forEach(value =>
-    issues.push(
-      issue(
-        'invalid-calibration-evidence',
-        `calibrationLedger.${value.path}`,
-        value.message
-      )
-    )
+    issues.push(issue('invalid-calibration-evidence', `calibrationLedger.${value.path}`, value.message))
   )
   const entries = calibrationControlEntries(index)
   const entryByPacketId = new Map<
@@ -457,9 +450,7 @@ export const calibrationEvidenceIssues = (
       return
     }
     const assignment = assignments.get(evidence.assignmentId)
-    const relevantResults = calibrationResults.filter(
-      result => result.assignmentId === evidence.assignmentId
-    )
+    const relevantResults = calibrationResults.filter(result => result.assignmentId === evidence.assignmentId)
     if (
       !assignment ||
       reviewerConfigurationId(assignment.reviewer) !== calibration.reviewerConfigurationId ||
@@ -479,11 +470,7 @@ export const calibrationEvidenceIssues = (
       )
       return
     }
-    const expectedReceipt = createCalibrationEvidenceReceipt(
-      evidence.assignmentId,
-      index,
-      relevantResults
-    )
+    const expectedReceipt = createCalibrationEvidenceReceipt(evidence.assignmentId, index, relevantResults)
     if (checksumReviewRecord(evidence) !== checksumReviewRecord(expectedReceipt)) {
       issues.push(
         issue(
@@ -494,8 +481,8 @@ export const calibrationEvidenceIssues = (
       )
     }
     const resultFor = (entry: ReviewPacketIndexEntry, lane: 'blind' | 'comparison') =>
-      relevantResults.find(result =>
-        result.packetId === (lane === 'blind' ? entry.blindPacketId : entry.comparisonPacketId)
+      relevantResults.find(
+        result => result.packetId === (lane === 'blind' ? entry.blindPacketId : entry.comparisonPacketId)
       )
     const defects = entries.filter(entry => entry.calibrationKind === 'defect')
     const insufficient = entries.filter(entry => entry.calibrationKind === 'insufficient-evidence')
@@ -891,12 +878,7 @@ const packetOutcomeIssues = (
   const issues: CertificationIssue[] = []
   const blindAll = resultIndex.get(entry.blindPacketId) ?? []
   const comparisonAll = resultIndex.get(entry.comparisonPacketId) ?? []
-  const blind = matchingResults(
-    entry.blindPacketId,
-    entry.blindPacketChecksum,
-    resultIndex,
-    assignments
-  )
+  const blind = matchingResults(entry.blindPacketId, entry.blindPacketChecksum, resultIndex, assignments)
   const comparison = matchingResults(
     entry.comparisonPacketId,
     entry.comparisonPacketChecksum,
@@ -957,9 +939,7 @@ const packetOutcomeIssues = (
       )
     )
   }
-  issues.push(
-    ...blindSequenceIssues(entry, blind, comparison, assignments, `${entryPath}.comparison`)
-  )
+  issues.push(...blindSequenceIssues(entry, blind, comparison, assignments, `${entryPath}.comparison`))
   return issues
 }
 
@@ -1139,12 +1119,7 @@ export const evaluateCertification = (input: CertificationEvaluationInput): Cert
     isEntryReviewed(entry, resultIndex, assignments)
   const machineIssues = liveEntries.flatMap(entry => packetOutcomeIssues(entry, resultIndex, assignments))
   const partialImports = liveEntries.filter(entry => {
-    const blind = matchingResults(
-      entry.blindPacketId,
-      entry.blindPacketChecksum,
-      resultIndex,
-      assignments
-    )
+    const blind = matchingResults(entry.blindPacketId, entry.blindPacketChecksum, resultIndex, assignments)
     const comparison = matchingResults(
       entry.comparisonPacketId,
       entry.comparisonPacketChecksum,

--- a/src/aos4/review/certificationCommand.ts
+++ b/src/aos4/review/certificationCommand.ts
@@ -374,11 +374,7 @@ export const runCertificationCheck = async (
     resolutions: namedJson<FindingResolution[]>('review-resolutions', manifest.inputs, files),
     verifications: namedJson<FindingVerification[]>('review-verifications', manifest.inputs, files),
   })
-  const calibrationResults = namedJson<ReviewerResult[]>(
-    'review-calibration-results',
-    manifest.inputs,
-    files
-  )
+  const calibrationResults = namedJson<ReviewerResult[]>('review-calibration-results', manifest.inputs, files)
   const protocol = namedJson<ProtocolFile>('review-protocol', manifest.inputs, files)
   const rubric = namedJson<RubricFile>('review-rubric', manifest.inputs, files)
   const inventoryFile = namedJson<SourceInventory>('source-inventory', manifest.inputs, files)

--- a/src/aos4/review/packets.ts
+++ b/src/aos4/review/packets.ts
@@ -38,12 +38,7 @@ export const profileOnlyFactCandidateKey = (factChecksum: string): string =>
 export const ignoredRecordCandidateKey = (sourceRecordId: SourceRecordId): string =>
   `ignored-record:${sourceRecordId}`
 
-export const CALIBRATION_CASE_KINDS = [
-  'pass',
-  'defect',
-  'disagreement',
-  'insufficient-evidence',
-] as const
+export const CALIBRATION_CASE_KINDS = ['pass', 'defect', 'disagreement', 'insufficient-evidence'] as const
 
 export type CalibrationCaseKind = (typeof CALIBRATION_CASE_KINDS)[number]
 
@@ -66,8 +61,7 @@ const CALIBRATION_CONTROL_OUTCOMES = {
 
 export const calibrationControlOutcomes = (
   kind: CalibrationCaseKind
-): readonly [ReviewerResult['outcome'], ReviewerResult['outcome']] =>
-  CALIBRATION_CONTROL_OUTCOMES[kind]
+): readonly [ReviewerResult['outcome'], ReviewerResult['outcome']] => CALIBRATION_CONTROL_OUTCOMES[kind]
 
 export const REQUIRED_HIGH_RISK_COHORTS = [
   'high-risk:policy-or-override',

--- a/src/aos4/select/catalog.ts
+++ b/src/aos4/select/catalog.ts
@@ -28,4 +28,3 @@ export const createCatalogIndex = (catalog: Aos4Catalog): CatalogIndex => {
     outgoingByEntityId,
   }
 }
-

--- a/src/aos4/select/diagnostics.ts
+++ b/src/aos4/select/diagnostics.ts
@@ -20,9 +20,7 @@ export interface SelectionDiagnostic {
   rulesContextId?: RulesContextId
 }
 
-export const normalizeSelectionDiagnostics = (
-  diagnostics: SelectionDiagnostic[]
-): SelectionDiagnostic[] => {
+export const normalizeSelectionDiagnostics = (diagnostics: SelectionDiagnostic[]): SelectionDiagnostic[] => {
   const unique = new Map<string, SelectionDiagnostic>()
   diagnostics.forEach(diagnostic => {
     const key = `${diagnostic.code}|${diagnostic.subject}|${diagnostic.rulesContextId ?? ''}`
@@ -36,4 +34,3 @@ export const normalizeSelectionDiagnostics = (
       left.message.localeCompare(right.message)
   )
 }
-

--- a/src/aos4/select/resolveSelection.ts
+++ b/src/aos4/select/resolveSelection.ts
@@ -1,15 +1,6 @@
-import type {
-  Aos4Catalog,
-  CanonicalId,
-  ContentEntity,
-  ContentRelationship,
-  RulesContextId,
-} from '../domain'
+import type { Aos4Catalog, CanonicalId, ContentEntity, ContentRelationship, RulesContextId } from '../domain'
 import { createCatalogIndex } from './catalog'
-import {
-  normalizeSelectionDiagnostics,
-  type SelectionDiagnostic,
-} from './diagnostics'
+import { normalizeSelectionDiagnostics, type SelectionDiagnostic } from './diagnostics'
 
 export interface ResolveSelectionInput {
   explicitIds: CanonicalId[]
@@ -75,10 +66,7 @@ const sortCauses = (causes: SelectionCause[]): SelectionCause[] =>
       left.relationshipPath.join('>').localeCompare(right.relationshipPath.join('>'))
   )
 
-export const resolveSelection = (
-  catalog: Aos4Catalog,
-  input: ResolveSelectionInput
-): ResolvedSelection => {
+export const resolveSelection = (catalog: Aos4Catalog, input: ResolveSelectionInput): ResolvedSelection => {
   const index = createCatalogIndex(catalog)
   const contextIds = new Set(catalog.rulesContexts.map(context => context.id))
   const overlayStatuses = new Set(

--- a/src/components/payment/paypal/paypalButton.tsx
+++ b/src/components/payment/paypal/paypalButton.tsx
@@ -102,8 +102,7 @@ const PaypalButton = (props: IPayPalButtonProps) => {
         : undefined,
       onApprove: (data: IApprovalResponse) => handlersRef.current.onSuccess?.(data),
       onCancel: (data: unknown) => handlersRef.current.onCancel?.(data),
-      onClick: () =>
-        isAuthenticated ? handlersRef.current.onClick?.() : handlersRef.current.login(),
+      onClick: () => (isAuthenticated ? handlersRef.current.onClick?.() : handlersRef.current.login()),
     })
 
     if (buttons.isEligible && !buttons.isEligible()) return

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -10,19 +10,10 @@ import { useTheme } from 'context/useTheme'
 import qs from 'qs'
 import React, { useState } from 'react'
 import { IconContext } from 'react-icons'
-import {
-  logBeginCheckout,
-  logCheckoutCancelled,
-  logClick,
-  logPurchase,
-} from 'utils/analytics'
+import { logBeginCheckout, logCheckoutCancelled, logClick, logPurchase } from 'utils/analytics'
 import { isDev, STRIPE_KEY } from 'utils/env'
 import useLogin from 'utils/hooks/useLogin'
-import {
-  ISubscriptionPlan,
-  SubscriptionPlans,
-  toSubscriptionAnalyticsItem,
-} from 'utils/plans'
+import { ISubscriptionPlan, SubscriptionPlans, toSubscriptionAnalyticsItem } from 'utils/plans'
 import { SubscriptionApi } from '../../api/subscriptionApi'
 
 const PricingPlansComponent = () => {

--- a/src/tests/aos4/battleProfiles.test.ts
+++ b/src/tests/aos4/battleProfiles.test.ts
@@ -165,7 +165,11 @@ const fragmentedAndBleedingTextPage = (): PdfTextItem[] => [
   item('Wa r Hyd ra', 40, 700),
   item('1', 160, 700),
   item('170', 210, 700),
-  item('R E L E V A N T K E Y WOR DS Da e m o n, C ava l r y NOTES This unit cannot be reinforced.', 260, 700),
+  item(
+    'R E L E V A N T K E Y WOR DS Da e m o n, C ava l r y NOTES This unit cannot be reinforced.',
+    260,
+    700
+  ),
   item('120 × 92mm', 520, 700),
 ]
 
@@ -232,17 +236,15 @@ const fragmentedOfficialUnitNamesPage = (): PdfTextItem[] => [
 ]
 
 const fragmentedOfficialRegimentNamesPage = (): PdfTextItem[] =>
-  ['Nu rg le’s Gi ft', 'K r it tok ’s Claw pack', 'Phu lgot h ’s Shudderhood'].flatMap(
-    (name, index) => {
-      const y = 700 - index * 30
-      return [
-        item(name, 40, y),
-        item('1 Unit', 130, y),
-        item('300', 250, y),
-        item('Order armies only.', 320, y),
-      ]
-    }
-  )
+  ['Nu rg le’s Gi ft', 'K r it tok ’s Claw pack', 'Phu lgot h ’s Shudderhood'].flatMap((name, index) => {
+    const y = 700 - index * 30
+    return [
+      item(name, 40, y),
+      item('1 Unit', 130, y),
+      item('300', 250, y),
+      item('Order armies only.', 320, y),
+    ]
+  })
 
 const fakeLoader = (
   pageCount: number,

--- a/src/tests/aos4/catalogIntegrity.test.ts
+++ b/src/tests/aos4/catalogIntegrity.test.ts
@@ -139,9 +139,7 @@ describe('AoS 4 catalog generation integrity', () => {
       AOS4_CATALOG.entities.filter(entity => entity.kind === 'faction').map(entity => entity.id)
     )
     const offeringFactionCount = (name: string, kind: 'content-group' | 'warscroll') => {
-      const targets = AOS4_CATALOG.entities.filter(
-        entity => entity.kind === kind && entity.name === name
-      )
+      const targets = AOS4_CATALOG.entities.filter(entity => entity.kind === kind && entity.name === name)
       expect(targets).toHaveLength(1)
       return new Set(
         AOS4_CATALOG.relationships

--- a/src/tests/aos4/certification.test.ts
+++ b/src/tests/aos4/certification.test.ts
@@ -416,13 +416,7 @@ describe('AoS 4 certification evaluation', () => {
   it('requires certification to occur after all bound review evidence', () => {
     const input = passingInput()
 
-    expect(
-      certificationChronologyIssues(
-        '2026-07-28T12:00:30.000Z',
-        input.ledger,
-        []
-      )
-    ).toContainEqual(
+    expect(certificationChronologyIssues('2026-07-28T12:00:30.000Z', input.ledger, [])).toContainEqual(
       expect.objectContaining({
         code: 'certification-before-evidence',
         path: 'manifest.certifiedAt',
@@ -430,12 +424,7 @@ describe('AoS 4 certification evaluation', () => {
     )
     expect(certificationChronologyIssues(REVIEWED_AT, input.ledger, [])).toEqual([])
     expect(
-      certificationChronologyIssues(
-        '2026-07-28T12:04:00.000Z',
-        input.ledger,
-        [],
-        '2026-07-28T12:05:00.000Z'
-      )
+      certificationChronologyIssues('2026-07-28T12:04:00.000Z', input.ledger, [], '2026-07-28T12:05:00.000Z')
     ).toContainEqual(
       expect.objectContaining({
         code: 'certification-before-evidence',
@@ -607,11 +596,7 @@ describe('AoS 4 certification evaluation', () => {
 
   it('counts each review entry once per distinct coverage key', () => {
     const input = passingInput()
-    input.index.entries[0].cohortIds = [
-      'high-risk:reaction',
-      'high-risk:reaction',
-      SAMPLING_METADATA_COHORT,
-    ]
+    input.index.entries[0].cohortIds = ['high-risk:reaction', 'high-risk:reaction', SAMPLING_METADATA_COHORT]
 
     expect(evaluateCertification(input).summary.coverageByCohort).toMatchObject({
       'high-risk:reaction': { reviewed: 1, expected: 1 },
@@ -787,16 +772,9 @@ describe('AoS 4 certification evaluation', () => {
           packetId: entry.comparisonPacketId,
           packetChecksum: entry.comparisonPacketChecksum,
           reviewedAt: `2026-07-28T10:5${entryIndex}:30.000Z`,
-          outcome:
-            entry.calibrationKind === 'defect'
-              ? 'finding'
-              : insufficient
-                ? 'cannot-verify'
-                : 'pass',
+          outcome: entry.calibrationKind === 'defect' ? 'finding' : insufficient ? 'cannot-verify' : 'pass',
           findings:
-            entry.calibrationKind === 'defect'
-              ? [seededControlFinding(entry.comparisonPacketId)]
-              : [],
+            entry.calibrationKind === 'defect' ? [seededControlFinding(entry.comparisonPacketId)] : [],
         }),
       ]
     })
@@ -822,8 +800,7 @@ describe('AoS 4 certification evaluation', () => {
 
     expect(calibrationEvidenceIssues(index, ledger, calibrationResults)).toEqual([])
 
-    const defectComparisonId = entries.find(entry => entry.calibrationKind === 'defect')!
-      .comparisonPacketId
+    const defectComparisonId = entries.find(entry => entry.calibrationKind === 'defect')!.comparisonPacketId
     const withEvidenceFor = (results: ReviewerResult[]): ReviewLedger => ({
       ...ledger,
       calibrations: ledger.calibrations.map(calibration => ({
@@ -955,10 +932,7 @@ describe('AoS 4 certification evaluation', () => {
       input.index.entries.push(...calibrationEntries, goldenEntry)
       input.index.coverage.highRiskCohorts = [...REQUIRED_HIGH_RISK_COHORTS]
       const assignment = createReviewAssignment({
-        packetIds: input.index.entries.flatMap(entry => [
-          entry.blindPacketId,
-          entry.comparisonPacketId,
-        ]),
+        packetIds: input.index.entries.flatMap(entry => [entry.blindPacketId, entry.comparisonPacketId]),
         reviewer: agentReviewer,
         execution: 'local',
         assignedAt: '2026-07-28T10:49:00.000Z',
@@ -986,15 +960,10 @@ describe('AoS 4 certification evaluation', () => {
       const calibrationResults = calibrationEntries.flatMap((entry, entryIndex) => {
         const kind = entry.calibrationKind!
         const comparisonOutcome: ReviewerResult['outcome'] =
-          kind === 'defect'
-            ? 'finding'
-            : kind === 'insufficient-evidence'
-              ? 'cannot-verify'
-              : 'pass'
+          kind === 'defect' ? 'finding' : kind === 'insufficient-evidence' ? 'cannot-verify' : 'pass'
         const blindOutcome: ReviewerResult['outcome'] =
           kind === 'insufficient-evidence' ? 'cannot-verify' : 'pass'
-        const seededFinding =
-          kind === 'defect' ? [seededControlFinding(entry.comparisonPacketId)] : []
+        const seededFinding = kind === 'defect' ? [seededControlFinding(entry.comparisonPacketId)] : []
         return [
           fixtureResult({
             assignmentId: assignment.id,
@@ -1017,11 +986,7 @@ describe('AoS 4 certification evaluation', () => {
       input.ledger.calibrations = [
         {
           ...input.ledger.calibrations[0],
-          evidence: createCalibrationEvidenceReceipt(
-            assignment.id,
-            input.index,
-            calibrationResults
-          ),
+          evidence: createCalibrationEvidenceReceipt(assignment.id, input.index, calibrationResults),
         },
       ]
       const structured: Record<string, unknown> = {

--- a/src/tests/aos4/importOfficialApp.test.ts
+++ b/src/tests/aos4/importOfficialApp.test.ts
@@ -95,7 +95,7 @@ describe('official AoS app text import', () => {
 
     it('treats a • Legends bullet as a mark on the unit above, not an enhancement', () => {
       const parsed = decode(
-        'Gloomspite Gitz | Da King\'s Gitz',
+        "Gloomspite Gitz | Da King's Gitz",
         'Regiment 1',
         'Loonboss (70)',
         '• Legends',
@@ -265,9 +265,9 @@ describe('official AoS app text import', () => {
         'Gatebreaker Mega-Gargant',
       ])
       // Members are cross-faction by design; the flag is what lets them resolve outside Ironjawz.
-      expect(parsed?.selections.filter(s => s.kindHint === 'warscroll').every(s => s.isRegimentOfRenown)).toBe(
-        true
-      )
+      expect(
+        parsed?.selections.filter(s => s.kindHint === 'warscroll').every(s => s.isRegimentOfRenown)
+      ).toBe(true)
     })
 
     it('marks only regiment of renown members as cross-faction', () => {
@@ -308,7 +308,7 @@ describe('official AoS app text import', () => {
 
     it('ignores roster bookkeeping the app emits alongside composition', () => {
       const parsed = decode(
-        'Gloomspite Gitz | Da King\'s Gitz',
+        "Gloomspite Gitz | Da King's Gitz",
         'Army of Renown',
         'Auxiliaries: 2 (+20 Points)',
         'Drops: 5',

--- a/src/tests/aos4/rulesRadar1757.test.ts
+++ b/src/tests/aos4/rulesRadar1757.test.ts
@@ -7,9 +7,7 @@ const catalog = JSON.parse(
 ) as Aos4Catalog
 
 const abilitiesNamed = (name: string): Ability[] =>
-  catalog.entities.filter(
-    (entity): entity is Ability => entity.kind === 'ability' && entity.name === name
-  )
+  catalog.entities.filter((entity): entity is Ability => entity.kind === 'ability' && entity.name === name)
 
 const profileNamed = (name: string): BattleProfile => {
   const profile = catalog.entities.find(
@@ -42,9 +40,7 @@ describe('29 July 2026 rules radar acceptance', () => {
         },
       ],
     })
-    expect(abilitiesNamed('REDOLENCE OF VIOLENCE')[0].text.effect).toContain(
-      'banished and removed from play'
-    )
+    expect(abilitiesNamed('REDOLENCE OF VIOLENCE')[0].text.effect).toContain('banished and removed from play')
     expect(abilitiesNamed('THE PRINCE IN THE MIRROR')[0].text.declare).toContain(
       'even if he is a replacement unit'
     )
@@ -52,9 +48,7 @@ describe('29 July 2026 rules radar acceptance', () => {
       'The target is considered by you to be POLLUTED for the rest of the battle.'
     )
     expect(abilitiesNamed('TASTY MORSELS')[0].text.effect).toContain('‘Hungry Sinkhole’')
-    expect(abilitiesNamed('PRIME GUTSERVER')[0].text.effect).toContain(
-      'within 1" of a friendly Mawpit'
-    )
+    expect(abilitiesNamed('PRIME GUTSERVER')[0].text.effect).toContain('within 1" of a friendly Mawpit')
     expect(abilitiesNamed('DAMNED VESSEL')[0]).toMatchObject({
       abilityKind: 'passive',
       text: {
@@ -78,15 +72,12 @@ describe('29 July 2026 rules radar acceptance', () => {
       points: 150,
       notes: expect.arrayContaining([expect.stringContaining('as a Swamp Beast')]),
     })
-    expect(profileNamed('Deathmaster Crixxit battle profile').regimentOptions).toContain(
-      '0-1 Clanrats'
-    )
+    expect(profileNamed('Deathmaster Crixxit battle profile').regimentOptions).toContain('0-1 Clanrats')
   })
 
   it('removes the retired Hero keyword from Thyrielle’s Zephyrites', () => {
     const warscroll = catalog.entities.find(
-      (entity): entity is Warscroll =>
-        entity.kind === 'warscroll' && entity.name === 'Thyrielle’s Zephyrites'
+      (entity): entity is Warscroll => entity.kind === 'warscroll' && entity.name === 'Thyrielle’s Zephyrites'
     )
 
     expect(warscroll?.keywords).not.toContain('HERO')

--- a/src/tests/aos4/selectionGraph.test.ts
+++ b/src/tests/aos4/selectionGraph.test.ts
@@ -142,26 +142,16 @@ describe('AoS 4 selection resolution', () => {
       rulesContextId: contextIds.standard,
     })
 
-    expect(result.selectedIds).toEqual([
-      ids.formation,
-      ids.unit,
-      ids.ability,
-      ids.mandatory,
-      ids.faction,
-    ])
+    expect(result.selectedIds).toEqual([ids.formation, ids.unit, ids.ability, ids.mandatory, ids.faction])
     expect(result.availableIds).toEqual([ids.formation])
     expect(
-      result.causes
-        .filter(cause => cause.entityId === ids.ability)
-        .map(cause => cause.entityPath)
+      result.causes.filter(cause => cause.entityId === ids.ability).map(cause => cause.entityPath)
     ).toEqual([
       [ids.formation, ids.ability],
       [ids.unit, ids.ability],
     ])
     expect(
-      result.causes
-        .filter(cause => cause.entityId === ids.mandatory)
-        .map(cause => cause.entityPath)
+      result.causes.filter(cause => cause.entityId === ids.mandatory).map(cause => cause.entityPath)
     ).toEqual([
       [ids.formation, ids.ability, ids.mandatory],
       [ids.unit, ids.ability, ids.mandatory],

--- a/src/tests/aos4/wahapediaAdapter.test.ts
+++ b/src/tests/aos4/wahapediaAdapter.test.ts
@@ -342,9 +342,7 @@ describe('Wahapedia AoS 4 export adapter', () => {
         severity: 'warning',
       })
     )
-    expect(fact.diagnostics).not.toContainEqual(
-      expect.objectContaining({ code: 'reaction-flag-mismatch' })
-    )
+    expect(fact.diagnostics).not.toContainEqual(expect.objectContaining({ code: 'reaction-flag-mismatch' }))
   })
 
   it.each([

--- a/src/tests/support/newRecruitManifest.ts
+++ b/src/tests/support/newRecruitManifest.ts
@@ -12,10 +12,7 @@ import { createHash } from 'node:crypto'
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
-export const FIXTURE_ROOT = path.resolve(
-  process.cwd(),
-  'src/tests/fixtures/aos4/import/new-recruit'
-)
+export const FIXTURE_ROOT = path.resolve(process.cwd(), 'src/tests/fixtures/aos4/import/new-recruit')
 export const LISTS_ROOT = path.join(FIXTURE_ROOT, 'lists')
 export const MANIFEST_PATH = path.join(FIXTURE_ROOT, 'manifest.json')
 
@@ -86,9 +83,7 @@ export const buildManifest = (): Manifest => {
       rulesContext: meta.rulesContext,
       pointsLimit: meta.pointsLimit,
       legalForPlay: meta.legality?.legalForPlay ?? true,
-      shapes: [...(meta.shapes ?? [])].sort((left: string, right: string) =>
-        left.localeCompare(right)
-      ),
+      shapes: [...(meta.shapes ?? [])].sort((left: string, right: string) => left.localeCompare(right)),
       files,
     }
   })
@@ -119,8 +114,7 @@ export const buildManifest = (): Manifest => {
   }
 }
 
-export const serializeManifest = (manifest: Manifest): string =>
-  `${JSON.stringify(manifest, null, 2)}\n`
+export const serializeManifest = (manifest: Manifest): string => `${JSON.stringify(manifest, null, 2)}\n`
 
 export const writeManifest = (): Manifest => {
   const manifest = buildManifest()


### PR DESCRIPTION
`yarn format` had drifted out of sync with the tree. Running prettier with the repository's own config touches 23 files.

Kept separate from #1802 (the 6.0.0 release prep) so neither diff buries the other.

## What changed

Formatting only — mostly re-joining wrapped lines and multi-line imports that now fit inside the configured 110-column `printWidth`:

```diff
-import type {
-  AbilityText,
-  AbilityTiming,
-  CanonicalId,
-  SourceReference,
-  TimingKind,
-} from '../domain'
+import type { AbilityText, AbilityTiming, CanonicalId, SourceReference, TimingKind } from '../domain'
```

That accounts for the lopsided 85 insertions / 258 deletions. Spread: 13 files in `src/aos4/`, 8 in `src/tests/`, 2 in `src/components/`.

## Why this is safe

`prettier-plugin-organize-imports` can legitimately delete imports, so I checked for that specifically rather than assuming:

- **No import was dropped.** Module specifiers and named bindings are identical before and after in all 23 files.
- **No side-effect import was removed** (`import 'foo'` with no bindings) — those would be invisible to a type-driven unused check.
- **No generated module was touched.** `src/aos4/generated/` is *not* in `.prettierignore`, so a sweep could have hand-edited generated catalog output and broken deterministic generation. None of those modules were dirty, so nothing there changed.

## Testing

```
yarn lint                  clean
yarn tsc --noEmit          clean
yarn test --run            70 files, 1091 tests passed
yarn build                 built in 19.77s
yarn data:aos4:verify:beta 79598 pass, 0 finding, 0 cannot-verify
```

`yarn data:aos4:generate:candidate` could **not** be run here — it needs raw source artifacts under the ignored `.cache/aos4/` tree, which are absent locally, and re-acquiring them is a deliberate network operation. I confirmed it fails identically on a clean checkout without these changes, so it is an environment gap rather than a regression. Worth a run by someone with a populated cache, since this sweep does touch `src/aos4/generate/corpus.ts` and `src/aos4/review/certification.ts`.

## Note

Merging this before #1802 will conflict on one file, `src/tests/aos4/importOfficialApp.test.ts`, which both branches touch. The resolution is trivial (this PR reflows it; #1802 changes an import path).

https://claude.ai/code/session_01B4YUvkgbHVyyerjbwCXHJw
