### PR TITLE
feat(infra): add immutable DynamoDB export backups

### DIFF
--- a/infra/dynamodb-backups/README.md
+++ b/infra/dynamodb-backups/README.md
@@ -1,0 +1,70 @@
+# DynamoDB production backups
+
+This independent CloudFormation stack exports every AoS Reminders production DynamoDB table to
+S3 each night at 09:00 UTC. It is deliberately outside every application service stack, so an app
+rollback or `serverless remove` cannot delete the backup schedule or bucket.
+
+The bucket has versioning, public-access blocking, AES-256 server-side encryption, and S3 Object
+Lock in governance mode for 35 days. Current exports expire after 45 days; once an object becomes
+noncurrent, lifecycle cleanup removes it after its retention has elapsed. CloudFormation retains
+the bucket if this stack is deleted.
+
+## Deploy
+
+From the repository root:
+
+```powershell
+aws cloudformation validate-template `
+  --region us-east-1 `
+  --template-body file://infra/dynamodb-backups/template.yaml
+
+aws cloudformation deploy `
+  --region us-east-1 `
+  --stack-name aos-reminders-dynamodb-backups `
+  --template-file infra/dynamodb-backups/template.yaml `
+  --capabilities CAPABILITY_IAM `
+  --no-fail-on-empty-changeset
+```
+
+The default bucket name is `aos-reminders-dynamodb-backups`. Override `BackupBucketName` during
+the first deployment only if that globally unique name is unavailable. Object Lock cannot be
+disabled after bucket creation.
+
+## Verify exports
+
+Invoke the function once after deployment instead of waiting for the nightly rule:
+
+```powershell
+aws lambda invoke `
+  --region us-east-1 `
+  --function-name aos-reminders-dynamodb-backup-export `
+  --cli-binary-format raw-in-base64-out `
+  .cache/aos4/dynamodb-backup-invocation.json
+
+aws dynamodb list-exports `
+  --region us-east-1 `
+  --query 'ExportSummaries[].{Arn:ExportArn,Status:ExportStatus}'
+```
+
+Each table prefix contains an `AWSDynamoDB` export directory. Inspect a data object's retention
+metadata with `aws s3api head-object --bucket aos-reminders-dynamodb-backups --key <key>` and
+confirm `ObjectLockMode` is `GOVERNANCE` with an `ObjectLockRetainUntilDate` at least 35 days after
+creation.
+
+## Prove a restore
+
+DynamoDB import creates a new table; it never overwrites the source table. Use the data directory
+for one completed export, not the export's parent prefix:
+
+```powershell
+aws dynamodb import-table `
+  --region us-east-1 `
+  --s3-bucket-source S3Bucket=aos-reminders-dynamodb-backups,S3KeyPrefix=<table>/<date>/AWSDynamoDB/<export-id>/data/ `
+  --input-format DYNAMODB_JSON `
+  --input-compression-type GZIP `
+  --table-creation-parameters file://<throwaway-table-parameters.json>
+```
+
+Wait for the import to complete, compare the throwaway table's `ItemCount` with the export's
+`ItemCount`, then delete only the explicitly named throwaway table. The retained S3 export remains
+the recovery source.

