### PR TITLE
fix: enforce version 6 production API security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 VITE_ARMY_API_URL=https://your-http-api.execute-api.us-east-1.amazonaws.com
+VITE_SUBSCRIPTION_API_URL=https://your-subscription-http-api.execute-api.us-east-1.amazonaws.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,16 +21,11 @@ jobs:
       SITE_BUILD_DIR: ./dist/
       CF_DIST_ID: E3OO9Y9QRVZ2L1
       CF_PATH: /*
+      VITE_ARMY_API_URL: ${{ vars.PRODUCTION_ARMY_API_URL }}
+      VITE_SUBSCRIPTION_API_URL: ${{ vars.PRODUCTION_SUBSCRIPTION_API_URL }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-
-      - name: Configure AWS cli
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -41,8 +36,33 @@ jobs:
       - name: Install dependencies with yarn
         run: yarn install --frozen-lockfile
 
-      - name: Build with TypeScript
+      - name: Validate production API configuration
+        run: yarn release:validate-config
+
+      - name: Lint with eslint
+        run: yarn lint
+
+      - name: Test with vitest
+        run: yarn test --run
+
+      - name: Validate AoS 4 beta data readiness
+        run: yarn data:aos4:verify:beta
+
+      - name: Check TypeScript
+        run: yarn tsc --noEmit
+
+      - name: Build production artifact
         run: yarn build
+
+      - name: Inspect production artifact
+        run: yarn release:inspect-artifact
+
+      - name: Configure AWS cli
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
       - name: Deploy build bundle to S3 bucket
         run: aws s3 sync --delete ${{ env.SITE_BUILD_DIR }} ${{ env.SITE_S3 }} --exclude "*build_log.txt" --exclude "*.idea*" --exclude "*.sh" --exclude "*.git*" --exclude "*.DS_Store"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,12 +103,13 @@ The launch-hardening client on this branch retires the shared browser key and se
 Auth0 bearer token for every subscription account operation. Production remains blocked until the
 companion subscription change in `aos-reminders-subscription-api#17` is reviewed, deployed, and
 live-verified: it must derive account ownership from verified claims, reject cross-account access,
-verify and deduplicate provider callbacks, rotate/revoke exposed credentials, and pass the negative
-authorization matrix. Preserve the familiar account UI while this work is tracked in issue #1720;
-do not describe the production subscription API as secure before those checks pass. The army/share
-client likewise sends the bearer token for the `https://api.aosreminders.com` audience; its private
-collection hardening and production rollout remain tracked in `aos-reminders-rest-api#11` and issue
-#1804.
+verify and deduplicate provider callbacks, review the private-repository credential history, and
+pass the negative authorization matrix. The repository history is not evidence of public credential
+exposure; rotate a credential only when access history, policy, or other evidence requires it.
+Preserve the familiar account UI while this work is tracked in issue #1720; do not describe the
+production subscription API as secure before those checks pass. The army/share client likewise
+sends the bearer token for the `https://api.aosreminders.com` audience; its private collection
+hardening and production rollout remain tracked in `aos-reminders-rest-api#11` and issue #1804.
 
 ## Migration program
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,14 +99,16 @@ community trusts that experience; an AoS 4 data/domain migration does not author
 - Do not add a migration-workbench aesthetic, new visual language, or broad reskin unless the user
   explicitly requests one.
 
-The restored subscription API is a migration-only compatibility risk: its shared browser key is
-public and its account operations are not authorized with the user's Auth0 token. An
-Auth0-protected route is not API authorization. Production launch is blocked until the
-subscription backend verifies Auth0 bearer tokens, derives account ownership server-side, rejects
-cross-account access, rotates the shared key, and passes negative authorization tests. Preserve
-the familiar account UI while this work is explicitly tracked; do not describe the subscription
-API as secure. The newer army/share API is different: `src/api/armyApi.ts` sends the user's Auth0
-bearer token for the `https://api.aosreminders.com` audience on every account operation.
+The launch-hardening client on this branch retires the shared browser key and sends the user's
+Auth0 bearer token for every subscription account operation. Production remains blocked until the
+companion subscription change in `aos-reminders-subscription-api#17` is reviewed, deployed, and
+live-verified: it must derive account ownership from verified claims, reject cross-account access,
+verify and deduplicate provider callbacks, rotate/revoke exposed credentials, and pass the negative
+authorization matrix. Preserve the familiar account UI while this work is tracked in issue #1720;
+do not describe the production subscription API as secure before those checks pass. The army/share
+client likewise sends the bearer token for the `https://api.aosreminders.com` audience; its private
+collection hardening and production rollout remain tracked in `aos-reminders-rest-api#11` and issue
+#1804.
 
 ## Migration program
 
@@ -172,8 +174,10 @@ The companion API services (`aos-reminders-rest-api`, `aos-reminders-subscriptio
 `nodejs22.x`/Serverless v4/AWS SDK v3 with characterization tests and CI (plan
 `2026-07-28-002`, units U2/U3). Issue #1727 completed authenticated CI `serverless package` gates,
 dev verification, and the dev/prod runtime deploys. The later AoS 4-native army/share service in
-`aos-reminders-rest-api#10` is dev-validated but still needs a coordinated production deployment
-and a production `VITE_ARMY_API_URL` in the frontend build; issue #1804 tracks that rollout. Live
+`aos-reminders-rest-api#10` is dev-validated; its private-read/production hardening is prepared in
+`aos-reminders-rest-api#11` but still needs the coordinated production deployment and frontend API
+configuration tracked in issue #1804. Subscription authorization and verified webhook handling are
+prepared in `aos-reminders-subscription-api#17` but remain a production gate under issue #1720. Live
 real-money Stripe and PayPal verification after the Version 6 frontend deploy remains tracked in
 issue #1731, and the full production smoke/operational handoff is issue #1805.
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ network or cache access. Future beta reports and source updates reopen only the 
 through the candidate pipeline; they do not restart the completed migration.
 
 Phase 2 continues after this release while the accepted AoS 4 data contracts remain stable. The
-legacy subscription API still has the authorization gap tracked in
-[#1720](https://github.com/daviseford/aos-reminders/issues/1720), and
-[#1804](https://github.com/daviseford/aos-reminders/issues/1804) tracks the secure army/share API
-deployment and production Vite configuration. Do not describe either gate as complete until its
-production checks pass.
+Auth0 subscription and private army/share implementations are prepared in launch-hardening PRs,
+but their production rollout and live negative checks remain tracked in
+[#1720](https://github.com/daviseford/aos-reminders/issues/1720) and
+[#1804](https://github.com/daviseford/aos-reminders/issues/1804). Do not describe either production
+gate as complete until those checks pass.
 
 ## Sources
 

--- a/docs/plans/2026-07-28-002-feat-aos4-user-accounts-plan.md
+++ b/docs/plans/2026-07-28-002-feat-aos4-user-accounts-plan.md
@@ -10,6 +10,13 @@ execution: code
 
 # AoS 4 User Accounts
 
+**Status note (2026-07-31).** The production cutover details in this plan are superseded by
+`2026-07-31-001-fix-version-6-production-security-and-cloud-rollout-plan.md`. The subscription
+repository is private. Its history contains a production-formatted Stripe key, but that alone is
+not evidence of public exposure; credential rotation is conditional on repository access history,
+organizational policy, or other evidence. The later plan also makes army collections private rather
+than preserving the public-read design explored below.
+
 Signed-in users must be able to save and update armies and preferences against the AoS 4 domain,
 and the account APIs behind them must authorize requests properly. Today neither is true: the
 saved-army client was removed in the AoS 4 cutover, and both backend services authorize with a
@@ -135,9 +142,10 @@ R20. Both services have a test harness and a CI workflow that runs it.
 
 **Secret hygiene**
 
-R21. The live Stripe secret key is rotated, and no credential is read from a committed file.
-R22. `sub-api: config.dev.json` and `sub-api: config.prod.json` are removed from the working tree
-and purged from git history.
+R21. No credential is read from a committed file. Review the private repository's access history
+and policy, and rotate a provider credential only when that review or other evidence requires it.
+R22. `sub-api: config.dev.json` and `sub-api: config.prod.json` are removed from the working tree.
+History rewriting is separate, explicitly authorized maintenance and is not evidence of exposure.
 R23. Hardcoded migration keys in `rest-api: items/migrate.js`, `rest-api: items/migrate_v4.js`, and
 `sub-api: migrations/migrate_v4.js` are removed along with their endpoints, which served the 2021
 migration and have no remaining purpose.
@@ -342,8 +350,9 @@ named and should be done first.
    U1 and every authorization unit.
 2. **Create a Serverless Framework license key** and add it to CI secrets for both API repos. Blocks
    U2, U3.
-3. **Rotate the live Stripe secret key** in the Stripe dashboard and store the replacement in SSM
-   Parameter Store. Blocks U11.
+3. **Review the historical Stripe configuration** against private-repository access history and
+   organizational policy. Rotate only if that review or other evidence requires it, and store the
+   active value in the encrypted deployment secret store. Blocks U11 production sign-off.
 4. **Authorize each AWS deploy.** Every unit touching a service definition is code-complete at PR;
    deploying is a separate approval.
 
@@ -673,9 +682,10 @@ gap there as a launch blocker; gaps on the army side are ordinary test debt.
 
 **Verification.** Both suites green in CI and required for merge.
 
-### U11. Secret rotation, history purge, SSM wiring
+### U11. Secret externalization and access review
 
-**Goal.** Remove committed credentials and stop reading secrets from files in the repo.
+**Goal.** Stop reading secrets from files in the repo and review the private credential history
+without presuming public exposure.
 
 **Requirements.** R21, R22.
 
@@ -684,22 +694,21 @@ gap there as a launch blocker; gaps on the army side are ordinary test debt.
 **Files.** `sub-api: config.dev.json`, `sub-api: config.prod.json`, `sub-api: util/env.js`,
 `sub-api: serverless.yml`, `sub-api: .gitignore`.
 
-**Approach.** Source the Stripe key from SSM Parameter Store at deploy time instead of a committed
-JSON file, delete both config files, and purge them from history. Rotate the live key first so the
-purge is a cleanup of an already-dead credential rather than the control that protects it — history
-rewrite does not invalidate a key, and clones and forks may retain it.
-
-**Execution note.** History rewrite is coordinated: it changes every commit hash on both repos'
-default branches. Confirm no open work depends on the current hashes before rewriting.
+**Approach.** Source the Stripe key from the encrypted deployment environment instead of committed
+JSON, and delete both config files from the working tree. Review private-repository access history
+and organizational policy. If rotation is required, verify the replacement before revoking the old
+value. Do not rewrite history without separate explicit authorization; rewriting history does not
+invalidate a credential.
 
 **Test scenarios.**
-- No credential literal remains in the working tree or in history.
-- A deploy resolves the Stripe key from SSM.
-- A missing SSM parameter fails the deploy loudly rather than deploying a service with an undefined
-  key.
+- No credential literal remains in the working tree or packaged service.
+- A deploy resolves the Stripe key from the encrypted deployment environment.
+- A missing required deployment secret fails packaging loudly rather than deploying a service with
+  an undefined key.
 
-**Verification.** Secret scan clean across history; deploy succeeds against SSM; the rotated key is
-the only one that works.
+**Verification.** Working-tree and package scans are clean; deploy succeeds against external secret
+configuration. If policy requires rotation, confirm the replacement works before revoking the old
+value.
 
 ### U12. Frontend army API client and collection sync
 
@@ -835,7 +844,7 @@ All are deferred — none blocks implementation.
 | Endpoint URLs change with the HTTP API migration (KTD3) | Old clients break at cutover | Coordinate frontend and API deploys in one window; keep the old stack deployed until the new one is verified |
 | SDK v2 to v3 call-shape differences | Silent behavior change in untested handlers | Characterization tests before the swap (U2, U3 execution notes) |
 | Stripe client is four years stale | Billing regression during the runtime upgrade | Treat billing characterization tests as a hard gate in U3 |
-| History rewrite in U11 | Invalidates existing clones and hashes | Rotate the key first so the purge is cleanup, not the protecting control |
+| Historical private-repository credential remains active | A person with repository access during that interval may have been able to use it; public exposure is not established | Review access history and policy; rotate only when that review or other evidence requires it |
 | Adding a GSI to a live table | Backfill time and throughput cost | Verify table size and provisioned capacity before U5; fall back to a rebuild path if blocked |
 | Serverless v4 CLI authentication | CI cannot deploy without a license key | Operator prerequisite 2, ahead of U2 |
 | Two auth implementations (KTD1) | Drift between services | Keep helper shape identical; U10 enumerates the same matrix against both |

--- a/docs/plans/2026-07-31-001-fix-version-6-production-security-and-cloud-rollout-plan.md
+++ b/docs/plans/2026-07-31-001-fix-version-6-production-security-and-cloud-rollout-plan.md
@@ -1,0 +1,1176 @@
+---
+title: Version 6 Production Security and Cloud Rollout - Plan
+type: fix
+date: 2026-07-31
+deepened: 2026-07-31
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+issues:
+  - 1720
+  - 1804
+  - 1731
+  - 1805
+  - 1806
+---
+
+# Version 6 Production Security and Cloud Rollout - Plan
+
+This plan spans three repositories. Unprefixed paths belong to `daviseford/aos-reminders`.
+`sub-api:` paths belong to `daviseford/aos-reminders-subscription-api`, and `rest-api:` paths
+belong to `daviseford/aos-reminders-rest-api`.
+
+## Goal Capsule
+
+- **Objective:** Close the remaining Version 6 production blockers by authorizing subscription
+  operations, verifying payment-provider callbacks, deploying the AoS 4 army/share service with
+  fail-closed configuration, completing the production evidence in #1731 and #1805, and retiring
+  migration-branch guidance after a verified live cutover through #1806.
+- **Authority order:** Repository `AGENTS.md` and issues #1720, #1804, #1731, #1805, and #1806; the
+  confirmed scope of this plan; current code and deployed-service evidence; the earlier account and
+  capability-restoration plans; official Auth0, AWS, Stripe, and PayPal contracts.
+- **Execution profile:** Make security and deployment changes in the two companion APIs first, wire
+  the frontend to their verified contracts, prove both services in dev, and enter one explicitly
+  authorized production cutover window.
+- **Stop conditions:** Stop before any production deploy, provider-console mutation, secret rotation,
+  `master` merge, or frontend production release unless the project owner authorizes that operation.
+  Also stop if a CloudFormation change set replaces a retained table or if a verified Auth0 token
+  lacks the claim needed to locate the caller's subscription record.
+- **Tail ownership:** Code lands through reviewed PRs in the owning repository. Production evidence
+  remains attached to #1720, #1804, #1731, #1805, and #1806 until each issue's own completion
+  condition is met; a delayed natural renewal and the post-cutover branch-policy update do not
+  disappear into undocumented launch follow-ups.
+
+---
+
+## Product Contract
+
+### Summary
+
+Create a security-first launch path across the frontend and both companion APIs. Subscription and
+private cloud-account operations use the caller's verified Auth0 identity, payment callbacks use
+provider signatures, and the production build cannot advertise cloud features without compatible
+configured services.
+
+### Problem Frame
+
+Version 6 has the AoS 4 cloud collection, sharing, subscription UI, and account shell in the
+integration branch, but the production trust boundaries are incomplete. The subscription browser
+client still reads another account by a caller-supplied email and sends a shared key for
+cancellation, PayPal grants, redemption, and theme updates. The subscription API still exposes
+those operations through unauthenticated REST API routes, and its Stripe and PayPal handlers parse
+callback bodies without first proving the provider sent them.
+
+The army/share service is further along. Its merged code uses an API Gateway JWT authorizer on
+writes, derives ownership from the Auth0 subject, checks active entitlement, validates AoS 4
+documents, and creates owner-free opaque shares. Production still runs the legacy surface, however,
+and the checked-in frontend deployment does not provide `VITE_ARMY_API_URL`. The current service also
+leaves collection reads public and accepts a caller-supplied owner query, which does not satisfy
+issue #1804's production acceptance contract for private cloud armies.
+
+The frontend deployment runs automatically after a push to `master`, independently from the normal
+CI workflow. A launch therefore needs more than green branch checks: both API contracts must exist
+in production, the frontend build must prove it received their endpoints, and rollback must never
+restore the insecure subscription routes merely to recover availability.
+
+### Actors
+
+| Actor | Role in this plan |
+|---|---|
+| Authenticated account holder | Reads and mutates only their subscription, preferences, and cloud armies |
+| Active subscriber | Uses cloud mutations, share creation, import, and subscriber themes |
+| Second authenticated account | Supplies the cross-account negative cases for both services |
+| Signed-out share recipient | Reads an opaque shared snapshot without receiving owner identity |
+| Stripe or PayPal | Delivers independently verified payment lifecycle callbacks |
+| Release operator | Supplies production configuration, authorizes deploys, observes signals, and executes rollback |
+| Repository contributor | Targets the live primary branch without mistaking that policy for deploy authorization |
+
+### Requirements
+
+#### Subscription identity and ownership
+
+R1. Every browser-initiated subscription or preference request carries an Auth0 access token for
+the `https://api.aosreminders.com` audience.
+
+R2. API Gateway validates the token signature, issuer, audience, and time claims before an
+account-scoped subscription handler runs.
+
+R3. The subscription API requires a verified-email claim, derives the normalized account email from
+verified token claims, and never uses a request email, user ID, row ID, or subscription ID to
+establish ownership.
+
+R4. A valid account can read and mutate only its own subscription record and theme. Redemption may
+also consume only the valid one-time gift or coupon named by the request, atomically with the grant;
+foreign account identifiers cause no provider call or unrelated DynamoDB mutation.
+
+R5. The current-account response exposes only fields consumed by the Version 6 account UI and never
+returns an unrelated account or provider-only metadata.
+
+R6. `SUBSCRIPTION_AUTH_KEY`, `UI_AUTH_KEY`, browser-reachable administrative keys, and the retired
+migration key are removed from active code and deployed routes.
+
+#### Payment boundary
+
+R7. Every Stripe callback verifies the `Stripe-Signature` header against the unchanged raw request
+body and the correct stage-and-endpoint secret before parsing or mutating data.
+
+R8. Every PayPal callback verifies the transmission headers, webhook ID, and full event through
+PayPal's verification contract before mutating data.
+
+R9. Payment-provider callbacks remain separate from Auth0 account routes and fail closed when
+signature verification or its dependency is unavailable.
+
+R10. The browser PayPal grant, cancellation, coupon redemption, and gift redemption flows preserve
+their current behavior while deriving the receiving account from the verified token.
+
+R22. Each verified provider event is claimed once through a retained idempotency record; provider
+retries cannot repeat a grant, gift, renewal, or cancellation transition.
+
+R23. A browser PayPal grant verifies the approved subscription with PayPal and matches its verified
+account email, plan, and eligible status before issuing temporary access.
+
+R24. Coupon and gift redemption consume their one-time entitlement atomically, so concurrent or
+replayed requests cannot grant it twice.
+
+#### Cloud armies and sharing
+
+R11. Production cloud collection reads and writes require a valid token and derive the collection
+owner from its `sub` claim; request owner fields are ignored.
+
+R12. Army mutations also require an active entitlement, and an unavailable or inactive entitlement
+check causes no DynamoDB mutation.
+
+R13. Public access exists only through an opaque share token; a public share response and browser
+state contain no owner subject, email, or private collection metadata.
+
+R14. Loading a cloud army or share validates the AoS 4 document and selection graph and cannot
+replace local work until the user confirms.
+
+#### Configuration, rollout, and evidence
+
+R15. Dev and production service packaging fail when required issuer, audience, entitlement, share,
+CORS, or provider-verification configuration is absent; production configuration has no localhost
+or placeholder fallback.
+
+R16. The frontend deployment workflow supplies explicit subscription and army API endpoints and
+fails before upload when either production endpoint is missing, non-HTTPS, or inconsistent with the
+expected service contract.
+
+R17. The established account, payment, cloud-army, sharing, navigation, responsive, and theme UI is
+preserved without a redesign.
+
+R18. Automated route inventories, handler tests, and dev-stage black-box checks cover missing,
+malformed, expired, wrong-issuer, wrong-audience, and valid-but-foreign authorization cases.
+
+R19. The production cutover records deployed revisions, endpoint/configuration evidence, monitoring
+signals, and a rollback decision before #1720 or #1804 is closed.
+
+R20. Launch-day validation completes the applicable #1731 and #1805 checks, while delayed payment
+renewal observations remain explicitly owned until their real events occur.
+
+R21. `docs/release.md`, the Version 6 integration PR, and the tracked launch issues state the actual
+production result and any remaining observation tail.
+
+R25. After a verified `FrontendLive` cutover, live contributor instructions name `master` as the
+primary branch and normal PR target while preserving its explicit merge/deploy authorization rule.
+A rollback leaves the migration-branch guidance intact until the next authorized cutover.
+
+### Key Flows
+
+#### F1. Current-account request
+
+1. The signed-in browser obtains an audience-scoped Auth0 access token through the existing token
+   accessor.
+2. The browser calls the subscription or army HTTP API with the bearer token and action data only.
+3. API Gateway validates the token and passes verified claims to the Lambda handler.
+4. The handler derives email or subject from those claims and loads the caller-owned record. A
+   redemption may also conditionally consume only the named one-time gift or coupon as part of its
+   atomic grant.
+5. A failure returns a recoverable account/cloud error without discarding the local AoS 4 document.
+
+#### F2. Provider callback
+
+1. Stripe or PayPal sends a callback to its provider-specific endpoint.
+2. The handler preserves the raw body and collects the provider signature or transmission headers.
+3. A shared verifier validates the callback with stage-specific secret material or PayPal's
+   verification API.
+4. The service conditionally claims the verified provider event ID in a retained event table.
+5. Only the winning claim reaches the existing billing transition logic; completed duplicates
+   return success and incomplete claims follow the bounded retry contract.
+6. Invalid, unverifiable, unavailable, or already-running claims produce no Stripe, PayPal, or
+   subscription-table mutation and emit a bounded operational signal.
+
+#### F3. Production cutover
+
+1. The operator confirms backups, required configuration, dev evidence, rollback artifacts, and
+   explicit authorization.
+2. The secured subscription API deploys and its direct production checks pass.
+3. The private AoS 4 army/share API deploys against the verified subscription entitlement endpoint
+   and its direct checks pass.
+4. The frontend endpoint variables are confirmed, and the explicitly authorized merge triggers a
+   build that repeats release gates before uploading.
+5. The operator completes the Version 6 smoke matrix and records go/no-go evidence.
+
+#### F4. Security-safe rollback
+
+1. A no-go signal stops further rollout and identifies whether the failing boundary is subscription,
+   army/share, or frontend.
+2. Retained DynamoDB data is left in place and the last known-good artifact for the affected layer is
+   selected.
+3. The subscription service never rolls back to browser-key authorization or unsigned callbacks.
+4. If no secure frontend/API combination is available, account/cloud actions remain unavailable
+   while local army functionality is restored.
+5. The rollback revision, data checks, and remaining outage are recorded in #1805.
+
+#### F5. Post-cutover branch-policy cleanup
+
+1. The operator confirms U7 reached `FrontendLive` and #1805 records a successful production smoke,
+   not `SafeRollback`.
+2. Current contributor and operator docs replace live `aos4-migration` targeting instructions with
+   `master` as the primary branch and normal PR target.
+3. The `master` merge/deploy authorization warning remains explicit, and historical plan artifacts
+   remain unchanged.
+4. Issue #1806 records the search evidence and closes; a rollback skips this flow.
+
+### Acceptance Examples
+
+#### Foreign subscription mutation
+
+```gherkin
+Given account A and account B each have a valid Auth0 access token
+And account A has an active subscription row
+When account B submits account A's email, row id, or subscription id to any account operation
+Then the API resolves account B from the verified token
+And account A's row is neither returned nor mutated
+And no payment-provider call is made for account A
+```
+
+#### Forged callback
+
+```gherkin
+Given a syntactically valid Stripe or PayPal event body
+When it arrives without a valid provider signature or transmission verification
+Then the callback fails before billing transition logic runs
+And no subscription, gift, coupon, or temporary-grant row changes
+```
+
+#### Private army and public share
+
+```gherkin
+Given account A saved an AoS 4 army and created an opaque share
+When account B calls the private collection or army endpoint
+Then account A's army is not returned or mutated
+When a signed-out browser calls the share endpoint with the opaque token
+Then the shared document is returned without owner identity
+And local work is unchanged until the recipient confirms
+```
+
+#### Missing deployment configuration
+
+```gherkin
+Given a production frontend build has no subscription or army API endpoint
+When the deployment workflow reaches its configuration gate
+Then the build stops before the S3 synchronization step
+And the existing production site is unchanged
+```
+
+#### Security-safe rollback
+
+```gherkin
+Given the Version 6 frontend fails after the secured APIs are deployed
+When the operator rolls back the frontend
+Then the vulnerable subscription routes remain absent
+And local army use remains available even if account features are temporarily unavailable
+```
+
+#### Post-cutover branch policy
+
+```gherkin
+Given the Version 6 production result is recorded as FrontendLive
+When current repository instructions are updated
+Then master is the primary branch and normal pull-request target
+And master merges and production changes still require explicit authorization
+And historical migration plans remain unchanged
+```
+
+### Success Criteria
+
+- The subscription API's complete browser route inventory is JWT-protected and ownership-negative
+  tests prove foreign-account inputs cannot redirect an operation.
+- Stripe and PayPal callback tests prove invalid provider evidence is rejected before any downstream
+  billing call or write beyond the verification boundary.
+- The production army/share service uses the intended subscription entitlement endpoint, Auth0
+  issuer/audience, production share base URL, and production-only browser origin.
+- A production build artifact contains the intended subscription and army API endpoints and contains
+  no shared subscription authorization key.
+- Two-account production checks pass for subscription reads/mutations and cloud collection
+  reads/mutations; anonymous share loading remains owner-free.
+- #1805 records a successful product smoke test or a specific rollback, and #1731 retains ownership
+  of payment observations that cannot occur on launch day.
+- A verified live cutover leaves current branch guidance pointed at `master`; a rollback leaves the
+  migration guidance untouched for the next authorized attempt.
+
+### Scope Boundaries
+
+**In scope.** Closing #1720 and #1804; the code, configuration, secret rotation, dev evidence, and
+production operations needed to close them; launch-day #1731 payment checks; the technical product
+smoke and operational evidence in #1805; release documentation updates caused by those results; and
+the post-cutover branch-policy cleanup in #1806.
+
+**Non-goals.**
+
+- Broad Vite, TypeScript, Sass, PWA, Stripe UI, PayPal UI, or other package modernization.
+- Changes to pricing, plan definitions, subscription duration, redemption policy, or payment-provider
+  business rules.
+- A redesign of account, Subscribe, Profile, cloud-army, import, share, or payment surfaces.
+- AoS 4 rules-data acquisition, reconciliation, generation, or accepted-corpus changes.
+- AoS 3 compatibility, translation, or restoration of retired code paths.
+- Full offline cloud synchronization, multi-device conflict resolution, or background sync.
+
+#### Deferred to Follow-Up Work
+
+- Subscriber release communication in #1762 is coordinated after technical sign-off but is not a
+  completion criterion for this security and deployment plan.
+- Migrating legacy subscription rows from email ownership to Auth0 `sub` remains a separate data
+  migration; this launch keeps the existing key and derives its email from the verified token.
+- A natural Stripe renewal and the first-days provider dashboard watch remain open in #1731 when the
+  required real event has not occurred by the end of launch day.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+KTD1. **Use two independent trust boundaries: Auth0 for browser account operations and provider
+signatures for payment callbacks.** An Auth0 token proves the signed-in user, not that Stripe or
+PayPal sent an event. Conversely, a valid webhook proves the provider sent the event but grants no
+browser account authority. This division satisfies R1-R10 and R22-R24 and keeps provider routes out
+of the user authorizer.
+
+KTD2. **Use the subscription service's existing HTTP API JWT authorizer for every browser account
+route.** The service already proves this pattern on `/entitlement`, and the army service uses the
+same issuer and audience. Extending that native authorizer avoids custom JWT verification code and
+lets API Gateway reject signature, issuer, audience, and time-claim failures before Lambda.
+
+KTD3. **Expose current-account routes that do not contain account identity.** The account lookup,
+theme, cancellation, PayPal grant, coupon redemption, and gift redemption routes accept only their
+action inputs. Handlers require a verified email, derive the normalized legacy subscription key from
+that claim, query the row, and use stored provider/row identifiers. This replaces the old email path
+and `{ id, userName, subscriptionId, authKey }` request contracts while preserving the UI behavior
+in R10 and R17.
+
+KTD4. **Retire public privileged and unused account routes instead of teaching them end-user
+authorization.** Remove the HTTP events for administrative subscription/gift/coupon creation,
+delete the retired migration endpoint, and remove the unused favorite-faction routes. If operator
+administration remains necessary, invoke a no-HTTP Lambda through AWS IAM and remove its hardcoded
+key. An end-user token must never mint an administrative entitlement.
+
+KTD5. **Private cloud collections replace the earlier open-read collection posture; opaque shares
+remain public.** The current #1804 acceptance contract requires a second account to be unable to
+read another user's private army. Protect collection listing and item reads, derive `ownerId` from
+the verified `sub`, and remove the caller-supplied owner query. `/links/{token}` remains the sole
+anonymous document-read path and strips ownership.
+
+KTD6. **Preserve provider endpoint URLs and add verification adapters ahead of existing transition
+logic.** Repointing every Stripe and PayPal dashboard endpoint during the security fix creates an
+avoidable cutover variable. Each existing callback route gets its stage-specific verification
+material; shared adapters verify the untouched request before handing the parsed event to the
+characterized billing handler.
+
+KTD7. **Make public stage configuration checked-in and secret material externally resolved.** Auth0
+issuer/audience, production origin, share base URL, and service-to-service URLs are non-secret
+deployment inputs with no permissive production defaults. Stripe API keys, Stripe endpoint secrets,
+PayPal client credentials, and PayPal webhook IDs resolve from encrypted AWS configuration and are
+rotated when their existing copies are exposed or committed. Rotation prepares replacement
+credentials alongside the current values, deploys and verifies the replacement, and revokes the old
+value only after direct checks pass so the security fix does not create an avoidable provider gap.
+
+KTD8. **Treat endpoint variables as required release inputs, not optional feature flags.** The
+frontend reads `VITE_SUBSCRIPTION_API_URL` and `VITE_ARMY_API_URL` from GitHub Actions configuration,
+validates both before building, and records them in deployment evidence. A missing endpoint stops
+the workflow before any S3 synchronization rather than shipping a disabled paid capability.
+
+KTD9. **Use an expand-secure-cutover-observe rollout with a no-insecure-rollback rule.** All code is
+merged and dev-proven before production changes. In the authorized window, secured APIs deploy
+before the frontend, which may briefly make current account actions unavailable. Rollback may trade
+account availability for safety but may not restore browser-key routes or unsigned callbacks.
+
+KTD10. **Deduplicate verified callbacks before billing transitions.** A valid provider signature
+does not make a replay safe. Claim each stage/provider/event-ID tuple through a conditional write in
+a small retained event table before running transition logic. Commit the subscription-row mutation
+and claim completion in one DynamoDB transaction so a crash cannot leave an applied transition with
+a retryable claim. An already-completed event returns success without reapplying the transition; a
+failure before that transaction remains retryable. The claim records `processing`, `complete`, and
+retryable `failed` states, uses a bounded lease to recover abandoned work, and expires only after the
+provider's documented retry horizon. Callback-side provider operations remain read-only; if
+characterization finds an unavoidable external mutation, it needs its own durable step marker and
+provider idempotency key before this KTD is satisfied.
+
+KTD11. **Treat browser payment proof as a locator, not authority.** A PayPal approval's subscription
+ID and plan ID help locate the purchase, but the service independently retrieves it from PayPal and
+matches the verified account email, expected plan, and eligible status before issuing a provisional
+grant. Coupon and gift redemptions similarly use conditional writes so bearer authentication cannot
+turn a race or replay into duplicate value.
+
+### High-Level Technical Design
+
+#### Service and trust topology
+
+```mermaid
+flowchart LR
+  Browser[Version 6 browser] -->|Auth0 bearer token| Subscription[Subscription HTTP API]
+  Browser -->|Auth0 bearer token| Army[Army and share HTTP API]
+  Auth0[Auth0 issuer and JWKS] -->|JWT validation| Subscription
+  Auth0 -->|JWT validation| Army
+  Army -->|Forward original bearer token| Entitlement[Subscription entitlement route]
+  Stripe[Stripe] -->|Signed callbacks| Subscription
+  PayPal[PayPal] -->|Signed callbacks| Subscription
+  Subscription --> SubscriptionTable[(Subscription tables)]
+  Subscription --> EventTable[(Retained provider event claims)]
+  Army --> ArmyTable[(Army and link tables)]
+  Anonymous[Signed-out recipient] -->|Opaque token only| Share[Public share route]
+  Share --> ArmyTable
+```
+
+#### Verification sequence
+
+```mermaid
+sequenceDiagram
+  participant C as Browser or provider
+  participant G as API Gateway
+  participant V as Auth or provider verifier
+  participant H as Handler
+  participant D as Provider and DynamoDB
+  C->>G: Request plus bearer token or provider evidence
+  G->>V: Validate route-specific trust evidence
+  alt Evidence invalid or unavailable
+    V-->>C: Fail closed
+  else Evidence valid
+    V->>H: Verified claims or verified event
+    H->>D: Owner-scoped operation or billing transition
+    D-->>H: Result
+    H-->>C: Minimal response
+  end
+```
+
+#### Rollout state machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> CodeReady
+  CodeReady --> DevVerified: all repository gates pass
+  DevVerified --> AwaitingAuthorization: evidence recorded
+  AwaitingAuthorization --> SubscriptionSecure: owner authorizes production window
+  SubscriptionSecure --> ArmySecure: subscription direct checks pass
+  ArmySecure --> FrontendLive: army/share direct checks pass and master merge is authorized
+  FrontendLive --> Observing: launch smoke passes
+  Observing --> SignedOff: immediate issue gates pass
+  Observing --> FollowUpOpen: renewal or first-days observation is pending
+  SubscriptionSecure --> SafeRollback: no-go signal
+  ArmySecure --> SafeRollback: no-go signal
+  FrontendLive --> SafeRollback: no-go signal
+  SafeRollback --> AwaitingAuthorization: insecure routes stay retired
+```
+
+### Sequencing and Dependencies
+
+1. Complete subscription security and payment callback verification before depending on the
+   subscription service as the army service's production entitlement authority.
+2. Complete the matching frontend subscription contract and army privacy changes before the
+   integrated dev matrix.
+3. Make production configuration and frontend workflow changes reviewable before requesting a
+   production window.
+4. Land frontend work through migration sub-PRs targeting `aos4-migration`; land each companion API
+   change through a reviewed PR in its owning repository. Do not push a launch fix directly to
+   `master`.
+5. Deploy secured production backends before allowing the Version 6 frontend deployment to begin.
+6. Run immediate production smoke checks before starting delayed provider observation.
+
+### Operator Prerequisites
+
+- Confirm the Auth0 API identifier, issuer, signing algorithm, and the access-token claim that holds
+  the normalized account email in both dev and production.
+- Create or rotate Stripe API and webhook secrets and PayPal verification credentials in encrypted
+  AWS configuration without copying their values into issues, PRs, logs, or repository files.
+- Record the PayPal webhook ID associated with each deployed callback URL and stage.
+- Create GitHub Actions configuration variables for the production subscription and army HTTP API
+  endpoints after those endpoints are known.
+- Prepare two production Auth0 accounts, including one active subscriber, for owner/foreign-account
+  checks without modifying unrelated customer data.
+- Capture restorable DynamoDB backups and inspect CloudFormation change sets for retained tables
+  before each authorized production deployment.
+- Obtain explicit project-owner authorization for each production API deployment and for the
+  `master` merge that triggers the frontend deployment.
+
+### Alternatives Considered
+
+| Alternative | Decision |
+|---|---|
+| Keep REST API v1 account routes and add a custom Lambda JWT authorizer | Rejected because the existing HTTP API already has the native JWT authorizer and custom token validation adds security-critical code. |
+| Treat the browser-visible key as a second factor | Rejected because every visitor can extract it from the bundle and replay it. |
+| Put provider callbacks behind Auth0 | Rejected because Stripe and PayPal do not authenticate as site users; their signatures are the correct authority. |
+| Keep cloud army reads public and rely on hard-to-guess owner IDs | Rejected for launch because #1804 defines cloud armies as private and opaque shares already provide intentional public access. |
+| Merge the frontend first and configure APIs afterward | Rejected because the deployed UI would advertise paid capabilities that are unavailable or incompatible. |
+| Roll back the subscription service to its current routes if Version 6 fails | Rejected because recovery cannot reopen a known authorization bypass. |
+
+---
+
+## Implementation Units
+
+### Phase A: Close the code and configuration gaps
+
+### U1. Authorize the subscription current-account API
+
+**Goal.** Replace browser-key and caller-identity account operations with one JWT-authorized,
+current-account contract.
+
+**Requirements.** R1-R6, R10, R17-R18, R24.
+
+**Dependencies.** Auth0 claim confirmation from Operator Prerequisites.
+
+**Files.**
+
+- Modify `sub-api: serverless.yml`.
+- Modify `sub-api: util/auth.js`, `util/env.js`, and `util/response.js`.
+- Modify `sub-api: user/get.js` and `user/theme.js`.
+- Modify `sub-api: subscription/cancel.js`, `subscription/coupon.js`, and
+  `subscription/gift.js`.
+- Modify `sub-api: paypal/grant.js`.
+- Remove or detach the HTTP events and dead code owned by `sub-api: user/favorite.js`,
+  `subscription/adminCreate.js`, administrative exports in `subscription/gift.js` and
+  `subscription/coupon.js`, and `migrations/migrate_v4.js` as specified by KTD4.
+- Add `sub-api: tests/authorization.test.js` and extend `tests/user.test.js`,
+  `tests/subscription.test.js`, and `tests/gift-coupon.test.js`.
+- Update `sub-api: README.md`.
+
+**Approach.** Extend the `/entitlement` HTTP API authorizer pattern to a current-account API. Use
+the verified email claim to query the legacy row, and use the row's stored composite key and provider
+IDs for all subsequent actions. Accept only action data such as a theme, coupon code, gift locator,
+or PayPal approval proof. Return the existing UI flags through an allowlisted response. Remove the
+shared browser key and ensure every function in the deployed route inventory is classified as an
+Auth0 route, a provider callback, a public non-account route, or a non-HTTP operator function. For
+gift and coupon redemption, conditionally consume the one-time value and grant the verified
+recipient in one DynamoDB transaction; retain enough redemption ownership/result metadata for a
+same-account retry after a lost response to converge without consuming or granting twice.
+
+**Test scenarios.**
+
+- A current-account read with verified mixed-case email claims queries the normalized email and
+  returns only the allowlisted account fields.
+- A missing or unverified email claim fails before DynamoDB access even when the request supplies an
+  email.
+- Theme, cancellation, PayPal grant, coupon redemption, and gift redemption ignore supplied account,
+  row, or subscription identifiers and operate on the verified caller's row.
+- A valid token for account B plus account A's identifiers cannot read or mutate account A and makes
+  no Stripe call.
+- Two concurrent coupon or gift redemption requests can consume the entitlement once, and the loser
+  receives the existing already-used/invalid outcome without a second subscription grant.
+- A response failure after a committed redemption lets the same account retry to its recorded result
+  without a second grant; a different account receives no value.
+- An old `authKey` payload without verified claims fails and causes no provider or database call.
+- A signed-in user with no row retains the current not-subscribed behavior, while transport and
+  authorization failures remain recoverable errors.
+- The route-inventory test fails when a browser account route lacks the JWT authorizer or an unknown
+  HTTP route appears.
+- No administrative, migration, or favorite-faction HTTP route remains deployed.
+
+**Verification.** The subscription test suite passes, a packaged route table contains only the
+intended account/provider/public classifications, and repository/bundle scans find no browser shared
+key or deployed hardcoded administrative key.
+
+### U2. Verify Stripe and PayPal callbacks and externalize secrets
+
+**Goal.** Prove a payment provider sent every callback before existing billing logic can run.
+
+**Requirements.** R6-R10, R15, R18, R22-R23.
+
+**Dependencies.** U1's authenticated PayPal grant contract; provider endpoint inventories and
+encrypted configuration from Operator Prerequisites.
+
+**Files.**
+
+- Add shared verification adapters under `sub-api: util/`.
+- Modify `sub-api: subscription/create.js`, `subscription/renew.js`, and the Stripe callback in
+  `subscription/gift.js`.
+- Modify `sub-api: paypal/create.js`, `paypal/renew.js`, and `paypal/cancel.js`.
+- Modify `sub-api: serverless.yml`, `util/env.js`, `util/clients.js`, `config.dev.json`,
+  `config.prod.json`, and `.gitignore`.
+- Add the retained provider-event claim resource and a small idempotency adapter under
+  `sub-api: util/`.
+- Modify `sub-api: paypal/grant.js` to verify browser approval locators with PayPal before granting
+  access.
+- Extend `sub-api: tests/subscription.test.js`, `tests/paypal.test.js`, and
+  `tests/gift-coupon.test.js`; add focused verifier tests when clearer.
+- Update `sub-api: README.md` with secret names, provider endpoint ownership, and verification
+  failure signals without recording values.
+
+**Approach.** Put one verifier in front of each provider handler and pass only a verified parsed
+event into the characterized transition logic. Stripe verification reconstructs the exact request
+bytes from `event.body` and `isBase64Encoded` without parsing or re-serializing them, then uses the
+signature header and secret for that exact endpoint/stage. PayPal verification sends the required
+transmission headers, configured webhook ID, and complete event to its official verification API.
+Malformed or invalid evidence fails before database or provider-client calls; a verifier timeout or
+dependency outage returns a retryable non-success response, while a completed duplicate returns 2xx.
+Claim the verified stage/provider/event-ID tuple before its transition. Finish by atomically writing
+the characterized subscription change and completed claim, so a duplicate delivery cannot repeat
+value and a crash cannot make an applied change look retryable. Model pre-transition claims as
+`processing` or retryable `failed`, recover an abandoned `processing` claim only after a bounded
+lease, and set TTL beyond the longest documented provider retry horizon. Define the event table as
+an additive retained resource so stack rollback cannot delete the replay ledger. Treat a browser
+PayPal approval as a locator and retrieve authoritative subscription details before a temporary
+grant. Move Stripe and PayPal credentials out of tracked JSON and hardcoded environment modules;
+rotate any exposed production credential before it is considered safe.
+
+**Test scenarios.**
+
+- A valid Stripe fixture with a generated test signature reaches each existing transition path.
+- The same Stripe body with changed whitespace, changed data, missing signature, or the wrong
+  endpoint secret is rejected before DynamoDB and Stripe clients are called.
+- Text and base64-encoded API Gateway events reconstruct the same signed bytes; JSON parse/stringify
+  output is never substituted for the signed body.
+- A PayPal callback with all required headers and a successful verification response reaches the
+  matching CREATED, ACTIVATED, renewal, or cancellation path.
+- A missing PayPal transmission header, failed verification, malformed response, timeout, or wrong
+  webhook ID causes no mutation.
+- A valid Auth0 access token without provider evidence cannot invoke a provider transition.
+- Two deliveries of the same verified provider event produce one transition, while a retry after a
+  pre-transition failure can complete safely.
+- A worker interruption before the final transaction leaves a lease-bounded claim that a later
+  provider retry can recover; interruption after the transaction observes a completed claim and
+  cannot repeat the subscription mutation.
+- A PayPal grant locator with an unknown subscription, wrong account email, wrong plan, or
+  ineligible status cannot create or refresh a temporary grant.
+- Dev and production packaging fail when the stage's required API key, callback secret, client
+  credential, or webhook ID is missing.
+- Existing Stripe legacy-payload and PayPal order-independence characterization tests still pass
+  after verification succeeds.
+
+**Verification.** The payment test suites pass with explicit no-write and single-transition
+assertions, the retained event table is present in the dev and production service packages,
+packaged functions resolve encrypted configuration, the packaged change set contains no table
+replacement or deletion, and no live credential remains in the working tree.
+
+### U3. Send bearer tokens through the frontend subscription client
+
+**Goal.** Move every browser subscription action onto U1's current-account API without changing the
+visible account experience.
+
+**Requirements.** R1, R3-R6, R10, R16-R18.
+
+**Dependencies.** U1's request and response contract.
+
+**Files.**
+
+- Modify `src/api/subscriptionApi.ts`, `src/utils/authToken.ts`, and `src/utils/env.ts`.
+- Modify `src/context/useSubscription.tsx` and `src/context/useTheme.tsx`.
+- Modify `src/components/payment/pricingPlans.tsx`, `src/components/routes/Join.tsx`, and
+  `src/components/routes/Redeem.tsx` only where token/action wiring requires it.
+- Modify `src/tests/subscriptionApi.test.ts`, `src/tests/aos4/subscriptionApi.test.ts`,
+  `src/tests/aos4/subscriptionContext.test.tsx`, `src/tests/aos4/subscriberTheme.test.tsx`, and
+  `src/tests/aos4/pricingPlans.test.tsx`.
+- Update `.env.example`.
+
+**Approach.** Give the subscription client an injected endpoint and the same audience-token source
+already used by the army client. The subscription provider owns token acquisition for status and
+cancellation; the theme and redemption/payment call sites use the shared token accessor without
+copying account identity into API payloads. Remove the shared-key constant and the email-path
+encoding workaround with the retired contract. Preserve existing context methods, loading/error
+states, route behavior, and account copy.
+
+**Test scenarios.**
+
+- Subscription lookup, cancellation, theme, PayPal grant, coupon redemption, and gift redemption
+  send the audience bearer token and only their action inputs.
+- Signed-out calls do not reach the network and surface the established authentication recovery.
+- A rejected silent token refresh leaves local army state and the account shell intact.
+- An inactive subscriber, unknown account, transport error, and authorization error remain distinct
+  in the current UI states.
+- No request contains `authKey`, caller email, row ID, or provider subscription ID for ownership.
+- Account navigation, Profile, Subscribe, Join, Redeem, payment modal, and subscriber theme tests
+  preserve their existing landmarks and text.
+
+**Verification.** Focused frontend tests pass, the full frontend verification contract is green,
+and a production bundle scan contains neither the retired browser key nor an unconfigured
+subscription endpoint.
+
+### U4. Make the army/share service production-private and fail-closed
+
+**Goal.** Satisfy #1804's private collection, public share, entitlement, CORS, and production
+configuration contract before deploying the service.
+
+**Requirements.** R11-R19.
+
+**Dependencies.** U1's production-compatible `/entitlement` contract; production configuration from
+Operator Prerequisites.
+
+**Files.**
+
+- Modify `rest-api: serverless.yml` and add sanitized stage configuration files.
+- Modify `rest-api: items/list.js` and `items/get.js`.
+- Modify `rest-api: util/auth.js`, `util/entitlement.js`, `util/env.js`, and response helpers as
+  required by the private-read contract.
+- Remove the legacy public user-list route in `rest-api: user/get.js` if it has no non-retired
+  consumer.
+- Modify `rest-api: tests/auth.test.js`, `tests/items.test.js`, `tests/links.test.js`, and
+  `tests/clients.test.js`; add a route/configuration contract test.
+- Update `rest-api: README.md`.
+- Modify `src/api/armyApi.ts`, `src/context/useArmyCollection.tsx`,
+  `src/tests/aos4/armyApi.test.ts`, and `src/tests/aos4/armyCollection.test.tsx` to remove the
+  caller-supplied collection owner.
+
+**Approach.** Attach the existing JWT authorizer to collection listing and individual army reads.
+Derive `ownerId` from verified claims for every collection operation and query the existing GSI with
+that value. Keep only the opaque share read public, and continue stripping owner fields. Replace
+packaging defaults with required stage inputs for entitlement URL, Auth0 issuer/audience, share base
+URL, and allowed browser origin. Production allows `https://aosreminders.com`; localhost origins
+remain dev-only. Preserve table retention and reject any planned resource replacement.
+
+**Test scenarios.**
+
+- Account A lists and reads its own structurally valid AoS 4 armies with a valid token.
+- Account B cannot list, read, update, or delete account A's army when it supplies account A's
+  subject, item ID, or legacy username.
+- Missing verified claims and inactive or unavailable entitlement checks cause no mutation.
+- A signed-out browser can load a valid share but cannot call collection or item routes.
+- Share responses exclude `ownerId`, `userName`, and other private collection metadata.
+- Production CORS emits allow headers for the production origin and no allow header for localhost or
+  an unapproved origin; tests do not confuse CORS with API authorization.
+- Production packaging fails on a placeholder entitlement URL, localhost share base, missing issuer,
+  missing audience, or missing allowed origin.
+- The proposed CloudFormation change set retains both existing DynamoDB tables and adds no delete or
+  replacement action.
+
+**Verification.** REST API tests and both stage packages pass, the prod package contains the exact
+required public configuration, and the frontend army client no longer sends an owner query or path
+identity.
+
+### U5. Gate the production frontend build on compatible APIs
+
+**Goal.** Ensure the `master` deployment cannot upload Version 6 without its two compatible account
+API endpoints and the normal release checks.
+
+**Requirements.** R15-R17, R19, R21.
+
+**Dependencies.** U3 and U4; known dev and production HTTP API endpoints.
+
+**Files.**
+
+- Modify `.github/workflows/deploy.yml`.
+- Add a focused deployment-configuration validator under `scripts/` or `src/tests/support/`.
+- Modify `.env.example`, `package.json`, and `vite.config.mts` only as required to expose and validate
+  the two endpoint variables.
+- Add focused validator tests.
+- Modify `docs/release.md`.
+
+**Approach.** Read the two non-secret endpoint values from GitHub Actions configuration and validate
+their scheme, presence, and expected environment before the build. Repeat lint, tests, beta
+verification, type/build checks, and endpoint validation inside the credentialed deployment job
+before its first mutating AWS step; the separate CI workflow remains useful but is not the deploy
+job's dependency. Inspect the built artifact for the intended endpoints and absence of retired
+authorization material before S3 sync. Keep the `master`-only trigger and established S3/CloudFront
+mechanics.
+
+**Test scenarios.**
+
+- Missing or blank subscription or army endpoints fail before build/upload.
+- An HTTP, localhost, placeholder, or unexpected-stage endpoint fails the production validator.
+- Valid production endpoints reach the build and appear in the intended client configuration.
+- A bundle containing the retired shared key fails the artifact inspection.
+- A failed lint, test, beta, type, build, or configuration gate prevents S3 synchronization and
+  CloudFront invalidation.
+- The workflow remains incapable of deploying `aos4-migration` or a migration sub-branch.
+
+**Verification.** Workflow validation tests pass, a non-mutating production build produces an
+artifact with both intended endpoints, and every route/account presentation test remains green.
+
+### Phase B: Prove, deploy, and close the launch tail
+
+### U6. Run the integrated dev authorization and callback matrix
+
+**Goal.** Produce repeatable evidence that the code/configuration combination is safe before any
+production change is requested.
+
+**Requirements.** R2-R20, R22-R24.
+
+**Dependencies.** U1-U5 deployed or configured against dev-stage services.
+
+**Files.**
+
+- Add or update black-box verification scripts under `sub-api: scripts/` and `rest-api: scripts/`.
+- Add sanitized evidence templates to both API `README.md` files or a small `docs/` runbook.
+- Update the companion API PR descriptions and issues #1720 and #1804 with results.
+
+**Approach.** Exercise API Gateway rather than only calling handlers. The script accepts short-lived
+tokens and provider test evidence through process environment, never stores them, and records only
+case/result metadata. Use two accounts to prove owner isolation. Run the full token matrix against
+each authenticated route, the provider-signature matrix against each callback, and CORS preflights
+against approved and unapproved origins. Then use a frontend preview configured to the dev endpoints
+to exercise the established UI flows and local-state safeguards.
+
+**Test scenarios.**
+
+- Missing, malformed, expired, wrong-issuer, and wrong-audience tokens are rejected by API Gateway
+  before the account handler runs.
+- Valid account A and account B tokens prove cross-account subscription and army reads/mutations
+  fail without writes or provider calls.
+- Active and inactive entitlements prove army mutations succeed or fail at the intended boundary.
+- Valid Stripe test callbacks and PayPal sandbox verification reach their characterized transitions;
+  invalid evidence reaches none.
+- Production-like CORS configuration accepts only the expected browser origin.
+- The preview completes status, cancellation, redemption, theme, cloud collection, and share flows
+  without changing recognizable desktop or mobile presentation.
+- Every temporary dev row, share, army, gift/coupon use, and entitlement change is inventoried and
+  removed or restored after the run.
+
+**Verification.** Both service test/package gates, the black-box matrix, frontend preview, cleanup
+audit, and written PR evidence pass before U7 can request authorization.
+
+### U7. Execute the explicitly authorized production cutover
+
+**Goal.** Deploy the secured backends and compatible frontend in a controlled window with observable
+go/no-go points and a security-safe rollback.
+
+**Requirements.** R15-R24.
+
+**Dependencies.** U6; all Operator Prerequisites; explicit authorization for each production
+operation.
+
+**Files and systems.**
+
+- Production stacks for `aos-reminders-subscription-api` and `aos-reminders-rest-api`.
+- Auth0, Stripe, PayPal, AWS encrypted configuration, DynamoDB backups, and CloudWatch.
+- GitHub Actions configuration for `daviseford/aos-reminders`.
+- PR #1717, issues #1720 and #1804, and `docs/release.md`.
+
+**Approach.** Capture deployed revisions, table backups, CloudFormation change sets, provider
+endpoint mappings, configuration fingerprints, and rollback artifacts before mutation. After the
+owner authorizes the window, stage replacement provider credentials, deploy the secured subscription
+service, and prove current-account and signed-callback behavior directly before revoking the old
+credentials. Deploy the army/share service against its production entitlement endpoint and prove
+private collection, entitlement, share, and CORS behavior directly. Set and double-check the
+frontend endpoint variables. Only then may the owner authorize the #1717 merge and resulting
+frontend deployment. Stop at the first no-go signal. Roll back the affected safe layer or leave
+account/cloud operations unavailable; never restore the insecure subscription surface.
+
+**Test scenarios.**
+
+- The subscription stack reports the intended revision and exposes protected account routes,
+  independently verified callbacks, and no retired browser/admin/migration route.
+- Same-account production status/theme/cancel behavior works and a second account cannot redirect an
+  operation.
+- The army stack reports the intended revision and passes active, inactive, anonymous, foreign-owner,
+  public-share, and production-CORS checks.
+- The frontend deployment logs the two intended endpoints and completes every gate before S3 sync.
+- An injected or naturally observed no-go signal stops the next stage and follows F4 without table
+  deletion or insecure route restoration.
+
+**Verification.** If the rollout reaches `FrontendLive`, the recorded production evidence satisfies
+issues #1720 and #1804 and the deployed frontend commit matches the intended `master` revision. If it
+reaches `SafeRollback`, #1720 and/or #1804 remain open, and #1805 records the restored revision, data
+invariants, unavailable account capabilities, and next authorization boundary.
+
+### U8. Complete the Version 6 production smoke and observation handoff
+
+**Goal.** Validate the deployed product rather than only its build and assign every delayed
+observation to a tracked owner.
+
+**Requirements.** R17, R19-R21, R25.
+
+**Dependencies.** U7 reached `FrontendLive` or executed and documented `SafeRollback`.
+
+**Files and systems.**
+
+- `docs/release.md`, `AGENTS.md`, and PR #1717.
+- Issues #1720, #1804, #1731, #1805, and #1806.
+- Production site, GitHub Actions, CloudWatch, Stripe/PayPal dashboards, GA4, service worker, and the
+  Rules Radar workflow.
+
+**Approach.** When U7 reaches `FrontendLive`, run #1805 against the deployed commit at desktop and
+mobile widths: local army editing/persistence, all roster inputs, PDF variants, subscription states,
+cloud collection, public sharing, GA4, service-worker update, and Rules Radar operational checks. Use
+two production accounts for isolation. Run the launch-day Stripe purchase/cancel and PayPal
+activation/grant/cancel checks in issue #1731, verify provider delivery and database convergence, and
+refund/cancel test purchases. Keep natural renewal and first-days dashboard observation open with an
+explicit owner and expected event; do not claim they occurred. If U7 reaches `SafeRollback`, run only
+the rollback-safe local/edit/reload and restoration checks, record the skipped live-account/payment
+cases, and leave their owning issues open for the next authorized attempt. In either branch, update
+docs and issue/PR bodies with the actual result, and remove the subscription launch warning from
+`AGENTS.md` only after production authorization evidence passes. After the live smoke passes, only
+the `FrontendLive` branch may resolve #1806 by making `master` the primary branch/normal PR target
+and removing live `aos4-migration` instructions; retain the explicit authorization boundary for
+merges and deploys, and leave historical plans unchanged.
+
+**Test scenarios.**
+
+- In the live branch, the deployed footer, GitHub workflow revisions, API endpoints, and production
+  asset revision agree; in the rollback branch, the restored revision and intentionally unavailable
+  account capabilities match #1805.
+- Desktop and mobile local edit/play, notes, hide/show, ordering, faction switching, and reload
+  persistence remain recognizable and correct.
+- Official-app, Listbot, New Recruit `.ros`/`.rosz`/`.json`, malformed-input safety, and Standard and
+  Compact A4/Letter PDFs pass.
+- Two accounts complete cloud create/list/load/update/rename/delete with foreign-account failures;
+  a signed-out share remains owner-free and preserves local work until confirmation.
+- Subscription status, theme, coupon/gift redemption, Stripe checkout/cancel, and PayPal
+  activation/grant/cancel pass without an authorization or callback-verification regression.
+- GA4, service-worker update, production console/network, and the first manual Rules Radar run show
+  no release-blocking regression.
+- Any delayed Stripe renewal, PayPal delivery, or first-days dashboard watch remains open in #1731
+  with a named observation and no false completion claim.
+- After a live cutover, current contributor/operator docs contain no instruction to target
+  `aos4-migration` and still warn that `master` mutations deploy production; after a rollback, the
+  branch instructions remain unchanged.
+
+**Verification.** #1805 contains a complete go/no-go record, #1720 and #1804 close only after their
+production criteria pass, #1731 closes only after its real-event tail finishes, and all launch docs
+match the observed state. Issue #1806 closes only after a verified live cutover and the branch-policy
+search passes.
+
+---
+
+## Verification Contract
+
+### Repository gates
+
+Run the normal clean-install gate in `aos-reminders` with Node `v22.23.2` and Yarn Classic:
+
+```powershell
+yarn install --frozen-lockfile
+yarn lint
+yarn tsc --noEmit
+yarn test --run
+yarn build
+yarn data:aos4:verify:beta
+```
+
+Run focused frontend coverage for subscription auth, account state, themes, cloud clients,
+collection state, public sharing, account presentation, and legacy isolation. The production-config
+validator must also prove the built artifact received both intended endpoints and no retired shared
+key.
+
+In each companion API repository, run:
+
+```powershell
+yarn install --frozen-lockfile
+yarn test
+npx serverless@4 package --stage dev
+npx serverless@4 package --stage prod
+```
+
+Packaging uses non-secret public stage configuration plus encrypted provider inputs and must not
+deploy. Both API CI workflows remain required to run tests and packaging when credentials are
+available.
+
+### Authorization matrix
+
+| Boundary | Positive proof | Required negative proof |
+|---|---|---|
+| Subscription account routes | Same-account audience token | Missing, malformed, expired, wrong issuer, wrong audience, missing email claim, foreign identifiers |
+| Army collection routes | Same-owner audience token and active entitlement for writes | Missing/malformed token, wrong token claims, foreign owner/item, inactive entitlement, entitlement outage |
+| Public share read | Valid opaque token without authentication | Unknown token, invalid document, owner fields in response |
+| Stripe callbacks | Valid signature over unchanged raw body | Missing/wrong signature, changed bytes, wrong endpoint secret |
+| PayPal callbacks | Successful transmission verification for configured webhook | Missing headers, wrong webhook ID, failed/malformed/timeout verification |
+
+Handler tests prove owner derivation and no-write behavior. Dev black-box checks prove the API
+Gateway token matrix. Production smoke repeats the same-account/foreign-account cases without
+recording tokens or private row contents.
+
+### Production gates
+
+- Both companion API PRs are merged, their CI is green, and dev evidence is attached.
+- Frontend units U3-U5 are merged into `aos4-migration`, and PR #1717 points at those exact reviewed
+  revisions without unrelated launch work.
+- The subscription deployment resolves verified Auth0 email claims and every provider-verification
+  secret before its change set is approved.
+- The army deployment change set retains existing tables and has exact production entitlement,
+  Auth0, share, and origin configuration.
+- GitHub Actions has non-empty production API variables, and the credentialed frontend deployment
+  repeats all release checks before uploading.
+- The project owner authorizes each production deploy and the #1717 merge separately.
+- Any authorization bypass, forged callback acceptance, cross-account read/mutation, owner leak,
+  unconfigured endpoint, table replacement, subscription regression, or recognizable UI regression
+  is a no-go.
+
+### Production data invariants
+
+Capture these checks immediately before the first production change, after each backend deploy, and
+after smoke cleanup. Store counts and hashes or redacted aggregates in #1805; never export customer
+rows into the issue.
+
+| Data surface | Invariant |
+|---|---|
+| Subscription table | Counts by status and `createdBy` remain unchanged except for labeled smoke/payment rows and characterized provider transitions |
+| Active entitlements | The active-subscriber aggregate does not drop unexpectedly; every planned test transition has a matching provider event and final row |
+| Gifts and coupons | Only named smoke inputs change state, and each one-time record is consumed at most once under concurrent/replayed requests |
+| Army and share tables | Existing row counts and schema remain unchanged until named smoke records are created; cleanup restores the baseline delta |
+| Provider event claims | Only verified provider event IDs appear; duplicates leave one completed transition, and no claim remains `processing` past its lease |
+| CloudFormation resources | Change sets contain no replacement or deletion of retained subscriber, army, share, or event-claim tables |
+| Recovery assets | Backup identifiers, deployed artifacts, configuration fingerprints, and rollback revisions are recorded before mutation |
+
+### Monitoring and no-go signals
+
+| Signal | Expected launch behavior | No-go or escalation condition |
+|---|---|---|
+| JWT authorizer denials | Expected only for deliberate negative tests | A valid same-account token is denied, or a wrong-audience/foreign request reaches a handler mutation |
+| Subscription/army handler errors | No unexplained 5xx during direct checks or smoke | Sustained or repeated 5xx, cross-account result, or a write after dependency failure |
+| Provider verification | Test events verify once; forged events fail before transition | Valid production events repeatedly fail, unverifiable events mutate state, or verification dependency errors are hidden |
+| Event-claim conditional writes | Duplicate deliveries produce bounded conditional conflicts and one transition | A duplicate transition occurs or a `processing` claim exceeds its lease without an operational signal |
+| Entitlement checks | Active and inactive accounts follow their expected paths | Entitlement outage permits a write or prevents local army use |
+| Billing convergence | Provider event, subscription row, and UI entitlement agree after the documented delay | Mismatch persists beyond the runbook threshold or requires an unsafe manual data edit |
+| Deployment workflow | Exact revisions/endpoints pass gates before upload | Upload begins with missing/stale endpoints, failed release checks, or an unexpected artifact revision |
+
+---
+
+## System-Wide Impact
+
+### Trust boundaries and API contracts
+
+The browser subscription contract changes from identity-bearing requests on the REST API URL to
+action-only requests on the subscription HTTP API URL. The army collection contract changes from a
+public owner query to a JWT-derived private collection. Public shares remain stable. Provider
+callbacks keep their deployed URLs but gain an authenticity gate before existing transition logic.
+
+### State and data lifecycle
+
+Subscription rows remain keyed by legacy normalized email, while army rows remain keyed by Auth0
+subject. No production backfill is required. Deployments may update indexes and routes around
+retained tables, so change-set inspection and backups precede mutation. Tests and smoke runs create
+only inventoried temporary data and clean it up after evidence is captured.
+
+### Failure propagation
+
+Auth0 failure blocks account operations before Lambda. Entitlement failure blocks army writes but
+does not block local armies or public shares. Provider-verification failure blocks a billing event
+and alerts operators, so provider retry behavior can recover it. Missing frontend configuration
+blocks deployment, and an API/frontend mismatch degrades account/cloud availability without
+discarding local army state.
+
+### Observability and privacy
+
+Logs may record route names, event IDs, verification outcomes, owner-safe correlation IDs, deployed
+revisions, and bounded status classes. They must not record bearer tokens, signature secrets,
+provider credentials, full callback bodies, full subscription rows, email-address lists, or army
+documents. API Gateway and CloudWatch metrics plus structured-log dashboard checks distinguish JWT
+denial, entitlement denial, provider-verification failure, handler error, and DynamoDB conditional
+failure. The release runbook queries for claims older than their processing lease during launch and
+the first-days observation window.
+
+### Human-only boundaries
+
+Auth0 tenant changes, provider secret rotation, PayPal webhook configuration, DynamoDB backups,
+production deploys, the `master` merge, refunds, and rollback are operator actions. Scripts and
+runbooks prepare or verify them but do not expand the authorization granted by this plan.
+
+---
+
+## Risks and Dependencies
+
+| Risk | Consequence | Mitigation |
+|---|---|---|
+| Production Auth0 token lacks the expected email claim | Subscription ownership cannot be derived | Verify the actual token before implementation/deploy; stop and configure a namespaced claim rather than trusting request email |
+| Auth0 account email changes after launch | A legacy subscription row becomes orphaned | Keep normalization deterministic, surface a support path, and track a future `sub` backfill separately |
+| API Gateway changes the body used for Stripe verification | Valid callbacks fail or altered bodies bypass the intended check | Preserve/test raw bytes through the deployed integration and replay provider test events before prod |
+| PayPal verification API is slow or unavailable | Valid callbacks are delayed | Use a bounded timeout, fail closed, monitor failures, and rely on provider retry rather than accepting unverifiable events |
+| A callback worker dies after claiming an event | The provider retries but the transition stays blocked, or an unsafe takeover repeats value | Use explicit claim states, a bounded processing lease, conditional takeover, retained records, and launch/first-days checks for claims older than the lease |
+| Existing tracked provider credentials remain valid | Repository access can become provider access | Rotate before sign-off, store replacements encrypted, and confirm old credentials fail |
+| CloudFormation proposes table replacement | Subscriber or army data can be lost | Stop, retain backups, and revise the template; never approve a replacement in the launch window |
+| Production endpoint variables are missing or stale | Paid features deploy disabled or against the wrong stage | Required pre-upload validator plus artifact inspection and direct API checks |
+| Secured APIs deploy before the frontend | Current account actions can be temporarily unavailable | Use a bounded maintenance window and communicate it; prefer safe unavailability to vulnerable compatibility |
+| Frontend rollback points to retired routes | Account features fail after rollback | Keep secured APIs in place and accept temporary account/cloud unavailability; never restore insecure routes |
+| CORS is mistaken for API authorization | Non-browser callers can still reach a route | Treat CORS only as browser-origin policy and require JWT/provider verification independently |
+| A natural renewal does not occur during launch | #1731 cannot close immediately | Keep the issue open with explicit monitoring ownership and close only after the real event |
+
+---
+
+## Documentation and Operational Notes
+
+- Update both API READMEs with route classification, required public configuration, secret locations
+  by name only, package/test gates, dev verification, monitoring, and rollback boundaries.
+- Update `.env.example` and `docs/release.md` with both frontend API variables and their fail-closed
+  deployment behavior.
+- Update PR #1717 and issues #1720/#1804 with exact merged/deployed revisions and evidence links.
+- Use #1805 as the production go/no-go ledger and #1731 as the real-payment observation ledger.
+- Use #1806 for the post-cutover switch from migration-branch guidance to `master`; do not rewrite
+  historical plan artifacts or close it after a rollback.
+- Remove the subscription security warning from `AGENTS.md` only after the production negative
+  matrix passes; replace it with the resulting stable authorization contract when useful.
+- Never paste tokens, webhook secrets, provider credentials, raw customer callbacks, or customer
+  records into documentation, PRs, issues, or test artifacts.
+
+---
+
+## Sources and Research
+
+### Repository sources
+
+- Issues [#1720](https://github.com/daviseford/aos-reminders/issues/1720),
+  [#1804](https://github.com/daviseford/aos-reminders/issues/1804),
+  [#1731](https://github.com/daviseford/aos-reminders/issues/1731), and
+  [#1805](https://github.com/daviseford/aos-reminders/issues/1805), plus post-cutover branch-policy
+  issue [#1806](https://github.com/daviseford/aos-reminders/issues/1806).
+- `docs/plans/2026-07-28-002-feat-aos4-user-accounts-plan.md` for the service split, Auth0 audience,
+  legacy subscription-key constraint, and prior authorization design.
+- `docs/plans/2026-07-29-001-feat-phase2-capability-restoration-plan.md` for entitlement, cloud,
+  sharing, import, UI-continuity, and release-gate contracts.
+- `src/api/subscriptionApi.ts`, `src/context/useSubscription.tsx`, `src/context/useTheme.tsx`, and
+  `src/utils/authToken.ts` for the current frontend boundary.
+- `sub-api: serverless.yml`, `util/auth.js`, account handlers, provider handlers, and tests for the
+  current mixed REST/HTTP API and shared-key/provider-callback behavior.
+- `rest-api: serverless.yml`, `util/auth.js`, `util/entitlement.js`, item/link handlers, and tests for
+  the current dev-proven army/share model.
+- `.github/workflows/deploy.yml` and `docs/release.md` for the current production trigger, missing
+  endpoint injection, validation order, and runbook.
+
+### External authorities
+
+- [Auth0 React SPA quickstart](https://auth0.com/docs/quickstart/spa/react) for requesting an API
+  audience and sending the access token as a bearer credential.
+- [AWS API Gateway JWT authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-jwt-authorizer.html)
+  for signature, issuer, audience, expiry, optional scope validation, and verified claim delivery to
+  Lambda.
+- [AWS HTTP API CORS](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-cors.html)
+  for browser-origin response behavior and its separation from authorization.
+- [Stripe webhook signature verification](https://docs.stripe.com/webhooks/signature?lang=node) for
+  verifying the signature against unchanged request bytes and the endpoint secret.
+- [PayPal webhook signature verification](https://developer.paypal.com/api/webhooks/v1/verify-webhook-signature-post/)
+  for transmission-header, webhook-ID, and full-event verification.
+- [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html)
+  for encrypted configuration references and IAM-controlled retrieval.
+- [GitHub Actions variables](https://docs.github.com/en/actions/concepts/workflows-and-actions/variables)
+  for non-secret production endpoint configuration.
+
+---
+
+## Definition of Done
+
+### Global
+
+- Every requirement R1-R25 is satisfied, with evidence linked from its owning issue.
+- Every browser account route is JWT-protected and derives ownership only from verified claims.
+- Every payment callback verifies provider authenticity before parsing into billing transition
+  logic.
+- Cloud collections are private to the verified subject; public shares remain owner-free.
+- No browser shared key, browser-reachable administrative key, retired migration key, or live
+  provider credential remains active in tracked code.
+- Dev and production packages, the frontend verification suite, the beta gate, and the dev
+  black-box matrix pass against the exact revisions proposed for production.
+- The explicitly authorized production deployment either passes #1805 or performs and records a
+  security-safe rollback without deleting retained data.
+- #1720 and #1804 are closed only after production evidence passes; #1731 remains open until its
+  delayed real-event criteria pass.
+- #1806 closes only after the live cutover is verified and current instructions make `master` the
+  primary branch without weakening production authorization.
+- Release docs and `AGENTS.md` describe the resulting production truth without premature security or
+  availability claims.
+- Abandoned handlers, routes, configuration paths, fixtures, and experiments from superseded
+  approaches are removed from the final changes.
+
+### Per unit
+
+- The unit's listed files and contracts are complete in the owning repository.
+- Its positive, foreign-owner, malformed-input, dependency-failure, and no-mutation scenarios are
+  implemented where applicable.
+- Its verification result is attached to the relevant PR or issue without secrets or customer data.
+- No unit deploys production or merges `master` unless U7's explicit authorization boundary is met.

--- a/docs/plans/2026-07-31-001-fix-version-6-production-security-and-cloud-rollout-plan.md
+++ b/docs/plans/2026-07-31-001-fix-version-6-production-security-and-cloud-rollout-plan.md
@@ -382,9 +382,11 @@ characterized billing handler.
 KTD7. **Make public stage configuration checked-in and secret material externally resolved.** Auth0
 issuer/audience, production origin, share base URL, and service-to-service URLs are non-secret
 deployment inputs with no permissive production defaults. Stripe API keys, Stripe endpoint secrets,
-PayPal client credentials, and PayPal webhook IDs resolve from encrypted AWS configuration and are
-rotated when their existing copies are exposed or committed. Rotation prepares replacement
-credentials alongside the current values, deploys and verifies the replacement, and revokes the old
+PayPal client credentials, and PayPal webhook IDs resolve from encrypted AWS configuration. A
+production-formatted Stripe key existed in the private subscription-repository history; that fact is
+not evidence of public exposure. Review repository access history and policy, and rotate only when
+that review or other evidence requires it. When rotation is required, prepare replacement
+credentials alongside the current values, deploy and verify the replacement, and revoke the old
 value only after direct checks pass so the security fix does not create an avoidable provider gap.
 
 KTD8. **Treat endpoint variables as required release inputs, not optional feature flags.** The
@@ -492,8 +494,9 @@ stateDiagram-v2
 
 - Confirm the Auth0 API identifier, issuer, signing algorithm, and the access-token claim that holds
   the normalized account email in both dev and production.
-- Create or rotate Stripe API and webhook secrets and PayPal verification credentials in encrypted
-  AWS configuration without copying their values into issues, PRs, logs, or repository files.
+- Verify Stripe API and webhook secrets and PayPal verification credentials in encrypted AWS
+  configuration without copying their values into issues, PRs, logs, or repository files. Rotate
+  only when repository access history, organizational policy, or other evidence requires it.
 - Record the PayPal webhook ID associated with each deployed callback URL and stage.
 - Create GitHub Actions configuration variables for the production subscription and army HTTP API
   endpoints after those endpoints are known.
@@ -620,8 +623,9 @@ value and a crash cannot make an applied change look retryable. Model pre-transi
 lease, and set TTL beyond the longest documented provider retry horizon. Define the event table as
 an additive retained resource so stack rollback cannot delete the replay ledger. Treat a browser
 PayPal approval as a locator and retrieve authoritative subscription details before a temporary
-grant. Move Stripe and PayPal credentials out of tracked JSON and hardcoded environment modules;
-rotate any exposed production credential before it is considered safe.
+grant. Move Stripe and PayPal credentials out of tracked JSON and hardcoded environment modules. Do
+not infer public exposure from the private repository history; review access and policy, and rotate
+a production credential only when that review or other evidence requires it.
 
 **Test scenarios.**
 
@@ -1074,7 +1078,7 @@ runbooks prepare or verify them but do not expand the authorization granted by t
 | API Gateway changes the body used for Stripe verification | Valid callbacks fail or altered bodies bypass the intended check | Preserve/test raw bytes through the deployed integration and replay provider test events before prod |
 | PayPal verification API is slow or unavailable | Valid callbacks are delayed | Use a bounded timeout, fail closed, monitor failures, and rely on provider retry rather than accepting unverifiable events |
 | A callback worker dies after claiming an event | The provider retries but the transition stays blocked, or an unsafe takeover repeats value | Use explicit claim states, a bounded processing lease, conditional takeover, retained records, and launch/first-days checks for claims older than the lease |
-| Existing tracked provider credentials remain valid | Repository access can become provider access | Rotate before sign-off, store replacements encrypted, and confirm old credentials fail |
+| A historically tracked private-repository credential remains valid | A person with repository access during that interval may have been able to use it; public exposure is not established | Review access history and policy; if rotation is required, store the replacement encrypted and confirm the old credential fails |
 | CloudFormation proposes table replacement | Subscriber or army data can be lost | Stop, retain backups, and revise the template; never approve a replacement in the launch window |
 | Production endpoint variables are missing or stale | Paid features deploy disabled or against the wrong stage | Required pre-upload validator plus artifact inspection and direct API checks |
 | Secured APIs deploy before the frontend | Current account actions can be temporarily unavailable | Use a bounded maintenance window and communicate it; prefer safe unavailability to vulnerable compatibility |

--- a/docs/release.md
+++ b/docs/release.md
@@ -26,8 +26,12 @@ yarn install --frozen-lockfile
 yarn lint
 yarn tsc --noEmit
 yarn test --run
-yarn build
 yarn data:aos4:verify:beta
+$env:VITE_ARMY_API_URL = 'https://<production-army-api-id>.execute-api.us-east-1.amazonaws.com'
+$env:VITE_SUBSCRIPTION_API_URL = 'https://<production-subscription-api-id>.execute-api.us-east-1.amazonaws.com'
+yarn release:validate-config
+yarn build
+yarn release:inspect-artifact
 ```
 
 Before merging #1717, confirm all of the following:
@@ -39,9 +43,9 @@ Before merging #1717, confirm all of the following:
 - the AoS 4-native army/share service from `aos-reminders-rest-api#10` is deployed to production
   with the production entitlement URL, Auth0 issuer/audience, share base URL, and CORS origins;
   [#1804](https://github.com/daviseford/aos-reminders/issues/1804) tracks the coordinated rollout;
-- the production frontend build receives `VITE_ARMY_API_URL` for that service. The checked-in
-  deployment workflow does not currently provide this variable, so cloud armies and sharing are
-  unconfigured unless the build environment is coordinated before merge;
+- repository variables `PRODUCTION_ARMY_API_URL` and `PRODUCTION_SUBSCRIPTION_API_URL` contain the
+  compatible production HTTP API endpoints. The deployment workflow maps them to the two Vite
+  variables, validates them, and confirms both are embedded in the artifact;
 - the subscription-account authorization work in
   [#1720](https://github.com/daviseford/aos-reminders/issues/1720) is resolved and its negative
   authorization matrix passes. The public shared browser key is not an identity boundary and must
@@ -53,10 +57,11 @@ publish paid-feature claims for capabilities that are unavailable or insufficien
 ## Deployment mechanics
 
 `.github/workflows/deploy.yml` builds the exact `master` revision, synchronizes `dist/` to the
-production S3 bucket with deletion enabled, and invalidates the CloudFront distribution. The
-separate `Lint, Test, and Build` workflow runs lint, Vitest, the beta gate, and the production build
-for `master`. The two workflows run independently; the deployment does not wait for post-merge CI,
-which is why every pre-merge check above must already be green.
+production S3 bucket with deletion enabled, and invalidates the CloudFront distribution. Before it
+loads AWS credentials or mutates production, that same job validates both API endpoints, runs lint,
+Vitest, the beta gate, TypeScript, the production build, and artifact inspection. The separate
+`Lint, Test, and Build` workflow remains an earlier non-credentialed signal but is not treated as a
+deployment dependency.
 
 The Rules Radar schedule also becomes active only after the workflow exists on the default branch.
 After the merge, manually run `AoS 4 Rules Radar` once with `source: all` and `report_only: true`,

--- a/docs/release.md
+++ b/docs/release.md
@@ -54,6 +54,26 @@ Before merging #1717, confirm all of the following:
 The last two bullets are production gates, not documentation warnings. Merging without them can
 publish paid-feature claims for capabilities that are unavailable or insufficiently authorized.
 
+## Cutover evidence record
+
+Create the release-window record in #1805 before the first production mutation. Do not put tokens,
+provider secrets, raw callback bodies, account emails, or database rows in the issue. Record only:
+
+- the owner's authorization timestamp and the exact operation it covers;
+- frontend, subscription API, and army API commit SHAs;
+- reviewed CloudFormation change-set IDs and confirmation that retained tables have no replacement
+  or deletion action;
+- DynamoDB backup names and restore checkpoints;
+- Auth0 issuer/audience, CORS origin, share base, entitlement route, and provider endpoint mappings
+  as redacted fingerprints or route names rather than secrets;
+- the dev verification case counts, cleanup counts, and any intentionally retained test event;
+- the two GitHub repository-variable names and redacted endpoint host fingerprints;
+- start/end times, CloudWatch alarm state, go/no-go decision, and rollback revision.
+
+Production operations remain individually authorized. Approval to prepare or review this record is
+not approval to deploy either API, change provider configuration, rotate credentials, merge #1717,
+push `master`, upload S3 assets, or invalidate CloudFront.
+
 ## Deployment mechanics
 
 `.github/workflows/deploy.yml` builds the exact `master` revision, synchronizes `dist/` to the

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "react-select": "5.10.2",
     "react-switch": "7.1.0",
     "sass": "1.32.13",
-    "string.prototype.matchall": "4.0.10",
-    "superagent": "7.1.6"
+    "string.prototype.matchall": "4.0.10"
   },
   "scripts": {
     "build": "tsc && vite build",
@@ -104,7 +103,6 @@
     "@types/react-dom": "19.2.3",
     "@types/react-modal": "3.13.1",
     "@types/react-router-dom": "5.3.3",
-    "@types/superagent": "4.1.24",
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",
     "@vitejs/plugin-react-swc": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "gitclean": "git branch | grep -v \"master\" | xargs git branch -D",
     "lint": "eslint src --max-warnings 0",
     "prepush": "yarn lint && yarn tsc --noEmit && yarn test --run && yarn build",
+    "release:inspect-artifact": "vite-node --script scripts/validateDeploymentConfig.ts artifact dist",
+    "release:validate-config": "vite-node --script scripts/validateDeploymentConfig.ts config",
     "start": "vite",
     "test": "cross-env TZ=UTC vitest",
     "up": "yarn install && yarn upgrade-interactive --latest"

--- a/scripts/deploymentConfig.ts
+++ b/scripts/deploymentConfig.ts
@@ -1,0 +1,96 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+export interface DeploymentEndpoints {
+  armyApiUrl: string
+  subscriptionApiUrl: string
+}
+
+const endpointNames = {
+  armyApiUrl: 'VITE_ARMY_API_URL',
+  subscriptionApiUrl: 'VITE_SUBSCRIPTION_API_URL',
+} satisfies Record<keyof DeploymentEndpoints, string>
+
+const productionApiHost = /^[a-z0-9-]+\.execute-api\.us-east-1\.amazonaws\.com$/i
+const nonProductionStage = /\/(?:dev|development|local|preview|qa|staging|test)(?:\/|$)/i
+
+const validateEndpoint = (name: string, value: string): string => {
+  if (!value?.trim()) throw new Error(`${name} is required for a production build.`)
+
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${name} must be an absolute URL.`)
+  }
+
+  if (url.protocol !== 'https:') throw new Error(`${name} must use HTTPS.`)
+  if (!productionApiHost.test(url.hostname)) {
+    throw new Error(`${name} must identify a production HTTP API in us-east-1.`)
+  }
+  if (url.username || url.password || url.port || url.search || url.hash) {
+    throw new Error(`${name} cannot contain credentials, a port, query parameters, or a fragment.`)
+  }
+  if (nonProductionStage.test(url.pathname)) {
+    throw new Error(`${name} cannot identify a non-production stage.`)
+  }
+  if (/placeholder|your-/i.test(value)) {
+    throw new Error(`${name} cannot contain a placeholder.`)
+  }
+
+  return value.replace(/\/+$/, '')
+}
+
+export const validateDeploymentEndpoints = (endpoints: DeploymentEndpoints): DeploymentEndpoints => {
+  const validated = Object.fromEntries(
+    Object.entries(endpointNames).map(([key, name]) => [
+      key,
+      validateEndpoint(name, endpoints[key as keyof DeploymentEndpoints]),
+    ])
+  ) as unknown as DeploymentEndpoints
+
+  if (validated.armyApiUrl === validated.subscriptionApiUrl) {
+    throw new Error('Army and subscription API endpoints must be distinct.')
+  }
+  return validated
+}
+
+export const deploymentEndpointsFromEnvironment = (
+  environment: NodeJS.ProcessEnv = process.env
+): DeploymentEndpoints =>
+  validateDeploymentEndpoints({
+    armyApiUrl: environment.VITE_ARMY_API_URL || '',
+    subscriptionApiUrl: environment.VITE_SUBSCRIPTION_API_URL || '',
+  })
+
+const artifactExtensions = new Set(['.css', '.html', '.js', '.json', '.webmanifest'])
+
+const artifactFiles = (directory: string): string[] => {
+  if (!statSync(directory).isDirectory()) throw new Error(`${directory} is not a build directory.`)
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) return artifactFiles(path)
+    const extension = entry.name.includes('.') ? `.${entry.name.split('.').pop()}` : ''
+    return artifactExtensions.has(extension) ? [path] : []
+  })
+}
+
+export const inspectDeploymentArtifact = (
+  directory: string,
+  endpoints: DeploymentEndpoints
+): { filesInspected: number } => {
+  const validated = validateDeploymentEndpoints(endpoints)
+  const files = artifactFiles(directory)
+  if (!files.length) throw new Error('The build artifact contains no inspectable files.')
+  const contents = files.map(file => readFileSync(file, 'utf8')).join('\n')
+
+  for (const [key, name] of Object.entries(endpointNames)) {
+    const endpoint = validated[key as keyof DeploymentEndpoints]
+    if (!contents.includes(endpoint)) throw new Error(`The build artifact does not contain ${name}.`)
+  }
+  if (/\bauthKey\b|SUBSCRIPTION_AUTH_KEY/.test(contents)) {
+    throw new Error('The build artifact contains retired authorization material.')
+  }
+
+  return { filesInspected: files.length }
+}

--- a/scripts/validateDeploymentConfig.ts
+++ b/scripts/validateDeploymentConfig.ts
@@ -1,0 +1,24 @@
+import { deploymentEndpointsFromEnvironment, inspectDeploymentArtifact } from './deploymentConfig'
+
+const run = () => {
+  const mode = process.argv[2]
+  const endpoints = deploymentEndpointsFromEnvironment()
+
+  if (mode === 'config') {
+    console.log('Production API endpoint configuration is valid.')
+    return
+  }
+  if (mode === 'artifact') {
+    const result = inspectDeploymentArtifact(process.argv[3] || 'dist', endpoints)
+    console.log(`Inspected ${result.filesInspected} build artifact files.`)
+    return
+  }
+  throw new Error('Usage: validateDeploymentConfig.ts <config|artifact> [artifact-directory]')
+}
+
+try {
+  run()
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+}

--- a/src/api/armyApi.ts
+++ b/src/api/armyApi.ts
@@ -119,8 +119,8 @@ export const createArmyApi = (endpoint: string, fetcher: Fetcher = fetch) => {
 
   return {
     isConfigured: Boolean(baseUrl),
-    async listArmies(ownerId: string, token: string): Promise<RemoteArmy[]> {
-      const value = await request(`/items?ownerId=${encodeURIComponent(ownerId)}`, {}, token)
+    async listArmies(token: string): Promise<RemoteArmy[]> {
+      const value = await request('/items', {}, token)
       if (!Array.isArray(value)) throw new ArmyApiError('The service returned an invalid army list.', 502)
       return value.map(parseRemoteArmy)
     },

--- a/src/api/subscriptionApi.ts
+++ b/src/api/subscriptionApi.ts
@@ -1,64 +1,94 @@
-import request from 'superagent'
 import type { TThemeType } from 'types/theme'
-import { SUBSCRIPTION_AUTH_KEY } from 'utils/env'
-import { isDev } from 'utils/env'
 
-const devEndpoint = 'https://pitljgzx18.execute-api.us-east-1.amazonaws.com/dev'
-const prodEndpoint = 'https://kd0sjpg6oe.execute-api.us-east-1.amazonaws.com/prod'
-const api = isDev ? devEndpoint : prodEndpoint
-const requestTimeout = { deadline: 10_000, response: 5_000 }
+export class SubscriptionApiError extends Error {
+  readonly status: number
 
-/*
- * The subscription API is an API Gateway REST API, and it does not decode percent-encoded path
- * parameters — `%40` arrives at the lambda literally, never matches a stored userName, and the
- * lookup answers 501. `useSubscription` reads 501 as "this user has no subscription", so a plain
- * `encodeURIComponent` here makes every subscriber look unsubscribed, silently.
- *
- * `@` is a legal path character (RFC 3986 pchar), so leaving it alone is correct as well as
- * necessary. Encoding the rest still guards against `/`, `?`, and `#` in an address.
- */
-const encodeUserName = (userName: string) => encodeURIComponent(userName).replace(/%40/g, '@')
-
-const getSubscription = (userName: string) =>
-  request.get(`${api}/user/${encodeUserName(userName)}`).timeout(requestTimeout)
-
-const cancelSubscription = (data: { userName: string; subscriptionId: string }) =>
-  request
-    .post(`${api}/cancel`)
-    .send({ ...data, authKey: SUBSCRIPTION_AUTH_KEY })
-    .timeout(requestTimeout)
-
-// subscriptionId + planId let the API create a provisional row when the
-// CREATED webhook hasn't arrived yet (the grant-vs-webhook race)
-const requestGrant = (data: { userName: string; subscriptionId?: string; planId?: string }) =>
-  request
-    .post(`${api}/paypal_grant`)
-    .send({ ...data, authKey: SUBSCRIPTION_AUTH_KEY })
-    .timeout(requestTimeout)
-
-const redeemCoupon = (data: { couponId: string; userName: string }) =>
-  request
-    .post(`${api}/redeem_coupon`)
-    .send({ ...data, authKey: SUBSCRIPTION_AUTH_KEY })
-    .timeout(requestTimeout)
-
-const redeemGift = (data: { giftId: string; userId: string; userName: string }) =>
-  request
-    .post(`${api}/redeem`)
-    .send({ ...data, authKey: SUBSCRIPTION_AUTH_KEY })
-    .timeout(requestTimeout)
-
-const updateTheme = (data: { id: string; userName: string; theme: TThemeType }) =>
-  request
-    .post(`${api}/theme`)
-    .send({ ...data, authKey: SUBSCRIPTION_AUTH_KEY })
-    .timeout(requestTimeout)
-
-export const SubscriptionApi = {
-  cancelSubscription,
-  getSubscription,
-  redeemCoupon,
-  redeemGift,
-  requestGrant,
-  updateTheme,
+  constructor(message: string, status = 0) {
+    super(message)
+    this.name = 'SubscriptionApiError'
+    this.status = status
+  }
 }
