### PR TITLE
feat: overlay content available by default, grouped in dropdowns (#1812)

### DIFF
--- a/src/aos4/runtime/armyStorage.ts
+++ b/src/aos4/runtime/armyStorage.ts
@@ -60,37 +60,41 @@ export const loadAos4ArmyDocument = (storage: Storage, catalog: Aos4Catalog): Lo
   return { document, diagnostics: restored.diagnostics, source: 'reset' }
 }
 
-export type Aos4OverlayFlag = 'allowsLegends' | 'allowsHistorical'
-
-export const setAos4OverlayFlag = (
+// The builder offers Legends and historical content to everyone, so the document's overlay flags
+// follow the selections instead of a user setting. Validation elsewhere (the army API client, the
+// reminder view) still resolves with exactly the flags a document carries, so a document that
+// selects overlay content must declare it — and one that no longer does should not.
+export const deriveAos4OverlayFlags = (
   catalog: Aos4Catalog,
-  document: Aos4ArmyDocument,
-  flag: Aos4OverlayFlag,
-  enabled: boolean
+  document: Aos4ArmyDocument
 ): Aos4ArmyDocument => {
-  const next = createAos4ArmyDocument(
-    flag === 'allowsLegends'
-      ? { ...document, allowsLegends: enabled }
-      : { ...document, allowsHistorical: enabled }
-  )
-  if (enabled) return next
+  const inapplicableUnder = (flags: { allowsLegends?: boolean; allowsHistorical?: boolean }) =>
+    new Set(
+      resolveSelection(catalog, {
+        explicitIds: document.explicitSelectionIds,
+        rulesContextId: document.rulesContextId,
+        ...flags,
+      })
+        .diagnostics.filter(diagnostic => diagnostic.code === 'inapplicable-explicit-selection')
+        .flatMap(diagnostic => diagnostic.entityIds ?? [])
+    )
 
-  // Turning an overlay off can strand explicit selections that only resolved under it. Prune the
-  // now-inapplicable ids so the document stays valid for the builder, cloud sync, and shares.
-  const selection = resolveSelection(catalog, {
-    explicitIds: next.explicitSelectionIds,
-    rulesContextId: next.rulesContextId,
-    ...(next.allowsLegends ? { allowsLegends: true } : {}),
-    ...(next.allowsHistorical ? { allowsHistorical: true } : {}),
-  })
-  const inapplicable = new Set(
-    selection.diagnostics
-      .filter(diagnostic => diagnostic.code === 'inapplicable-explicit-selection')
-      .flatMap(diagnostic => diagnostic.entityIds ?? [])
-  )
-  if (inapplicable.size === 0) return next
+  const strict = inapplicableUnder({})
+  let needsLegends = false
+  let needsHistorical = false
+  if (strict.size > 0) {
+    const stillWithLegends = inapplicableUnder({ allowsLegends: true })
+    const stillWithHistorical = inapplicableUnder({ allowsHistorical: true })
+    needsLegends = Array.from(strict).some(id => !stillWithLegends.has(id))
+    needsHistorical = Array.from(strict).some(id => !stillWithHistorical.has(id))
+  }
+
+  if (Boolean(document.allowsLegends) === needsLegends && Boolean(document.allowsHistorical) === needsHistorical) {
+    return document
+  }
   return createAos4ArmyDocument({
-    ...next,
-    explicitSelectionIds: next.explicitSelectionIds.filter(id => !inapplicable.has(id)),
+    ...document,
+    allowsLegends: needsLegends,
+    allowsHistorical: needsHistorical,
   })
 }

--- a/src/aos4/view/builder.ts
+++ b/src/aos4/view/builder.ts
@@ -9,6 +9,7 @@ export interface Aos4BuilderOption {
   groupType?: string
   selected: boolean
   available: boolean
+  overlay?: 'legends' | 'historical'
 }
 
 export interface Aos4BuilderWarscroll {
@@ -23,12 +24,32 @@ export interface Aos4BuilderWarscroll {
 }
 
 export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4ArmyDocument) => {
+  // Every army offers its full catalog: current-standard content plus the Legends and historical
+  // (Scourge of Ghyran) overlays. Options carry an `overlay` marker so the UI can group them
+  // rather than asking the player to opt in first.
   const selection = resolveSelection(catalog, {
     explicitIds: document.explicitSelectionIds,
     rulesContextId: document.rulesContextId,
-    ...(document.allowsLegends ? { allowsLegends: true } : {}),
-    ...(document.allowsHistorical ? { allowsHistorical: true } : {}),
+    allowsLegends: true,
+    allowsHistorical: true,
   })
+  const strictAvailable = new Set(
+    resolveSelection(catalog, {
+      explicitIds: document.explicitSelectionIds,
+      rulesContextId: document.rulesContextId,
+    }).availableIds
+  )
+  const legendsAvailable = new Set(
+    resolveSelection(catalog, {
+      explicitIds: document.explicitSelectionIds,
+      rulesContextId: document.rulesContextId,
+      allowsLegends: true,
+    }).availableIds
+  )
+  const overlayFor = (id: CanonicalId): 'legends' | 'historical' | undefined => {
+    if (strictAvailable.has(id)) return undefined
+    return legendsAvailable.has(id) ? 'legends' : 'historical'
+  }
   const selected = new Set(selection.selectedIds)
   const available = new Set(selection.availableIds)
   const entityById = new Map(catalog.entities.map(entity => [entity.id, entity]))
@@ -39,6 +60,7 @@ export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4A
     .flatMap(id => {
       const entity = entityById.get(id)
       if (!entity) return []
+      const overlay = overlayFor(id)
       return [
         {
           id,
@@ -47,6 +69,7 @@ export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4A
           ...(entity.kind === 'content-group' ? { groupType: entity.groupType } : {}),
           selected: selected.has(id),
           available: available.has(id),
+          ...(overlay ? { overlay } : {}),
         },
       ]
     })

--- a/src/components/input/army_builder.tsx
+++ b/src/components/input/army_builder.tsx
@@ -83,11 +83,26 @@ const SelectionCard = ({
   const { theme } = useTheme()
   const isMobile = useIsMobile()
   const [isExpanded, setIsExpanded] = useState(initiallyExpanded)
-  const options: Option[] = group.options.map(option => ({
+  const toOption = (option: BuilderOption): Option => ({
     label: option.name,
     value: option.id,
     disabled: !option.available && !option.selected,
-  }))
+  })
+  // Current-standard content lists first; Legends and Scourge of Ghyran content is always offered
+  // but sits under its own group header so its provenance stays visible.
+  const currentOptions = group.options.filter(option => !option.overlay).map(toOption)
+  const legendsOptions = group.options.filter(option => option.overlay === 'legends').map(toOption)
+  const historicalOptions = group.options
+    .filter(option => option.overlay === 'historical')
+    .map(toOption)
+  const options: Option[] = [...currentOptions, ...legendsOptions, ...historicalOptions]
+  const groupedOptions = [
+    ...currentOptions,
+    ...(legendsOptions.length ? [{ label: 'Legends', options: legendsOptions }] : []),
+    ...(historicalOptions.length
+      ? [{ label: 'Scourge of Ghyran (2025-26)', options: historicalOptions }]
+      : []),
+  ]
   const selectedValues = options.filter(option =>
     group.options.some(candidate => candidate.id === option.value && candidate.selected)
   )
@@ -119,7 +134,7 @@ const SelectionCard = ({
           <Select<Option, true>
             aria-label={group.title}
             value={selectedValues}
-            options={options}
+            options={groupedOptions}
             isMulti
             isClearable
             closeMenuOnSelect={false}

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -4,10 +4,9 @@ import type { PrintPageSize } from '../../aos4/print/presets'
 import type { PrintPreset } from '../../aos4/print/types'
 import {
   createDefaultAos4ArmyDocument,
+  deriveAos4OverlayFlags,
   loadAos4ArmyDocument,
   saveAos4ArmyDocument,
-  setAos4OverlayFlag,
-  type Aos4OverlayFlag,
 } from '../../aos4/runtime'
 import { createAos4ArmyDocument, setAos4ReminderPreference, type Aos4ArmyDocument } from '../../aos4/state'
 import {
@@ -23,7 +22,6 @@ import Toolbar from 'components/input/toolbar/toolbar'
 import Footer from 'components/page/footer'
 import { Header } from 'components/page/homeHeader'
 import { ArmyCollectionProvider } from 'context/useArmyCollection'
-import { useTheme } from 'context/useTheme'
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
 import { logFactionSelection, logGameModeChange, logPdfDownload } from 'utils/analytics'
 import { consumePendingShareId } from 'utils/shareLink'
@@ -110,45 +108,6 @@ const SkipToReminders = () => (
   </a>
 )
 
-type OverlayTogglesProps = {
-  document: Aos4ArmyDocument
-  onToggle: (flag: Aos4OverlayFlag, enabled: boolean) => void
-}
-
-const OverlayToggles = ({ document, onToggle }: OverlayTogglesProps) => {
-  const { theme } = useTheme()
-  return (
-    <div className="container-fluid d-flex justify-content-center flex-wrap gap-4 pt-3">
-      <div className="form-check form-switch">
-        <input
-          checked={Boolean(document.allowsLegends)}
-          className="form-check-input"
-          id="toggle-allows-legends"
-          onChange={event => onToggle('allowsLegends', event.target.checked)}
-          role="switch"
-          type="checkbox"
-        />
-        <label className={`form-check-label ${theme.text}`} htmlFor="toggle-allows-legends">
-          Include Legends units
-        </label>
-      </div>
-      <div className="form-check form-switch">
-        <input
-          checked={Boolean(document.allowsHistorical)}
-          className="form-check-input"
-          id="toggle-allows-historical"
-          onChange={event => onToggle('allowsHistorical', event.target.checked)}
-          role="switch"
-          type="checkbox"
-        />
-        <label className={`form-check-label ${theme.text}`} htmlFor="toggle-allows-historical">
-          Include Scourge of Ghyran (2025-26)
-        </label>
-      </div>
-    </div>
-  )
-}
-
 const HomeContent = () => {
   const [document, setDocument] = useState(loadDocument)
   const [isGameMode, setIsGameMode] = useState(false)
@@ -219,10 +178,16 @@ const HomeContent = () => {
   const setSelections = (groupIds: CanonicalId[], selectedIds: CanonicalId[]) => {
     setDocument(current => {
       const group = new Set(groupIds)
-      return createAos4ArmyDocument({
-        ...current,
-        explicitSelectionIds: [...current.explicitSelectionIds.filter(id => !group.has(id)), ...selectedIds],
-      })
+      return deriveAos4OverlayFlags(
+        AOS4_CATALOG,
+        createAos4ArmyDocument({
+          ...current,
+          explicitSelectionIds: [
+            ...current.explicitSelectionIds.filter(id => !group.has(id)),
+            ...selectedIds,
+          ],
+        })
+      )
     })
   }
 
@@ -247,10 +212,6 @@ const HomeContent = () => {
         reminderPreferences: {},
       })
     )
-  }
-
-  const handleOverlayToggle = (flag: Aos4OverlayFlag, enabled: boolean) => {
-    setDocument(current => setAos4OverlayFlag(AOS4_CATALOG, current, flag, enabled))
   }
 
   const toggleGameMode = () => {
@@ -321,8 +282,6 @@ const HomeContent = () => {
       />
 
       <AppBanner />
-
-      {!isGameMode && <OverlayToggles document={document} onToggle={handleOverlayToggle} />}
 
       {!isGameMode && <ArmyBuilder builder={builder} onSetGroupSelections={setSelections} />}
 

--- a/src/tests/aos4/overlayFlags.test.ts
+++ b/src/tests/aos4/overlayFlags.test.ts
@@ -1,7 +1,8 @@
 import { AOS4_CATALOG } from '../../aos4/generated'
-import { createDefaultAos4ArmyDocument, setAos4OverlayFlag } from '../../aos4/runtime'
+import { createDefaultAos4ArmyDocument, deriveAos4OverlayFlags } from '../../aos4/runtime'
 import { resolveSelection } from '../../aos4/select'
 import { createAos4ArmyDocument } from '../../aos4/state'
+import { createAos4BuilderViewModel } from '../../aos4/view'
 import { describe, expect, it } from 'vitest'
 
 const base = createDefaultAos4ArmyDocument()
@@ -24,72 +25,98 @@ const overlayOnlyIds = (flag: 'allowsLegends' | 'allowsHistorical') => {
   throw new Error(`The catalog has no ${flag}-gated content to exercise`)
 }
 
-describe('AoS 4 overlay flags', () => {
-  it('enabling an overlay keeps the document and exposes gated content', () => {
+describe('AoS 4 overlay flags follow the selections', () => {
+  it('selecting Legends content derives allowsLegends on the document', () => {
     const { factionId, overlayOnly } = overlayOnlyIds('allowsLegends')
     const document = createAos4ArmyDocument({
       ...base,
-      explicitSelectionIds: [factionId],
-    })
-
-    const enabled = setAos4OverlayFlag(AOS4_CATALOG, document, 'allowsLegends', true)
-    expect(enabled.allowsLegends).toBe(true)
-    expect(enabled.explicitSelectionIds).toEqual([factionId])
-
-    const selection = resolveSelection(AOS4_CATALOG, {
-      explicitIds: [...enabled.explicitSelectionIds, overlayOnly[0]],
-      rulesContextId: enabled.rulesContextId,
-      allowsLegends: true,
-    })
-    expect(selection.diagnostics.filter(d => d.severity === 'error')).toEqual([])
-  })
-
-  it('disabling an overlay prunes selections that only resolved under it', () => {
-    const { factionId, overlayOnly } = overlayOnlyIds('allowsLegends')
-    const document = createAos4ArmyDocument({
-      ...base,
-      allowsLegends: true,
       explicitSelectionIds: [factionId, overlayOnly[0]],
     })
 
-    const disabled = setAos4OverlayFlag(AOS4_CATALOG, document, 'allowsLegends', false)
-    expect(disabled.allowsLegends).toBeUndefined()
-    expect(disabled.explicitSelectionIds).toEqual([factionId])
+    const derived = deriveAos4OverlayFlags(AOS4_CATALOG, document)
+    expect(derived.allowsLegends).toBe(true)
+    expect(derived.allowsHistorical).toBeUndefined()
+    expect(derived.explicitSelectionIds).toEqual(document.explicitSelectionIds)
+  })
 
+  it('selecting historical content derives allowsHistorical on the document', () => {
+    const { factionId, overlayOnly } = overlayOnlyIds('allowsHistorical')
+    const document = createAos4ArmyDocument({
+      ...base,
+      explicitSelectionIds: [factionId, overlayOnly[0]],
+    })
+
+    const derived = deriveAos4OverlayFlags(AOS4_CATALOG, document)
+    expect(derived.allowsHistorical).toBe(true)
+  })
+
+  it('removing overlay content clears stale flags', () => {
+    const { factionId } = overlayOnlyIds('allowsLegends')
+    const document = createAos4ArmyDocument({
+      ...base,
+      allowsLegends: true,
+      allowsHistorical: true,
+      explicitSelectionIds: [factionId],
+    })
+
+    const derived = deriveAos4OverlayFlags(AOS4_CATALOG, document)
+    expect(derived.allowsLegends).toBeUndefined()
+    expect(derived.allowsHistorical).toBeUndefined()
+  })
+
+  it('a derived document round-trips the army API validation', () => {
+    const { factionId, overlayOnly } = overlayOnlyIds('allowsLegends')
+    const derived = deriveAos4OverlayFlags(
+      AOS4_CATALOG,
+      createAos4ArmyDocument({ ...base, explicitSelectionIds: [factionId, overlayOnly[0]] })
+    )
     const selection = resolveSelection(AOS4_CATALOG, {
-      explicitIds: disabled.explicitSelectionIds,
-      rulesContextId: disabled.rulesContextId,
+      explicitIds: derived.explicitSelectionIds,
+      rulesContextId: derived.rulesContextId,
+      ...(derived.allowsLegends ? { allowsLegends: true } : {}),
+      ...(derived.allowsHistorical ? { allowsHistorical: true } : {}),
     })
     expect(selection.diagnostics.filter(d => d.severity === 'error')).toEqual([])
   })
+})
 
-  it('disabling an overlay with no gated selections only clears the flag', () => {
-    const document = createAos4ArmyDocument({ ...base, allowsLegends: true })
-    const disabled = setAos4OverlayFlag(AOS4_CATALOG, document, 'allowsLegends', false)
-    expect(disabled.allowsLegends).toBeUndefined()
-    expect(disabled.explicitSelectionIds).toEqual(base.explicitSelectionIds)
+describe('AoS 4 builder offers overlay content by default', () => {
+  const ogorFaction = AOS4_CATALOG.entities.find(
+    entity => entity.id.startsWith('faction:') && /ogor mawtribes/i.test((entity as { name?: string }).name ?? '')
+  )
+
+  it('offers Scourge of Ghyran formations without any document flag (issue #1812)', () => {
+    const builder = createAos4BuilderViewModel(
+      AOS4_CATALOG,
+      createAos4ArmyDocument({ ...base, explicitSelectionIds: [ogorFaction!.id] })
+    )
+    const byName = new Map(builder.options.map(option => [option.name, option]))
+    for (const name of ['Mawpath Menaces', 'Greedy Eaters']) {
+      const option = byName.get(name)
+      expect(option, name).toBeDefined()
+      expect(option!.available, name).toBe(true)
+      expect(option!.overlay, name).toBe('historical')
+    }
   })
 
-  it('the historical overlay exposes Scourge of Ghyran content groups (issue #1812)', () => {
-    const ogorFaction = AOS4_CATALOG.entities.find(
-      entity => entity.id.startsWith('faction:') && /ogor mawtribes/i.test((entity as { name?: string }).name ?? '')
+  it('marks Legends options with the legends overlay', () => {
+    const builder = createAos4BuilderViewModel(
+      AOS4_CATALOG,
+      createAos4ArmyDocument({ ...base, explicitSelectionIds: [ogorFaction!.id] })
     )
-    expect(ogorFaction).toBeDefined()
+    const legends = builder.options.filter(option => option.overlay === 'legends')
+    expect(legends.map(option => option.name)).toEqual(
+      expect.arrayContaining(['Gorlok Blackpowder', 'Hrothgorn Mantrapper'])
+    )
+  })
 
-    const strict = resolveSelection(AOS4_CATALOG, {
-      explicitIds: [ogorFaction!.id],
-      rulesContextId: base.rulesContextId,
-    })
-    const historical = resolveSelection(AOS4_CATALOG, {
-      explicitIds: [ogorFaction!.id],
-      rulesContextId: base.rulesContextId,
-      allowsHistorical: true,
-    })
-    const strictAvailable = new Set(strict.availableIds)
-    const addedNames = historical.availableIds
-      .filter(id => !strictAvailable.has(id))
-      .map(id => (AOS4_CATALOG.entities.find(entity => entity.id === id) as { name?: string })?.name)
-
-    expect(addedNames).toEqual(expect.arrayContaining(['Mawpath Menaces', 'Greedy Eaters']))
+  it('leaves current-standard options unmarked', () => {
+    const builder = createAos4BuilderViewModel(
+      AOS4_CATALOG,
+      createAos4ArmyDocument({ ...base, explicitSelectionIds: [ogorFaction!.id] })
+    )
+    const butcher = builder.options.find(option => option.name === 'Butcher')
+    expect(butcher).toBeDefined()
+    expect(butcher!.overlay).toBeUndefined()
   })
 })


### PR DESCRIPTION
Owner feedback on the #1813 toggles: users should not need to check boxes to see all of their army's units, and the switches crowded the mobile layout.

## Change

- The toggles are removed. The builder always offers current-standard, Legends, and Scourge of Ghyran content.
- Inside each dropdown, overlay content is grouped under **Legends** and **Scourge of Ghyran (2025-26)** headers (current content lists first, ungrouped), so provenance stays visible without any setting.
- Document flags are now **derived from the selections** (`deriveAos4OverlayFlags`): selecting a Legends unit sets `allowsLegends`, deselecting the last one clears it. Cloud-save validation (#1810), shares, and the reminder view keep resolving with exactly the flags a document carries, so round-trips stay correct.

## Tests

7 focused cases: flag derivation (set both ways + cleared when stale + API-validation round-trip) and builder classification (SoG formations available with `overlay: 'historical'` and no document flag, Legends marked, current content unmarked). Full suite: 1,110 passed.

https://claude.ai/code/session_015nfmMygHX8CizzD6vQT8UG