--- a/infra/dynamodb-backups/template.yaml
+++ b/infra/dynamodb-backups/template.yaml
@@ -1,0 +1,236 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Independent nightly DynamoDB exports for AoS Reminders production data.
+
+Parameters:
+  BackupBucketName:
+    Type: String
+    Default: aos-reminders-dynamodb-backups
+    Description: Globally unique S3 bucket created with Object Lock enabled.
+
+Resources:
+  BackupBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Ref BackupBucketName
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireExportsAfterRetention
+            Status: Enabled
+            Prefix: ''
+            ExpirationInDays: 45
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 7
+          - Id: RemoveExpiredDeleteMarkers
+            Status: Enabled
+            Prefix: ''
+            ExpiredObjectDeleteMarker: true
+      ObjectLockEnabled: true
+      ObjectLockConfiguration:
+        ObjectLockEnabled: Enabled
+        Rule:
+          DefaultRetention:
+            Mode: GOVERNANCE
+            Days: 35
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+      Tags:
+        - Key: application
+          Value: aos-reminders
+        - Key: purpose
+          Value: dynamodb-backups
+
+  BackupBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref BackupBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: '*'
+            Action: s3:*
+            Resource:
+              - !GetAtt BackupBucket.Arn
+              - !Sub '${BackupBucket.Arn}/*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'false'
+
+  BackupExportRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: export-production-tables
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ExportProductionTables
+                Effect: Allow
+                Action: dynamodb:ExportTableToPointInTime
+                Resource:
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/aos-reminders-subscription-api-v2-prod
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/aos-reminders-subscription-api-v2-provider-events-prod
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/aos-reminders-rest-api-prod
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/aos-reminders-link-api-prod
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/aos-reminders-coupon-api-prod
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/aos-reminders-admin-audit
+              - Sid: WriteBackupObjects
+                Effect: Allow
+                Action:
+                  - s3:AbortMultipartUpload
+                  - s3:PutObject
+                  - s3:PutObjectAcl
+                Resource: !Sub '${BackupBucket.Arn}/*'
+              - Sid: WriteFunctionLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/aos-reminders-dynamodb-backup-export:*
+      Tags:
+        - Key: application
+          Value: aos-reminders
+        - Key: purpose
+          Value: dynamodb-backups
+
+  BackupExportLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/aos-reminders-dynamodb-backup-export
+      RetentionInDays: 30
+
+  BackupExportFunction:
+    Type: AWS::Lambda::Function
+    DependsOn: BackupExportLogGroup
+    Properties:
+      FunctionName: aos-reminders-dynamodb-backup-export
+      Description: Starts full point-in-time exports of every AoS Reminders production table.
+      Runtime: nodejs22.x
+      Handler: index.handler
+      MemorySize: 128
+      Timeout: 30
+      ReservedConcurrentExecutions: 1
+      Role: !GetAtt BackupExportRole.Arn
+      Environment:
+        Variables:
+          BACKUP_BUCKET_NAME: !Ref BackupBucket
+          BACKUP_BUCKET_OWNER: !Ref AWS::AccountId
+          TABLE_ARNS: !Join
+            - ','
+            - - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/aos-reminders-subscription-api-v2-prod
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/aos-reminders-subscription-api-v2-provider-events-prod
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/aos-reminders-rest-api-prod
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/aos-reminders-link-api-prod
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/aos-reminders-coupon-api-prod
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/aos-reminders-admin-audit
+      Code:
+        ZipFile: |
+          const crypto = require('node:crypto')
+          const {
+            DynamoDBClient,
+            ExportTableToPointInTimeCommand,
+          } = require('@aws-sdk/client-dynamodb')
+
+          const dynamodb = new DynamoDBClient({})
+          const bucketName = process.env.BACKUP_BUCKET_NAME
+          const bucketOwner = process.env.BACKUP_BUCKET_OWNER
+          const tableArns = process.env.TABLE_ARNS.split(',')
+
+          exports.handler = async event => {
+            const scheduledTime = event && event.time ? new Date(event.time) : new Date()
+            const exportDate = scheduledTime.toISOString().slice(0, 10)
+
+            const exports = await Promise.all(
+              tableArns.map(async tableArn => {
+                const tableName = tableArn.split('/').at(-1)
+                const clientToken = crypto
+                  .createHash('sha256')
+                  .update(`${exportDate}:${tableArn}:${bucketName}`)
+                  .digest('hex')
+                const result = await dynamodb.send(
+                  new ExportTableToPointInTimeCommand({
+                    TableArn: tableArn,
+                    ClientToken: clientToken,
+                    S3Bucket: bucketName,
+                    S3BucketOwner: bucketOwner,
+                    S3Prefix: `${tableName}/${exportDate}`,
+                    S3SseAlgorithm: 'AES256',
+                    ExportFormat: 'DYNAMODB_JSON',
+                    ExportType: 'FULL_EXPORT',
+                  }),
+                )
+
+                return {
+                  tableName,
+                  exportArn: result.ExportDescription.ExportArn,
+                  status: result.ExportDescription.ExportStatus,
+                }
+              }),
+            )
+
+            const summary = { exportDate, exports }
+            console.log(JSON.stringify(summary))
+            return summary
+          }
+      Tags:
+        - Key: application
+          Value: aos-reminders
+        - Key: purpose
+          Value: dynamodb-backups
+
+  NightlyExportRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: aos-reminders-dynamodb-backup-nightly
+      Description: Starts immutable production DynamoDB exports every night at 09:00 UTC.
+      ScheduleExpression: cron(0 9 * * ? *)
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt BackupExportFunction.Arn
+          Id: BackupExportFunction
+          RetryPolicy:
+            MaximumEventAgeInSeconds: 3600
+            MaximumRetryAttempts: 2
+
+  AllowNightlyExportInvocation:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BackupExportFunction
+      Principal: events.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
+      SourceArn: !GetAtt NightlyExportRule.Arn
+
+Outputs:
+  BackupBucketName:
+    Value: !Ref BackupBucket
+  BackupExportFunctionName:
+    Value: !Ref BackupExportFunction
+  BackupExportRoleArn:
+    Value: !GetAtt BackupExportRole.Arn
+  NightlyExportRuleArn:
+    Value: !GetAtt NightlyExportRule.Arn