+
+type Fetcher = typeof fetch
+
+interface SubscriptionResponse<T = unknown> {
+  body: T
+}
+
+const configuredEndpoint = (import.meta.env.VITE_SUBSCRIPTION_API_URL || '').replace(/\/+$/, '')
+
+const responseBody = async (response: Response): Promise<unknown> => {
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+const responseMessage = (value: unknown): string => {
+  if (typeof value === 'string' && value) return value
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'message' in value &&
+    typeof value.message === 'string'
+  ) {
+    return value.message
+  }
+  return 'The subscription service could not complete the request.'
+}
+
+export const createSubscriptionApi = (endpoint: string, fetcher: Fetcher = fetch) => {
+  const baseUrl = endpoint.replace(/\/+$/, '')
+
+  const request = async <T>(
+    path: string,
+    token: string,
+    options: RequestInit = {}
+  ): Promise<SubscriptionResponse<T>> => {
+    if (!baseUrl) throw new SubscriptionApiError('Subscriptions are not configured for this build.', 503)
+    if (!token) throw new SubscriptionApiError('Please log in again to continue.', 401)
+
+    const headers = new Headers(options.headers)
+    headers.set('Accept', 'application/json')
+    headers.set('Authorization', `Bearer ${token}`)
+    if (options.body) headers.set('Content-Type', 'application/json')
+
+    let response: Response
+    try {
+      response = await fetcher(`${baseUrl}${path}`, {
+        ...options,
+        headers,
+        signal: options.signal ?? AbortSignal.timeout(10_000),
+      })
+    } catch {
+      throw new SubscriptionApiError('The subscription service is temporarily unavailable.')
+    }
+
+    const body = await responseBody(response)
+    if (!response.ok) throw new SubscriptionApiError(responseMessage(body), response.status)
+    return { body: body as T }
+  }
+
+  const post = <T>(path: string, token: string, data?: object) =>
+    request<T>(path, token, {
+      method: 'POST',
+      body: data ? JSON.stringify(data) : undefined,
+    })
+
+  return {
+    isConfigured: Boolean(baseUrl),
+    getSubscription: (token: string) => request('/account', token),
+    cancelSubscription: (token: string) => post('/account/cancel', token),
+    requestGrant: (data: { subscriptionId: string }, token: string) =>
+      post('/account/paypal-grant', token, data),
+    redeemCoupon: (data: { couponId: string }, token: string) =>
+      post<{ error?: string; success?: boolean }>('/account/redeem-coupon', token, data),
+    redeemGift: (data: { giftId: string; userId: string }, token: string) =>
+      post<{ error?: string; success?: boolean }>('/account/redeem-gift', token, data),
+    updateTheme: (data: { theme: TThemeType }, token: string) => post('/account/theme', token, data),
+  }
+}
+
+export const SubscriptionApi = createSubscriptionApi(configuredEndpoint)

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -11,6 +11,7 @@ import qs from 'qs'
 import React, { useState } from 'react'
 import { IconContext } from 'react-icons'
 import { logBeginCheckout, logCheckoutCancelled, logClick, logPurchase } from 'utils/analytics'
