### PR TITLE
docs: record merged launch hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,10 +175,10 @@ The companion API services (`aos-reminders-rest-api`, `aos-reminders-subscriptio
 `nodejs22.x`/Serverless v4/AWS SDK v3 with characterization tests and CI (plan
 `2026-07-28-002`, units U2/U3). Issue #1727 completed authenticated CI `serverless package` gates,
 dev verification, and the dev/prod runtime deploys. The later AoS 4-native army/share service in
-`aos-reminders-rest-api#10` is dev-validated; its private-read/production hardening is prepared in
+`aos-reminders-rest-api#10` is dev-validated; its private-read/production hardening merged in
 `aos-reminders-rest-api#11` but still needs the coordinated production deployment and frontend API
-configuration tracked in issue #1804. Subscription authorization and verified webhook handling are
-prepared in `aos-reminders-subscription-api#17` but remain a production gate under issue #1720. Live
+configuration tracked in issue #1804. Subscription authorization and verified webhook handling
+merged in `aos-reminders-subscription-api#17` but remain a production gate under issue #1720. Live
 real-money Stripe and PayPal verification after the Version 6 frontend deploy remains tracked in
 issue #1731, and the full production smoke/operational handoff is issue #1805.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -40,7 +40,7 @@ Before merging #1717, confirm all of the following:
 - the accepted beta pointer still resolves to
   `data/aos4/certifications/aos4-corpus-2026-07-30-machine-r3`;
 - the project owner explicitly authorizes the `master` merge and resulting frontend deployment;
-- the AoS 4-native army/share service from `aos-reminders-rest-api#10` is deployed to production
+- the AoS 4-native army/share service through `aos-reminders-rest-api#11` is deployed to production
   with the production entitlement URL, Auth0 issuer/audience, share base URL, and CORS origins;
   [#1804](https://github.com/daviseford/aos-reminders/issues/1804) tracks the coordinated rollout;
 - repository variables `PRODUCTION_ARMY_API_URL` and `PRODUCTION_SUBSCRIPTION_API_URL` contain the


### PR DESCRIPTION
## Summary

Launch documentation now distinguishes merged implementation from the production deployment and
live-verification gates that remain before #1717. The release runbook also points to the final
army/share hardening PR instead of its earlier dev baseline.

This changes no runtime behavior or production configuration.

## Validation

- `git diff --check`

## Related

Related: #1717, #1720, #1804