--- a/src/tests/deployment/dynamodbBackupInfrastructure.test.ts
+++ b/src/tests/deployment/dynamodbBackupInfrastructure.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const template = readFileSync(resolve('infra/dynamodb-backups/template.yaml'), 'utf8')
+
+const productionTables = [
+  'aos-reminders-subscription-api-v2-prod',
+  'aos-reminders-subscription-api-v2-provider-events-prod',
+  'aos-reminders-rest-api-prod',
+  'aos-reminders-link-api-prod',
+  'aos-reminders-coupon-api-prod',
+  'aos-reminders-admin-audit',
+] as const
+
+describe('DynamoDB backup infrastructure', () => {
+  it('retains immutable export objects outside DynamoDB', () => {
+    expect(template).toMatch(/DeletionPolicy: Retain/)
+    expect(template).toMatch(/ObjectLockEnabled: true/)
+    expect(template).toMatch(/Mode: GOVERNANCE\s+Days: 35/)
+    expect(template).toMatch(/VersioningConfiguration:\s+Status: Enabled/)
+    expect(template).toMatch(/BlockPublicAcls: true/)
+    expect(template).toMatch(/BlockPublicPolicy: true/)
+    expect(template).toMatch(/IgnorePublicAcls: true/)
+    expect(template).toMatch(/RestrictPublicBuckets: true/)
+    expect(template).toMatch(/ExpirationInDays: 45/)
+    expect(template).toMatch(/NoncurrentDays: 1/)
+  })
+
+  it('exports every production table from a dedicated scheduled role', () => {
+    for (const tableName of productionTables) expect(template).toContain(tableName)
+    expect(template).toMatch(/Runtime: nodejs22\.x/)
+    expect(template).toMatch(/dynamodb:ExportTableToPointInTime/)
+    expect(template).toMatch(/ScheduleExpression: cron\(0 9 \* \* \? \*\)/)
+    expect(template).toMatch(/S3Prefix: `\$\{tableName\}\/\$\{exportDate\}`/)
+    expect(template).toMatch(/ExportFormat: 'DYNAMODB_JSON'/)
+    expect(template).toMatch(/ExportType: 'FULL_EXPORT'/)
+  })
+})


### PR DESCRIPTION
## Summary

Production data now has a recovery copy outside DynamoDB, so an application-stack rollback or table deletion cannot erase the only recovery path. A dedicated stack exports all six production tables nightly to a retained S3 bucket with versioning, public-access blocking, 35-day governance Object Lock, and 45-day lifecycle cleanup.

The stack uses a new execution role limited to exporting the six named tables and writing the backup bucket; it does not modify an existing IAM user, group, or policy. All six tables were also enabled for deletion protection and PITR live on July 31, 2026, with their owning templates covered by the companion PRs below.

## Production validation

- Deployed `aos-reminders-dynamodb-backups`; the stack is `CREATE_COMPLETE` and its 09:00 UTC EventBridge schedule is enabled.
- Manually invoked the exporter and completed all six exports. Their manifest objects report `GOVERNANCE` retention through September 4, 2026.
- Imported the subscription export into a throwaway table, verified all 1,667 exported items with a consistent scan, then deleted only the throwaway table.
- Rechecked every source table: deletion protection is true, PITR is enabled, and the latest export is complete.

No AoS rules source, accepted corpus, generated catalog, or runtime data changed. The existing beta certification remains checksum-valid.

## Related

- daviseford/aos-reminders-subscription-api#18
- daviseford/aos-reminders-rest-api#12
- daviseford/aos-reminders-admin#15

## Verification

- `yarn lint`
- `yarn tsc --noEmit`
- `yarn test --run` — 72 files and 1,104 tests passed.
- `yarn build`
- `yarn data:aos4:verify:beta` — 79,598 checks passed with no findings.
- `aws cloudformation validate-template --template-body file://infra/dynamodb-backups/template.yaml`
- Live export, Object Lock metadata, restore-count, and cleanup checks described above.

## Post-deploy monitoring and validation

- Watch Lambda `aos-reminders-dynamodb-backup-export` Errors, Throttles, Duration, and `/aws/lambda/aos-reminders-dynamodb-backup-export` logs; watch EventBridge `FailedInvocations` for `aos-reminders-dynamodb-backup-nightly`.
- Expect one invocation at 09:00 UTC and six completed exports each day. Treat any missing export by 10:00 UTC, Lambda error, or absent Object Lock metadata as a backup failure.
- First response: inspect the Lambda error, confirm source-table PITR and role permissions, then invoke the function manually after correction. Disable only the schedule if repeated bad invocations require containment; retain the bucket and completed exports.
- Review daily for the first seven days after merge, then weekly. The repository owner remains the operational owner.

## Recovery boundary

Governance-mode Object Lock in the same AWS account protects against table deletion, ordinary object deletion, and application-stack removal. It does not protect against loss of the AWS account or an account compromise with enough privilege to bypass governance retention; that threat requires a separately controlled cross-account copy.

## New concepts

### Independent immutable backup plane

The backup schedule and destination live outside every application stack, so rolling back or removing a service cannot remove its recovery mechanism at the same time.

| Decision | Why it is used here |
| --- | --- |
| Dedicated CloudFormation stack | Separates backup lifetime from service deployment lifetime. |
| Governance Object Lock for 35 days | Prevents ordinary deletion and lifecycle cleanup during the recovery window while retaining an authorized break-glass path. |
| Lifecycle expiration after 45 days | Bounds storage after the immutable window has elapsed. |

This pattern is useful when the primary system's own restore history is not a sufficiently independent copy. It is not enough when the threat model includes loss or compromise of the entire AWS account; use a separately administered destination for that case.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