+import { useApiAccessToken } from 'utils/authToken'
 import { isDev, STRIPE_KEY } from 'utils/env'
 import useLogin from 'utils/hooks/useLogin'
 import { ISubscriptionPlan, SubscriptionPlans, toSubscriptionAnalyticsItem } from 'utils/plans'
@@ -164,7 +165,7 @@ export const PlanComponent = (props: IPlanProps) => {
 }
 
 const PayPalComponent = (props: IPlanProps) => {
-  const { user } = useAuth0()
+  const getAccessToken = useApiAccessToken()
   const [modalIsOpen, setModalIsOpen] = useState(false)
   const [approval, setApproval] = useState<IApprovalResponse | null>(null)
 
@@ -172,16 +173,12 @@ const PayPalComponent = (props: IPlanProps) => {
   const planId = isDev ? paypal_dev : paypal_prod
   const analyticsItem = toSubscriptionAnalyticsItem(props.supportPlan)
 
-  // The approval response is proof of payment — passing its subscriptionID
-  // lets the API grant access even before PayPal's webhooks arrive. The modal
-  // retries this every poll tick, so a lost first attempt is not fatal.
+  // The approval response supplies a locator. The API retrieves the authoritative PayPal
+  // subscription before granting access, and the modal retries while callback activation lands.
   const requestGrant = async (data: IApprovalResponse | null = approval) => {
-    if (!user?.email) return null
-    return SubscriptionApi.requestGrant({
-      userName: user.email,
-      subscriptionId: data?.subscriptionID,
-      planId: data?.subscriptionID ? planId : undefined,
-    })
+    if (!data?.subscriptionID) return null
+    const token = await getAccessToken()
+    return SubscriptionApi.requestGrant({ subscriptionId: data.subscriptionID }, token)
   }
 
   const handleSuccess = async (data: IApprovalResponse) => {

--- a/src/components/routes/Join.tsx
+++ b/src/components/routes/Join.tsx
@@ -7,6 +7,7 @@ import { useSubscription } from 'context/useSubscription'
 import { useTheme } from 'context/useTheme'
 import React, { lazy, Suspense, useEffect, useState } from 'react'
 import { logAccountAction } from 'utils/analytics'
+import { useApiAccessToken } from 'utils/authToken'
 import useLogin from 'utils/hooks/useLogin'
 import { SubscriptionApi } from '../../api/subscriptionApi'
 
@@ -69,6 +70,7 @@ const Preamble = () => (
 
 const RedeemSection = () => {
   const { user } = useAuth0()
+  const getAccessToken = useApiAccessToken()
   const [couponId, setCouponId] = useState('')
   const [isRedeeming, setIsRedeeming] = useState(false)
   const [success, setSuccess] = useState(false)
@@ -82,12 +84,12 @@ const RedeemSection = () => {
 
   const handleRedeem = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const userName = user?.email
-    if (!canRedeem || !userName) return
+    if (!canRedeem) return
 
     setIsRedeeming(true)
     try {
-      const { body } = await SubscriptionApi.redeemCoupon({ couponId: code, userName })
+      const token = await getAccessToken()
+      const { body } = await SubscriptionApi.redeemCoupon({ couponId: code }, token)
       if (body.error) {
         setError(body.error)
       } else {

--- a/src/components/routes/Redeem.tsx
+++ b/src/components/routes/Redeem.tsx
@@ -10,6 +10,7 @@ import { isString } from 'lodash'
 import qs from 'qs'
 import React, { lazy, Suspense, useEffect, useState } from 'react'
 import { logAccountAction } from 'utils/analytics'
+import { useApiAccessToken } from 'utils/authToken'
 import useLogin from 'utils/hooks/useLogin'
 import { RedemptionStorage } from 'utils/redemptionStorage'
 import { SubscriptionApi } from '../../api/subscriptionApi'
@@ -102,6 +103,7 @@ const MissingRedemption = () => (
 
 const RedeemSection = () => {
   const { user } = useAuth0()
+  const getAccessToken = useApiAccessToken()
   /*
    * Captured once. It used to be re-read on every render while handleRedeem cleared the cache
    * mid-flow, so what the page believed it was holding depended on when it last re-rendered — and a
@@ -118,16 +120,15 @@ const RedeemSection = () => {
 
   const handleRedeem = async (event: React.MouseEvent) => {
     event.preventDefault()
-    const userName = user?.email
-    if (!canRedeem || !redemption || !userName) return
+    if (!canRedeem || !redemption) return
 
     setIsRedeeming(true)
     try {
-      const { body } = await SubscriptionApi.redeemGift({
-        giftId: redemption.giftId,
-        userId: redemption.userId,
-        userName,
-      })
+      const token = await getAccessToken()
+      const { body } = await SubscriptionApi.redeemGift(
+        { giftId: redemption.giftId, userId: redemption.userId },
+        token
+      )
       if (body.error) {
         setError(body.error)
       } else if (body.success) {

--- a/src/context/useArmyCollection.tsx
+++ b/src/context/useArmyCollection.tsx
@@ -25,14 +25,14 @@ const messageForError = (error: unknown): string => {
 }
 
 export const ArmyCollectionProvider = ({ children }: React.PropsWithChildren<object>) => {
-  const { isAuthenticated, user } = useAuth0()
+  const { isAuthenticated } = useAuth0()
   const getAccessToken = useApiAccessToken()
   const [armies, setArmies] = useState<RemoteArmy[]>([])
   const [collectionError, setCollectionError] = useState<string | null>(null)
   const [collectionLoading, setCollectionLoading] = useState(false)
 
   const refreshArmies = useCallback(async () => {
-    if (!isAuthenticated || !user?.sub) {
+    if (!isAuthenticated) {
       setArmies([])
       setCollectionError(null)
       return
@@ -41,13 +41,13 @@ export const ArmyCollectionProvider = ({ children }: React.PropsWithChildren<obj
     setCollectionError(null)
     try {
       const token = await getAccessToken()
-      setArmies(await ArmyApi.listArmies(user.sub, token))
+      setArmies(await ArmyApi.listArmies(token))
     } catch (error) {
       setCollectionError(messageForError(error))
     } finally {
       setCollectionLoading(false)
     }
-  }, [getAccessToken, isAuthenticated, user?.sub])
+  }, [getAccessToken, isAuthenticated])
 
   const createArmy = useCallback(
     async (document: Aos4ArmyDocument) => {

--- a/src/context/useSubscription.tsx
+++ b/src/context/useSubscription.tsx
@@ -40,7 +40,7 @@ interface SubscriptionContextValue {
 const SubscriptionContext = React.createContext<SubscriptionContextValue | undefined>(undefined)
 
 const SubscriptionProvider = ({ children }: React.PropsWithChildren<object>) => {
-  const { isLoading, user } = useAuth0()
+  const { isAuthenticated, isLoading, user } = useAuth0()
   const getAccessToken = useApiAccessToken()
   const [subscription, setSubscription] = useState(emptySubscription)
   const [subscriptionError, setSubscriptionError] = useState<string | null>(null)
@@ -49,11 +49,11 @@ const SubscriptionProvider = ({ children }: React.PropsWithChildren<object>) => 
 
   useEffect(() => {
     if (isLoading) return
-    if (!user) setIsNotSubscribed(true)
-  }, [isLoading, user])
+    if (!isAuthenticated || !user) setIsNotSubscribed(true)
+  }, [isAuthenticated, isLoading, user])
 
   const getSubscription = useCallback(async () => {
-    if (!user) {
+    if (!isAuthenticated || !user) {
       setSubscription(emptySubscription)
       setSubscriptionError(null)
       setIsNotSubscribed(true)
@@ -78,17 +78,19 @@ const SubscriptionProvider = ({ children }: React.PropsWithChildren<object>) => 
     } finally {
       setSubscriptionLoading(false)
     }
-  }, [getAccessToken, user])
+  }, [getAccessToken, isAuthenticated, user])
 
   useEffect(() => {
     if (!isLoading) void getSubscription()
   }, [getSubscription, isLoading])
 
   const cancelSubscription = useCallback(async () => {
+    if (!isAuthenticated) return
+
     const token = await getAccessToken()
     await SubscriptionApi.cancelSubscription(token)
     await getSubscription()
-  }, [getAccessToken, getSubscription])
+  }, [getAccessToken, getSubscription, isAuthenticated])
 
   const value = useMemo(
     () => ({

--- a/src/context/useSubscription.tsx
+++ b/src/context/useSubscription.tsx
@@ -2,6 +2,7 @@ import { useAuth0 } from '@auth0/auth0-react'
 import { SubscriptionApi } from '../api/subscriptionApi'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import type { Subscription } from 'types/subscription'
+import { useApiAccessToken } from 'utils/authToken'
 import {
   hasActiveGrant,
   hasExpiredGrant,
@@ -15,8 +16,6 @@ import {
 } from 'utils/subscriptionUtils'
 
 const emptySubscription: Subscription = {
-  id: '',
-  userName: '',
   subscribed: false,
 }
 
@@ -42,6 +41,7 @@ const SubscriptionContext = React.createContext<SubscriptionContextValue | undef
 
 const SubscriptionProvider = ({ children }: React.PropsWithChildren<object>) => {
   const { isLoading, user } = useAuth0()
+  const getAccessToken = useApiAccessToken()
   const [subscription, setSubscription] = useState(emptySubscription)
   const [subscriptionError, setSubscriptionError] = useState<string | null>(null)
   const [subscriptionLoading, setSubscriptionLoading] = useState(false)
@@ -53,7 +53,7 @@ const SubscriptionProvider = ({ children }: React.PropsWithChildren<object>) => 
   }, [isLoading, user])
 
   const getSubscription = useCallback(async () => {
-    if (!user?.email) {
+    if (!user) {
       setSubscription(emptySubscription)
       setSubscriptionError(null)
       setIsNotSubscribed(true)
@@ -63,34 +63,32 @@ const SubscriptionProvider = ({ children }: React.PropsWithChildren<object>) => 
     setSubscriptionLoading(true)
     setSubscriptionError(null)
     try {
-      const response = await SubscriptionApi.getSubscription(user.email)
+      const token = await getAccessToken()
+      const response = await SubscriptionApi.getSubscription(token)
       setSubscription(response.body as Subscription)
       setIsNotSubscribed(false)
     } catch (error) {
       const status =
         typeof error === 'object' && error !== null && 'status' in error ? Number(error.status) : undefined
       setSubscription(emptySubscription)
-      setIsNotSubscribed(status === 501)
-      if (status !== 501) {
+      setIsNotSubscribed(status === 404)
+      if (status !== 404) {
         setSubscriptionError('Subscription status is temporarily unavailable. Please try again.')
       }
     } finally {
       setSubscriptionLoading(false)
     }
-  }, [user?.email])
+  }, [getAccessToken, user])
 
   useEffect(() => {
     if (!isLoading) void getSubscription()
   }, [getSubscription, isLoading])
 
   const cancelSubscription = useCallback(async () => {
-    if (!subscription.userName || !subscription.subscriptionId) return
-    await SubscriptionApi.cancelSubscription({
-      userName: subscription.userName,
-      subscriptionId: subscription.subscriptionId,
-    })
+    const token = await getAccessToken()
+    await SubscriptionApi.cancelSubscription(token)
     await getSubscription()
-  }, [getSubscription, subscription.subscriptionId, subscription.userName])
+  }, [getAccessToken, getSubscription])
 
   const value = useMemo(
     () => ({

--- a/src/context/useTheme.tsx
+++ b/src/context/useTheme.tsx
@@ -4,6 +4,7 @@ import DarkTheme from 'theme/dark'
 import LightTheme from 'theme/light'
 import { ITheme, TThemeType } from 'types/theme'
 import { logThemeChange } from 'utils/analytics'
+import { useApiAccessToken } from 'utils/authToken'
 import { SubscriptionApi } from '../api/subscriptionApi'
 
 const LOCAL_THEME_KEY = 'theme'
@@ -25,6 +26,7 @@ const ThemeContext = React.createContext<IThemeProvider | void>(undefined)
 
 const ThemeProvider = ({ children }: React.PropsWithChildren<object>) => {
   const { isActive, subscription } = useSubscription()
+  const getAccessToken = useApiAccessToken()
   const [theme, setTheme] = useState(getLocalTheme() === 'dark' ? DarkTheme : LightTheme)
   const [isDark, setIsDark] = useState(getLocalTheme() === 'dark')
 
@@ -40,15 +42,16 @@ const ThemeProvider = ({ children }: React.PropsWithChildren<object>) => {
   const toggleTheme = useCallback(() => {
     const theme = isDark ? 'light' : 'dark'
     setLocalTheme(theme)
-    const { id, userName } = subscription
-    if (isActive && id && userName) {
-      void SubscriptionApi.updateTheme({ id, userName, theme }).catch(error => {
-        console.error('Unable to save subscriber theme', error)
-      })
+    if (isActive) {
+      void getAccessToken()
+        .then(token => SubscriptionApi.updateTheme({ theme }, token))
+        .catch(error => {
+          console.error('Unable to save subscriber theme', error)
+        })
     }
     logThemeChange(theme)
     return isDark ? setLightTheme() : setDarkTheme()
-  }, [isActive, isDark, setDarkTheme, setLightTheme, subscription])
+  }, [getAccessToken, isActive, isDark, setDarkTheme, setLightTheme])
 
   const setThemeFromValue = useCallback(
     (val: TThemeType | null) => {

--- a/src/tests/aos4/armyApi.test.ts
+++ b/src/tests/aos4/armyApi.test.ts
@@ -25,7 +25,7 @@ describe('AoS 4 army API client', () => {
       ])
     )
     const api = createArmyApi('https://army.example/', fetcher)
-    const armies = await api.listArmies('auth0|owner', 'access-token')
+    const armies = await api.listArmies('access-token')
 
     expect(armies).toEqual([
       {
@@ -36,7 +36,7 @@ describe('AoS 4 army API client', () => {
       },
     ])
     const [url, options] = fetcher.mock.calls[0]
-    expect(url).toBe('https://army.example/items?ownerId=auth0%7Cowner')
+    expect(url).toBe('https://army.example/items')
     expect(new Headers(options.headers).get('Authorization')).toBe('Bearer access-token')
   })
 
@@ -77,7 +77,7 @@ describe('AoS 4 army API client', () => {
       ])
     )
     await expect(
-      createArmyApi('https://army.example', invalidFetcher).listArmies('owner', 'token')
+      createArmyApi('https://army.example', invalidFetcher).listArmies('token')
     ).rejects.toMatchObject({ status: 502 })
 
     const deniedFetcher = vi.fn().mockResolvedValue(jsonResponse('An active subscription is required.', 403))

--- a/src/tests/aos4/armyCollection.test.tsx
+++ b/src/tests/aos4/armyCollection.test.tsx
@@ -112,7 +112,7 @@ describe('cloud army collection state', () => {
         scope: 'openid profile email',
       },
     })
-    expect(armyApi.listArmies).toHaveBeenCalledWith('auth0|owner-1', 'access-token')
+    expect(armyApi.listArmies).toHaveBeenCalledWith('access-token')
     expect(container.querySelector('[data-testid="armies"]')?.textContent).toBe('cloud-1')
   })
 

--- a/src/tests/aos4/homePresentation.test.tsx
+++ b/src/tests/aos4/homePresentation.test.tsx
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const auth = vi.hoisted(() => ({
   isAuthenticated: false,
   isLoading: false,
+  getAccessTokenSilently: vi.fn(),
   loginWithPopup: vi.fn(),
   logout: vi.fn(),
   user: undefined as { email: string } | undefined,
@@ -100,8 +101,10 @@ describe('AoS 4 home presentation', () => {
     auth.isLoading = false
     auth.user = undefined
     auth.loginWithPopup.mockReset()
+    auth.getAccessTokenSilently.mockReset()
+    auth.getAccessTokenSilently.mockResolvedValue('audience-token')
     getSubscription.mockReset()
-    getSubscription.mockRejectedValue({ status: 501 })
+    getSubscription.mockRejectedValue({ status: 404 })
     historyPush.mockReset()
     Object.defineProperty(window, 'localStorage', {
       configurable: true,
@@ -176,7 +179,7 @@ describe('AoS 4 home presentation', () => {
     const findButton = (label: string) =>
       Array.from(container.querySelectorAll('button')).find(button => button.textContent?.trim() === label)
 
-    expect(getSubscription).toHaveBeenCalledWith('inactive@example.com')
+    expect(getSubscription).toHaveBeenCalledWith('audience-token')
     expect(findButton('My Armies')?.disabled).toBe(false)
     expect(findButton('Share Army')?.disabled).toBe(false)
 

--- a/src/tests/aos4/pricingPlans.test.tsx
+++ b/src/tests/aos4/pricingPlans.test.tsx
@@ -30,7 +30,13 @@ const analytics = vi.hoisted(() => ({
   logPurchase: vi.fn(),
 }))
 
+const token = vi.hoisted(() => ({ get: vi.fn() }))
+
 vi.mock('utils/analytics', () => analytics)
+
+vi.mock('utils/authToken', () => ({
+  useApiAccessToken: () => token.get,
+}))
 
 vi.mock('@auth0/auth0-react', () => ({
   useAuth0: () => ({
@@ -75,6 +81,8 @@ describe('subscription pricing plans', () => {
   beforeEach(() => {
     stripe.redirectToCheckout.mockReset()
     paypal.callbacks = null
+    token.get.mockReset()
+    token.get.mockResolvedValue('audience-token')
     vi.clearAllMocks()
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -191,5 +199,9 @@ describe('subscription pricing plans', () => {
       provider: 'paypal',
       transactionId: 'subscription-id',
     })
+    expect(SubscriptionApi.requestGrant).toHaveBeenCalledWith(
+      { subscriptionId: 'subscription-id' },
+      'audience-token'
+    )
   })
 })

--- a/src/tests/aos4/subscriberTheme.test.tsx
+++ b/src/tests/aos4/subscriberTheme.test.tsx
@@ -19,12 +19,20 @@ const subscriptionApi = vi.hoisted(() => ({
   updateTheme: vi.fn(),
 }))
 
+const token = vi.hoisted(() => ({
+  get: vi.fn(),
+}))
+
 vi.mock('context/useSubscription', () => ({
   useSubscription: () => account,
 }))
 
 vi.mock('../../api/subscriptionApi', () => ({
   SubscriptionApi: subscriptionApi,
+}))
+
+vi.mock('utils/authToken', () => ({
+  useApiAccessToken: () => token.get,
 }))
 
 const Probe = () => {
@@ -61,6 +69,8 @@ describe('subscriber theme continuity', () => {
     })
     subscriptionApi.updateTheme.mockReset()
     subscriptionApi.updateTheme.mockResolvedValue({})
+    token.get.mockReset()
+    token.get.mockResolvedValue('audience-token')
     container = document.createElement('div')
     container.id = 'root'
     document.body.appendChild(container)
@@ -88,16 +98,13 @@ describe('subscriber theme continuity', () => {
     expect(container.textContent).toBe('Dark')
     expect(window.localStorage.getItem('theme')).toBe('dark')
 
-    act(() => {
+    await act(async () => {
       container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
     })
 
     expect(container.textContent).toBe('Light')
     expect(window.localStorage.getItem('theme')).toBe('light')
-    expect(subscriptionApi.updateTheme).toHaveBeenCalledWith({
-      id: 'account-1',
-      theme: 'light',
-      userName: 'general@example.com',
-    })
+    expect(subscriptionApi.updateTheme).toHaveBeenCalledWith({ theme: 'light' }, 'audience-token')
   })
 })

--- a/src/tests/aos4/subscriptionApi.test.ts
+++ b/src/tests/aos4/subscriptionApi.test.ts
@@ -1,54 +1,22 @@
-import { SubscriptionApi } from '../../api/subscriptionApi'
+import { createSubscriptionApi } from '../../api/subscriptionApi'
 import { describe, expect, it, vi } from 'vitest'
 
-/*
- * The subscription API is an API Gateway REST API and does not decode percent-encoded path
- * parameters. A `%40` in place of `@` reaches the lambda literally, matches no stored userName, and
- * answers 501 — which `useSubscription` reads as "no subscription". Encoding the address therefore
- * made every subscriber look unsubscribed, in both the dev and prod stacks, without an error.
- */
+describe('subscription API ownership boundary', () => {
+  it('never puts caller identity or the retired browser key into a request', async () => {
+    const requests: RequestInit[] = []
+    const fetcher = vi.fn(async (_input: RequestInfo | URL, options?: RequestInit) => {
+      requests.push(options || {})
+      return new Response(JSON.stringify({ success: true }), { status: 200 })
+    })
+    const api = createSubscriptionApi('https://subscriptions.example.test', fetcher)
 
-const requested: string[] = []
+    await api.cancelSubscription('token')
+    await api.updateTheme({ theme: 'light' }, 'token')
+    await api.redeemCoupon({ couponId: 'COUPON1' }, 'token')
 
-vi.mock('superagent', () => {
-  const chain = { timeout: () => chain, send: () => chain }
-  return {
-    default: {
-      get: (url: string) => {
-        requested.push(url)
-        return chain
-      },
-      post: (url: string) => {
-        requested.push(url)
-        return chain
-      },
-    },
-  }
-})
-
-describe('subscription API client', () => {
-  it('leaves @ literal in the user lookup path', () => {
-    requested.length = 0
-    SubscriptionApi.getSubscription('davis.e.ford.alt@gmail.com')
-
-    expect(requested).toHaveLength(1)
-    expect(requested[0]).toContain('/user/davis.e.ford.alt@gmail.com')
-    expect(requested[0]).not.toContain('%40')
-  })
-
-  it('still escapes characters that would break path routing', () => {
-    requested.length = 0
-    SubscriptionApi.getSubscription('a/b?c#d@example.com')
-
-    const [url] = requested
-    const path = url.slice(url.indexOf('/user/') + '/user/'.length)
-    expect(path).toBe('a%2Fb%3Fc%23d@example.com')
-  })
-
-  it('preserves plus-addressed accounts', () => {
-    requested.length = 0
-    SubscriptionApi.getSubscription('davis+aos@gmail.com')
-
-    expect(requested[0]).toContain('/user/davis%2Baos@gmail.com')
+    for (const options of requests) {
+      const serialized = String(options.body || '')
+      expect(serialized).not.toMatch(/authKey|userName|email|subscriptionId|"id"/)
+    }
   })
 })

--- a/src/tests/aos4/subscriptionContext.test.tsx
+++ b/src/tests/aos4/subscriptionContext.test.tsx
@@ -15,6 +15,10 @@ const subscriptionApi = vi.hoisted(() => ({
   getSubscription: vi.fn(),
 }))
 
+const token = vi.hoisted(() => ({
+  get: vi.fn(),
+}))
+
 vi.mock('@auth0/auth0-react', () => ({
   useAuth0: () => auth,
 }))
@@ -23,13 +27,16 @@ vi.mock('../../api/subscriptionApi', () => ({
   SubscriptionApi: subscriptionApi,
 }))
 
+vi.mock('utils/authToken', () => ({
+  useApiAccessToken: () => token.get,
+}))
+
 const Probe = () => {
   const {
     cancelSubscription,
     getSubscription,
     isActive,
     isNotSubscribed,
-    subscription,
     subscriptionError,
     subscriptionLoading,
   } = useSubscription()
@@ -40,7 +47,6 @@ const Probe = () => {
         {subscriptionLoading ? 'loading' : isActive ? 'active' : isNotSubscribed ? 'none' : 'unknown'}
       </span>
       <span data-testid="error">{subscriptionError}</span>
-      <span data-testid="user">{subscription.userName}</span>
       <button type="button" onClick={() => void cancelSubscription()}>
         Cancel
       </button>
@@ -60,6 +66,8 @@ describe('subscription account state', () => {
     subscriptionApi.cancelSubscription.mockReset()
     subscriptionApi.cancelSubscription.mockResolvedValue({})
     subscriptionApi.getSubscription.mockReset()
+    token.get.mockReset()
+    token.get.mockResolvedValue('audience-token')
     container = document.createElement('div')
     document.body.appendChild(container)
   })
@@ -89,18 +97,15 @@ describe('subscription account state', () => {
     subscriptionApi.getSubscription.mockResolvedValue({
       body: {
         active: true,
-        id: 'account-1',
         subscribed: true,
-        subscriptionId: 'subscription-1',
-        userName: 'general@example.com',
       },
     })
 
     await renderProbe()
 
-    expect(subscriptionApi.getSubscription).toHaveBeenCalledWith('general@example.com')
+    expect(token.get).toHaveBeenCalled()
+    expect(subscriptionApi.getSubscription).toHaveBeenCalledWith('audience-token')
     expect(container.querySelector('[data-testid="status"]')?.textContent).toBe('active')
-    expect(container.querySelector('[data-testid="user"]')?.textContent).toBe('general@example.com')
     expect(container.querySelector('[data-testid="error"]')?.textContent).toBe('')
   })
 
@@ -108,9 +113,7 @@ describe('subscription account state', () => {
     subscriptionApi.getSubscription.mockRejectedValueOnce({ status: 503 }).mockResolvedValueOnce({
       body: {
         active: true,
-        id: 'account-1',
         subscribed: true,
-        userName: 'general@example.com',
       },
     })
 
@@ -132,8 +135,8 @@ describe('subscription account state', () => {
     expect(container.querySelector('[data-testid="status"]')?.textContent).toBe('active')
   })
 
-  it('treats the legacy no-subscription response as an inactive account rather than an outage', async () => {
-    subscriptionApi.getSubscription.mockRejectedValue({ status: 501 })
+  it('treats an unknown account as inactive rather than an outage', async () => {
+    subscriptionApi.getSubscription.mockRejectedValue({ status: 404 })
 
     await renderProbe()
 
@@ -141,14 +144,21 @@ describe('subscription account state', () => {
     expect(container.querySelector('[data-testid="error"]')?.textContent).toBe('')
   })
 
+  it('keeps a silent-token failure distinct from an inactive account', async () => {
+    token.get.mockRejectedValue(new Error('login required'))
+
+    await renderProbe()
+
+    expect(subscriptionApi.getSubscription).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-testid="status"]')?.textContent).toBe('unknown')
+    expect(container.querySelector('[data-testid="error"]')?.textContent).toContain('temporarily unavailable')
+  })
+
   it('cancels a Stripe subscription and refreshes its server state', async () => {
     const subscription = {
       active: true,
       createdBy: 'stripe',
-      id: 'account-1',
       subscribed: true,
-      subscriptionId: 'subscription-1',
-      userName: 'general@example.com',
     }
     subscriptionApi.getSubscription.mockResolvedValue({ body: subscription })
 
@@ -159,10 +169,7 @@ describe('subscription account state', () => {
       await Promise.resolve()
     })
 
-    expect(subscriptionApi.cancelSubscription).toHaveBeenCalledWith({
-      subscriptionId: 'subscription-1',
-      userName: 'general@example.com',
-    })
+    expect(subscriptionApi.cancelSubscription).toHaveBeenCalledWith('audience-token')
     expect(subscriptionApi.getSubscription).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/tests/aos4/subscriptionContext.test.tsx
+++ b/src/tests/aos4/subscriptionContext.test.tsx
@@ -6,6 +6,7 @@ import { act } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const auth = vi.hoisted(() => ({
+  isAuthenticated: true,
   isLoading: false,
   user: { email: 'general@example.com' } as { email: string } | undefined,
 }))
@@ -61,6 +62,7 @@ describe('subscription account state', () => {
   let container: HTMLDivElement
 
   beforeEach(() => {
+    auth.isAuthenticated = true
     auth.isLoading = false
     auth.user = { email: 'general@example.com' }
     subscriptionApi.cancelSubscription.mockReset()
@@ -106,6 +108,17 @@ describe('subscription account state', () => {
     expect(token.get).toHaveBeenCalled()
     expect(subscriptionApi.getSubscription).toHaveBeenCalledWith('audience-token')
     expect(container.querySelector('[data-testid="status"]')?.textContent).toBe('active')
+    expect(container.querySelector('[data-testid="error"]')?.textContent).toBe('')
+  })
+
+  it('does not load subscription state for a signed-out session with stale user data', async () => {
+    auth.isAuthenticated = false
+
+    await renderProbe()
+
+    expect(token.get).not.toHaveBeenCalled()
+    expect(subscriptionApi.getSubscription).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-testid="status"]')?.textContent).toBe('none')
     expect(container.querySelector('[data-testid="error"]')?.textContent).toBe('')
   })
 

--- a/src/tests/deploymentConfig.test.ts
+++ b/src/tests/deploymentConfig.test.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { inspectDeploymentArtifact, validateDeploymentEndpoints } from '../../scripts/deploymentConfig'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const validEndpoints = {
+  armyApiUrl: 'https://army123.execute-api.us-east-1.amazonaws.com',
+  subscriptionApiUrl: 'https://subs123.execute-api.us-east-1.amazonaws.com',
+}
+
+describe('production deployment configuration', () => {
+  const temporaryDirectories: string[] = []
+
+  afterEach(() => {
+    temporaryDirectories.splice(0).forEach(directory => rmSync(directory, { recursive: true }))
+  })
+
+  it('accepts distinct production HTTP API endpoints', () => {
+    expect(validateDeploymentEndpoints(validEndpoints)).toEqual(validEndpoints)
+  })
+
+  it.each([
+    ['', /VITE_ARMY_API_URL/],
+    ['http://army123.execute-api.us-east-1.amazonaws.com', /HTTPS/],
+    ['https://localhost:3000', /production HTTP API/],
+    ['https://subscription-api.invalid', /production HTTP API/],
+    ['https://army123.execute-api.us-east-1.amazonaws.com/dev', /production stage/],
+    ['https://army123.execute-api.eu-west-1.amazonaws.com', /us-east-1/],
+  ])('rejects an unsafe army endpoint %s', (armyApiUrl, expected) => {
+    expect(() => validateDeploymentEndpoints({ ...validEndpoints, armyApiUrl })).toThrow(expected)
+  })
+
+  it('rejects a missing or reused subscription endpoint', () => {
+    expect(() => validateDeploymentEndpoints({ ...validEndpoints, subscriptionApiUrl: '' })).toThrow(
+      /VITE_SUBSCRIPTION_API_URL/
+    )
+    expect(() =>
+      validateDeploymentEndpoints({
+        ...validEndpoints,
+        subscriptionApiUrl: validEndpoints.armyApiUrl,
+      })
+    ).toThrow(/distinct/)
+  })
+
+  it('requires both intended endpoints and no retired authorization material in the bundle', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'aos-reminders-deploy-'))
+    temporaryDirectories.push(directory)
+    writeFileSync(join(directory, 'index.js'), JSON.stringify(validEndpoints))
+
+    expect(inspectDeploymentArtifact(directory, validEndpoints)).toMatchObject({ filesInspected: 1 })
+
+    writeFileSync(
+      join(directory, 'index.js'),
+      `${JSON.stringify(validEndpoints)};const request={authKey:'retired'}`
+    )
+    expect(() => inspectDeploymentArtifact(directory, validEndpoints)).toThrow(/retired authorization/)
+  })
+
+  it('keeps every release gate before AWS mutation and deploys only master', () => {
+    const workflow = readFileSync(join(process.cwd(), '.github', 'workflows', 'deploy.yml'), 'utf8')
+    const syncIndex = workflow.indexOf('aws s3 sync')
+
+    expect(workflow).toMatch(/branches:\s*\n\s*- master/)
+    expect(workflow).not.toMatch(/branches:\s*\[[^\]]*aos4-migration/)
+    for (const command of [
+      'yarn release:validate-config',
+      'yarn lint',
+      'yarn test --run',
+      'yarn data:aos4:verify:beta',
+      'yarn tsc --noEmit',
+      'yarn build',
+      'yarn release:inspect-artifact',
+    ]) {
+      const commandIndex = workflow.indexOf(command)
+      expect(commandIndex, `${command} is present`).toBeGreaterThan(-1)
+      expect(commandIndex, `${command} runs before upload`).toBeLessThan(syncIndex)
+    }
+  })
+})

--- a/src/tests/subscriptionApi.test.ts
+++ b/src/tests/subscriptionApi.test.ts
@@ -1,46 +1,61 @@
+import { createSubscriptionApi, SubscriptionApiError } from '../api/subscriptionApi'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const timeout = vi.fn(() => Promise.resolve({ ok: true }))
-const send = vi.fn((data: Record<string, unknown>) => ({ timeout, data }))
-const post = vi.fn((url: string) => ({ send, url }))
-const get = vi.fn((url: string) => ({ timeout, url }))
+describe('subscription current-account API', () => {
+  const requests: Array<{ url: string; options?: RequestInit }> = []
+  const fetcher = vi.fn(async (url: string | URL | Request, options?: RequestInit) => {
+    requests.push({ url: String(url), options })
+    return new Response(JSON.stringify({ success: true }), { status: 200 })
+  })
+  const api = createSubscriptionApi('https://subscriptions.example.test/base/', fetcher)
 
-vi.mock('superagent', () => ({
-  default: {
-    post: (url: string) => post(url),
-    get: (url: string) => get(url),
-  },
-}))
-
-import { SubscriptionApi } from '../api/subscriptionApi'
-
-describe('SubscriptionApi.requestGrant', () => {
   beforeEach(() => {
-    post.mockClear()
-    send.mockClear()
+    requests.length = 0
+    fetcher.mockClear()
   })
 
-  it('sends the payment proof (subscriptionId + planId) with the grant request', async () => {
-    await SubscriptionApi.requestGrant({
-      userName: 'user@example.com',
-      subscriptionId: 'I-ABC123XYZ',
-      planId: 'P-54G67667NT497912UL5TBTBQ',
-    })
+  it('sends bearer auth and action-only bodies for every account operation', async () => {
+    const token = 'audience-token'
+    await api.getSubscription(token)
+    await api.cancelSubscription(token)
+    await api.requestGrant({ subscriptionId: 'I-ABC123XYZ' }, token)
+    await api.redeemCoupon({ couponId: 'COUPON1' }, token)
+    await api.redeemGift({ giftId: 'gift-1', userId: 'giver-1' }, token)
+    await api.updateTheme({ theme: 'dark' }, token)
 
-    expect(post).toHaveBeenCalledWith(expect.stringContaining('/paypal_grant'))
-    const payload = send.mock.calls[0][0]
-    expect(payload.userName).toEqual('user@example.com')
-    expect(payload.subscriptionId).toEqual('I-ABC123XYZ')
-    expect(payload.planId).toEqual('P-54G67667NT497912UL5TBTBQ')
-    expect(typeof payload.authKey).toEqual('string')
+    expect(requests.map(request => request.url)).toEqual([
+      'https://subscriptions.example.test/base/account',
+      'https://subscriptions.example.test/base/account/cancel',
+      'https://subscriptions.example.test/base/account/paypal-grant',
+      'https://subscriptions.example.test/base/account/redeem-coupon',
+      'https://subscriptions.example.test/base/account/redeem-gift',
+      'https://subscriptions.example.test/base/account/theme',
+    ])
+    for (const request of requests) {
+      expect(new Headers(request.options?.headers).get('Authorization')).toBe('Bearer audience-token')
+    }
+    expect(requests.map(request => request.options?.body)).toEqual([
+      undefined,
+      undefined,
+      JSON.stringify({ subscriptionId: 'I-ABC123XYZ' }),
+      JSON.stringify({ couponId: 'COUPON1' }),
+      JSON.stringify({ giftId: 'gift-1', userId: 'giver-1' }),
+      JSON.stringify({ theme: 'dark' }),
+    ])
   })
 
-  it('degrades to a userName-only grant when no approval data is available', async () => {
-    await SubscriptionApi.requestGrant({ userName: 'user@example.com' })
+  it('fails before network access when the endpoint is absent', async () => {
+    const unconfigured = createSubscriptionApi('', fetcher)
+    await expect(unconfigured.getSubscription('token')).rejects.toMatchObject({ status: 503 })
+    expect(fetcher).not.toHaveBeenCalled()
+  })
 
-    const payload = send.mock.calls[0][0]
-    expect(payload.userName).toEqual('user@example.com')
-    expect(payload.subscriptionId).toBeUndefined()
-    expect(payload.planId).toBeUndefined()
+  it('preserves HTTP status for account-state recovery', async () => {
+    const unavailable = createSubscriptionApi('https://subscriptions.example.test', async () =>
+      Promise.resolve(new Response(JSON.stringify('Not authorized'), { status: 401 }))
+    )
+    await expect(unavailable.getSubscription('token')).rejects.toEqual(
+      expect.objectContaining<Partial<SubscriptionApiError>>({ status: 401 })
+    )
   })
 })

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -6,32 +6,22 @@ export interface IGiftSubscription {
   planInterval: string
   planIntervalCount: number
   url: string
-  userName: string
 }
 
 export interface Subscription {
   active?: boolean
-  createdAt?: number
   createdBy?: 'admin' | 'stripe' | 'paypal' | 'gift' | 'coupon'
-  customerId?: string
   expired?: boolean
-  favoriteFaction?: string
   giftSubscriptions?: IGiftSubscription[]
   has_grant?: boolean
-  id: string
-  livemode?: boolean
   planId?: string
   planInterval?: string
   planIntervalCount?: number
   subscribed: boolean
-  subscriptionCreated?: number
-  subscriptionEnd?: number
   subscriptionId?: string
   subscriptionStart?: number
   subscriptionStatus?: 'active' | 'canceled' | 'pending_activation' | 'temporary_grant'
   theme?: TThemeType
-  updatedAt?: number
-  userName: string
 }
 
 export type ISubscription = Subscription

--- a/src/utils/authToken.ts
+++ b/src/utils/authToken.ts
@@ -15,12 +15,14 @@ export const useApiAccessToken = (): (() => Promise<string>) => {
   return useCallback(async () => {
     if (!isAuthenticated) throw new AuthenticationRequiredError()
     try {
-      return await getAccessTokenSilently({
+      const token = await getAccessTokenSilently({
         authorizationParams: {
           audience: config.audience,
           scope: 'openid profile email',
         },
       })
+      if (!token) throw new AuthenticationRequiredError()
+      return token
     } catch {
       throw new AuthenticationRequiredError()
     }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -11,7 +11,6 @@ export const PAYPAL_CLIENT_ID = isProd
   : 'AUdnPSV280IH8pjveo62IzfQJgfFo0MoJ9w-zouTipgjAethtmcvHFjV8DXCCqoti4WHdbjhMNnwn9oa'
 
 export const BASE_URL = isProd ? 'https://aosreminders.com' : 'http://localhost:3000'
-export const SUBSCRIPTION_AUTH_KEY = 'b5bef450-e624-11e9-81b4-2a2ae2dbcce4'
 export const GITHUB_URL = '//github.com/daviseford/aos-reminders'
 
 export const ROUTES = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,11 +882,6 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/cookiejar@*":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.1.tgz#90b68446364baf9efd8e8349bb36bd3852b75b80"
-  integrity sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==
-
 "@types/estree@1.0.5", "@types/estree@^1.0.0":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
@@ -1050,14 +1045,6 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
-
-"@types/superagent@4.1.24":
-  version "4.1.24"
-  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.24.tgz#e1f9ad3b66a21ed13c047e8529009735732dde0a"
-  integrity sha512-mEafCgyKiMFin24SDzWN7yAADt4gt6YawFiNMp0QS5ZPboORfyxFt0s3VzJKhTaKg9py/4FUmrHLTNfJKt9Rbw==
-  dependencies:
-    "@types/cookiejar" "*"
-    "@types/node" "*"
 
 "@types/use-sync-external-store@^0.0.6":
   version "0.0.6"
@@ -1460,11 +1447,6 @@ arraybuffer.prototype.slice@^1.0.3:
     is-array-buffer "^3.0.4"
     is-shared-array-buffer "^1.0.2"
 
-asap@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
-
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -1824,11 +1806,6 @@ compare-versions@^3.6.0:
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
   integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
 
-component-emitter@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
-  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1845,11 +1822,6 @@ convert-source-map@^1.7.0:
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
   dependencies:
     safe-buffer "~5.1.1"
-
-cookiejar@^2.1.3:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
-  integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
 copy-to-clipboard@^3.3.1:
   version "3.3.3"
@@ -2085,14 +2057,6 @@ dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
-
-dezalgo@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
-  integrity sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=
-  dependencies:
-    asap "^2.0.0"
-    wrappy "1"
 
 diff-sequences@^29.6.3:
   version "29.6.3"
@@ -2703,11 +2667,6 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-safe-stringify@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
-  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
-
 fastq@^1.6.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.9.0.tgz#e16a72f338eaca48e91b5c23593bcc2ef66b7947"
@@ -2814,16 +2773,6 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
-
-formidable@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-2.0.1.tgz#4310bc7965d185536f9565184dee74fbb75557ff"
-  integrity sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==
-  dependencies:
-    dezalgo "1.0.3"
-    hexoid "1.0.0"
-    once "1.4.0"
-    qs "6.9.3"
 
 frac@~1.1.2:
   version "1.1.2"
@@ -3167,11 +3116,6 @@ hasown@^2.0.3:
   dependencies:
     function-bind "^1.1.2"
 
-hexoid@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
-  integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
-
 history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
@@ -3306,7 +3250,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3:
+inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3937,13 +3881,6 @@ loupe@^3.1.0, loupe@^3.1.1:
   dependencies:
     get-func-name "^2.0.1"
 
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
-
 luxon@2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.5.2.tgz#17ed497f0277e72d58a4756d6a9abee4681457b6"
@@ -3976,11 +3913,6 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
-  integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
-
 micromatch@^4.0.4:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
@@ -4000,11 +3932,6 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
   dependencies:
     mime-db "1.44.0"
-
-mime@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
-  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -4223,7 +4150,7 @@ omggif@1.0.7:
   resolved "https://registry.yarnpkg.com/omggif/-/omggif-1.0.7.tgz#59d2eecb0263de84635b3feb887c0c9973f1e49d"
   integrity sha1-WdLuywJj3oRjWz/riHwMmXPx5J0=
 
-once@1.4.0, once@^1.3.0:
+once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -4567,18 +4494,6 @@ qs@6.11.2:
   dependencies:
     side-channel "^1.0.4"
 
-qs@6.9.3:
-  version "6.9.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.3.tgz#bfadcd296c2d549f1dffa560619132c977f5008e"
-  integrity sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==
-
-qs@^6.10.3:
-  version "6.12.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.12.3.tgz#e43ce03c8521b9c7fd7f1f13e514e5ca37727754"
-  integrity sha512-AWJm14H1vVaO/iNZ4/hO+HyaTehuy9nRqVdkTqlJt0HWvBiBIEXFmb4C0DGeYo3Xes9rrEW+TxHsaigCbN5ICQ==
-  dependencies:
-    side-channel "^1.0.6"
-
 qs@~6.5.2:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
@@ -4782,15 +4697,6 @@ react@19.2.8:
   version "19.2.8"
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.8.tgz#a80663dbb58d69c6fe3fd291d3cb324e8a7dff2d"
   integrity sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==
-
-readable-stream@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
 
 readdirp@~3.5.0:
   version "3.5.0"
@@ -5023,7 +4929,7 @@ safe-array-concat@^1.1.2:
     has-symbols "^1.0.3"
     isarray "^2.0.5"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -5094,13 +5000,6 @@ semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^7.3.7:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
-  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
-  dependencies:
-    lru-cache "^6.0.0"
 
 semver@^7.6.0:
   version "7.6.2"
@@ -5399,13 +5298,6 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
 strip-ansi@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
@@ -5454,23 +5346,6 @@ stylis@^4.0.3:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.6.tgz#0d8b97b6bc4748bea46f68602b6df27641b3c548"
   integrity sha512-1igcUEmYFBEO14uQHAJhCUelTR5jPztfdVKrYxRnDa5D5Dn3w0NxXupJNPr/VV/yRfZYEAco8sTIRZzH3sRYKg==
-
-superagent@7.1.6:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-7.1.6.tgz#64f303ed4e4aba1e9da319f134107a54cacdc9c6"
-  integrity sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==
-  dependencies:
-    component-emitter "^1.3.0"
-    cookiejar "^2.1.3"
-    debug "^4.3.4"
-    fast-safe-stringify "^2.1.1"
-    form-data "^4.0.0"
-    formidable "^2.0.1"
-    methods "^1.1.2"
-    mime "2.6.0"
-    qs "^6.10.3"
-    readable-stream "^3.6.0"
-    semver "^7.3.7"
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -5854,11 +5729,6 @@ use-sync-external-store@^1.4.0, use-sync-external-store@^1.6.0:
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
-util-deprecate@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
-
 uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -6175,11 +6045,6 @@ y18n@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
   integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0:
   version "1.10.0"


### PR DESCRIPTION
## Summary

Version 6's paid-account and cloud features now have an explicit secure cutover path instead of
depending on a shared browser key, caller-selected ownership, or optional backend configuration.
The SPA sends the same audience-scoped Auth0 bearer token to subscription and army operations,
signed-out sessions make no account request, and cloud collection reads no longer submit an owner.

The production workflow now requires distinct production HTTP API endpoints, validates them before
loading AWS credentials, and confirms both endpoints—and no retired authorization material—are in
the built artifact before S3 synchronization. The release runbook and implementation plan record
the service order, retained-data checks, evidence boundaries, no-insecure-rollback rule, smoke
matrix, and the operations that still require explicit authorization.

| Surface | Prepared change | Release role |
| --- | --- | --- |
| Frontend | This PR | Bearer-token clients, private collection contract, fail-closed deploy gate |
| Subscription API | daviseford/aos-reminders-subscription-api#17 | Current-account authorization, verified/replay-safe callbacks |
| Army/share API | daviseford/aos-reminders-rest-api#11 | Account-private collections, opaque public shares |
| Version 6 release | #1717 | Later `aos4-migration` → `master` cutover; not merged by this PR |

## Remaining launch gates

- The companion-service PRs are merged but not deployed. Deploy and dev-prove both services;
  review the private subscription repository's credential history and rotate only if access
  history, policy, or other evidence requires it.
- Populate `PRODUCTION_ARMY_API_URL` and `PRODUCTION_SUBSCRIPTION_API_URL` with the reviewed
  production endpoints. Those repository variables are currently absent, so a `master` deployment
  intentionally fails before AWS credentials or S3 access.
- Run the two-account cloud matrix and subscription/provider matrix against deployed dev stacks,
  then record only redacted result metadata in the launch issue.
- Obtain explicit project-owner authorization for each production API change and, separately, for
  merging #1717. This PR performs none of those operations.

## Validation

- `yarn lint` and `yarn tsc --noEmit` passed.
- `yarn test --run` passed 1,102 tests across 71 files. A certification test initially exceeded its
  existing five-second timeout while the suite, beta gate, and build ran concurrently; it passed in
  111 ms alone, and the complete serial rerun passed.
- `yarn data:aos4:verify:beta` passed 79,598 checks with zero findings and zero cannot-verify results.
- Production-config validation, `yarn build`, and artifact inspection passed with two safe stand-in
  execute-api endpoints; 32 artifact files were inspected. Stand-ins demonstrate the gate, not
  production readiness.
- The companion services passed 83 subscription tests and 29 army/share tests, plus dev/prod
  Serverless packaging and unsafe-production-config rejection.

The local machine exposed Node 25.2.1 rather than the repository's required Node 22.23.2; the
GitHub workflows remain pinned to Node 22 and must be green before rollout.

## Post-Deploy Monitoring & Validation

After authorized dev deployments, run the included black-box harnesses with two active accounts,
inactive/unverified identities, expired/wrong-issuer/wrong-audience tokens, signed provider events,
duplicate delivery, CORS probes, cross-account cloud attempts, public-share redaction, and cleanup.

For production, deploy subscription security first, then the army/share API, set the two repository
variables, and only then consider #1717. Monitor provider dashboards, API Gateway/Lambda error and
authorization rates, the replay ledger, entitlement failures, and DynamoDB alarms; inspect the live
bundle endpoints and complete the account/cloud/import/print/local-state smoke matrix. Availability
may be rolled back, but the browser key, unsigned callbacks, and public collection reads may not.

## Related

Related: #1720, #1731, #1804, #1805, #1806

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
