### PR TITLE
fix: exclude core-rules example abilities from reminders

### DIFF
--- a/data/aos4/reviews/corpus-2026-07-31.json
+++ b/data/aos4/reviews/corpus-2026-07-31.json
@@ -1,0 +1,9509 @@
+{
+  "abilityTextOverrides": [
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A39"
+      ],
+      "reason": "The July 2026 Blades of Khorne update replaces Sigil of Doom, including its target ability type and effect.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fblades-of-khorne%2Fwarscrolls.html%23datasheet%3ABleeding-Icon%2Fability%3A1",
+      "text": {
+        "declare": "Pick a visible friendly BLADES OF KHORNE unit wholly within 8\" of this MANIFESTATION to be the target. Then, pick a passive BLOOD TITHE ability that you have not unlocked this battle.",
+        "effect": "Roll a dice. If the roll equals or exceeds the blood tithe points cost of the chosen ability, until the start of your next turn, the effects of that ability apply to the target as if it had been unlocked."
+      }
+    },
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A51"
+      ],
+      "reason": "The July 2026 Hedonites of Slaanesh update clarifies that replacement Sigvald can be replaced.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fhedonites-of-slaanesh%2F%23faction-ability%3ABattle-Traits-4%3Aability%3A2",
+      "text": {
+        "declare": "If the friendly Sigvald has been destroyed, pick him to be the target. He can be replaced even if he is a replacement unit.",
+        "effect": "Set up a replacement unit identical to the target wholly within 6\" of a friendly Contorted Epitome and not in combat."
+      }
+    },
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A51"
+      ],
+      "reason": "The July 2026 Hedonites of Slaanesh update requires a banished manifestation to be removed from play.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fhedonites-of-slaanesh%2Fwarscrolls.html%23datasheet%3ADexcessa-the-Talon-of-Slaanesh%2Fability%3A4",
+      "text": {
+        "declare": "Pick an enemy unit in combat with this unit to be the target.",
+        "effect": "Roll 2D6. If this unit charged this turn, add 2 to the roll. If the roll exceeds the target’s Health characteristic, 1 model in the target is automatically slain. If the target is a MANIFESTATION and the roll exceeds its banishment value, it is banished and removed from play."
+      }
+    },
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A58"
+      ],
+      "reason": "The July 2026 Maggotkin of Nurgle update replaces the keyword mutation with the current Polluted status wording.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fmaggotkin-of-nurgle%2Fwarscrolls.html%23datasheet%3AGelgus-Pust-the-Prince-of-Sores%2Fability%3A1",
+      "text": {
+        "declare": "Pick a terrain feature within 6\" of this unit to be the target.",
+        "effect": "The target is considered by you to be POLLUTED for the rest of the battle."
+      }
+    },
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A61"
+      ],
+      "reason": "The July 2026 Nighthaunt update replaces Damned Vessel with a passive ability.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fnighthaunt%2F%23faction-ability%3AHeroic-Traits-2%3Aability%3A1",
+      "text": {
+        "effect": "Whenever you declare a SPELL ability for a friendly Nagash within 18\" of this unit, you can measure the range and visibility of that SPELL ability from this unit instead of that Nagash."
+      }
+    },
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:240af53bd83954067cc8fdb3486bdc55f32dbd103bc8d2fd1081c06790b6333d%3Apage%3A19"
+      ],
+      "reason": "The August 2026 Armies of Renown update changes the Mawpit ability that earns tasty morsels.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fogor-mawtribes%2F%23faction-ability%3ABattle-Traits-2%3Aability%3A1",
+      "text": {
+        "effect": "Each time a model is slain by a friendly Mawpit’s ‘Hungry Sinkhole’ ability, you gain 1 tasty morsel."
+      }
+    },
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:240af53bd83954067cc8fdb3486bdc55f32dbd103bc8d2fd1081c06790b6333d%3Apage%3A20"
+      ],
+      "reason": "The August 2026 Armies of Renown update replaces the Head Butcher condition with proximity to a Mawpit.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fogor-mawtribes%2F%23faction-ability%3AHeroic-Traits-1%3Aability%3A1",
+      "text": {
+        "effect": "If this unit is within 1\" of a friendly Mawpit, gain 1 tasty morsel."
+      }
+    },
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A2"
+      ],
+      "reason": "The July 2026 Core Rules update replaces the final sentence with the current setup restriction.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Fthe-rules%2Fquick-start-guide%2F%23rules-ability%3ARules-Reference%3Aability%3A3",
+      "text": {
+        "declare": "Pick a regiment from your army roster to be the target. No units in that regiment can have already been deployed.",
+        "effect": "Keep using DEPLOY abilities without alternating until all units in that regiment have been deployed. You cannot set up units that are not in that regiment on the battlefield or in reserve as part of any of those DEPLOY abilities."
+      }
+    },
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A2"
+      ],
+      "reason": "The July 2026 Core Rules update replaces the final sentence with the current setup restriction.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Fthe-rules%2Fthe-core-rules%2F%23rules-ability%3AUniversal-Deployment-Phase-Abilities%3Aability%3A3",
+      "text": {
+        "declare": "Pick a regiment from your army roster to be the target. No units in that regiment can have already been deployed.",
+        "effect": "Keep using DEPLOY abilities without alternating until all units in that regiment have been deployed. You cannot set up units that are not in that regiment on the battlefield or in reserve as part of any of those DEPLOY abilities."
+      }
+    }
+  ],
+  "additionalRulesContexts": [
+    {
+      "battlepack": "Spearhead",
+      "id": "rules-context:90000000-0000-4000-8000-000000000002",
+      "mode": "spearhead",
+      "name": "Age of Sigmar Fourth Edition Spearhead",
+      "status": "current",
+      "validFrom": "2024-07-13"
+    },
+    {
+      "id": "rules-context:90000000-0000-4000-8000-000000000003",
+      "mode": "standard",
+      "name": "Age of Sigmar Fourth Edition Historical",
+      "status": "historical",
+      "validFrom": "2024-07-13",
+      "validTo": "2026-07-05"
+    },
+    {
+      "id": "rules-context:90000000-0000-4000-8000-000000000004",
+      "mode": "other",
+      "name": "Age of Sigmar Fourth Edition Legends",
+      "status": "legends",
+      "validFrom": "2024-07-13"
+    },
+    {
+      "battlepack": "Scourge of Aqshy",
+      "id": "rules-context:90000000-0000-4000-8000-000000000006",
+      "mode": "standard",
+      "name": "Age of Sigmar Fourth Edition General's Handbook 2026-27",
+      "season": "2026-27",
+      "status": "seasonal",
+      "validFrom": "2026-07-06"
+    }
+  ],
+  "approvedFactionIds": [
+    "BoC",
+    "BoK",
+    "BS",
+    "CoS",
+    "DoK",
+    "DoT",
+    "EnS",
+    "FE",
+    "FY",
+    "GG",
+    "HoH",
+    "HS",
+    "ID",
+    "IJ",
+    "KB",
+    "KO",
+    "LRL",
+    "MoN",
+    "NT",
+    "OB",
+    "OM",
+    "SE",
+    "SG",
+    "SN",
+    "SoB",
+    "ST",
+    "StD",
+    "SY"
+  ],
+  "contextOverrides": [],
+  "currentWahapediaHtml": {
+    "expectedArtifacts": 72,
+    "expectedCollectionArtifacts": 27,
+    "expectedFactionAbilities": 1847,
+    "expectedFactionArtifacts": 28,
+    "expectedFactionGroups": 1048,
+    "expectedFactionRootWarscrolls": 212,
+    "expectedRulesAbilities": 590,
+    "expectedRulesArtifacts": 17,
+    "expectedRulesGroups": 213,
+    "expectedWarnings": 181,
+    "expectedWarscrolls": 1286,
+    "reconciliation": {
+      "checksum": "941b57d7c38c753e719c41f6f1fef749a8185e8db9f4d84f6006efa5b215fc00",
+      "expectedDiscrepancies": 413,
+      "expectedMatchedOfficialUnitFacts": 928,
+      "expectedPages": 1286,
+      "expectedUnmatchedOfficialUnitFacts": 12
+    },
+    "reviewedAt": "2026-07-30T21:00:00.000Z",
+    "rulesPages": [
+      {
+        "application": "reference",
+        "reason": "Path to Glory is not a supported runtime context; the page remains structured audit evidence without leaking campaign rules into standard armies.",
+        "url": "https://wahapedia.ru/aos4/the-rules/ascension/"
+      },
+      {
+        "application": "reference",
+        "reason": "Path to Glory is not a supported runtime context; the page remains structured audit evidence without leaking campaign rules into standard armies.",
+        "url": "https://wahapedia.ru/aos4/the-rules/blighted-wilds/"
+      },
+      {
+        "application": "optional",
+        "reason": "Bunker is a standalone battleplan, so its reminder-bearing rules apply only when a player explicitly selects that module.",
+        "url": "https://wahapedia.ru/aos4/the-rules/bunker/"
+      },
+      {
+        "application": "reference",
+        "reason": "City of Ash is an alternate Spearhead campaign and cannot be applied to every Spearhead army without an explicit battlepack selection.",
+        "url": "https://wahapedia.ru/aos4/the-rules/city-of-ash/"
+      },
+      {
+        "application": "reference",
+        "reason": "The FAQ is authoritative secondary validation evidence whose corrections must be applied to their owning rules; its replacement examples are not standalone reminders.",
+        "url": "https://wahapedia.ru/aos4/the-rules/faqs/"
+      },
+      {
+        "application": "reference",
+        "groups": [
+          {
+            "application": "universal",
+            "externalId": "Reinforcements",
+            "reason": "Fire and Jade defines Call for Reinforcements as the shared Spearhead ability for every army with the Reinforcements keyword; card commands remain contextual."
+          }
+        ],
+        "reason": "Fire and Jade contains a shared Spearhead rule plus battlefield- and card-specific content; only independently applicable groups may enter every Spearhead army.",
+        "url": "https://wahapedia.ru/aos4/the-rules/fire-and-jade/"
+      },
+      {
+        "application": "reference",
+        "reason": "First Blood contributes battlepack structure but exposes no standalone ability card in the bounded parser, so it remains material source evidence.",
+        "url": "https://wahapedia.ru/aos4/the-rules/first-blood/"
+      },
+      {
+        "application": "reference",
+        "reason": "The 2024-25 handbook is retained as historical structured evidence; the aggregate historical context cannot safely imply that every prior season applies together.",
+        "url": "https://wahapedia.ru/aos4/the-rules/general-s-handbook-2024-25/"
+      },
+      {
+        "application": "reference",
+        "reason": "The 2025-26 handbook is retained as historical structured evidence; the aggregate historical context cannot safely imply that every prior season applies together.",
+        "url": "https://wahapedia.ru/aos4/the-rules/general-s-handbook-2025-26/"
+      },
+      {
+        "application": "reference",
+        "groups": [
+          {
+            "application": "universal",
+            "externalId": "Season-Rules-2026-27",
+            "reason": "The handbook states that both players can use the Season Rules 2026-27 abilities in this battlepack."
+          },
+          {
+            "application": "optional",
+            "externalId": "Into-the-Fire",
+            "reason": "These abilities apply only when Into the Fire is the chosen battleplan."
+          },
+          {
+            "application": "optional",
+            "externalId": "Bloodstained-Coasts",
+            "reason": "These abilities apply only when Bloodstained Coasts is the chosen battleplan."
+          },
+          {
+            "application": "optional",
+            "externalId": "Avalanche-of-Ash",
+            "reason": "These abilities apply only when Avalanche of Ash is the chosen battleplan."
+          },
+          {
+            "application": "optional",
+            "externalId": "Caverns-of-Slaughter",
+            "reason": "These abilities apply only when Caverns of Slaughter is the chosen battleplan."
+          },
+          {
+            "application": "optional",
+            "externalId": "What-s-Yours-Is-Ours",
+            "reason": "These abilities apply only when What's Yours Is Ours is the chosen battleplan."
+          },
+          {
+            "application": "optional",
+            "externalId": "Hidden-Under-Ash-Clouds",
+            "reason": "These abilities apply only when Hidden Under Ash-Clouds is the chosen battleplan."
+          },
+          {
+            "application": "optional",
+            "externalId": "Warped-Ruins",
+            "reason": "These abilities apply only when Warped Ruins is the chosen battleplan."
+          },
+          {
+            "application": "optional",
+            "externalId": "Curse-of-the-Gnaw",
+            "reason": "These abilities apply only when Curse of the Gnaw is the chosen battleplan."
+          },
+          {
+            "application": "optional",
+            "externalId": "Seize-the-Embers",
+            "reason": "These abilities apply only when Seize the Embers is the chosen battleplan."
+          },
+          {
+            "application": "optional",
+            "externalId": "Treacherous-Ground",
+            "reason": "These abilities apply only when Treacherous Ground is the chosen battleplan."
+          },
+          {
+            "application": "optional",
+            "externalId": "Escape-from-the-Coast",
+            "reason": "These abilities apply only when Escape from the Coast is the chosen battleplan."
+          },
+          {
+            "application": "optional",
+            "externalId": "Power-of-the-Realms",
+            "reason": "These abilities apply only when Power of the Realms is the chosen battleplan."
+          }
+        ],
+        "reason": "The current handbook contains universal season rules and mutually exclusive battleplan rules; page-wide automatic application would be misleading.",
+        "url": "https://wahapedia.ru/aos4/the-rules/general-s-handbook-2026-27/"
+      },
+      {
+        "application": "reference",
+        "reason": "The quick-start page repeats a simplified subset of the Core Rules and is retained for reconciliation without creating duplicate runtime facts.",
+        "url": "https://wahapedia.ru/aos4/the-rules/quick-start-guide/"
+      },
+      {
+        "application": "reference",
+        "reason": "Path to Glory is not a supported runtime context; the page remains structured audit evidence without leaking campaign rules into standard armies.",
+        "url": "https://wahapedia.ru/aos4/the-rules/ravaged-coast/"
+      },
+      {
+        "application": "optional",
+        "reason": "The Red Gobbo scenario is a standalone battleplan, so its abilities apply only when that module is explicitly selected.",
+        "url": "https://wahapedia.ru/aos4/the-rules/red-gobbo-battleplan/"
+      },
+      {
+        "application": "reference",
+        "reason": "Sand and Bone is an alternate Spearhead battlepack and cannot be applied to every Spearhead army without explicit battlefield selection.",
+        "url": "https://wahapedia.ru/aos4/the-rules/sand-and-bone/"
+      },
+      {
+        "application": "optional",
+        "reason": "Siege of Lethis is a Flashpoint module, so its abilities apply only when that module is explicitly selected.",
+        "url": "https://wahapedia.ru/aos4/the-rules/siege-of-lethis/"
+      },
+      {
+        "application": "reference",
+        "reason": "Spearhead Doubles changes battle setup but exposes no standalone ability cards and must not silently replace the single-player Spearhead battlepack.",
+        "url": "https://wahapedia.ru/aos4/the-rules/spearhead-doubles/"
+      },
+      {
+        "application": "universal",
+        "contextKinds": {
+          "seasonal": [
+            "seasonal",
+            "legends"
+          ],
+          "standard": [
+            "standard",
+            "spearhead",
+            "legends",
+            "historical"
+          ]
+        },
+        "reason": "The Core Rules define universal abilities and passive rules for every supported AoS 4 army; 2026-27 Advanced Rules remain restricted to current seasonal and Legends play.",
+        "url": "https://wahapedia.ru/aos4/the-rules/the-core-rules/"
+      }
+    ]
+  },
+  "decoderDiagnosticPolicies": [
+    {
+      "code": "duplicate-identical-record",
+      "reason": "The decoder compares complete row bytes and retains one deterministic copy of byte-identical duplicate primary keys."
+    },
+    {
+      "code": "empty-association-record",
+      "reason": "Blank keyword association sentinels carry no game fact and are intentionally excluded by the decoder."
+    },
+    {
+      "code": "polluted-marker",
+      "reason": "Wahapedia cross-reference markers are presentation metadata; normalized text removes marker tokens while retaining the human-readable rule text."
+    },
+    {
+      "code": "missing-faction",
+      "file": "Warscrolls_RoRfactions.csv",
+      "reason": "The LCA association points to a faction absent from this accepted export and is explicitly dispositioned instead of inventing a faction.",
+      "row": 212
+    },
+    {
+      "code": "missing-faction",
+      "file": "Warscrolls_RoRfactions.csv",
+      "reason": "The LCA association points to a faction absent from this accepted export and is explicitly dispositioned instead of inventing a faction.",
+      "row": 283
+    }
+  ],
+  "defaultRulesContextId": "rules-context:90000000-0000-4000-8000-000000000006",
+  "generatedAt": "2026-07-31T21:30:00.000Z",
+  "ignoredSourceRecords": [
+    {
+      "reason": "The accepted bulk export truncates Advance in Formation before its Effect; the incomplete rule is excluded instead of being presented as current.",
+      "sourceRecordId": "source-record:wahapedia:Faction_abilities.csv%3ACoS%3A000000529%3A000002058%3A2"
+    },
+    {
+      "reason": "Illustrative EXAMPLE PRAYER card (Resurrection) that the General's Handbook 2024-25 page reproduces from the core rulebook to show the ability-card format; it is not a playable AoS 4 ability and must not appear as a reminder (customer report 2026-07-31).",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Fthe-rules%2Fgeneral-s-handbook-2024-25%2F%23rules-ability%3APrayers%3Aability%3A1"
+    },
+    {
+      "reason": "Illustrative EXAMPLE SPELL card (Mystic Shield) that the General's Handbook 2024-25 page reproduces from the core rulebook to show the ability-card format; it is not a playable AoS 4 ability and must not appear as a reminder (customer report 2026-07-31).",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Fthe-rules%2Fgeneral-s-handbook-2024-25%2F%23rules-ability%3ASpells%3Aability%3A1"
+    },
+    {
+      "reason": "Illustrative EXAMPLE PRAYER card (Resurrection) that the General's Handbook 2025-26 page reproduces from the core rulebook to show the ability-card format; it is not a playable AoS 4 ability and must not appear as a reminder (customer report 2026-07-31).",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Fthe-rules%2Fgeneral-s-handbook-2025-26%2F%23rules-ability%3APrayers%3Aability%3A2"
+    },
+    {
+      "reason": "Illustrative EXAMPLE SPELL card (Mystic Shield) that the General's Handbook 2025-26 page reproduces from the core rulebook to show the ability-card format; it is not a playable AoS 4 ability and must not appear as a reminder (customer report 2026-07-31).",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Fthe-rules%2Fgeneral-s-handbook-2025-26%2F%23rules-ability%3ASpells%3Aability%3A1"
+    },
+    {
+      "reason": "Illustrative EXAMPLE PRAYER card (Resurrection) that the core rules page reproduces from the core rulebook to show the ability-card format; it is not a playable AoS 4 ability and must not appear as a reminder (customer report 2026-07-31).",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Fthe-rules%2Fthe-core-rules%2F%23rules-ability%3APrayers%3Aability%3A2"
+    },
+    {
+      "reason": "Illustrative EXAMPLE SPELL card (Mystic Shield) that the core rules page reproduces from the core rulebook to show the ability-card format; it is not a playable AoS 4 ability and must not appear as a reminder (customer report 2026-07-31).",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Fthe-rules%2Fthe-core-rules%2F%23rules-ability%3ASpells%3Aability%3A1"
+    }
+  ],
+  "normalizationDiagnosticPolicies": [
+    {
+      "code": "unlabeled-ability-preamble",
+      "reason": "The normalizer retains unlabeled preamble text immediately before the labeled Effect instead of discarding or reinterpreting it."
+    },
+    {
+      "code": "source-phase-conflict",
+      "reason": "The displayed condition is the canonical timing statement; the separate ability_phase column is retained as review evidence but does not override explicit condition text."
+    },
+    {
+      "code": "source-timing-correction",
+      "reason": "The bounded normalizer corrects only the reviewed current-source typos 'Comhat' to 'Combat', 'Hero Quest' to 'Hero Phase', and 'Ypur' to 'Your'."
+    },
+    {
+      "code": "source-kind-correction",
+      "reason": "Extremis Chamber is a continuously applicable effect; the contradictory Wahapedia label 'Reaction: Passive' is classified as Passive instead of inventing a reaction trigger.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fstormcast-eternals%2Fwarscrolls.html%23datasheet%3ADrakesworn-Templar%2Fability%3A2"
+    },
+    {
+      "code": "source-kind-correction",
+      "reason": "The War Despot effect applies continuously; the contradictory Wahapedia label 'Reaction: Passive' is classified as Passive instead of inventing a reaction trigger.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fhelsmiths-of-hashut%2Fwarscrolls.html%23datasheet%3AScourge-of-Ghyran-War-Despot%2Fability%3A2"
+    },
+    {
+      "code": "source-kind-correction",
+      "reason": "The Light of Eltharion effect applies continuously; the contradictory Wahapedia label 'Reaction: Passive' is classified as Passive instead of inventing a reaction trigger.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Flumineth-realm-lords%2Fwarscrolls.html%23datasheet%3AScourge-of-Ghyran-The-Light-of-Eltharion%2Fability%3A2"
+    },
+    {
+      "code": "passive-declare-promoted",
+      "reason": "Sparking Claws is explicitly Passive and its complete characteristic effect is mislabeled Declare; the bounded normalizer retains that source sentence as the effect without inventing text.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Fthe-rules%2Fravaged-coast%2F%23rules-ability%3APath-of-the-Pack%3Aability%3A4"
+    },
+    {
+      "code": "effect-phase-windows",
+      "reason": "The effect explicitly labels each phase branch, so the one-per-phase rule is projected into all named phase windows.",
+      "sourceRecordId": "source-record:wahapedia:Faction_abilities.csv%3AOB%3A000001045%3A000004250%3A3"
+    },
+    {
+      "code": "missing-ability-effect",
+      "reason": "Overdrive Switch is a reaction whose complete outcome was mislabeled Declare; the reviewed projection promotes that retained section to Effect.",
+      "sourceRecordId": "source-record:wahapedia:Faction_abilities.csv%3AHoH%3A000000891%3A000003165%3A3"
+    },
+    {
+      "code": "duplicate-ability-section",
+      "reason": "Both sequential Effect paragraphs are retained in source order as one effect.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000002687%3A1"
+    },
+    {
+      "code": "duplicate-ability-section",
+      "reason": "Both sequential Effect paragraphs are retained in source order as one effect.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000002688%3A1"
+    },
+    {
+      "code": "unknown-timing",
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A57"
+      ],
+      "reason": "The export omitted the timing for Multiple Parts; the current Games Workshop update supplies Passive timing.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000000851%3A2"
+    },
+    {
+      "code": "source-phase-conflict",
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A60"
+      ],
+      "reason": "The current Nighthaunt update removes the older End of Any Turn timing from Light a Pyre; the explicit current usage text is phase-independent.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000001746%3A1"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Reaction clause in the condition is canonical; the false helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Faction_abilities.csv%3ABoC%3A000000479%3A000001931%3A2"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Reaction clause in the condition is canonical; the false helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000002695%3A3"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Reaction clause in the condition is canonical; the false helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000000651%3A1"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Reaction clause in the condition is canonical; the false helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000002289%3A1"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Reaction clause in the condition is canonical; the false helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Faction_abilities.csv%3AID%3A000000858%3A000002911%3A2"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Reaction clause in the condition is canonical; the false helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Faction_abilities.csv%3ANT%3A000000864%3A000002932%3A2"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Reaction clause in the condition is canonical; the false helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Faction_abilities.csv%3ANT%3A000000868%3A000002938%3A2"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Reaction clause in the condition is canonical; the false helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Faction_abilities.csv%3ANT%3A000000868%3A000002938%3A4"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Reaction clause in the condition is canonical; the false helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000002397%3A1"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A71"
+      ],
+      "reason": "The explicit Reaction clause is corroborated by the current Stormcast Eternals erratum.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000001718%3A5"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A71"
+      ],
+      "reason": "The explicit Reaction clause is corroborated by the current Stormcast Eternals erratum.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000001884%3A3"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Reaction clause in the condition is canonical; the false helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000001090%3A2"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Reaction clause in the condition is canonical; the false helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Faction_abilities.csv%3AST%3A000001012%3A000004130%3A2"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Passive condition is canonical; the true reaction helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000002370%3A2"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Passive condition is canonical; the true reaction helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000002658%3A2"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Your Movement Phase condition is canonical; the true reaction helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Faction_abilities.csv%3AOM%3A000001039%3A000004225%3A4"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Passive condition is canonical; the true reaction helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000000087%3A2"
+    },
+    {
+      "code": "reaction-flag-mismatch",
+      "reason": "The explicit Any Combat Phase condition is canonical; the true reaction helper flag is stale metadata.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000000208%3A1"
+    },
+    {
+      "code": "source-incomplete-weapon-profile",
+      "reason": "The export supplies the special hit marker but omits downstream characteristics; the missing fields are retained explicitly instead of guessed.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_weapons.csv%3A000003380%3A1"
+    },
+    {
+      "code": "source-incomplete-weapon-profile",
+      "reason": "The export omits Rend for this profile; the missing field is retained explicitly instead of treating blank as a numeric value.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_weapons.csv%3A000002339%3A2"
+    },
+    {
+      "code": "source-incomplete-weapon-profile",
+      "reason": "The export omits Rend for this profile; the missing field is retained explicitly instead of treating blank as a numeric value.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_weapons.csv%3A000002339%3A3"
+    },
+    {
+      "code": "source-incomplete-weapon-profile",
+      "reason": "The export supplies the special hit marker but omits downstream characteristics; the missing fields are retained explicitly instead of guessed.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_weapons.csv%3A000000249%3A1"
+    },
+    {
+      "code": "source-incomplete-weapon-profile",
+      "reason": "The export supplies the special hit marker but omits downstream characteristics; the missing fields are retained explicitly instead of guessed.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_weapons.csv%3A000001683%3A1"
+    },
+    {
+      "code": "source-incomplete-weapon-profile",
+      "reason": "The export supplies a special hit marker and omits downstream characteristics; the missing fields are retained explicitly instead of guessed.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_weapons.csv%3A000003395%3A1"
+    },
+    {
+      "code": "source-incomplete-weapon-profile",
+      "reason": "The export supplies the special hit marker but omits downstream characteristics; the missing fields are retained explicitly instead of guessed.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_weapons.csv%3A000000429%3A1"
+    },
+    {
+      "code": "source-marker-removed",
+      "reason": "An HTML-encoded KY keyword wrapper is presentation metadata; the marker is removed while the Blacktalons keyword text is retained.",
+      "sourceRecordId": "source-record:wahapedia:Warscrolls_abilities.csv%3A000001708%3A2"
+    },
+    {
+      "code": "missing-ability-effect",
+      "reason": "The historical Overdrive Switch source labels its resolution text as Declare instead of Effect; the full bounded source text is retained rather than inferred or discarded.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fhelsmiths-of-hashut%2F%23faction-ability%3AAccursed-Device%3Aability%3A2"
+    },
+    {
+      "code": "effect-phase-windows",
+      "reason": "The Spearhead Relentless Discipline effect explicitly labels Movement, Charge, and Combat branches, so the reminder projection retains all three named phase windows.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fossiarch-bonereapers%2F%23faction-ability%3ABattle-Traits-7%3Aability%3A2"
+    },
+    {
+      "code": "source-incomplete-weapon-profile",
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A17"
+      ],
+      "reason": "The secondary source split the official merged 'See below' cells into a malformed Wound value and blank Rend and Damage values; the accepted Games Workshop supplement supplies the canonical profile.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fcities-of-sigmar%2Fwarscrolls.html%23datasheet%3ABattlemage-on-Luminark-of-Hysh%2Fweapon%3A1"
+    },
+    {
+      "code": "source-incomplete-weapon-profile",
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A17"
+      ],
+      "reason": "The secondary source split the official merged 'See below' cells into a malformed Wound value and blank Rend and Damage values; the accepted Games Workshop supplement supplies the canonical profile.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fcities-of-sigmar%2Fwarscrolls.html%23datasheet%3ALuminark-of-Hysh%2Fweapon%3A1"
+    },
+    {
+      "code": "source-incomplete-weapon-profile",
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:64cbf4bd20cd400f4e609236e1f16d53d73f6b74ced10f0ca34192c0f08b47be%3Apage%3A39"
+      ],
+      "reason": "The secondary source omitted the official no-Rend dash and lost the Wound target suffix; the accepted Games Workshop Legends warscroll supplies both canonical values.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fgloomspite-gitz%2Fwarscrolls.html%23datasheet%3ABorgit-s-Beastgrabbaz%2Fweapon%3A2"
+    },
+    {
+      "code": "source-incomplete-weapon-profile",
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:64cbf4bd20cd400f4e609236e1f16d53d73f6b74ced10f0ca34192c0f08b47be%3Apage%3A39"
+      ],
+      "reason": "The secondary source omitted the official no-Rend dash and lost the Wound target suffix; the accepted Games Workshop Legends warscroll supplies both canonical values.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fgloomspite-gitz%2Fwarscrolls.html%23datasheet%3ABorgit-s-Beastgrabbaz%2Fweapon%3A3"
+    },
+    {
+      "code": "source-incomplete-weapon-profile",
+      "reason": "The live profile delegates Wound, Rend, and Damage to the Sceptre of the Prime ability; the projection retains the source representation.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fstormcast-eternals%2Fwarscrolls.html%23datasheet%3ACelestant-Prime-Hammer-of-Sigmar%2Fweapon%3A1"
+    },
+    {
+      "code": "duplicate-ability-section",
+      "reason": "The current Wun of Da Boyz source repeats the Effect label for its linked deployment clauses; both clauses are retained in source order.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fironjawz%2Fwarscrolls.html%23datasheet%3ADakkbad-Grotkicker%2Fability%3A1"
+    },
+    {
+      "code": "unknown-timing",
+      "reason": "The current Multiple Parts source contains no textual timing label; the generator preserves that unknown explicitly rather than importing a historical assumption.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Flumineth-realm-lords%2Fwarscrolls.html%23datasheet%3ASanctum-of-Amyntok%2Fability%3A2"
+    },
+    {
+      "code": "duplicate-ability-section",
+      "reason": "The current Battlefield Enhancements source repeats the Effect label for its trigger and resolution clauses; both clauses are retained in source order.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fossiarch-bonereapers%2Fwarscrolls.html%23datasheet%3AThe-Grand-Necromystic%2Fability%3A1"
+    }
+  ],
+  "officialDocuments": [
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 22449748,
+        "checksum": "240af53bd83954067cc8fdb3486bdc55f32dbd103bc8d2fd1081c06790b6333d",
+        "etag": "\"886b8d1a5160aa0334aaefb5091661b4\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_rules_of_renown_armies_of_renown-1ditzyyjxc-bavmt4bifv.pdf",
+        "lastModified": "Fri, 24 Jul 2026 13:05:21 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_rules_of_renown_armies_of_renown-1ditzyyjxc-bavmt4bifv.pdf",
+        "retrievedAt": "2026-07-30T00:53:09.204Z"
+      },
+      "documentKind": "reference",
+      "effectiveDate": "2026-07-29",
+      "publicationDate": "2026-07-29",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:240af53bd83954067cc8fdb3486bdc55f32dbd103bc8d2fd1081c06790b6333d%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "dd497e0a13a69b053820e59b588fc1ed5e60bdd976921783efd1caa770e656e6"
+        },
+        {
+          "id": "source-record:games-workshop:240af53bd83954067cc8fdb3486bdc55f32dbd103bc8d2fd1081c06790b6333d%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "75ac8933a10edee65ed50913b0d349e8a300e295d6476b10e1c56a04b3328f68"
+        }
+      ],
+      "title": "Armies of Renown",
+      "version": "August 2026"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 1352081,
+        "checksum": "5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2",
+        "etag": "\"e1d1a14c03c0137b427edaf542dd95b2\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_core_rules_battle_profiles-mhh9urxjwe-tagofadxuo.pdf",
+        "lastModified": "Fri, 24 Jul 2026 13:10:15 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_core_rules_battle_profiles-mhh9urxjwe-tagofadxuo.pdf",
+        "retrievedAt": "2026-07-30T00:52:59.723Z"
+      },
+      "documentKind": "battle-profiles",
+      "effectiveDate": "2026-07-29",
+      "publicationDate": "2026-07-29",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000004",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "060e7ae6af32fc61fb79d9ae99c421382080fd2a40a650d4064ef36e3f70b5b0"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "c7bd555151c9ff8863f7d58446f8289055dbd3863c4f7c670aded820a7c4011b"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "ed9dae88fb950dcd4ec0721f3f92977d11f588c48c8cf61a9b662563438d0bcf"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "c0fbbaa3aa3e7b181a0dc89033e502f4c2b496671c3ccf4cb6def763b1baa822"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "772736c486182b760192525bd310fc0abd31740b9be8fbdf99983c91d35c2f1a"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "c33effe0d8e3b540a9b8b139ffed41910d86e8aee7828e2747158043b0f12fde"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "5f88f394ee09a30ae359c70a05e67432a3e86809d26f045349976b2baf248af0"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "6d23d2ea0f22a8e00fc1b2e30149432604c92532ddd09e4e45347793af96bc41"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "04cee7e5c0f524e3a4a41926bd75a0f91dd4a54300a2d3f6892a2d7489ba7936"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "95c4c6fb4a833e6d1598c42a2216a1dfba53e0a9d4da8a44c2bf68a7f977a012"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "6c13ec3a65e6f8afa35711037172e79c0b2bd0c973789d01410f919eb5e999e8"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "18d8c48f815d3d0ca4d9da8a777a0480a8eda2fef57434b4349ea2a945019946"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "d390bab4e654f3460b8aa3d17475b3e79a0c81c599498158b8aaecc3890b85a4"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "0df3f5dc9c75764c670929578c315a00addee0e0df9b03e9b64c1eb2da66fbb8"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "efd8347e8affaee43522de82ba584d119f07f912dc881bd3855b9fc891b873cb"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "6c31ad78f2b24ee2c303c6da720dabce3fb4c07f98bfc3d1cebea88faaefc2f6"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "551bad9fd30e984cb248a35b1cb7052c73da578a22aad2d2bda15fa29cda107a"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "434fafc9889493dcfa078285d0c654b9799235bb6d0874bada6fa2030d465a76"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A21",
+          "page": 21,
+          "recordChecksum": "ac0077169852c59bc8a9e32a419e09821bf76c5b313e0ce6ed32cd35e743519a"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A22",
+          "page": 22,
+          "recordChecksum": "5dac786b310507ec8dd40171035acf3c916f31240f7ebaf9e16f50623532e02c"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A23",
+          "page": 23,
+          "recordChecksum": "008b9d0764f00f3fd206059460e7f3f54a50592a2ee0413953b1f265297f2d0a"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A24",
+          "page": 24,
+          "recordChecksum": "97f073787f37d9310c1f08e765e39652aada1bec95f5cc7fab04d982044819eb"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A25",
+          "page": 25,
+          "recordChecksum": "97316ced001242b034277984d3cb4a3d458ec3fe9551715f59b437774e3cf924"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A26",
+          "page": 26,
+          "recordChecksum": "16d3de07edc5bcc329049809b819351cd00713b2659dee368ab74ae8d8b26f0e"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A27",
+          "page": 27,
+          "recordChecksum": "e468ac52d56b6b27660b27dbdd9efa96063cb21c4fda646e052efc58abf53de7"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A28",
+          "page": 28,
+          "recordChecksum": "de54e4f6863cb71bcd56200391491cc4db5811028197d787cad4ef270921dadf"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A29",
+          "page": 29,
+          "recordChecksum": "db68d199701eee65ffd1b645824d562a7986a4e8db1b31e9602aa3da0b30e2d0"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A30",
+          "page": 30,
+          "recordChecksum": "89d957318214251b352d4e9bd164f765d415c8ade092065ee29807d2f07f270a"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A31",
+          "page": 31,
+          "recordChecksum": "0b5144c5bad855ef7a38857d6635640e481c8de9c901a03d3a19e4995c5763d3"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A32",
+          "page": 32,
+          "recordChecksum": "1b6575179597a01c55ddb900a29d52e179f2d692ebf5d9d5d38b2d73278ef755"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A33",
+          "page": 33,
+          "recordChecksum": "bd019b3e51e067129f588d91fd9860389916abcf2668dd4e67aa010960905a5a"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A34",
+          "page": 34,
+          "recordChecksum": "b1636976192d1d40b409e2b9cb35e987e2743cb9710f549364f79586f454c30d"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A35",
+          "page": 35,
+          "recordChecksum": "5cbd9735b4e4f629ed88d8f67f733fca4a9437c81e052c23d7ac535d8d534cb7"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A36",
+          "page": 36,
+          "recordChecksum": "3013562ac272ab8db68c7bba916eb30ec3adaf9ae01d32b318f7c198818c938e"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A37",
+          "page": 37,
+          "recordChecksum": "33ebea882f9a4d2d2b5c8c9906af5e7d96cf28f0f4bc26679d07d32579ad713b"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A38",
+          "page": 38,
+          "recordChecksum": "d7cb966ed7d22b48d552c6e9a713a71d9e82ca72fc66c87c102343874f6fa606"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A39",
+          "page": 39,
+          "recordChecksum": "e13ed3ab5a173fd143ea9e31189f503f5ef7e504b6d60ec04db2f74bf88944b4"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A40",
+          "page": 40,
+          "recordChecksum": "06b39a5a35ea813422c9b992fcfb528bf418add916ebeb674babf4b61684143e"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A41",
+          "page": 41,
+          "recordChecksum": "9d67901060c9ecc005bd24496c3f24c407b3a703756cd3fdafc7219af1c0a670"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A42",
+          "page": 42,
+          "recordChecksum": "725a78bf87327c9ec4bdb86726d4cda733fd687fd1119a26374abf92f2f7df20"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A43",
+          "page": 43,
+          "recordChecksum": "b86422bc7b9d1d936a6c94b8a9a08245483d076dba799ca8986c0ed40d371609"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A44",
+          "page": 44,
+          "recordChecksum": "f3324cf54e6116395abad7ac6d39ff684ec328d425117bb4a7f40dacf144f03a"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A45",
+          "page": 45,
+          "recordChecksum": "ec50260fb1a53ac796ffe62a00ea0f4fa0df409af5074d1b0f11fc39b39dcfe2"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A46",
+          "page": 46,
+          "recordChecksum": "94726e5bef1cf69275e690e531bb38815f2099bc9ac3ce54d40f839d558452a6"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A47",
+          "page": 47,
+          "recordChecksum": "f3ec631b458f473e9ef0f57c8a7a3a7e63a932320a78a4ac05f53d45026be1c9"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A48",
+          "page": 48,
+          "recordChecksum": "ecd625737ce0dd17f0c89152753c9d57331de66f13ff7bc0550d07be122c7db1"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A49",
+          "page": 49,
+          "recordChecksum": "962532ba3eb65da1dea3b638446eab8b7c6e40d5c7c67a4d1ab5dbbf55d6fb8e"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A50",
+          "page": 50,
+          "recordChecksum": "30358630808a9050160658976121cd4bea6bd8caa7554e7a0ffec6ff50db8d56"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A51",
+          "page": 51,
+          "recordChecksum": "ab159ff1c9f3bf5f62957396ca9e36e5447c8d4e62134161e91e5fdd7f022212"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A52",
+          "page": 52,
+          "recordChecksum": "75a56f9e08933bdf2bfebac02891546350e7237a32897a4bc3056a199ef5097a"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A53",
+          "page": 53,
+          "recordChecksum": "55dfb66bc76ffe74181988056bcc18191e990043c4332bc6af7d33e299bf0bc7"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A54",
+          "page": 54,
+          "recordChecksum": "a1b1456e79d914d125c6c0e30b9f72d37aa9f4002b7ed7dfb5b81ca63c2ce580"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A55",
+          "page": 55,
+          "recordChecksum": "1f475d04a01a91128c6d848f026d1d8672241a8ee785730471d6ea0f6c62b3fb"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A56",
+          "page": 56,
+          "recordChecksum": "70289e3bae5188efeeaa90516e82ccec7b30452dfc793efeff1e8cad16f0bd4f"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A57",
+          "page": 57,
+          "recordChecksum": "61706e87a70948f33b964dd26d24681ff35495e2ef7d13471153780146c13aa3"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A58",
+          "page": 58,
+          "recordChecksum": "79ebd43da4a74a104a30078816bbd91853f1140d3f84a067cb94eaccdf5fdb92"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A59",
+          "page": 59,
+          "recordChecksum": "b1144ff88b39bd0b4cb6fc815a32f6b8054a0aac6704ebba28ecfd2cf9f25069"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A60",
+          "page": 60,
+          "recordChecksum": "ed406f94ecb9bad377543c5564cfdc9f5d80ac0e7759e9dcfb93fd41fcb2dca5"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A61",
+          "page": 61,
+          "recordChecksum": "03c647805683e21188b86bafce68d35d8f93d703461bf4fde416cfcb6cbf7a8b"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A62",
+          "page": 62,
+          "recordChecksum": "ee03c2b0c366ecb6dec1df7f3360869546eb3ce7b41f2c8a5fc81aeab8ab3f00"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A63",
+          "page": 63,
+          "recordChecksum": "fca2e2cb322049185490b5ee29f871a4780600a5af75625cb4db99dfb229c6cc"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A64",
+          "page": 64,
+          "recordChecksum": "476c835b6d5479864c342bb764281f7cce4289ecfa08a565e83be214d2a81c90"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A65",
+          "page": 65,
+          "recordChecksum": "57afe75a501caf58f50882c36ea8fbeeac402a2df42ba3243b98886452bc12e9"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A66",
+          "page": 66,
+          "recordChecksum": "4474e53f1a23b7a01d1ecc06a25f39b603f1de2aa35923883d73082869b246dc"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A67",
+          "page": 67,
+          "recordChecksum": "81f9d8fe4c03c3fd6816454a6b47db87c792c1563ffea1e2cc99ea1588e39e41"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A68",
+          "page": 68,
+          "recordChecksum": "75426b21dc59eca4facaf1b2220ec5baa8b098d25c28238c0b9957981e576bea"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A69",
+          "page": 69,
+          "recordChecksum": "9e81320d97bbb704c36e1f6e14e69cd07da71b96632de2f8587b453afbf71378"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A70",
+          "page": 70,
+          "recordChecksum": "2cc1bbfa740c61f586651f0f800d98b97fd65ca433705ebcc591d5416d61ac5c"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A71",
+          "page": 71,
+          "recordChecksum": "39da148bbc36a191a0e356acd7697d88b2543a1e9fb0a85b19957a02bed9be68"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A72",
+          "page": 72,
+          "recordChecksum": "72a8b17a57d17ab72713d684115369f06f585f23dd9c7c832a8a076ea0f9d65c"
+        },
+        {
+          "id": "source-record:games-workshop:5fbaa128ff5087235bb133b5e48a0885119d7a0e4422aa38e3c71604db2f81f2%3Apage%3A73",
+          "page": 73,
+          "recordChecksum": "a0f29192839255e8168d2f03d49883446d11a1964309b8a11d461cab4a31e9ea"
+        }
+      ],
+      "title": "Battle Profiles",
+      "version": "July 2026"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 663202,
+        "checksum": "052a8f5ca298950eea814ef8795160134aa4eb152896dc894dfdb1553ba55750",
+        "etag": "\"9703c0138720369d406bc7fab88a07cb\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_15-07_aos_battle_profiles_ogor_mawtribes-xyrqrriy18-i8lyby0m4w.pdf",
+        "lastModified": "Thu, 09 Jul 2026 09:00:55 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_15-07_aos_battle_profiles_ogor_mawtribes-xyrqrriy18-i8lyby0m4w.pdf",
+        "retrievedAt": "2026-07-28T03:05:25.831Z"
+      },
+      "documentKind": "battle-profile-supplement",
+      "faction": "Ogor Mawtribes",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:052a8f5ca298950eea814ef8795160134aa4eb152896dc894dfdb1553ba55750%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "fdfaac19b9708f713c5ecead6a8d0a9e2389d4941661800eb94d8b46f7b579d4"
+        },
+        {
+          "id": "source-record:games-workshop:052a8f5ca298950eea814ef8795160134aa4eb152896dc894dfdb1553ba55750%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "5809f710c9c3c5c837ddf28e2d9d2d34366e965bd19ec8cf349d1df33bc8caa8"
+        },
+        {
+          "id": "source-record:games-workshop:052a8f5ca298950eea814ef8795160134aa4eb152896dc894dfdb1553ba55750%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "7ee995db8b38af2b03eea4deba3fd4eddd994cb0a8b82dc9373901cfb93ed51c"
+        }
+      ],
+      "title": "Battle Profiles - Ogor Mawtribes"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 6967360,
+        "checksum": "61aa2013a8a9154801f0b044f52d4ae40198a39ae02d28b2d1bed1932a12b2a4",
+        "etag": "\"253bf210c0a8da1945a392e0048d1b25\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_08-08_aos_other_rules_battleplan_the_adamantine_chain_quakes-nktlgojrjd-ugev9w72st.pdf",
+        "lastModified": "Fri, 08 Aug 2025 10:18:48 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_08-08_aos_other_rules_battleplan_the_adamantine_chain_quakes-nktlgojrjd-ugev9w72st.pdf",
+        "retrievedAt": "2026-07-28T19:27:44.500Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:61aa2013a8a9154801f0b044f52d4ae40198a39ae02d28b2d1bed1932a12b2a4%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "ff5e0c4cec0f30431e0c99539c6a508d1299eafe9440e3635af4d8d4a4b77a1b"
+        },
+        {
+          "id": "source-record:games-workshop:61aa2013a8a9154801f0b044f52d4ae40198a39ae02d28b2d1bed1932a12b2a4%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "132f747d4be389310acc3eca8e2d2aca22a8c3eb7fc0f46c6327597281659788"
+        }
+      ],
+      "title": "Battleplan: The Adamantine Chain Quakes"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 5639891,
+        "checksum": "398637f848d69e30838d14f77d1e3e7b8dfd6387e1c7cd6bc2f613619b4b6bcb",
+        "etag": "\"cae0a0e40fe8c1915ab019ce312c9fe9\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_30-07_aos_faction_pack_blades_of_khorne_supplement-4cwo8kiocz-on0x33plgl.pdf",
+        "lastModified": "Tue, 22 Jul 2025 08:28:46 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_30-07_aos_faction_pack_blades_of_khorne_supplement-4cwo8kiocz-on0x33plgl.pdf",
+        "retrievedAt": "2026-07-28T17:49:31.895Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:398637f848d69e30838d14f77d1e3e7b8dfd6387e1c7cd6bc2f613619b4b6bcb%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "dcbdfb4ce31fc5edbc25e621c36f2b37c3a6af08ce81500326112f83d0e39884"
+        },
+        {
+          "id": "source-record:games-workshop:398637f848d69e30838d14f77d1e3e7b8dfd6387e1c7cd6bc2f613619b4b6bcb%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "587251039a71a5bdaba2172642ec547a7d4a3daf429e54170254cdfe95368cff"
+        },
+        {
+          "id": "source-record:games-workshop:398637f848d69e30838d14f77d1e3e7b8dfd6387e1c7cd6bc2f613619b4b6bcb%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "b7347af060d895efaf26f3cb1b9100fbb68a51cf965efa05ba7a7e435b2b28b7"
+        }
+      ],
+      "title": "Battletome Supplement: Blades of Khorne"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 12969238,
+        "checksum": "031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75",
+        "etag": "\"d272d9465edbfbfa625838a0528b1678\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_cities_of_sigmar_battletome_supplement-7lw8joaurh-qxaulcoztd.pdf",
+        "lastModified": "Wed, 17 Jun 2026 14:48:29 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_cities_of_sigmar_battletome_supplement-7lw8joaurh-qxaulcoztd.pdf",
+        "retrievedAt": "2026-07-28T03:05:48.588Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "89bb8d91e7f5c404018219915ea550c5b21eacfb8a9144909054c6771c15136c"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "cbbd5eb5b08778fd2277ed4806f146d1dcf8bc95c5b09d295ea9627ff9c45665"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "f47b3623e07757f2ba147c9ac49c12169cfd8eef183e7aa011b6e46551cc4282"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "3694a710ad176b54aff9abf752adc47cbf66af64c1cbf49367c35b46899f6ac9"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "eb4e2e24f5201a4279cb8ceec250d1c648baa08996e417114702fbb68705a9bf"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "47585a51291b4d63abb948944ed5e537dc6da8d86aa5fe211c2deed744d06092"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "31ef0c43bd1e488342cd73a8f6fe1cc9f33c8d8ec9447d1acba30a741f6d5dbf"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "372c3c499e0c35a29b75b3fa11ee3cd9c29ae1e15697b49ffd880662ac9290f7"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "640f3b68a22e82a245c3f8cf7be32a72def2696ea09bfabd3ebdad08a9479b10"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "60b4205dcf84fac2133fea53ce589a8722291f32f56d502827256a03e2c9fb68"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "9ba45becccee6af4c85e86d59a08179170bd9c32a814762006b0be96aa8a0b33"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "a17481c938aa6e12ebc2cf76ac473a3b3835e13410ae4b81c4b7f742a1a27a62"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "6e8e161e122915372557708afc0d56e775944ee8bf9f85c35a7a242fa9e9b94e"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "178649742dcca99b75c07bfa13e4da09372f9919f398febf5dcd576b88abbde1"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "3c6cf9176c87c5be1c67b774cc477c830a614eded3ad4ac3a6c82134ea355d0c"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "6b4a978fb4e448757387e893dff51c158bd8393454ed512da36b38ae95c76024"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "4857a8560c55a29fc89afe0797f5e6258521962140f67cd64b5a9e84a0dd9c51"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "4856cf7c083a45747cd07a6c6079e7b2f91849e2449e7e92d02091df81b225df"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "e2205a492cd7ea6bef749d0665b9c6948a46f06e21b0c0482d3f8ee2f145c9b2"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "3d805f8a774929b0a67d109beb144f7bb6618c68a30c0f667e95ec4f71617814"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A21",
+          "page": 21,
+          "recordChecksum": "b690076bd953e77cc2f88129403ee34d02c78763d4e0d67d81285f935fd76aac"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A22",
+          "page": 22,
+          "recordChecksum": "23d31d3b6d1cb0080b9f8d5e93f505859ae4ded98ddfd4da26c3c6dd7eefd842"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A23",
+          "page": 23,
+          "recordChecksum": "40a057fe190d86c199981d52a1fddbafcc2e8c2e080211cb2eec0dcb40a21644"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A24",
+          "page": 24,
+          "recordChecksum": "23128c963a94ade5af926866bc713d28c7007f3a1aa23716bd2e3df295a7aed4"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A25",
+          "page": 25,
+          "recordChecksum": "d392dcb25a005b4c668efff95c9b8d0469923cf429bfcea24622c295404472cf"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A26",
+          "page": 26,
+          "recordChecksum": "df4211f5725ec42e844c60b9fa2cfdecffa9557200205465fc29832d41908632"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A27",
+          "page": 27,
+          "recordChecksum": "a4e4cb69f78bc93271a1ba1ed4049524df3fc5fcb26164da372d320671caa3fa"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A28",
+          "page": 28,
+          "recordChecksum": "9154fdb514b4d8e80f8ee91996bb0ff4b17dd7eb4629554b764af71ebade0f6b"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A29",
+          "page": 29,
+          "recordChecksum": "47862557c899c0697569a944d7d74501d65d81d7f6d65238b0883f38536a34fe"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A30",
+          "page": 30,
+          "recordChecksum": "5de209a8332a855519d53d8b8eb77af20bd39d9daef455ce38cd90b3f868bd26"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A31",
+          "page": 31,
+          "recordChecksum": "48ba9b5e67726899be03e50ec5cc318e912ecb32cc5445e797c87382601507fb"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A32",
+          "page": 32,
+          "recordChecksum": "cf69515b0a3264aa4582654f3f5d88b89c5b8537d9c51bd5ad8e9350a69bd7f5"
+        },
+        {
+          "id": "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A33",
+          "page": 33,
+          "recordChecksum": "bd7252e97ee7ccf4edb5abb7ec8d2962843a331210b5da3e3c5132696093e645"
+        }
+      ],
+      "title": "Battletome Supplement: Cities of Sigmar"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3706424,
+        "checksum": "a9cf1ed5bebd0f2f093496cd41ee79f25b629b73b96dee8cf7452a0b728d6219",
+        "etag": "\"14ee385714ad8a5250f2b6202a087724\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_25-03_aos_otherrules_daughters_of_khaine_supplement-8ebcytpnh5-7chp80ejn3.pdf",
+        "lastModified": "Thu, 19 Mar 2026 10:27:17 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_25-03_aos_otherrules_daughters_of_khaine_supplement-8ebcytpnh5-7chp80ejn3.pdf",
+        "retrievedAt": "2026-07-28T17:49:32.093Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:a9cf1ed5bebd0f2f093496cd41ee79f25b629b73b96dee8cf7452a0b728d6219%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "0592b830954717f72eabcbf66ed2af18882f49195f61d54912250a6d7604cc1f"
+        },
+        {
+          "id": "source-record:games-workshop:a9cf1ed5bebd0f2f093496cd41ee79f25b629b73b96dee8cf7452a0b728d6219%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "621430fa45779fba9b79fc23f697f391351bd82fb74efa7952c5c9e5670b2ae0"
+        }
+      ],
+      "title": "Battletome Supplement: Daughters of Khaine"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3717581,
+        "checksum": "a692483ec93371cda07de3d15555f093cf200d84cf6e31ee2b057740eaa02ab3",
+        "etag": "\"702183ddfd12a7e7d523ad2a8a9b799f\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos4_disciples-of-tzeentch_supplement-qt5fmdu6n7-ahjfh2nm2k.pdf",
+        "lastModified": "Fri, 10 Apr 2026 09:46:46 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos4_disciples-of-tzeentch_supplement-qt5fmdu6n7-ahjfh2nm2k.pdf",
+        "retrievedAt": "2026-07-28T17:49:32.264Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:a692483ec93371cda07de3d15555f093cf200d84cf6e31ee2b057740eaa02ab3%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "85eb3ec781e33b557dea3d66fc7562a7aadead7c1176ffa09eaa2e3fa5752e3a"
+        },
+        {
+          "id": "source-record:games-workshop:a692483ec93371cda07de3d15555f093cf200d84cf6e31ee2b057740eaa02ab3%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "2cd3da62e249ba1353af47154f4ef1a269e2110a67241819a1a4eee47e5bdeac"
+        }
+      ],
+      "title": "Battletome Supplement: Disciples of Tzeentch"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 6116890,
+        "checksum": "3e1824783634ad97a9a4ad70052fff41ee1851c2565ee3c1d899407c519748ab",
+        "etag": "\"ee8a8ab7afce6f2403cf7f582b50a884\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_17-06_aos_battletome_supplement_hedonites_of_slaanesh-xp8xsjsx9r-jy2xzpt7ed.pdf",
+        "lastModified": "Mon, 15 Jun 2026 08:40:36 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_17-06_aos_battletome_supplement_hedonites_of_slaanesh-xp8xsjsx9r-jy2xzpt7ed.pdf",
+        "retrievedAt": "2026-07-28T03:05:28.362Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:3e1824783634ad97a9a4ad70052fff41ee1851c2565ee3c1d899407c519748ab%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "0d26cd31a199e138fa828d809221ec4d088791d4d42d578c9fff13ea1aa30261"
+        },
+        {
+          "id": "source-record:games-workshop:3e1824783634ad97a9a4ad70052fff41ee1851c2565ee3c1d899407c519748ab%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "8fab72f30afcf3525adf6228cb3af5564a3e2abb5fb8ed8a7e88f2f13ce0fd37"
+        },
+        {
+          "id": "source-record:games-workshop:3e1824783634ad97a9a4ad70052fff41ee1851c2565ee3c1d899407c519748ab%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "fd7271fddc010dd4d17313ef0b1ece0e12071acb9031d743b910fc68d795b288"
+        },
+        {
+          "id": "source-record:games-workshop:3e1824783634ad97a9a4ad70052fff41ee1851c2565ee3c1d899407c519748ab%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "9024d4839ee671a6f0bab5835d34259ec187fa0b64635747fd3bda2b1588e67f"
+        }
+      ],
+      "title": "Battletome Supplement: Hedonites of Slaanesh"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 5400640,
+        "checksum": "1be8fdf4d50dcabaab12b31d93d2dfd26d3791561ab8caf2574f937883fba98a",
+        "etag": "\"2eff80cea3d616cf19aa80facc4c3349\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_sept25_aos_nighthaunt_supplement-tgpq2gtghc-hkzcshgbyo.pdf",
+        "lastModified": "Tue, 23 Sep 2025 09:04:07 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_sept25_aos_nighthaunt_supplement-tgpq2gtghc-hkzcshgbyo.pdf",
+        "retrievedAt": "2026-07-28T17:49:32.472Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:1be8fdf4d50dcabaab12b31d93d2dfd26d3791561ab8caf2574f937883fba98a%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "f615df016d5200dbc825bb3a32f166b42575c1ca127958a5cdc68bc18780b911"
+        },
+        {
+          "id": "source-record:games-workshop:1be8fdf4d50dcabaab12b31d93d2dfd26d3791561ab8caf2574f937883fba98a%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "4abb6dabb90787893602470d3870a98a88088fb5a18943e60b33feb0b0c6af79"
+        },
+        {
+          "id": "source-record:games-workshop:1be8fdf4d50dcabaab12b31d93d2dfd26d3791561ab8caf2574f937883fba98a%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "aae9846f39cf6a2ee94b123602e1d0b2f102e49b03e1e0efae8ec849ca03a050"
+        }
+      ],
+      "title": "Battletome Supplement: Nighthaunt"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 6309699,
+        "checksum": "b750d1548cd2a786ac22b258ed2829e488f2655e16a2a851a3fdc10648704b5b",
+        "etag": "\"dae14bcc3c80f708b4bd53cc3af1cd8a\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_battletome_supplement_ogor_mawtribes-ivueka6svf-jdttrqk7mn.pdf",
+        "lastModified": "Fri, 24 Jul 2026 13:42:22 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_battletome_supplement_ogor_mawtribes-ivueka6svf-jdttrqk7mn.pdf",
+        "retrievedAt": "2026-07-30T00:52:59.028Z"
+      },
+      "documentKind": "reference",
+      "effectiveDate": "2026-07-29",
+      "faction": "Ogor Mawtribes",
+      "publicationDate": "2026-07-29",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:b750d1548cd2a786ac22b258ed2829e488f2655e16a2a851a3fdc10648704b5b%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "725b46e6f6d3718a4d37f36bb26f92064e01363aae7b0a42d8e1bf9a2aab03bd"
+        },
+        {
+          "id": "source-record:games-workshop:b750d1548cd2a786ac22b258ed2829e488f2655e16a2a851a3fdc10648704b5b%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "4d5dd0c2dcca72405a00eb0a7a8f85833b291e70ee6420302be3cb34dbdd1bbd"
+        },
+        {
+          "id": "source-record:games-workshop:b750d1548cd2a786ac22b258ed2829e488f2655e16a2a851a3fdc10648704b5b%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "80580fc7989a365e12709b66eb31145fbfc99035741a13808c694b5b52288d93"
+        },
+        {
+          "id": "source-record:games-workshop:b750d1548cd2a786ac22b258ed2829e488f2655e16a2a851a3fdc10648704b5b%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "e64d44650f88667d4e614293940d7e6edf850a7b0879719aab5cc6b2c432babb"
+        },
+        {
+          "id": "source-record:games-workshop:b750d1548cd2a786ac22b258ed2829e488f2655e16a2a851a3fdc10648704b5b%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "09a40a1467daa103e32e0b919b92d1b84622be98c228f6ec7786c0cd3fc166e6"
+        }
+      ],
+      "title": "Battletome Supplement: Ogor Mawtribes",
+      "version": "July 2026"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 22195655,
+        "checksum": "b4fe9a0b7e405437053ce140da05e0d3e9ea86f6bc19d9dc6ccacabedec2c7b4",
+        "etag": "\"a7a6ee75907e21b052dfacafa8d55d02\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_27-05_aos_battletome_supplement_skaven_eshin-2ojghsq8nz-1ug7vyjtjk.pdf",
+        "lastModified": "Fri, 22 May 2026 09:59:51 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_27-05_aos_battletome_supplement_skaven_eshin-2ojghsq8nz-1ug7vyjtjk.pdf",
+        "retrievedAt": "2026-07-28T17:49:32.992Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:b4fe9a0b7e405437053ce140da05e0d3e9ea86f6bc19d9dc6ccacabedec2c7b4%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "3a2951a996c7ed2a29ee9394b7a502c83faaf33984b9e18debf25173db19ef27"
+        },
+        {
+          "id": "source-record:games-workshop:b4fe9a0b7e405437053ce140da05e0d3e9ea86f6bc19d9dc6ccacabedec2c7b4%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "4920b6277d24c1479a58c54f696fb49a55b812e94b9c5d2fa2d7e141b4adf7ce"
+        },
+        {
+          "id": "source-record:games-workshop:b4fe9a0b7e405437053ce140da05e0d3e9ea86f6bc19d9dc6ccacabedec2c7b4%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "934596440511c82c7b9f97e7d69358deb8a3ee6eb817837c7285127f89bc4102"
+        },
+        {
+          "id": "source-record:games-workshop:b4fe9a0b7e405437053ce140da05e0d3e9ea86f6bc19d9dc6ccacabedec2c7b4%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "3323b528c114cc7f0c72d9971d8fccbb9146d2b66b67357361e468b1c257bcc1"
+        },
+        {
+          "id": "source-record:games-workshop:b4fe9a0b7e405437053ce140da05e0d3e9ea86f6bc19d9dc6ccacabedec2c7b4%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "8bbf8d35ca0dd788925ae549de6f5434c20255bd9b1b9a2ce039bca8c0449a8c"
+        },
+        {
+          "id": "source-record:games-workshop:b4fe9a0b7e405437053ce140da05e0d3e9ea86f6bc19d9dc6ccacabedec2c7b4%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "5e533df67b040bb4a590d6407c173c6576845381432a44b2100b4953ad3631e0"
+        },
+        {
+          "id": "source-record:games-workshop:b4fe9a0b7e405437053ce140da05e0d3e9ea86f6bc19d9dc6ccacabedec2c7b4%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "85ab3806a3ad5aa3a21a26c255aca1de3eae8c2b95878b787bc6f0a847f2ef9f"
+        }
+      ],
+      "title": "Battletome Supplement: Skaven Eshin"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 9198630,
+        "checksum": "32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e",
+        "etag": "\"02334e135ee7884b17b8e23a9ad14a4a\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_16-13k65olsxx.pdf",
+        "lastModified": "Mon, 14 Apr 2025 09:03:57 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_16-13k65olsxx.pdf",
+        "retrievedAt": "2026-07-28T17:49:33.402Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "8433ddf43e1cb0c8f2d0e73c505bb3ea7fb45977d9558a983262554338461b02"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "71140971f6f4c1110892eccf3d9cf56cd875bcd93d8810630a502422951e3e47"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "2dafd03ed7d56f7f3d144b41c012053f7fa4e5b0c7a03ba41f20754ae47a6681"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "67ee90c554d1407b6bdd92bd29f30750e98b934f869b32c7a56329a9d1174941"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "6074ab87fc218bf4fe92a0cdb03f4860a5daa5c2a0fd694be5f78318100cdd93"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "3197a3ffa27b0593c5036b622742ed1721902db714db8302a4e5bb4f519d8f8d"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "3eb0a5ae26aa516d32c873ef8988dfa7146066cecbdaf72c099150bd12b2408e"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "bcfcce1f8a02b67fee05f6a31f8718d6380502c8f9b7ca3f403febf70fd812f6"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "b05bcedea507826372f29aec58b041f9f1714d03c6f14aba6e1edf3db317aeb2"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "9521c0f1348dcc22b9729e943ae2c48c5b2387f7fd1563f1ef529a1d56b5e1a7"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "81f47c210c129368ba6cc278ade33324451869633f473e13f0b4273e7de76cde"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "18610f3f4d1c36ad090873b725f60a79f8abfa9df7f9d242060acbdc5a4b8759"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "ec0bffbbd85fcaa966df1ad0671c7916a1ab70fdfe3af543d49318c0722bf0ab"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "067a09a48ee231d3c6b43cf4889b7ae3d7aeb73a86e99ce1bed2a3391c253bba"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "c0fd68a79f0e2420d39848455c824476b9600ccee8aa081bbe8441cbcb8909f3"
+        },
+        {
+          "id": "source-record:games-workshop:32d78da93dbb3441406df67a13c7df040f820bb7f97abecba00a045438b3757e%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "1bbafa327fcff6393fdefb13b5abe28654c1ca31421a6610b942ea8371e11d0c"
+        }
+      ],
+      "title": "Battletome Supplement: Soulblight Gravelords"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 22154810,
+        "checksum": "fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df",
+        "etag": "\"7b1a109d1da5ef29141e42e499d4a038-3\"",
+        "finalUrl": "https://assets.warhammer-community.com/ageofsigmar_factionpacks_supplementstormcasteternals_eng_24.09-bcbyccauh7.pdf",
+        "lastModified": "Wed, 25 Sep 2024 15:47:20 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/ageofsigmar_factionpacks_supplementstormcasteternals_eng_24.09-bcbyccauh7.pdf",
+        "retrievedAt": "2026-07-28T17:49:34.142Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "796a9b4ef3a46e6d0c05eefe8e2ba7fd08c7d756a87e8a6712ab4b8a80f34c43"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "544052f5916fd24685300d31cbb736b75d7322cdb41417bea93ed7c509859970"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "d116c5208f245ad7f601f31521d917df9349842c3b65ebe67d526a5f5635cf16"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "ef51a478be08b1b61882389d35817b9e2c4b27290acd56eb92107e85553d575e"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "44b81189c7be646020cabe82e76855593bc7cea7ac56b51ab19c00080031e8b9"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "da9a1975fc69940cdb922d665a62bc748ee79ce732a9230c8bc528d7d40eccb4"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "db624fd5f623ba7781b27625ca291ef3e18452bea210f7324efb716a54142b59"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "40d44b58326dbe3d6f55170671b18428a4b2958deb33f0522924bbe29c6df13f"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "f55e955c536e44ec0960667e8ecf6b826a71028f6fa3bddce2befae29b8011c3"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "9211edc47534636df4f9ecab3404bd8afb1fae268f644d30eb02ae778373e45e"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "bd1679a04a7236550cd01be210562060eb383d4e04f6511b5d8d99b85d23fcd3"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "f16ad9b4ed5733777a1f70d56529f434323dd0b2524097aab0764988c95d7302"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "129a78cbe93cc8fd35119d211794b1f0d7bbc3a80d38c3443fd60087cd0212b0"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "17eda23fe0c3627dee752b62d273bea481ab73bc9e69538f4e2186c3f1a113f3"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "c121732cc38c6076d76eb48355ff6b25cb6932681738bd7ffa31beba38d65f6c"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A21",
+          "page": 21,
+          "recordChecksum": "f2e522a477e007279d0a30666597912ccb5fde8bed1cfeb5cc5e3ea09ca1a124"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A22",
+          "page": 22,
+          "recordChecksum": "f2ea772326d75f97782623397159a26827574012cbc952ce6e0615eca4f1d0d8"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A23",
+          "page": 23,
+          "recordChecksum": "cf75bc449e17a52c60c21ea3c18f745077aa6184557fd8374f49b83bf8951348"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A24",
+          "page": 24,
+          "recordChecksum": "a825e7bc4fc70d5814dd61dd3944696dc2415ca363e16c65c1701a66f54be9de"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A25",
+          "page": 25,
+          "recordChecksum": "d8bfad1111a0085ea751ebe040497dd728ebb22b0b9f1341109efba55cd93309"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A26",
+          "page": 26,
+          "recordChecksum": "779fa071e25b36ffaa5b7e471035c0151cdbca420fb4652f856416d4d8ba4567"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A27",
+          "page": 27,
+          "recordChecksum": "2a6305325d89dd5279f70ce45eac562bb6b298e6e7259d7f11d2601fdef69927"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A28",
+          "page": 28,
+          "recordChecksum": "51cc665b1d75916050b3c04df4675be5a8c3c20ae5d174014ea67f07ff97a74d"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A29",
+          "page": 29,
+          "recordChecksum": "0495ac7d7f0c885327a5542e681d6b68aaa278bc2779c59645ce3e02645a30ae"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A30",
+          "page": 30,
+          "recordChecksum": "26bfbce4a3db84052dcf19a58970e39d821b61a011666d7b6e021bf56786dceb"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A31",
+          "page": 31,
+          "recordChecksum": "5671b1b80ec4a886645cc328c7b57f53da1f6c664250d8c3ed3d0ce2bf92b06f"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A32",
+          "page": 32,
+          "recordChecksum": "73e32f5944b8a6b4f70eaf35bc2c238caeb8a1c6bedefb051dd3d3becf3906d2"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A33",
+          "page": 33,
+          "recordChecksum": "d089a4ad0b5dac423ce5783ae2283729fb9824ab3a22c06ab3b7fe81022e0d08"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A34",
+          "page": 34,
+          "recordChecksum": "3763fac265c762fc06b63f0c917983c19913fa18b4d357abd158832a31ebd03c"
+        },
+        {
+          "id": "source-record:games-workshop:fe2ccdfca34cc282c23ba67f5ea766cfceda2c3dcc0ea5d11c7baeb5664b06df%3Apage%3A35",
+          "page": 35,
+          "recordChecksum": "0b67c762a7264c9ae6b1b2ca8b3b668d986cac5f5224e6015778e3dd77ffa4e7"
+        }
+      ],
+      "title": "Battletome Supplement: Stormcast Eternals"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 18692689,
+        "checksum": "2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e",
+        "etag": "\"ac16e549b048a30145548ad157883768\"",
+        "finalUrl": "https://assets.warhammer-community.com/battletome_beasts_of_chaos_nov_24_eng_27-zetkuarzn0-6tritzktfq.pdf",
+        "lastModified": "Tue, 19 Nov 2024 15:41:12 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/battletome_beasts_of_chaos_nov_24_eng_27-zetkuarzn0-6tritzktfq.pdf",
+        "retrievedAt": "2026-07-28T17:49:35.409Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000004"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "8b8bd554adf60bf208f69ac0c49fe6515edc579cdc8a43865eefe12a977b4dcd"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "1d765a38ef56c23032bf4844b0dde14cb3c194097b70bb7c8f6d4f96d07f559e"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "615e121bd66f22ed069a79a732c5376c6a2abd1a75e703669f0b9ac7f5015d1d"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "663865026d9ff22b0bac09900632c41b6aa49355a9e7066d39d148adfba6f0c0"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "1c4240b2860775a39c336fcc5aa089fa333d5233c41d3d8565a643171f2406bd"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "0210bb05da0686b5724672e13e7b9149c9bce7dfbbae4bc4b0a272e6c7287fbf"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "64ef1cf7072ae44c1034ea3bf930ec32dbbd0a84ce36993a0dd13a3eac99bb2a"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "a8c7059edc35454bfd22392dd655d89f716521dc2c0c15fe504cbc2624ca3e2f"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "626762ee82ad0b23c6ce8ffcaf572e936aecbc4603fed683f388cd15527c1394"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "06169af7c4e341ec8e835b8ae495b3d62adf4aabf363c83694cc0423984bc69b"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "eb3695d581823b21041e027d651f5f66320d407bb44b48ab72bf858de17c7de0"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "37ac2e665b1cc071691de1931890f3f6b3c4b1e79ccb213eae476455375d08b1"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "f73e6a8ae1570ea831ae5537f20a0e41414b27ed817a42a15d42b37852a5aea8"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "4119c71db16ebf74d06c7f6b7f39c62f7661d9750dd946791feb34cb6b02d5b5"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "7534e17ecc24fd4174d3110251fc379f1cdb5a771c4a09bf57bb9bcbcea59253"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "9fe7313a9e428ddd947865ed1850a9b7697978e6cfdf7d62fa2e45d2b04c2649"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "a103149146a8a02593744b06d11f32900bda4773bee04ec5592367bb307de07f"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "9d91c7fde71cfa025828e20c456b1e61ef1c757c0c2789830af191fa4cf57802"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A21",
+          "page": 21,
+          "recordChecksum": "adbe9af3213e2dca366c3331e493e724e1d59168732fa5c4b3bcbae4ee4dd32f"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A22",
+          "page": 22,
+          "recordChecksum": "0dd86697218dc1b1b132f9fb28ceeb755e2457beb3235283570bcdce951b6ee6"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A23",
+          "page": 23,
+          "recordChecksum": "9cce74bd6c3e76ddfc61569b81e73d5fbbcf90d09dcba06b68d2351ff966fa6e"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A24",
+          "page": 24,
+          "recordChecksum": "14683cb149833b85c4740c2edcdfd137b98ca9e8aaf25143770b0113c2baf632"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A25",
+          "page": 25,
+          "recordChecksum": "25732b6eb88b9ff39fb6af152465d9298904b574b018eb97222ec09f13f8f02a"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A26",
+          "page": 26,
+          "recordChecksum": "a4f3ebf5691a3744497d24480ee54974e1e0109b87d606e3e9dbeec949ff5034"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A27",
+          "page": 27,
+          "recordChecksum": "81f18c1d5efcc354d019094f0cb9181e94147f5a807d32c772fe1e65105ed373"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A28",
+          "page": 28,
+          "recordChecksum": "bb16fb0709e6cb76fcfa4860476c4d5790a096b11d639a44a2510315d7a4fdfa"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A29",
+          "page": 29,
+          "recordChecksum": "6ffc3fd9b627a89c83f9b3a05d054f95e2e40e3c0c4c08ee6c8ec30a257d8ea4"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A30",
+          "page": 30,
+          "recordChecksum": "af188c0992c6d80b265bfb64df7e184a11b8a56a7954a28a5738ce47a4e08529"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A31",
+          "page": 31,
+          "recordChecksum": "e795e5c09500226615ca2fc72c40126e23fe9ec37da023b3cbe1f5f8ddef5a42"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A32",
+          "page": 32,
+          "recordChecksum": "7098df3face56c6dcb7ba6392c5522cb1faf52e9b309b4ac93ad11ef314045d1"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A33",
+          "page": 33,
+          "recordChecksum": "70b22b78ce9741968408bfc1aefddf1b12d0fed2b74d0d6e8d291a57cad66f39"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A34",
+          "page": 34,
+          "recordChecksum": "cce12b97d4bc4e6066ecd41eaf8b421723493c59f581702222d3b6451661a363"
+        },
+        {
+          "id": "source-record:games-workshop:2cd26633bbd48b1a8b7ba59bbf346f6ea1bdca527dd65186384372aab5deff1e%3Apage%3A35",
+          "page": 35,
+          "recordChecksum": "edaf3e003afb67e29ae61b6b8ff5cee0cb40207d22837d91d2733a40287cdd6c"
+        }
+      ],
+      "title": "Chaos Battletome: Beasts of Chaos"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 6548290,
+        "checksum": "dfbb72b3631d01f4b085daa7f0808eab17227dee70acbc9af384f2a3e4865cfb",
+        "etag": "\"6af9ef982317db73988854ae8d142c22\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_other_rules_darkwater_hero_warscrolls-mchfhe2c14-qmdnrnzdck.pdf",
+        "lastModified": "Fri, 24 Jul 2026 13:24:54 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_other_rules_darkwater_hero_warscrolls-mchfhe2c14-qmdnrnzdck.pdf",
+        "retrievedAt": "2026-07-30T00:53:03.633Z"
+      },
+      "documentKind": "reference",
+      "effectiveDate": "2026-07-29",
+      "publicationDate": "2026-07-29",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:dfbb72b3631d01f4b085daa7f0808eab17227dee70acbc9af384f2a3e4865cfb%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "a63404d10a72983050f0a38b7d5f25cc9859ef61da7d2cffce1c7085c9c8746e"
+        }
+      ],
+      "title": "Darkwater Hero Warscrolls",
+      "version": "July 2026"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 15867544,
+        "checksum": "7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63",
+        "etag": "\"13ae9338aa314bc519e1c5ca322eabf8\"",
+        "finalUrl": "https://assets.warhammer-community.com/battletome_bonesplitterz_nov_24_eng_27-qgqeetgmrl-e3pszl8jgm.pdf",
+        "lastModified": "Wed, 20 Nov 2024 08:40:58 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/battletome_bonesplitterz_nov_24_eng_27-qgqeetgmrl-e3pszl8jgm.pdf",
+        "retrievedAt": "2026-07-28T17:49:37.039Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000004"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "591217d574c5788c05e85457a5250e7674099c2d390dbd227b31969629d3b363"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "dccb7cf352d77518d1bb55df8c0147d4576f0adcf39c13508c9e0679aad86dfe"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "4d8085fc9c0ce1ba2d6762f72c3db28e014fe48ea379af005d23458c89803b94"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "4a8368597bc5fd6dbe4f1a54ee0168717bae5914affa1e1fbe268dd172202fd3"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "6affa8e59cc2ee581dd51b6cbafcf88f940be7fa6a8d87790aef336d1f559f6d"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "ce5d53705bc632c8645fae14f67c0d19d3f065501df28d4d606394477c650d74"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "7d72922f00fb1c2fedf7409fb17377f346bd9b0a81bbd95c1ebbf426dd89cc51"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "5978cf8c78d00e04ffa236d09a342edf2e54110aa09974691f0e1744eb1ea530"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "4a44dc15364204a80fe80e9039455cc1608281820fe2b24f1e5233ade6af1dd5"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "c2ee6c0589907205fedd3efad39ca113d3525427bdc75a0023d50cd0ea21c2c8"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "4e99a3e3b1b9233c75c6c52c5c4fecb3265c647c2cba5a218f8b08d1ee88ce0c"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "a90f9e0264e8ed92e6434a203ae8731a570ed3fe097cf228d07e228414fc637b"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "9658dbf90d384cf89fb587866402b25a00fdacd96fe0ab527e7dea4be3290079"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "dceb60b304ba4a94929c853195af178f0346f394082cbbfd3b84eb1ef0643b91"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "0833bd22f0adb1ae7315705b3b817ee67865bb25f314598eb2b58d50dfd19bd5"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "941912c7d4440c9e611c79960a0bf20342e3adca5bb89c96dfb934e9f1a2feb8"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "234169c9d80b1169e09ff46194373929db7a0cf009094c56b173a3960e547057"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "f9444cb38c56d9e6af9de78235f556b87c9f9be778dbdc7fc67c34bf8f165d44"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "ada705f9391b3b01137951298a32916ea29635778566b05261b1c7c0785d01a3"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A21",
+          "page": 21,
+          "recordChecksum": "21ab898a90c21cb8f71c8ea8590310e73a7951a0d8e2667a52368ee9826ba7ca"
+        },
+        {
+          "id": "source-record:games-workshop:7d46614bbb1ccf57471c75a9e16bf95a0a4f90afbf371cb4f3fc37d69a1e7f63%3Apage%3A22",
+          "page": 22,
+          "recordChecksum": "f4faba21ca65e1d57cc65139777b0503dab982f1bc060131525eb0a0527a3141"
+        }
+      ],
+      "title": "Destruction Battletome: Bonesplitterz"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 21299549,
+        "checksum": "9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338",
+        "etag": "\"36d371d0bb6839384f7200862e747ccc\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_29-06_aos_faction_packs_fyreslayers-w2mwukvu7p-peinebypox.pdf",
+        "lastModified": "Thu, 25 Jun 2026 09:47:35 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_29-06_aos_faction_packs_fyreslayers-w2mwukvu7p-peinebypox.pdf",
+        "retrievedAt": "2026-07-28T03:05:32.411Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "cbcbc26fcb0bbd939d6db907a5414cdc1bc41864b85f13f7c53c935994fc5575"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "e545764fcb4bd69be3e714d289f9584e1db986a5663db4a682b6b3b24654f9d2"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "c3710ce954fca4357d94098640ef5291824e88c6f67e1e19980d0c63c6d33599"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "b8af8bdb1afc25141a4bb4a958bfb64bd92e9cece3c742ef23fc1f4c56ccda56"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "3488a325a99bf58362328a5bbb1c901f1afa919d6bdd1b433cd6d15751d1ad9e"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "db16272ca376afaba5ffb706dc4a2186f136e2eb910bf6c23faed424e9a1a1c8"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "6b5b0dca60872cd89f0ae928a294925730887ef69fd2d8c0d107eaf6e4d3414b"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "9c83ab48973607702942316298cc14fc0682c129f66e60b1fd5eb5cb91695c9c"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "ef510de044e449230903219a099269be4b67594bb3c8ce11213d66862699c348"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "23a8bf10e36bdce6d5365d435b272cad17b30e017e0cd9910afebc87da1b4f3e"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "0fcd83109e873977ac40b40ec48bfa1d350415a8534e76f7c6315612a3a6e16b"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "2b8beb939316948b5ecfcd5ebb0d951d33ae262099e125c6809e0bf5f178b1ab"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "66eb4f90211991790ee8407c4375ffe1a307e51e68f470ca0d27f55e0cf011aa"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "43da693d6b4d2ae0c3fb282055759c14749315eea19978169ba06de8531354ab"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "9a0ab793c95a55e9de3d131af9b50198cf5a27440e3ce8688961ddfd2503860e"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "98c83e5b432c353157d7476e3e71654769658a0ebd19956220969aa22449a6fb"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "acc55186ae57c42f6e5bf68c3e93cb1c8b0b10e4c5d190d023d794b9d374d1c0"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "504269adb60a5297d3b9a3e6abd9d05bf23b580c8e463e8663c74efd0022b4c1"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "384460c49adbde9302df11ae867380cbac874ef3963263fa97bdb9830c003376"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "bc05fd580b66057911aeb594705e509568e4e115621cbcc9e0ca905b230c4680"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A21",
+          "page": 21,
+          "recordChecksum": "7e19a2cf0a2dc0099d1d600077b6dcede40520879d1770655263458e36263d07"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A22",
+          "page": 22,
+          "recordChecksum": "0d741735c5d4856397bb38b680cead14dafbddfb2c945d9bf3e5a92889f76aec"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A23",
+          "page": 23,
+          "recordChecksum": "e48a65eca5802c498e92ada77959b9f82191e87a3b759033467be781911e6782"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A24",
+          "page": 24,
+          "recordChecksum": "c941682a8dd50d94095c1677a2172b9a526d025f2dd272c462c78d5cbf67639e"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A25",
+          "page": 25,
+          "recordChecksum": "98b7405243a92ae163c5e6cc30824bc48c6bafef8e721d9f95383880ad677452"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A26",
+          "page": 26,
+          "recordChecksum": "179c40e06264e24419606428e3d81194f6a7c2d059024cc35eee4dcbd01a2fbb"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A27",
+          "page": 27,
+          "recordChecksum": "3d92fea7dccbe9da8d4975dc831841274a7c3e9b69b8c38a057b58f6aa705820"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A28",
+          "page": 28,
+          "recordChecksum": "06bf71ccdb65ac4396b968ff77b2b8c83e26265fee69ca3941f0c6610419559d"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A29",
+          "page": 29,
+          "recordChecksum": "c219868beecd6b8114a9943663206e0823c9dc407415679cdcdf7eaa332e11fa"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A30",
+          "page": 30,
+          "recordChecksum": "f1efec353ee6f97cfc852e1005eb3e22f7cf79230cc815328cbf9b6b53f6f44f"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A31",
+          "page": 31,
+          "recordChecksum": "33449a90b98832b402c7f41e56a61038f90ddc9db5210bf5bfd3ba7ff9eb83a1"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A32",
+          "page": 32,
+          "recordChecksum": "f18550d3f3d83ce8d47c7dfb6cf9ca6700049aad668eab188c68bc273a3821b7"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A33",
+          "page": 33,
+          "recordChecksum": "f18550d3f3d83ce8d47c7dfb6cf9ca6700049aad668eab188c68bc273a3821b7"
+        },
+        {
+          "id": "source-record:games-workshop:9dc9f6be519da7b1161556d704ffc2bfa469efc764e0c6c3c464bd069bc03338%3Apage%3A34",
+          "page": 34,
+          "recordChecksum": "17b9f3d3e95597b542defc80c2ab8cdff3701949c609538af731eeffb640df1d"
+        }
+      ],
+      "title": "Faction Pack: Fyreslayers"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 18006282,
+        "checksum": "d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863",
+        "etag": "\"cda4b23ea955785b7cbdb047778571a1\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_17-12_aos_factionpack_hedonites_of_slaanesh-aqiq6c6xox-dxnbnrgjrq.pdf",
+        "lastModified": "Mon, 15 Dec 2025 13:08:15 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_17-12_aos_factionpack_hedonites_of_slaanesh-aqiq6c6xox-dxnbnrgjrq.pdf",
+        "retrievedAt": "2026-07-28T17:49:37.806Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "f4205d60c150d151b308a8d3ce317361a5e7b83d0b872c1467c900e5637a44db"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "818c8a763c8666720c818fcffc4422e4962a949f1ccf2dcd3cbcebdaa8e139a0"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "ba91357ee7cbd15082a0d353d98cf3ce9224565ce74f80ce150c7c163f629f57"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "d4244586e3f4176754a594ecf5d59eeab052ce7f58f9642ee1833f86fc6a37ab"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "df5ac203e1a417945b1cd783d3a3691963d50395555a13946c9519eb15bc5523"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "a0f42f997af8462a15be9e00bf63ff4a366daa73ae5eef48a0019d897d8ffc56"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "37a1e8581f11d4f9239dbb5229cd933653900262e256ffef82b9945828661f16"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "75a57eb86d8e7e25e5be7e87a2c9f62127321b709179e45e368fd1f4534e8670"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "23542852472f04bb3b22f04915a2213bda2f5e955f81a36df89590d4f5bfda26"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "d6c496ad1f19cbc86f2bc7a7fe6a4ec644752717583b29a733d98d2707870ea3"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "56912b155038d54482860b5b3f6e7554113e417da43944da649c303e220fbfa6"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "a3b76d75e9f6e621229e9c5468fccb97afc6a3c8cb3f5f197ef9162bd3bdc234"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "e5d61c75b54b061d248f1062969a1f603f2da36e3c0730f13b8e6c7d04083938"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "b72efa3e44b905e6a4c6a2bbe510f30d739eb64720dc0c22f5932bd42d94c9a6"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "0d3e3c94c51bb3da06274823ac73c20cc4311c98a807ed8578a2f8c141340d7f"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "1bd1d264ca86458a14fe074f35fa165b90d1325ef3315727b14fed6354b653c5"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "8fbe2ef5707a3ee66b8ce4ed55a571e04f7e05b96e87c16003999338c11097fa"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "498cbcc5b3f175ed4cfb09a2826e6ae959f655fe5d6340f029d8ad561416c86f"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "684452f15d9bec1f278aa15670046b65a3349a23c01225103c3c763b3a838924"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "34067874be849e8eb8f038c2c96de204747404a0bb578df3326f1d32e51825d7"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A21",
+          "page": 21,
+          "recordChecksum": "d9475e1ef50dc9f520cc9015bed63ba476014b334fb69011aff7721c7c3e16bf"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A22",
+          "page": 22,
+          "recordChecksum": "19254cc940d9cdf5f0aafc7a845dbd7f2b7c8f8bc88106db9bca6765e252448b"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A23",
+          "page": 23,
+          "recordChecksum": "c957d95ed47f3a935136204b1a3194f2b41376a6ed563ce3308d9b316c1e9a38"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A24",
+          "page": 24,
+          "recordChecksum": "9b3bcf22d327addbc6d659669ad40b63ec3904b23827c9455cf1853831280eb3"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A25",
+          "page": 25,
+          "recordChecksum": "479c05ea58b6e9a2deeb2ddae6fe30095ac94944538e2e482c34b710c49a7452"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A26",
+          "page": 26,
+          "recordChecksum": "a24873e37f35b222b3cef2bb9fcd6e6e6d7f5c8f16f524a88a19e41f92588077"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A27",
+          "page": 27,
+          "recordChecksum": "aee4d7338f11f0e47ed0f5641d2f6c6d730be75991aabe649f3dd180ea17d048"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A28",
+          "page": 28,
+          "recordChecksum": "5d5c93b88dd3d80276913f8f2bbd1c28864ec662e032ac2849df5efee9d9d4bc"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A29",
+          "page": 29,
+          "recordChecksum": "07d0081f79d7eae9b840d26500e1bcfc3e8a62a818bab52280b37d62d2994159"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A30",
+          "page": 30,
+          "recordChecksum": "c65c1642c7889f532cfc5544e9d1dcebce2084631f181fe3e4def7c52af8f35a"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A31",
+          "page": 31,
+          "recordChecksum": "1cc56425d7f00d387fe39e03716aa696c220cd6c5f2ecf86459359beb6f68be7"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A32",
+          "page": 32,
+          "recordChecksum": "9b3b3082ed472d6cfecc9966dd5f13f34ae81a72f6719f6e0e8f761742d02913"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A33",
+          "page": 33,
+          "recordChecksum": "2f380fbd596329d27459d062940b3b2a6fbb3a2ad76e339c293f1783c0ab0424"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A34",
+          "page": 34,
+          "recordChecksum": "4dfa75c88255705e643c68fbe746e03c8dcbdece73e038da9eed636d13f5c9da"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A35",
+          "page": 35,
+          "recordChecksum": "13b47bd073172a3defdbb068e2a6d58e086d7fdfe2b3738a2b8d2367dd852f8d"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A36",
+          "page": 36,
+          "recordChecksum": "1dbbf38166a6e02a2b5e10d3a89bb76b75c6e0cc9d8f07f95bf23a452b2efea2"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A37",
+          "page": 37,
+          "recordChecksum": "3f99a48a43e2e531f28c47852068a239762935edbb2d2feb5ffa421b0f95e435"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A38",
+          "page": 38,
+          "recordChecksum": "3aaac129002a40abb4a3f9d169876178422beba13c632dcda9cda90c0a7ea86b"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A39",
+          "page": 39,
+          "recordChecksum": "b9bbf488fd1ab957c414f2e605a9917861b598570014321e85b5727be1d1c896"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A40",
+          "page": 40,
+          "recordChecksum": "9c308076dea38dab95df78ce5ab47cc0eb9b1279661db92342dace1964c6f72e"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A41",
+          "page": 41,
+          "recordChecksum": "725ea436aa992b706e64348b7f58dcea5fa6b08e548319e1a676210fb0476b5c"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A42",
+          "page": 42,
+          "recordChecksum": "6899ac44ce58f706f9d605e3c91f4a1294be3aae03a53410c12cab4d2a0abf28"
+        },
+        {
+          "id": "source-record:games-workshop:d3dfc5ddeb76f425332c0c2aa257a0c28c688865232f163a02663a4ce8744863%3Apage%3A43",
+          "page": 43,
+          "recordChecksum": "26407f82148229b1df1748fb88bb69c39c371f43cf4b23e0aab6a6a0da14a39e"
+        }
+      ],
+      "title": "Faction Pack: Hedonites of Slaanesh"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 11388733,
+        "checksum": "c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d",
+        "etag": "\"4fdff3a116e29f0267a8258a1f4eaef1\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_faction_pack_ogor_mawtribes_feb_25-xlqlumgo3x-gmvmgwt5ga.pdf",
+        "lastModified": "Mon, 24 Feb 2025 11:02:42 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_faction_pack_ogor_mawtribes_feb_25-xlqlumgo3x-gmvmgwt5ga.pdf",
+        "retrievedAt": "2026-07-28T17:49:39.977Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "707e1ccd01292fd06fd651683dd96c750fac96234643ed1fb9ef870ee25978f0"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "5ab79b95849bcfd547b3ab5df4305055d15fd723cd1946e26670bd6318adf877"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "93f780b9a3e0b8eb80f2a7856221bfbe0659b0f607cf1ee15efcd09f70d7b2a7"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "adbbfe71bdb8569864c50b51044b4ea838c74fc5acbd6bdb6c58542a5a09f003"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "a492ad0c0b30c466955ac5898069462065dbcb43a01230253143a117ecd0f528"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "52016ec72aca8cfcfdff85e9ac49818960455125c9ff2e8f8f6fd7d4b43300ae"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "a470d470efb5b51dea0c27dcdf4c5328ccd2a3c80bd0bfdadf143f3c9dd46687"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "b0337741f2a464424da303dbb8c5fc8f29a9bc843637e96d80afe02f25b6824c"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "ed2264ff0a6b56bbf1a9aedde9947fc6af919b12c716a9784226542a1984703e"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "e28811041c399fb752cdabcd3b4ef0235fad5ad1f15c3ea54a0a7c3bd574e771"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "afc0cb90690a4b9b91e42e156ad608caeb4069ab005d871e9953e5fd3225fde1"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "de4d841d9fc153657b73bc0a2a48b960ae834a2483e6b73bd0ac76a3ecea6841"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "e8f8e6de987f237d8326585f6057b427ebc625acee0ddff2c4db3f6e1ee952f8"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "704d9455baa1389c6a21cb8a6224fda74cf2d4e7c29a790c98fd634194e1fc7e"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "16f262fb85fb81b976c12505e66d6b73f043b253969793df53d849ba515dd120"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "b86d6774e7197ed62544c9b9fd454d1f1125e0f752287416af6e1417157156a4"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "e78bc6f045d7f3e8c39e88e76285dcfe9111916c195a6d55b697e3f33d13300d"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "6e08fd778bdb3b5b502fe897031313dbf31ed064ed70e9efb7c9775c4a718723"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "76589c4025ff1c024b76129a4259fbe7742ea5a411d16417baab53865f371357"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "b09510dd7c4c7a21294f039d2f0ffe21a78590def5d0c38f398653d64a89c97d"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A21",
+          "page": 21,
+          "recordChecksum": "9ab0449a8b258ae53fb81d7825bdacd37abdd6bb8394348451ac0da12ee95103"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A22",
+          "page": 22,
+          "recordChecksum": "20752831092cc0ea7751cad2df3684fdaa60d7456e7f8ff878011adf49903145"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A23",
+          "page": 23,
+          "recordChecksum": "acd271a65e9ab2011830f75090dce68690da013889c5bbfa8ffa94b4f9321cb1"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A24",
+          "page": 24,
+          "recordChecksum": "c7d9b98a1701fa8b445eca546882e9818d8f7522e6124a2b22457e135faa50aa"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A25",
+          "page": 25,
+          "recordChecksum": "56582549fee17768646718a03257c062b95937224bdfc09aa26259853326b70e"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A26",
+          "page": 26,
+          "recordChecksum": "318430187aa43239a0474b088b969c228ba6ad206e00c00cc3c61062a9e9311a"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A27",
+          "page": 27,
+          "recordChecksum": "facafa4183284899862e2d49c9734e6a1ba8fecddef66298d5166a1dfee96f7f"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A28",
+          "page": 28,
+          "recordChecksum": "8157b79126af53a7d81da68696f6ff96ba050a74639a5edef080621b87c49602"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A29",
+          "page": 29,
+          "recordChecksum": "6441740b5c866616705d425f428a4c9a574841b9bf2131cf6a47e96a4e0e06fc"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A30",
+          "page": 30,
+          "recordChecksum": "8ec643a77beb50d3e83f4fa28b60c7012b4eec62d131a081f7d5212029b5be9c"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A31",
+          "page": 31,
+          "recordChecksum": "d45954ef68f45965362b82f1510276815c928fc283c76cb70bae737b37cc6030"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A32",
+          "page": 32,
+          "recordChecksum": "126f0a5366990f9da4e7ee087b40560047d48139fe227bd3e0555bd2f575904b"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A33",
+          "page": 33,
+          "recordChecksum": "e3ea32f79c29372837bcf95906cafdfcf0f46b214055f6b09bb23b16436dcfdb"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A34",
+          "page": 34,
+          "recordChecksum": "35e5e1b2a8db51f0a68b9ba100e2ac6f24dd885aa5a33275e4490138da9d826b"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A35",
+          "page": 35,
+          "recordChecksum": "a8575714bcf8357977f295fcb7c2836634fb55a6e87ee9f6e37f22cf0d8a219f"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A36",
+          "page": 36,
+          "recordChecksum": "23fa5cf0473e2917159986d9761a609e1f8c1bc23e0c8bd6a9ecb87cadd22ae5"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A37",
+          "page": 37,
+          "recordChecksum": "2f9aa3bd3c8184790eeff718de07842b74360d254cb9a55670a2b30c5d9a225f"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A38",
+          "page": 38,
+          "recordChecksum": "11ac251c477b18e113ee8b0491ae4c89f4a79f97123d543a92bbfff4e840409f"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A39",
+          "page": 39,
+          "recordChecksum": "c84a90109c46c1485902ad1ece52efeb51a3730114b185dbaa1bf8d04a9b30d1"
+        },
+        {
+          "id": "source-record:games-workshop:c4b9bb48d389627b129f218b3d7bcc9e65c1b0f90bf550b6262ef6124fdbff0d%3Apage%3A40",
+          "page": 40,
+          "recordChecksum": "9f510ff351c39aa5d67d3f6263c9a9068ae89512e86418ad1811a69af6e9b5fc"
+        }
+      ],
+      "title": "Faction Pack: Ogor Mawtribes"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 12270437,
+        "checksum": "9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18",
+        "etag": "\"1792a333ebbb504d535fb89507915416\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_08-07_warhammer_age_of_sigmar_faction_packs_seraphon-8d05bllic2-ui4hbexqif.pdf",
+        "lastModified": "Mon, 06 Jul 2026 13:04:43 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_08-07_warhammer_age_of_sigmar_faction_packs_seraphon-8d05bllic2-ui4hbexqif.pdf",
+        "retrievedAt": "2026-07-28T17:49:41.236Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "6acb306f66e171f4db51a21a81bd59a1e80a9b8c57dd85de0429aac765c9d048"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "a17b859f7cd0485271aa66a2a2ce3f58d79b54b69bf9d955b06ba762a1879843"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "af03ce61146c6b3a1c12f7c3ab0971bd430f76f3db23ae0c934b44d2fff57b34"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "59460b6d02def5f0c4288cc3f3515905cea2fdbe5cc74bb7a031e71b2dec52e5"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "d724b95f3cce547ed634a66b242a7bec65fae4f50a0eeb6a22158121ad030575"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "27ef34f91c51ffea18e05683589f4195f863ef02369cd7754d25be93f10a19c2"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "134c3133246f209a4b799b0117158388d7a6d98938f24002015a311c88fc45b4"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "9f6047ff2d100b4b9ea811f98ac10e2609f660331f0a4256805bb84abb9d45ff"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "26c8c37cc35cd87b174d461f6c2def27fb3aa441409d92f7921bd73e99721abd"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "b48150f4c55c778f335f0521b7e66c715cc57e10d5af82c2b9fefcc7236eabf5"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "65292b7b69388b489c4407485d1fc41f5c51505ab7e95e79e860c51011de039a"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "6d3caaa93576e186fd4050e49e7c5a9612bd5d49ce13b19bd072bc4ddd7747e0"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "f8b4bdfe953ca578b87f8be666a9cfcc2df0c5f9d014c8d027833fde69e6fb24"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "dc7c2682295ba32e2fbba500dca22a4600a8c935d779982cb61666073f066dbd"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "daa99cb19b7f8a44877e10b2cff6bd5dba7a132f62156bf8f8b493e27c00f381"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "8b9b988a25e23516e9d995a345ba8c649404470de72308778cfc153626d06af3"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "8128d4c74b422f4931d4377b7a2d282086645c893d326b00b190e5f34f4ed50f"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "603beee23376c5af87c38224095896ede004dadecc40a64772fd4e16e2ae9280"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "2f4be166181c48ca087034cbe3fcd9229598fd3f1e7927f8b804ec72b4295f0f"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "e632cdab46afa146a1ff6975ebaccc35e1af4e1f582eb6ef801b74f28757fae0"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A21",
+          "page": 21,
+          "recordChecksum": "3d0db113de8fe411d3b09bbd9e4d7a38b6e07b65c7b2e93687ae5fb35c82075b"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A22",
+          "page": 22,
+          "recordChecksum": "91fadf2c2c8a68d2fd27987bb38ef871a2a15b8d953d5a9b534e12f914144dc1"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A23",
+          "page": 23,
+          "recordChecksum": "0656dee5113814d73d5c3a01ba9045778b6b05601d6d3efc80ef143b9ffc2ef5"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A24",
+          "page": 24,
+          "recordChecksum": "5af061b15c67c02ecadd01a1d060ef538ad734de017bcdffc77403712df9892d"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A25",
+          "page": 25,
+          "recordChecksum": "80310e8f3f0e732c80c760c692fb33995d9986bd52dfda2cfec3fe52f3936e48"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A26",
+          "page": 26,
+          "recordChecksum": "6e7e0166062f3da7a34fef4c9efeb8d31667976d1296f3ce8efd146ff4b3b074"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A27",
+          "page": 27,
+          "recordChecksum": "e3477182d3d26eddaabcdf7a0d64edd963a76808ad84e6aceff21f67441eb33a"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A28",
+          "page": 28,
+          "recordChecksum": "39b6da950f97c8b508e3832ebbb1d9db75b4214caf221a9b73d6f196938a2637"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A29",
+          "page": 29,
+          "recordChecksum": "f48c5c56a910953122c7f620910c2b7fd65529c834198a1bac3f4d07207b44e7"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A30",
+          "page": 30,
+          "recordChecksum": "c47d716354bfb9efcb208dae36b9d80ed196221aad4c49ffbf0efe74bff3e66c"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A31",
+          "page": 31,
+          "recordChecksum": "13b5a4c56f7c20a2ed13e28d85c41bd4e425a0c224cb343143b14afb352ce21f"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A32",
+          "page": 32,
+          "recordChecksum": "c8cb066edd2718ff22634306037c7beadf0aa70f3a84586fa2368935c08ba978"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A33",
+          "page": 33,
+          "recordChecksum": "060bc0701ae3048ab62d9e72c43bc62c661f169d5ec46d7b2299b92e0e317c01"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A34",
+          "page": 34,
+          "recordChecksum": "76cba17a729feac06e2b1c0f13f7823843ab3a55fbb280ddeb788d6a832bb3cf"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A35",
+          "page": 35,
+          "recordChecksum": "0bcb268f7533f0023b198ef77e77827edc284bd77dbd3483e5fd52dcf267a0c4"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A36",
+          "page": 36,
+          "recordChecksum": "9d16869be6b6a8d2ba0ba29e843ee1a29728d6ce149d131c56bab74f285d39ae"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A37",
+          "page": 37,
+          "recordChecksum": "11c8fae91d6e5c4a97ddcfdcfa595a39123833af3626ccec7c68bb1c50da3266"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A38",
+          "page": 38,
+          "recordChecksum": "ccb5a4f55df6c3333f85fe39d1125c7ee22f1031feba9cc541efa5022079af6b"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A39",
+          "page": 39,
+          "recordChecksum": "50bf491da7a01c93ff0970eeb8a0b0f5fbf921f2533ae22769abc175e6f811c9"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A40",
+          "page": 40,
+          "recordChecksum": "6a6170c1780246ba3af6923cf1c4e1e05dffd95c2f84a7a742c35d0c21212461"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A41",
+          "page": 41,
+          "recordChecksum": "6a6170c1780246ba3af6923cf1c4e1e05dffd95c2f84a7a742c35d0c21212461"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A42",
+          "page": 42,
+          "recordChecksum": "d5e809c2bead0174e0e7fa46a89424b74dd8e9e3b302182db47f78883e67b155"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A43",
+          "page": 43,
+          "recordChecksum": "d5e809c2bead0174e0e7fa46a89424b74dd8e9e3b302182db47f78883e67b155"
+        },
+        {
+          "id": "source-record:games-workshop:9341256d83906a6e4c044fd8145109706dea06c4dba10b7ec5e5fc664749ce18%3Apage%3A44",
+          "page": 44,
+          "recordChecksum": "bf3a5e38ad14d0192df004b9d34306b6e32c46e17b1f5bc78b4c310aef99e37f"
+        }
+      ],
+      "title": "Faction Pack: Seraphon"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 6275648,
+        "checksum": "037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044",
+        "etag": "\"1cccf1b5b744e6c3daca36c8975a4992\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_faction_pack_sons_of_behemat_feb25-pgkslka5gn-cdoku9c3vl.pdf",
+        "lastModified": "Mon, 24 Feb 2025 11:05:08 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_faction_pack_sons_of_behemat_feb25-pgkslka5gn-cdoku9c3vl.pdf",
+        "retrievedAt": "2026-07-28T17:49:41.904Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "92bc3a9ed0f711a4fa24818adc838c1d85882202db31c76a8eff2f10099d431b"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "b264627cd029c15cd2a53ce98b714e3d90e264b71bc0756968b1bcb31379b1a9"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "d870c76b0aeb7876df384da7704d65bd33a16b3adba8f28742012a9f3c5546e8"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "80d5ae732967b86475daa67a8462ebd3922d3ae48ba701025cbc34269ecba611"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "41c43ac59aab4780ce64664abff5040b3700dd1c6e77cf01b49a231fb7ad5bee"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "39e5fa729909615398b120ab42b8e4ae75b037294429d44b35b614bdc026dec9"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "efe02f1c7a83157435b01a8cae5188bd2663c94bb0b399b7ff0478f1e547c008"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "6fec78ae20d1155a6674c752ebeb59ec3e354b89481358319b22007c119406c0"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "4cf9db78642b2a11e78cda48b31415ba2b43fe49a3b0404a390a7fa6f3b31176"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "5efbb94efd99260504dfc7ca1e9cf7baa858dd6398af2bd2bf06e3fed3c3a7ff"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "5c19b494c31ec7ed32b49a050563982ba3aa3aee8b3b264fd25978d8bc6ab9d2"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "353c98119e4a693b43a135daad4be2a0fdb9cd66c9b74b15c22c853f9acef5de"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "1037fe4535540f66be4b420870486b3a21a4deb72d0be3b8de4304a8b71e5e82"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "20566eff76c24e895935ae4c41551c415679358e34f80da6e8feee48875e2deb"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "a2d5dfe96b59be7abdfb586dabc08a330706563e72fa35094abfcece91b2b2e8"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "8c2fc6b2f829023af56cb85bcd54bab3fa4aa40e10b8c1b7867a399ca5c9ce77"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "1f1a043e0aa12265ff5e68c9fa577fd4cfb90d3d6f1451a526593f414b9621f5"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "217ba2871f0d7a9aa94c5817b6f3204d79320d6728ba8a309293ed9e067ae3b3"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "39e4a7ec894729ff7ddf6dd2d806642f20c1f71eb3cae43ce1cc2dcfed32894e"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "7450e87a5852c67e6d208931d85803b1acbb3d8aa5cfb299208aa8ce388c029c"
+        },
+        {
+          "id": "source-record:games-workshop:037224ee7682732ccfd389016fd3ca81c92c26f10f71ca9d0f842463d2467044%3Apage%3A21",
+          "page": 21,
+          "recordChecksum": "828c19e88adc8dd8eb8b3201c95f8a1ba7e9774d5a98124cf35df726f8f3fbaf"
+        }
+      ],
+      "title": "Faction Pack: Sons of Behemat"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 5157666,
+        "checksum": "a025f685853b210d678c1d8f9ff28ab7c1c9127a5704ad7de5b061fe2392da64",
+        "etag": "\"24228c18f814f33f248f0376c845581d\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_24-09_aos_other_rules_regiments_of_renown-p3zpir4di8-8lor9bqfoi.pdf",
+        "lastModified": "Tue, 23 Sep 2025 10:28:07 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_24-09_aos_other_rules_regiments_of_renown-p3zpir4di8-8lor9bqfoi.pdf",
+        "retrievedAt": "2026-07-28T17:49:42.581Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:a025f685853b210d678c1d8f9ff28ab7c1c9127a5704ad7de5b061fe2392da64%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "d81e363cf6fa2c5fdca5d9f401ab00ee06e5a259013f8d488964bd89d7c4bb4a"
+        },
+        {
+          "id": "source-record:games-workshop:a025f685853b210d678c1d8f9ff28ab7c1c9127a5704ad7de5b061fe2392da64%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "c0c67a207865e524f7a3079df83ccc63d6ccb97ef9cf1f18c1272f103a1f5ce6"
+        },
+        {
+          "id": "source-record:games-workshop:a025f685853b210d678c1d8f9ff28ab7c1c9127a5704ad7de5b061fe2392da64%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "df10c6c9e182ab30a1286d069a1cf1fbeb2192e9728d887dc780c0008a39d8ad"
+        },
+        {
+          "id": "source-record:games-workshop:a025f685853b210d678c1d8f9ff28ab7c1c9127a5704ad7de5b061fe2392da64%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "810d2e60255b2edb7c159bba692c59ef685259184e8f56bb021e47cec6600b40"
+        },
+        {
+          "id": "source-record:games-workshop:a025f685853b210d678c1d8f9ff28ab7c1c9127a5704ad7de5b061fe2392da64%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "860fb0f05be0c1f99f709695578f22446ea70c59ea984cdb67bc9defd5f86ba9"
+        },
+        {
+          "id": "source-record:games-workshop:a025f685853b210d678c1d8f9ff28ab7c1c9127a5704ad7de5b061fe2392da64%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "7ed2e2bbef8cfbd1d21a9b91c8a3760bc2630c326a1cd783d9cbaacba4b3093f"
+        },
+        {
+          "id": "source-record:games-workshop:a025f685853b210d678c1d8f9ff28ab7c1c9127a5704ad7de5b061fe2392da64%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "db544821db20f4accb016490f66400fdc0b4f934d1a9005385ebb43bb74c7ef0"
+        },
+        {
+          "id": "source-record:games-workshop:a025f685853b210d678c1d8f9ff28ab7c1c9127a5704ad7de5b061fe2392da64%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "c1d62d8407ca83905a63166a29ec926994daa4f8a54ed208264ed27a5c6d51ed"
+        }
+      ],
+      "title": "Grotmas Advent: Regiments of Renown"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 48068089,
+        "checksum": "0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29",
+        "etag": "\"eb78bc8d625ca20cccc56d46846d9430\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_other_rules_legends_compendium-ayxvpdwbhd-op9l85twi1.pdf",
+        "lastModified": "Tue, 31 Mar 2026 07:44:20 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_other_rules_legends_compendium-ayxvpdwbhd-op9l85twi1.pdf",
+        "retrievedAt": "2026-07-28T17:49:43.578Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000004"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "d6493515f0af9534ce74ab7e82afcc926fdbc271534837119a87f4ba37f0bb9e"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "86cbfbae1d82551170ad0ae1ede186b8f1bd5097666dec3da6b5c5a746de44ff"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "48e7e6e48c3f9f6ff91e195340efead320e41efd6e287b48b77c47592a7e1d8a"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "4886c13a60ad8897032ca331e0d4db15da6b3fb432beaa9166809d54e3c49da3"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "133296cf153696ff5a58580649c45cb17df67004454b38cedde71b0dd6863307"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "515df39209d713763fe32ef0e773492d49c9c26f03375643b49d50b6b0bf93d4"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "20aa206bc0f20e6c0ef81f851d3745fdee72554c484bbd43904e964fc6bcfb24"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "91c7c90abf0e285dc2a6488707dd75d1748e9e84313c8b32271571c94913539f"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "d52629e25a225ae70a47776060a9d0707829bb269e1268185a3e99eb3ce84360"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "9870e4dc226a1dc068eca4f49751ee7e01de65a816ef7e338f779ec2925ff86e"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "43b31976afe7784ceb3b331ee935044baf6b0dcaff65dec91d738c65b805de60"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "1e9166c91693dd556e000048cec6bf8d03ba1207687784fab6479b523eb194be"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "290fb50024ee79a8245f77d0f3f5fdeae66f4f629d92d00176b4c8db685c8b8b"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "7bf332d91dde0898f23db74a798b4403629322bc5068b80f34078948aba1c4c3"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "367dad16eba788363a47bf786de29e81b9c4ee7cd20afd8b0f400a68ea893a4c"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "5e3185ba8f9761bca4cc7a1a64659a2194f9ba7117f3324e83bf9e9969890e33"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "9b3413cb7beae16bb81c151e1785ca6fcf6cc91774927ad1dfba01e009169553"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "a62f4549ee61004539e26b007cc425b465fc3b2ab0c041d3e4555ee55b28971d"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "1c4fa08f278c1ae3f8780215f4fa068b45721a9c02eabeb9ca857b94d5062982"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "16b298f8eb5599bd661519b5fb5a091ec62dc45f1764d8570a4ff1d75e422aaf"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A21",
+          "page": 21,
+          "recordChecksum": "1bc0a82250a1f8ba8ed645a986e6a70c713bb23155e25e0973d807444e1a1cdc"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A22",
+          "page": 22,
+          "recordChecksum": "5abb98e2c15256eebf4e239f521c9230b9a5a6f9304604e6d2a59dd552e723ff"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A23",
+          "page": 23,
+          "recordChecksum": "bd77112e4d8c63ec170c88a3da9d39c44520fb0dab5d0655d6fa3003486565ce"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A24",
+          "page": 24,
+          "recordChecksum": "ee9f73df950f622a277f5f5c00482612a4345dfc47e372bf120de4788d51c77f"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A25",
+          "page": 25,
+          "recordChecksum": "50f936af1bfbb70e1d2d3bbbcd3115322fffd14ed613e5d46f3e2eb152843d7f"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A26",
+          "page": 26,
+          "recordChecksum": "7857681d0362077876cfaa89a6619dd323ab76ea04587a200b5648d120a81b99"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A27",
+          "page": 27,
+          "recordChecksum": "0e75e41f9e19727723bb9f9cd34c58013ba272e97f2ac0ac42c9d8fbfc5b127d"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A28",
+          "page": 28,
+          "recordChecksum": "ced6a03b289f9de5ef2c5147414743e6746713055b07495b8dde100337acc231"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A29",
+          "page": 29,
+          "recordChecksum": "ff729935a7ca44143d017e650b1a036dfdf40aa84ed694865fa0db075706c8f9"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A30",
+          "page": 30,
+          "recordChecksum": "9ac7bb19313d460160ea3ab9c5baaa1b9dabd3f06446679210c69ef07b7df702"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A31",
+          "page": 31,
+          "recordChecksum": "a93bdb7b6c4c4b8e7ffbdedbb6c7d2733781f825871fa21e30ecb9be84ca7f79"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A32",
+          "page": 32,
+          "recordChecksum": "fb77702b88a0607e22c2017a36665b4cc037248f7c44984371665c237a28b476"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A33",
+          "page": 33,
+          "recordChecksum": "161e9bf2a2b0a10ad65649200d8278db83d1fa0cd6b29b25b6ad3fb2fb3228e2"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A34",
+          "page": 34,
+          "recordChecksum": "038a9d208ba9694fc4d3b60293917b1788cf59436fd2e56cf774d6d5f0be55ca"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A35",
+          "page": 35,
+          "recordChecksum": "9e105e4a070ff1f3ccbb2e4457ab2db17ea0f08508c15eec93144e612c19cc0a"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A36",
+          "page": 36,
+          "recordChecksum": "eaf068c8da03782f64fd514aae4b619277224bad76681c1f2f53cac9eb9b34d9"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A37",
+          "page": 37,
+          "recordChecksum": "8f351204c603e7be7e454809f8a8d8ee9e14906c3bba1b50762a634313413dd6"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A38",
+          "page": 38,
+          "recordChecksum": "3968666cedb4f155a211f86497171d4ddef0f5b732a5e2b9b75e0c8110af0569"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A39",
+          "page": 39,
+          "recordChecksum": "958a65c0df594caa2ff5712dbb5bed495a35a6c40bfe0912975da268973feec8"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A40",
+          "page": 40,
+          "recordChecksum": "4b55a11a963d2cc4f253796c8f0d4eecc0c7432e9faf48aad8698259f49ae75c"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A41",
+          "page": 41,
+          "recordChecksum": "bf3c75cbbf46e86b427a6f21e1872052a5f89a666b36023b64241aa327b57679"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A42",
+          "page": 42,
+          "recordChecksum": "2fd1004be01eafbbfb0d0bd1ee759c047d73701c5c7b5af06aa7b5e051b91cf5"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A43",
+          "page": 43,
+          "recordChecksum": "efc3f71819eafb283bcb0c4e2b0479eabafbc08bd558dd3b936992c462c99af8"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A44",
+          "page": 44,
+          "recordChecksum": "3b3499d45afce758ee548c60d7877acf61cf5142e9b17d116656d689c0ce86dc"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A45",
+          "page": 45,
+          "recordChecksum": "45cac40d62667456128ae2e7854c798e28cfd86b349d4049483df67717de5090"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A46",
+          "page": 46,
+          "recordChecksum": "4f93b923ab9ee446bb3e8909d40bff484681e07a64b957bf6f612055f7506d91"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A47",
+          "page": 47,
+          "recordChecksum": "be0831f08abaf912a8487794c1ca576d05e6041b074aa2317c56bb892d52f391"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A48",
+          "page": 48,
+          "recordChecksum": "4a6da92d076c62f3079acdb416e433c8cb4560e5b64ca881e563d2d5a619b12c"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A49",
+          "page": 49,
+          "recordChecksum": "6e16dad1c27557392d7a76fdebb5a979f42348b6d9f232c44c047fd4c3d35a4b"
+        },
+        {
+          "id": "source-record:games-workshop:0ba8c36cd64b1090df06fb2f76d56b226b6cfe85dd28923ea13386b652894d29%3Apage%3A50",
+          "page": 50,
+          "recordChecksum": "3104e95f31f6a1e97ff6b1365a441650124d2122f4fbe46dfa5beb98b981e1fa"
+        }
+      ],
+      "title": "Legends compendium"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 16313321,
+        "checksum": "dec8f536bfde90137bb887e42f22b27584cfa11f6c1715d9380c9cfbac5f6604",
+        "etag": "\"e26344072ea91e424952fa2eb8348e64\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_12-12_aos_darkwater_hero_warscrolls-hx54fodxtl-zgdh8irdsh.pdf",
+        "lastModified": "Tue, 09 Dec 2025 14:40:10 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_12-12_aos_darkwater_hero_warscrolls-hx54fodxtl-zgdh8irdsh.pdf",
+        "retrievedAt": "2026-07-28T17:49:44.625Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000004"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:dec8f536bfde90137bb887e42f22b27584cfa11f6c1715d9380c9cfbac5f6604%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "ad436d964a5c64b56954555bc404b9bf9c77548391ce75986c1d5da474e4a0ac"
+        },
+        {
+          "id": "source-record:games-workshop:dec8f536bfde90137bb887e42f22b27584cfa11f6c1715d9380c9cfbac5f6604%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "b4adc9c4e08b8284a3e0db7d928bd3543b34b5e897901d04d530161dbc1718db"
+        },
+        {
+          "id": "source-record:games-workshop:dec8f536bfde90137bb887e42f22b27584cfa11f6c1715d9380c9cfbac5f6604%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "14af7145a2132afda4ab74f6ef1344952bfd0b2ebddeb372a0249ebaefb170e6"
+        },
+        {
+          "id": "source-record:games-workshop:dec8f536bfde90137bb887e42f22b27584cfa11f6c1715d9380c9cfbac5f6604%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "ba86fa7fba7e994ed00f479a5a43d103e0f504cf74c7149c36d29183c449ea50"
+        },
+        {
+          "id": "source-record:games-workshop:dec8f536bfde90137bb887e42f22b27584cfa11f6c1715d9380c9cfbac5f6604%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "8b786a47ca5920ab69ec2cbecd76cbdcb53eb847fcb4c193236e2ac632d82d04"
+        }
+      ],
+      "title": "Legends Regiment of Renown - Heroes of the Jade Abbey"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 26519718,
+        "checksum": "64cbf4bd20cd400f4e609236e1f16d53d73f6b74ced10f0ca34192c0f08b47be",
+        "etag": "\"58c7f23c07049a3da8e73219c53aae7f\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_other_rules_legends_warscrolls-nvrifinwwq-gvzq3fuym2.pdf",
+        "lastModified": "Fri, 24 Jul 2026 13:32:51 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_other_rules_legends_warscrolls-nvrifinwwq-gvzq3fuym2.pdf",
+        "retrievedAt": "2026-07-30T00:53:06.264Z"
+      },
+      "documentKind": "reference",
+      "effectiveDate": "2026-07-29",
+      "publicationDate": "2026-07-29",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000004"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:64cbf4bd20cd400f4e609236e1f16d53d73f6b74ced10f0ca34192c0f08b47be%3Apage%3A39",
+          "page": 39,
+          "recordChecksum": "0e513e8632c67d61cd9d74e96171a12eba2580ebc3c2c6ae1708a9275ac7f5e1"
+        },
+        {
+          "id": "source-record:games-workshop:64cbf4bd20cd400f4e609236e1f16d53d73f6b74ced10f0ca34192c0f08b47be%3Apage%3A49",
+          "page": 49,
+          "recordChecksum": "404dc72d26511c9204a042a2955d2d582f0c4b8f07b253d91265894550b0f16a"
+        },
+        {
+          "id": "source-record:games-workshop:64cbf4bd20cd400f4e609236e1f16d53d73f6b74ced10f0ca34192c0f08b47be%3Apage%3A50",
+          "page": 50,
+          "recordChecksum": "e59202c9d35cce8e4ad2a366b10d15920e82fe0d041a36bfe118fd540669d549"
+        }
+      ],
+      "title": "Legends Warscrolls",
+      "version": "July 2026"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2192115,
+        "checksum": "9e1276ef3d44390ac1c07b7470a6ef3dc737df0af1c5201667443501ac8040a2",
+        "etag": "\"c2cf2f5fdc0dfb8b14c0b532e06dab6a\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aug25_aos_otherrules_ogor_mawtribes_mantrapper_warscroll-mjlskec2qw-buvkx9tkap.pdf",
+        "lastModified": "Tue, 26 Aug 2025 08:05:33 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aug25_aos_otherrules_ogor_mawtribes_mantrapper_warscroll-mjlskec2qw-buvkx9tkap.pdf",
+        "retrievedAt": "2026-07-28T17:49:44.897Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:9e1276ef3d44390ac1c07b7470a6ef3dc737df0af1c5201667443501ac8040a2%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "d1e3bd2ef4d1eaac6e61754afed34c02a1d5c56b748219156c4cad658185b74c"
+        }
+      ],
+      "title": "Ogor Mawtribes - Mantrapper Warscroll"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 15092327,
+        "checksum": "29573197f01e47457ca5db40f4a616a2008d9eee128c4d00cb4f0d2a781b947d",
+        "etag": "\"15059c7c39089eed68a372f94523f326-2\"",
+        "finalUrl": "https://assets.warhammer-community.com/ageofsigmar_corerules&keydownloads_quickstartguide_eng_24.09-xoffxcicsi.pdf",
+        "lastModified": "Wed, 25 Sep 2024 15:37:53 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/ageofsigmar_corerules&keydownloads_quickstartguide_eng_24.09-xoffxcicsi.pdf",
+        "retrievedAt": "2026-07-28T19:27:43.136Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000002",
+        "rules-context:90000000-0000-4000-8000-000000000003",
+        "rules-context:90000000-0000-4000-8000-000000000004",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:29573197f01e47457ca5db40f4a616a2008d9eee128c4d00cb4f0d2a781b947d%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "a1473f556ef8f657945de9a59134dc68c5afc5cc58a06b48d5eab1cf7a89bbee"
+        },
+        {
+          "id": "source-record:games-workshop:29573197f01e47457ca5db40f4a616a2008d9eee128c4d00cb4f0d2a781b947d%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "08f9f1b90aaea2cc82d8c6efa16fe103b1a47b7daf2164f027471ee9eb066ad2"
+        },
+        {
+          "id": "source-record:games-workshop:29573197f01e47457ca5db40f4a616a2008d9eee128c4d00cb4f0d2a781b947d%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "856a8f28cf69af945ed3028a78528420c47a1605f2eef19c297a0e7038fb5d15"
+        },
+        {
+          "id": "source-record:games-workshop:29573197f01e47457ca5db40f4a616a2008d9eee128c4d00cb4f0d2a781b947d%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "dd789f639f69d6cb8ec93b9a511064ba2358b5db82d2a3152c295f2a9f7780b4"
+        },
+        {
+          "id": "source-record:games-workshop:29573197f01e47457ca5db40f4a616a2008d9eee128c4d00cb4f0d2a781b947d%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "e096cf6fef1cbf6f96256e40fa0c0ddea29525731da650930a6fcf7aa3fd2bbf"
+        },
+        {
+          "id": "source-record:games-workshop:29573197f01e47457ca5db40f4a616a2008d9eee128c4d00cb4f0d2a781b947d%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "6f9b24e09aa2b11226012faed9ad84e85c59d3cd2bc73d33ea3f452c6f07de39"
+        }
+      ],
+      "title": "Quick Start Guide"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 5898250,
+        "checksum": "d5afa96ad02d0804dd54ba960792720795359e557281a727932189dc49099340",
+        "etag": "\"6273721fe3a3a18b5b9af291aeb70262\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_24-12_aos_misc_red_gobbo_battleplan-hl6d2rpbjc-i14genteyk.pdf",
+        "lastModified": "Tue, 16 Dec 2025 13:16:17 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_24-12_aos_misc_red_gobbo_battleplan-hl6d2rpbjc-i14genteyk.pdf",
+        "retrievedAt": "2026-07-28T19:27:49.855Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:d5afa96ad02d0804dd54ba960792720795359e557281a727932189dc49099340%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "12966f6db368a0908e3f6ba945a6db103d83f11544d9f5a403bc6a852430dbd3"
+        },
+        {
+          "id": "source-record:games-workshop:d5afa96ad02d0804dd54ba960792720795359e557281a727932189dc49099340%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "7fe491ebd520fc7b9183dfac7110a31d8e3b259bf05cec517ee9457c14ab6af2"
+        }
+      ],
+      "title": "Red Gobbo Battleplan"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 11065204,
+        "checksum": "256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5",
+        "etag": "\"35a8c5d71b4f130f4f2c794037f845c2\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_sept25_aos_regiments_of_renown-fmuoilpm8f-06hzdipnzs.pdf",
+        "lastModified": "Tue, 23 Sep 2025 09:07:51 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_sept25_aos_regiments_of_renown-fmuoilpm8f-06hzdipnzs.pdf",
+        "retrievedAt": "2026-07-28T17:49:45.198Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "0b82524451b5f232e60f542cc74dcfb82adc939b5bed9257c81d6746f37ccaa7"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "1578b05cbcd494169f23ab8078f4ea74e5063dac8df03bf28a97d060cf4f1113"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "5f520857376f152d9e3627cd66776e46d8f0cb7cf1f7a608b88591e9912edc48"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "c300d0209495f008e105db986aabdf46b3782c764ff04f217dbee451057ffffa"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "9d64195d2253d75fc132a5f5d93ab5c556d5b083f376facac34cbaaba663c982"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "365389dab1d424a02285a9115b9eb062aba3cfc824adab2c9ed974b9afd12266"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "9f936560eae1582e3efde6fb0eb897306abcfaccee8da080631cc192df2500a3"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "8b645f8ad8be31ba10914284fd37d46918b93b7c6820717807f889f6ccaf5c90"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "671ac9c4c533823b5b44c09fd4cd85732d1349c34877ac967bee530a3a861eb3"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "d39f52fb93f52c31e9e9d98f8498bba43897ccfeee481e46913fff6f6c134d33"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "a4fde6cafbdb8ac5d1379a0ae882a2db41becd0c898f9f4052bd954c1b2ef242"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "c2ca91d46ead41115eee5dd062e813d3ce3f21e31083704c88b2951c05edcc5e"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "b04ac8dd6d751e66e8bf896f2efa62bb684e8e16f0f21a862480c175b597aee7"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "886a06c3ddd30e02c8b1385d40399fc759338436249fac960d939a78a1e7e5dc"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "64e8b62a253adcbc8974b18e3fc505229e3d30c81be8d8382d1fb37c5d83549a"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "d5e183ec318c4591e39111fd7b8a345738d992be7c0db6f9b984f4a424444c97"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "267a2459a40841b36c2bf157f741f10da6d6b9fd0474d360b5f62e162efe0879"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "4391b1d1ab5345d2830a7e9b1d1e388b707e6ab38173b4296abbeaf7fdfea0e1"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "c3b777cb71f2ea7a661b495ba4aaabd463f4ceb33d217f7bd03ec944613e794b"
+        },
+        {
+          "id": "source-record:games-workshop:256609b95c19f6c5d8c705760f0b580906dc27015368f4ebf3dc3db2f6f757e5%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "90d284fb09ad8b8dc87772fcdb7d5cf0bd3ab795a6cfb71111a790074f31e11b"
+        }
+      ],
+      "title": "Regiments of Renown"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3486241,
+        "checksum": "ca5a5a1ef763e3864315a28f69936a263efeef1e9a48f6a31c40f35cbf1e52c0",
+        "etag": "\"c867f0ce6158e4462a2cd29a1ac0c241\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_blades_of_khorne_renown-nsoo3uhkpw-hvuwursmln.pdf",
+        "lastModified": "Fri, 10 Apr 2026 08:52:49 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_blades_of_khorne_renown-nsoo3uhkpw-hvuwursmln.pdf",
+        "retrievedAt": "2026-07-28T17:49:45.555Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:ca5a5a1ef763e3864315a28f69936a263efeef1e9a48f6a31c40f35cbf1e52c0%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "d446b6b9aac5a99d6fc1920dcab87433b2b692de30cbca5e71c59154c17c33c8"
+        },
+        {
+          "id": "source-record:games-workshop:ca5a5a1ef763e3864315a28f69936a263efeef1e9a48f6a31c40f35cbf1e52c0%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "1cbe8b33b98b01ef0e1738a30409ae4385951c170c6f26c485d05cb6a6fabfea"
+        }
+      ],
+      "title": "Regiments of Renown - Blades of Khorne"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2635901,
+        "checksum": "910cc610a5168b55a05810edc417eec63926be1d32144cb383ffbc51e8440ebc",
+        "etag": "\"ca4c2deeee802d57a08f57b11ffc7ed3\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_13-05_aos_rules_of_renown_cities_of_sigmar_regiments_of_renown-0qeutm0psk-wj3wsdwrlm.pdf",
+        "lastModified": "Mon, 11 May 2026 13:40:27 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_13-05_aos_rules_of_renown_cities_of_sigmar_regiments_of_renown-0qeutm0psk-wj3wsdwrlm.pdf",
+        "retrievedAt": "2026-07-28T03:05:25.649Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:910cc610a5168b55a05810edc417eec63926be1d32144cb383ffbc51e8440ebc%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "57058ff38d709d5501bd23c0d2f847d3696ee07839c24616984130c4556df1c9"
+        },
+        {
+          "id": "source-record:games-workshop:910cc610a5168b55a05810edc417eec63926be1d32144cb383ffbc51e8440ebc%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "709a9dd8b217d00bd98034e16ad4d5c6233025f12ec80d7d12d233334fba62e0"
+        },
+        {
+          "id": "source-record:games-workshop:910cc610a5168b55a05810edc417eec63926be1d32144cb383ffbc51e8440ebc%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "31d40bb0f650254097fd54fb10be3f0c4ff13c0d22b576893369af308ab97534"
+        },
+        {
+          "id": "source-record:games-workshop:910cc610a5168b55a05810edc417eec63926be1d32144cb383ffbc51e8440ebc%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "cdafd7a09d049d30083eed53424532e11e005c57c3034d8efb69f5cf4a4d1cfc"
+        }
+      ],
+      "title": "Regiments of Renown - Cities of Sigmar"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2380698,
+        "checksum": "2bf0e2bcd84a8f8cda8c9876bc948a41d2acf39576db99169cea326931fe2261",
+        "etag": "\"0b93ee6775b3c3a5d3edc24bbbc74bb0\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_25-03_aos_regiments_of_renown_daughters_of_khaine-j1lyj2odoa-qgboc13py0.pdf",
+        "lastModified": "Thu, 19 Mar 2026 09:52:48 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_25-03_aos_regiments_of_renown_daughters_of_khaine-j1lyj2odoa-qgboc13py0.pdf",
+        "retrievedAt": "2026-07-28T17:49:45.714Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:2bf0e2bcd84a8f8cda8c9876bc948a41d2acf39576db99169cea326931fe2261%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "2b9200a4c0f839ba166dcaf34e7931626145b2a7480944282565b92d6b9dc7fd"
+        },
+        {
+          "id": "source-record:games-workshop:2bf0e2bcd84a8f8cda8c9876bc948a41d2acf39576db99169cea326931fe2261%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "c9d4273b5d5ad424e7395f4805d8a0ff319b4c88d554a0cb2b0154b31cbc8921"
+        }
+      ],
+      "title": "Regiments of Renown - Daughters of Khaine"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 1490657,
+        "checksum": "68f1ec961992bf9ede349b994a1f35702c83fe0b037a7717da47a21b680bba07",
+        "etag": "\"d8ba2ce9db1b06530068417cedb722fa\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_04-02_aos_otherrules_disciples_of_tzeentch_renown-lzba9nkx5r-9oyitjtdcs.pdf",
+        "lastModified": "Mon, 02 Feb 2026 11:00:53 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_04-02_aos_otherrules_disciples_of_tzeentch_renown-lzba9nkx5r-9oyitjtdcs.pdf",
+        "retrievedAt": "2026-07-28T17:49:45.834Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:68f1ec961992bf9ede349b994a1f35702c83fe0b037a7717da47a21b680bba07%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "c0617bf3953369a95f6ee6db3e0d78bb91d1001358badb83f6829332326d3a6f"
+        },
+        {
+          "id": "source-record:games-workshop:68f1ec961992bf9ede349b994a1f35702c83fe0b037a7717da47a21b680bba07%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "863aa6eb88da58bbe4d1e91fbd648b9f897c424cc07e8554531dd6a395085894"
+        }
+      ],
+      "title": "Regiments of Renown - Disciples of Tzeentch"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3414557,
+        "checksum": "4fc3186369ec33fd3e57aa061af578a7bba084bab7ba1d8c831fc4f9a12ef54c",
+        "etag": "\"4a6d2412cf1180e4cb023c2cf6f9dd9a\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aug25_aos_otherrules_fec_renown-pyg710ssmj-4tj2qivyze.pdf",
+        "lastModified": "Tue, 26 Aug 2025 07:32:45 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aug25_aos_otherrules_fec_renown-pyg710ssmj-4tj2qivyze.pdf",
+        "retrievedAt": "2026-07-28T17:49:46.026Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:4fc3186369ec33fd3e57aa061af578a7bba084bab7ba1d8c831fc4f9a12ef54c%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "ebcc6f23ebf00f7b68906f07ea2de051bd03586d7cbf8f7e5a70efba798b9b2a"
+        },
+        {
+          "id": "source-record:games-workshop:4fc3186369ec33fd3e57aa061af578a7bba084bab7ba1d8c831fc4f9a12ef54c%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "a15633724553d6eee11fe843dd4d5c30bd73a037c5e17d9d4e19e1dc652d5381"
+        }
+      ],
+      "title": "Regiments of Renown - Flesh-eater Courts"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 9956917,
+        "checksum": "5491a992d1b984357e93b6f92c548849b39f07e24e5ade0767c53867631e735c",
+        "etag": "\"1aa58e1625e65f00cbd00bf005073fd0\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_gloomspite_gitz_renown-cbr2opxgnp-syk3n14yo4.pdf",
+        "lastModified": "Fri, 10 Apr 2026 08:35:25 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_gloomspite_gitz_renown-cbr2opxgnp-syk3n14yo4.pdf",
+        "retrievedAt": "2026-07-28T17:49:46.306Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:5491a992d1b984357e93b6f92c548849b39f07e24e5ade0767c53867631e735c%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "e50a441f638f217bbd76c446ceeee25b01a92d4ecc80050b6928f0a14fe5b6e4"
+        },
+        {
+          "id": "source-record:games-workshop:5491a992d1b984357e93b6f92c548849b39f07e24e5ade0767c53867631e735c%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "53311e691de2bc34052c83f5ba70c41df6dbb52a42770366adb6ae4ba0ec6004"
+        }
+      ],
+      "title": "Regiments of Renown - Gloomspite Gitz"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 8940352,
+        "checksum": "6cf9fa689a6e83c60c01c90f1e9ccce027aecb510d526e9074e1ac2fbe09293a",
+        "etag": "\"42dfc9e9fa2458f96185ff76aa3f2e51\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_17-06_aos4_rulesofrenown_hedonites_of_slaanesh-iwtglhosbf-vfkzgtyujy.pdf",
+        "lastModified": "Mon, 15 Jun 2026 08:03:52 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_17-06_aos4_rulesofrenown_hedonites_of_slaanesh-iwtglhosbf-vfkzgtyujy.pdf",
+        "retrievedAt": "2026-07-28T03:05:30.169Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:6cf9fa689a6e83c60c01c90f1e9ccce027aecb510d526e9074e1ac2fbe09293a%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "0c44bf80c44066b840480feaa8b9f7109c81744e39bc075eba2baf44c584625a"
+        },
+        {
+          "id": "source-record:games-workshop:6cf9fa689a6e83c60c01c90f1e9ccce027aecb510d526e9074e1ac2fbe09293a%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "03c9f65dfa8da4cb03faa3ddc308881a66b24c833732746190a213472019716c"
+        }
+      ],
+      "title": "Regiments of Renown - Hedonites of Slaanesh"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3000753,
+        "checksum": "e503df628f1fb6079b523effbd627039168585b8a7212c0ffc40a0a07db60f80",
+        "etag": "\"5627d3a45bfc8793926bafa5be4f76e4\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_24-09_aos_other_rules_regiments_of_renown_helsmiths_of_hashut-4noygos3ur-eeku9ibjic.pdf",
+        "lastModified": "Tue, 23 Sep 2025 12:47:47 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_24-09_aos_other_rules_regiments_of_renown_helsmiths_of_hashut-4noygos3ur-eeku9ibjic.pdf",
+        "retrievedAt": "2026-07-28T17:49:46.616Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:e503df628f1fb6079b523effbd627039168585b8a7212c0ffc40a0a07db60f80%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "6a2d74d5c4cbed91a88c535867a423803ecc1ff2a0e524caa728f70ccac33b20"
+        },
+        {
+          "id": "source-record:games-workshop:e503df628f1fb6079b523effbd627039168585b8a7212c0ffc40a0a07db60f80%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "33f50a0a4e6c238ed119b675f2e0bb95416f7d42aea0c4ae9d9ac353dc56c383"
+        }
+      ],
+      "title": "Regiments of Renown - Helsmiths of Hashut"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 4290457,
+        "checksum": "9522131a7e0994be1463e0b2ade875d46126fcb0f4b099e72797c26eebc4959d",
+        "etag": "\"12530f867a3f8ef15d57a378a6639fac\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos4_idoneth_deepkin_renown-gsdrup3pww-ayh72mfgnq.pdf",
+        "lastModified": "Tue, 15 Jul 2025 12:21:20 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos4_idoneth_deepkin_renown-gsdrup3pww-ayh72mfgnq.pdf",
+        "retrievedAt": "2026-07-28T17:49:46.784Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:9522131a7e0994be1463e0b2ade875d46126fcb0f4b099e72797c26eebc4959d%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "93d022fd1b52abe89c473007bbad235b38a8a8788717445cb19600af6eace7f2"
+        },
+        {
+          "id": "source-record:games-workshop:9522131a7e0994be1463e0b2ade875d46126fcb0f4b099e72797c26eebc4959d%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "7a0dbacbad65939c7f0e404668e4e58564c2386b30a7694528d593ed9a684221"
+        }
+      ],
+      "title": "Regiments of Renown - Idoneth Deepkin"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2871178,
+        "checksum": "eb80980c163c0df176d020302cf76ea65600a22e2761423b0c8451fed5b337ba",
+        "etag": "\"fc13a9ab60e92ecdccbb20225552cee0\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_kharadron_overlords_renown-s3dsfalnvm-5vzz7nvqmf.pdf",
+        "lastModified": "Fri, 10 Apr 2026 08:44:50 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_kharadron_overlords_renown-s3dsfalnvm-5vzz7nvqmf.pdf",
+        "retrievedAt": "2026-07-28T17:49:46.950Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:eb80980c163c0df176d020302cf76ea65600a22e2761423b0c8451fed5b337ba%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "688aca9b312a73adc0cc08ccc4122e407bc4f82e26c2728c27a82660d9e396a5"
+        },
+        {
+          "id": "source-record:games-workshop:eb80980c163c0df176d020302cf76ea65600a22e2761423b0c8451fed5b337ba%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "32ec7fc9675bb26f450926e90db3262cadcddf4fac36c701f2c5c3acd7cdfb1f"
+        }
+      ],
+      "title": "Regiments of Renown - Kharadron Overlords"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3609916,
+        "checksum": "47363c98528bcb9fb9fb2bf16df4c5ee268c917c55ab519e3780ef0b38e74427",
+        "etag": "\"02251bbb1ecb8de8fefc89138e8a1c1b\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_other_rules_regiments_of_renown_lumineth_realmlords-sflqxtafiy-lzvaprm2ay.pdf",
+        "lastModified": "Tue, 31 Mar 2026 07:48:34 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_other_rules_regiments_of_renown_lumineth_realmlords-sflqxtafiy-lzvaprm2ay.pdf",
+        "retrievedAt": "2026-07-28T17:49:47.153Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:47363c98528bcb9fb9fb2bf16df4c5ee268c917c55ab519e3780ef0b38e74427%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "b1a424c45fbcdeb00f55a35dd6d0a5bf17094d76b5cad279a8438bbd2cde0a93"
+        },
+        {
+          "id": "source-record:games-workshop:47363c98528bcb9fb9fb2bf16df4c5ee268c917c55ab519e3780ef0b38e74427%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "883b6cbc1040cda60a3e9b20bde88b9fc963a063b121cf4891b516fb644e4161"
+        }
+      ],
+      "title": "Regiments of Renown - Lumineth Realm-lords"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3373877,
+        "checksum": "a8618974f8ecdd534cd9bf6b45bca020288a99059b4cdb4d2ed474ae7c700ee3",
+        "etag": "\"0ec182462d5b2152a32fc335f40b99d3\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_14-12_aos_otherrules_maggotkin_of_nurgle_renown-lsddv8dqwc-kkwbysdapc.pdf",
+        "lastModified": "Mon, 12 Jan 2026 12:04:03 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_14-12_aos_otherrules_maggotkin_of_nurgle_renown-lsddv8dqwc-kkwbysdapc.pdf",
+        "retrievedAt": "2026-07-28T17:49:47.337Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:a8618974f8ecdd534cd9bf6b45bca020288a99059b4cdb4d2ed474ae7c700ee3%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "7cb90057206bb810fa62941a3258596aa97d52db4580b4d74eaf77c0e13e2350"
+        },
+        {
+          "id": "source-record:games-workshop:a8618974f8ecdd534cd9bf6b45bca020288a99059b4cdb4d2ed474ae7c700ee3%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "4c0b9d9be07bff4f127bdba3bf6ca2b654b6d16b7298024ec01baf8d598e8d5e"
+        }
+      ],
+      "title": "Regiments of Renown - Maggotkin of Nurgle"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2998455,
+        "checksum": "ff2cc58c2ea49b7bb5e1673a26b7d88903875e0341145be887e0ba790ecfcdd3",
+        "etag": "\"898d572486e6fa9fca20743e6eafd408\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_nighthaunt_renown-eb0uv8r27r-gqmyjrspmc.pdf",
+        "lastModified": "Fri, 10 Apr 2026 08:48:37 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_nighthaunt_renown-eb0uv8r27r-gqmyjrspmc.pdf",
+        "retrievedAt": "2026-07-28T17:49:47.538Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:ff2cc58c2ea49b7bb5e1673a26b7d88903875e0341145be887e0ba790ecfcdd3%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "fee543fe3e6494feebf6062e1561eacd0b4e0cc777108f33c8da2e4490eb481f"
+        },
+        {
+          "id": "source-record:games-workshop:ff2cc58c2ea49b7bb5e1673a26b7d88903875e0341145be887e0ba790ecfcdd3%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "822a3f609de457d6a9831ffef094c5e00e6d5931eba1cb58fad9c8a7ac188744"
+        }
+      ],
+      "title": "Regiments of Renown - Nighthaunt"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 7139704,
+        "checksum": "9470e84348578fe29d35ad56f56c38211a682b28c651a22ed1d9890c9324e46c",
+        "etag": "\"d249e954df0447cc05304771a9ed0a55\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_15-07_aos_rules_of_renown_regiments_of_renown_ogor_mawtribes-pmqlbxoavz-sefum5k5fn.pdf",
+        "lastModified": "Thu, 09 Jul 2026 09:10:58 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_15-07_aos_rules_of_renown_regiments_of_renown_ogor_mawtribes-pmqlbxoavz-sefum5k5fn.pdf",
+        "retrievedAt": "2026-07-28T03:05:27.606Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:9470e84348578fe29d35ad56f56c38211a682b28c651a22ed1d9890c9324e46c%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "c3a40899dc8f9839b3192d6af945af8a9be4dc7b28475fd881e2a2c211c1ddee"
+        },
+        {
+          "id": "source-record:games-workshop:9470e84348578fe29d35ad56f56c38211a682b28c651a22ed1d9890c9324e46c%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "b7c1da448eb36f255f1d05fa6e595613c8935292bf2ce160d92fdf441c19ddc8"
+        }
+      ],
+      "title": "Regiments of Renown - Ogor Mawtribes"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3328290,
+        "checksum": "cfdb2e0eba983a4f1bcd328847b56dfb34607cf424c0f99c30f2f51ee2e6eb5b",
+        "etag": "\"eb8281bae4d49080dfa1413ea81d809a\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_regiments_of_renown_orruk_warclans-el5qzxtdqk-zjpxott1rc.pdf",
+        "lastModified": "Fri, 10 Apr 2026 07:59:51 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_regiments_of_renown_orruk_warclans-el5qzxtdqk-zjpxott1rc.pdf",
+        "retrievedAt": "2026-07-28T17:49:47.726Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:cfdb2e0eba983a4f1bcd328847b56dfb34607cf424c0f99c30f2f51ee2e6eb5b%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "2ad680f262865531b83fae2d83f13c7a67d03d633f6bf7a3a9a72d64dd8a9ff4"
+        },
+        {
+          "id": "source-record:games-workshop:cfdb2e0eba983a4f1bcd328847b56dfb34607cf424c0f99c30f2f51ee2e6eb5b%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "f4d6709e8c2404a2a310f979c7d66b026862f8079adb9a55d6c4f380722290e8"
+        }
+      ],
+      "title": "Regiments of Renown - Orruk Warclans"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3098207,
+        "checksum": "b23c945c96f1a3844824e73ab4e87b60a1cd55247956666ed476a93ba2bb1c53",
+        "etag": "\"cd88c0eae91f6725997be80e13c11b99\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_18-02_aos_other_rules_ossiarch_bonereapers_renown-cqrypinecb-pitrqhkbw3.pdf",
+        "lastModified": "Mon, 16 Feb 2026 11:42:51 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_18-02_aos_other_rules_ossiarch_bonereapers_renown-cqrypinecb-pitrqhkbw3.pdf",
+        "retrievedAt": "2026-07-28T17:49:47.905Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:b23c945c96f1a3844824e73ab4e87b60a1cd55247956666ed476a93ba2bb1c53%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "4f9b214cfd1d7b0fb04960fbc129e1ea0818948d7650d43e926dc496f22b27e4"
+        },
+        {
+          "id": "source-record:games-workshop:b23c945c96f1a3844824e73ab4e87b60a1cd55247956666ed476a93ba2bb1c53%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "fec00d096eab58e5aec0b67a69f42ea1d9069dfa9b329e9a9085e4ead3ed3d49"
+        }
+      ],
+      "title": "Regiments of Renown - Ossiarch Bonereapers"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 6933491,
+        "checksum": "370cd6c1f7daed8bd290c88e698d364046c37233e2cc5a2145ebe8d989c0dd03",
+        "etag": "\"f6b34bb7d29739d0443a9cc3d284e832\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_regiments_of_renown_skaven-3w5brn3gpx-f8dry4xv7l.pdf",
+        "lastModified": "Fri, 10 Apr 2026 07:51:00 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_regiments_of_renown_skaven-3w5brn3gpx-f8dry4xv7l.pdf",
+        "retrievedAt": "2026-07-28T17:49:48.189Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:370cd6c1f7daed8bd290c88e698d364046c37233e2cc5a2145ebe8d989c0dd03%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "59ff1cb255ea92766ae647d7c9c6c33ca11268823e944f9f814120d154fe19e3"
+        },
+        {
+          "id": "source-record:games-workshop:370cd6c1f7daed8bd290c88e698d364046c37233e2cc5a2145ebe8d989c0dd03%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "f7253919085038b99bba91c9b023bf32c6e2161a6992e144ca90f149fee26050"
+        }
+      ],
+      "title": "Regiments of Renown - Skaven"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 5279646,
+        "checksum": "8e3bf431d5c0ac11dfee45c375455e61513d26284c1bc07c8ae6933195dc0d07",
+        "etag": "\"7ff0e077b324e60b4ae72ca0e036f5a1\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_slaves_to_darkness_renown-c3dn7qkraz-soqyo0nfqg.pdf",
+        "lastModified": "Fri, 10 Apr 2026 08:12:06 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_slaves_to_darkness_renown-c3dn7qkraz-soqyo0nfqg.pdf",
+        "retrievedAt": "2026-07-28T17:49:48.409Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:8e3bf431d5c0ac11dfee45c375455e61513d26284c1bc07c8ae6933195dc0d07%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "e2bacbefb22b5d93400d248660de20d738e91b1eb452aa5391e2be07d16b2296"
+        },
+        {
+          "id": "source-record:games-workshop:8e3bf431d5c0ac11dfee45c375455e61513d26284c1bc07c8ae6933195dc0d07%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "9c9b2c7570ee91badc6453d9e3b78ee4087c9ebe51d06eb720c015a1bdb80f80"
+        }
+      ],
+      "title": "Regiments of Renown - Slaves to Darkness"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 5618870,
+        "checksum": "59e25557b3429da860cea4550fcec2f10b20d648bbe9c571a89e3612a039fdeb",
+        "etag": "\"88e087731500ad710d9f3cc2aa6ee250\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_soulblight_renown-x2cq3nuawj-wbzpdomids.pdf",
+        "lastModified": "Fri, 10 Apr 2026 08:40:23 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_soulblight_renown-x2cq3nuawj-wbzpdomids.pdf",
+        "retrievedAt": "2026-07-28T17:49:48.613Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:59e25557b3429da860cea4550fcec2f10b20d648bbe9c571a89e3612a039fdeb%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "32683423952d2abc61a6129af4f87b3486bef80b27a0598b74ede550def1b891"
+        },
+        {
+          "id": "source-record:games-workshop:59e25557b3429da860cea4550fcec2f10b20d648bbe9c571a89e3612a039fdeb%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "568d5b96b1fa67dceff1de2c58fe6841ebf38c177d426930e2f516832df781fd"
+        }
+      ],
+      "title": "Regiments of Renown - Soulblight Gravelords"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 4735065,
+        "checksum": "443c28385f64d4c58fdba35b406572e42b0c1bbe1379a3da06c168af114412fe",
+        "etag": "\"1fef1f0e8bb4dbfa7db49c4036c46ee1\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_regiments_of_renown_stormcast_eternals-9x7ampyluz-l0unhqjmgb.pdf",
+        "lastModified": "Fri, 10 Apr 2026 07:43:24 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_regiments_of_renown_stormcast_eternals-9x7ampyluz-l0unhqjmgb.pdf",
+        "retrievedAt": "2026-07-28T17:49:48.816Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:443c28385f64d4c58fdba35b406572e42b0c1bbe1379a3da06c168af114412fe%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "ef4824fc95a413c33166f8d776aff1d5462b3dcae030a7d84e89beb7404a8148"
+        },
+        {
+          "id": "source-record:games-workshop:443c28385f64d4c58fdba35b406572e42b0c1bbe1379a3da06c168af114412fe%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "11fdf036a006c1d881a933973409177201d70f0292ae73c0138f17c35a51eedb"
+        }
+      ],
+      "title": "Regiments of Renown - Stormcast Eternals"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 5228019,
+        "checksum": "a69b20a03a0bced75d372eefa752fd6aba8b78e83048618966b1f2102060e065",
+        "etag": "\"16b35e56accee626abe16f3a0eb875c9\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_25-03_aos_other_rules_regiments_of_renown_sylvaneth-zhxjoncko9-9au3hd2olw.pdf",
+        "lastModified": "Thu, 19 Mar 2026 09:42:01 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_25-03_aos_other_rules_regiments_of_renown_sylvaneth-zhxjoncko9-9au3hd2olw.pdf",
+        "retrievedAt": "2026-07-28T17:49:49.031Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:a69b20a03a0bced75d372eefa752fd6aba8b78e83048618966b1f2102060e065%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "51a494aa79a7755c85a8115925759a3c5df8a5dbb783262f88509ab3d4119987"
+        },
+        {
+          "id": "source-record:games-workshop:a69b20a03a0bced75d372eefa752fd6aba8b78e83048618966b1f2102060e065%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "4068e0ab6fdf0785edffa7fc3563d6a32c28bcdc46f476f5c9031774d8f50926"
+        }
+      ],
+      "title": "Regiments of Renown - Sylvaneth"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 14591801,
+        "checksum": "f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2",
+        "etag": "\"1159ce053ef1916c18799e654eb34da7\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_core_rules_rules_updates-aittiy7gbv-sobi7rwdr7.pdf",
+        "lastModified": "Fri, 24 Jul 2026 13:45:39 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_core_rules_rules_updates-aittiy7gbv-sobi7rwdr7.pdf",
+        "retrievedAt": "2026-07-30T00:53:00.774Z"
+      },
+      "documentKind": "reference",
+      "effectiveDate": "2026-07-29",
+      "publicationDate": "2026-07-29",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000002",
+        "rules-context:90000000-0000-4000-8000-000000000003",
+        "rules-context:90000000-0000-4000-8000-000000000004",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "b71790d937a34b044e21d9a4af8bdb9a1b807745d4ba973dab02143e1e7d7e8a"
+        },
+        {
+          "id": "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A25",
+          "page": 25,
+          "recordChecksum": "fa98a73583e3efc9d03e64565df3dba9a3a309a052249a1c27b36b6fdf20dc9d"
+        },
+        {
+          "id": "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A33",
+          "page": 33,
+          "recordChecksum": "3f72a57ab745ec1d2ec4bace50f4c74f53061b06a2019a3f6c136d4191342473"
+        },
+        {
+          "id": "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A36",
+          "page": 36,
+          "recordChecksum": "d6a54e3dd431a8589b8ee541ef92f2b25cc3f20653ffd753c21a4a55d5773ff3"
+        },
+        {
+          "id": "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A37",
+          "page": 37,
+          "recordChecksum": "d821df44944e93962cc971e91f77d8e40492b24eff1df713d25eb0df9b86f3a4"
+        },
+        {
+          "id": "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A39",
+          "page": 39,
+          "recordChecksum": "ab5715f9e5e8a61467ab0f26f5111ca1558af736f8731bbba3a419bc951a2c98"
+        },
+        {
+          "id": "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A51",
+          "page": 51,
+          "recordChecksum": "35178f04d2af85de042b2c6605ab6c41a1c69ff32ec799d7d834478eb7ea339d"
+        },
+        {
+          "id": "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A57",
+          "page": 57,
+          "recordChecksum": "5c1684ecfe643bfbaa158ec857ac90b18af2f13012e884ae2e7ea3d9b251605e"
+        },
+        {
+          "id": "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A58",
+          "page": 58,
+          "recordChecksum": "c295b34177a9ba11e9e59afeb2f5a742ff9bcb551efef1d55a41a387439169ff"
+        },
+        {
+          "id": "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A60",
+          "page": 60,
+          "recordChecksum": "8bf3c7a6e6e888c218c546ab058597874d8506ef34d8ad0fa203e2611b67bb71"
+        },
+        {
+          "id": "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A61",
+          "page": 61,
+          "recordChecksum": "a68a85ffaff1f1042572310fd1ae541102d737efe7321a254308834c73d6e29f"
+        },
+        {
+          "id": "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A71",
+          "page": 71,
+          "recordChecksum": "76031d02dfb465e479320f991fa99dd92462862160f92bf58cfb23f8ad6d996d"
+        }
+      ],
+      "title": "Rules Updates",
+      "version": "July 2026"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2994653,
+        "checksum": "3973a5056e5362e9f7659eb0721a71bcac08795a6a89ea7ffb32d3c65d45995f",
+        "etag": "\"744f7ce5a4efe55fab11efc06fe41da7\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-07_warhammer_age_of_sigmar_scourge_of_aqshy_blades_of_khorne-z8olx2wisu-oxdgksim6x.pdf",
+        "lastModified": "Fri, 26 Jun 2026 08:54:05 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-07_warhammer_age_of_sigmar_scourge_of_aqshy_blades_of_khorne-z8olx2wisu-oxdgksim6x.pdf",
+        "retrievedAt": "2026-07-28T03:04:59.077Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:3973a5056e5362e9f7659eb0721a71bcac08795a6a89ea7ffb32d3c65d45995f%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "86b4988340c916aff794c8c145aa74afa5c91b244701364d7f9b20d83664e720"
+        },
+        {
+          "id": "source-record:games-workshop:3973a5056e5362e9f7659eb0721a71bcac08795a6a89ea7ffb32d3c65d45995f%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "7e05f1c19422e9b43eeb7dcdba0621e42b8c8c8b2d8f2a137c87a273bb264f36"
+        }
+      ],
+      "title": "Scourge of Aqshy - Blades of Khorne"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2980624,
+        "checksum": "f99bcf1d694e54031186c2ec423c2f28747fff0ea77aee75aac4c4f0196ee939",
+        "etag": "\"ff8042f582f3c3eeaa1d878a5d93b293\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_cities_of_sigmar-5iinsjs17f-gcwxupc4yt.pdf",
+        "lastModified": "Fri, 26 Jun 2026 07:33:57 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_cities_of_sigmar-5iinsjs17f-gcwxupc4yt.pdf",
+        "retrievedAt": "2026-07-28T03:05:34.434Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:f99bcf1d694e54031186c2ec423c2f28747fff0ea77aee75aac4c4f0196ee939%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "97ddecc5875b3d84a579e63ad91d983d8bff21de5fd0d2bd43df9506086b3af5"
+        },
+        {
+          "id": "source-record:games-workshop:f99bcf1d694e54031186c2ec423c2f28747fff0ea77aee75aac4c4f0196ee939%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "86f4b12fa03525f4ae68158e0039e26ed89359afcb71e4dd37b92f6877eb3e77"
+        }
+      ],
+      "title": "Scourge of Aqshy - Cities of Sigmar"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2895718,
+        "checksum": "8c9e0f6b0a358925c78ba7282cda3e6634ae59b57226557095bb770d95fc06c7",
+        "etag": "\"f71e0c3dd746d49d3466ae24fdfa363f\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_daughters_of_khaine-aoxtf4ksi1-dbbmbtyds5.pdf",
+        "lastModified": "Fri, 26 Jun 2026 07:39:55 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_daughters_of_khaine-aoxtf4ksi1-dbbmbtyds5.pdf",
+        "retrievedAt": "2026-07-28T03:05:35.869Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:8c9e0f6b0a358925c78ba7282cda3e6634ae59b57226557095bb770d95fc06c7%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "6199876be8f47ff94da542279b88fd955be001415f2d0e5fcadd7903a7afeb29"
+        },
+        {
+          "id": "source-record:games-workshop:8c9e0f6b0a358925c78ba7282cda3e6634ae59b57226557095bb770d95fc06c7%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "cf5fdfb6f3a24d6cd499d32319655b367ef0644dff7c354c54474dca1260441b"
+        }
+      ],
+      "title": "Scourge of Aqshy - Daughters of Khaine"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2870991,
+        "checksum": "e3256cb72d67b6bd1ece4fc76a868561d80230de94a0275682b4ed96abf23f92",
+        "etag": "\"066a89017b2d33f650a7772133b947d0\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-07_warhammer_age_of_sigmar_scourge_of_aqshy_disciples_of_tzeentch-kzpuvfnl96-r4gvg0bh4p.pdf",
+        "lastModified": "Fri, 26 Jun 2026 09:00:43 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-07_warhammer_age_of_sigmar_scourge_of_aqshy_disciples_of_tzeentch-kzpuvfnl96-r4gvg0bh4p.pdf",
+        "retrievedAt": "2026-07-28T03:05:00.630Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:e3256cb72d67b6bd1ece4fc76a868561d80230de94a0275682b4ed96abf23f92%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "61b542f857e3231caf486e5ebbca99698ca1c0305534c7334ef028fc8e1407a4"
+        },
+        {
+          "id": "source-record:games-workshop:e3256cb72d67b6bd1ece4fc76a868561d80230de94a0275682b4ed96abf23f92%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "b9d0bd98b02a1e74f01f472b77cc45f51a3ecfb49ad8afa224a828a6da99ae79"
+        }
+      ],
+      "title": "Scourge of Aqshy - Disciples of Tzeentch"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2762896,
+        "checksum": "f50036a9facaee939181bb27084c7d7f3d700484663c2eee3ed19d7c3ccc4373",
+        "etag": "\"e1d0acb7a2bfb76155eeda167388fb59\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_02-07_warhammer_age_of_sigmar_scourge_of_aqshy_flesheater_courts-xblz1p66c9-g7tuncg2r8.pdf",
+        "lastModified": "Fri, 26 Jun 2026 09:35:47 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_02-07_warhammer_age_of_sigmar_scourge_of_aqshy_flesheater_courts-xblz1p66c9-g7tuncg2r8.pdf",
+        "retrievedAt": "2026-07-28T03:05:09.285Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:f50036a9facaee939181bb27084c7d7f3d700484663c2eee3ed19d7c3ccc4373%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "26f03bed34f6b4203d5be82add48f4834224a6143cb03477aadbb67bd60ea915"
+        },
+        {
+          "id": "source-record:games-workshop:f50036a9facaee939181bb27084c7d7f3d700484663c2eee3ed19d7c3ccc4373%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "b0c08d56dc47c4aaecae162516b0000d9cc75e9e0bbafc1457b12105dd0c3b3c"
+        }
+      ],
+      "title": "Scourge of Aqshy - Flesh-Eater Courts"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2542879,
+        "checksum": "5abd7519ff2ae09f528bafaae1545ca2614944890ac055769418060a3b28f9d3",
+        "etag": "\"c762d275e3025ebd857e3c3a6f177602\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_fyreslayers-woen4hrxst-qcrepwmzox.pdf",
+        "lastModified": "Fri, 26 Jun 2026 07:44:47 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_fyreslayers-woen4hrxst-qcrepwmzox.pdf",
+        "retrievedAt": "2026-07-28T03:05:37.337Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:5abd7519ff2ae09f528bafaae1545ca2614944890ac055769418060a3b28f9d3%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "a5539b742d25997c1259ba8259d13432c71261d92281b8018a9a9ba251631749"
+        },
+        {
+          "id": "source-record:games-workshop:5abd7519ff2ae09f528bafaae1545ca2614944890ac055769418060a3b28f9d3%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "35b83c808048b8b9ae72bd40e70e32241610ab147e199247e9b009f52bef4d18"
+        },
+        {
+          "id": "source-record:games-workshop:5abd7519ff2ae09f528bafaae1545ca2614944890ac055769418060a3b28f9d3%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "afb3269b9a21c55025e7174f553289e0b3caf8b02e66b9313a26aba9fdb9a9ee"
+        }
+      ],
+      "title": "Scourge of Aqshy - Fyreslayers"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2634826,
+        "checksum": "abd6abfb33825cae2b06ea4dd5533def430722a1e1ba50282a189f31003ed6e5",
+        "etag": "\"947879571b8dc81015f1a39450d2fbf1\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_03-07_warhammer_age_of_sigmar_scourge_of_aqshy_gloomspite_gitz-okcv7krb07-b688aqhhch.pdf",
+        "lastModified": "Fri, 26 Jun 2026 10:00:37 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_03-07_warhammer_age_of_sigmar_scourge_of_aqshy_gloomspite_gitz-okcv7krb07-b688aqhhch.pdf",
+        "retrievedAt": "2026-07-28T03:05:15.418Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:abd6abfb33825cae2b06ea4dd5533def430722a1e1ba50282a189f31003ed6e5%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "7daed71d17debd212a8192d56d0163af755a2932b3f765355b0b28a4bc4769de"
+        },
+        {
+          "id": "source-record:games-workshop:abd6abfb33825cae2b06ea4dd5533def430722a1e1ba50282a189f31003ed6e5%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "3e4c39f13a3568010d436def0b8861604fc0897679ca18f1b04891398b9fe904"
+        }
+      ],
+      "title": "Scourge of Aqshy - Gloomspite Gitz"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3718413,
+        "checksum": "80b113d5b2e4fcffe13a214d0064de3415e49786537310cd43dacfd3107aa247",
+        "etag": "\"5bd8bd006a5a6aaeaeab0819e9a4925c\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-07_warhammer_age_of_sigmar_scourge_of_aqshy_hedonites_of_slaanesh-s0cawjvuni-nkxp9xbfmu.pdf",
+        "lastModified": "Fri, 26 Jun 2026 09:07:36 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-07_warhammer_age_of_sigmar_scourge_of_aqshy_hedonites_of_slaanesh-s0cawjvuni-nkxp9xbfmu.pdf",
+        "retrievedAt": "2026-07-28T03:05:02.240Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:80b113d5b2e4fcffe13a214d0064de3415e49786537310cd43dacfd3107aa247%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "a6d99e97a0dd0f1b08ee753ba67efb3860f71ac82cac8e1a103ee6113dcdf0a7"
+        },
+        {
+          "id": "source-record:games-workshop:80b113d5b2e4fcffe13a214d0064de3415e49786537310cd43dacfd3107aa247%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "c57584e9030633c7a927f980f1fe3ced8436a1b0c2e8058b6814932413a85e44"
+        }
+      ],
+      "title": "Scourge of Aqshy - Hedonites of Slaanesh"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 4431622,
+        "checksum": "f439283ae602126a27b9c5d259b3b80e6d799f4b48855b74db98c2ff312ab55e",
+        "etag": "\"e40ebbc38ea45099ba3ec493584fa713\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-07_warhammer_age_of_sigmar_scourge_of_aqshy_helsmiths_of_hashut-xera3snt6i-9vfhw0hfjv.pdf",
+        "lastModified": "Fri, 26 Jun 2026 09:12:35 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-07_warhammer_age_of_sigmar_scourge_of_aqshy_helsmiths_of_hashut-xera3snt6i-9vfhw0hfjv.pdf",
+        "retrievedAt": "2026-07-28T03:05:03.399Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:f439283ae602126a27b9c5d259b3b80e6d799f4b48855b74db98c2ff312ab55e%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "d886c210ed9a3cd5fd7457c405a85c474cd47c704c37587a552923af89db957e"
+        },
+        {
+          "id": "source-record:games-workshop:f439283ae602126a27b9c5d259b3b80e6d799f4b48855b74db98c2ff312ab55e%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "887329388e3e5b144b6fb04e1ab803d91f050eead0076083770a9fdff1e239ad"
+        },
+        {
+          "id": "source-record:games-workshop:f439283ae602126a27b9c5d259b3b80e6d799f4b48855b74db98c2ff312ab55e%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "5018441adcdf6b3d487d1dc945250b87eb6fb2012b3409b91a93afb93e5fd410"
+        }
+      ],
+      "title": "Scourge of Aqshy - Helsmiths of Hashut"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2776564,
+        "checksum": "ea699bb515551dbd8d4b9d1cf78d22485b06da3702fb06e84d129ca24075dbf1",
+        "etag": "\"6072e265dee9dcba89ef3afc015552f0\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_idoneth_deepkin-7iuluyz9qk-jrhxjn2wcu.pdf",
+        "lastModified": "Fri, 26 Jun 2026 07:49:55 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_idoneth_deepkin-7iuluyz9qk-jrhxjn2wcu.pdf",
+        "retrievedAt": "2026-07-28T03:05:38.837Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:ea699bb515551dbd8d4b9d1cf78d22485b06da3702fb06e84d129ca24075dbf1%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "2b3c918a4fe838477ba4c9b57724e4071e2cad5514b6bc3ccd949034e63636e7"
+        },
+        {
+          "id": "source-record:games-workshop:ea699bb515551dbd8d4b9d1cf78d22485b06da3702fb06e84d129ca24075dbf1%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "7aafc8a13d4c446172862e7d2cc07a7af7486e5ff4cea520e1cf388c1dc17c0a"
+        }
+      ],
+      "title": "Scourge of Aqshy - Idoneth Deepkin"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2665787,
+        "checksum": "8ac598a6a720c2dd48dfef2db74c97c516cd626bec15fbeb371bc9445a1615e0",
+        "etag": "\"3bae2508aac46814cbd3eeb901b516f1\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_03-07_warhammer_age_of_sigmar_scourge_of_aqshy_ironjawz-vp5rzj6jfr-kced7rkdjr.pdf",
+        "lastModified": "Fri, 26 Jun 2026 10:05:44 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_03-07_warhammer_age_of_sigmar_scourge_of_aqshy_ironjawz-vp5rzj6jfr-kced7rkdjr.pdf",
+        "retrievedAt": "2026-07-28T03:05:16.897Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:8ac598a6a720c2dd48dfef2db74c97c516cd626bec15fbeb371bc9445a1615e0%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "3221035431d99ea4072ab13097866e2e64d3b70d343c16b71f14cf2a44c2f172"
+        },
+        {
+          "id": "source-record:games-workshop:8ac598a6a720c2dd48dfef2db74c97c516cd626bec15fbeb371bc9445a1615e0%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "06c88c1fc9760b0d5b6417efe7ca295809594fa6b397467e54c9d39352b99719"
+        }
+      ],
+      "title": "Scourge of Aqshy - Ironjawz"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2576503,
+        "checksum": "d69b032641325e3ac4866121eed4a04348e97ebdf9318d0f858e5f007166890b",
+        "etag": "\"f237bb12657e966abc2ae32d12d1d4c5\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_kharadron_overlords-vjgmzcuzhh-ybyuy60n6k.pdf",
+        "lastModified": "Fri, 26 Jun 2026 07:59:57 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_kharadron_overlords-vjgmzcuzhh-ybyuy60n6k.pdf",
+        "retrievedAt": "2026-07-28T03:05:40.330Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:d69b032641325e3ac4866121eed4a04348e97ebdf9318d0f858e5f007166890b%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "00a1d4e6990b81e4026df65ec4c7abbcf30ddb59a7b0a024fde72f7036f55c18"
+        },
+        {
+          "id": "source-record:games-workshop:d69b032641325e3ac4866121eed4a04348e97ebdf9318d0f858e5f007166890b%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "e60615d675ab1d1b86034ee0eaf9d25d4ea1fd5a0353bd3ab1d01af830c26e30"
+        }
+      ],
+      "title": "Scourge of Aqshy - Kharadron Overlords"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2596767,
+        "checksum": "1d30a8a162195f9f5d01fc1c604435a266c0b9cbd55435756acbba729f5fa9ab",
+        "etag": "\"c2e85650e73917981cf2ddec65ced582\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_03-07_warhammer_age_of_sigmar_scourge_of_aqshy_kruleboyz-rgjpjlhsnj-4xu8ua7toi.pdf",
+        "lastModified": "Fri, 26 Jun 2026 10:10:35 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_03-07_warhammer_age_of_sigmar_scourge_of_aqshy_kruleboyz-rgjpjlhsnj-4xu8ua7toi.pdf",
+        "retrievedAt": "2026-07-28T03:05:18.354Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:1d30a8a162195f9f5d01fc1c604435a266c0b9cbd55435756acbba729f5fa9ab%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "e7f3863e1e92479ba59e61c795d65a44d042f7a57b810de846b62a70d231f2a5"
+        },
+        {
+          "id": "source-record:games-workshop:1d30a8a162195f9f5d01fc1c604435a266c0b9cbd55435756acbba729f5fa9ab%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "c7c79779351fcec8b41492ac2af933d490f34549d3705032038ee7006dd7264c"
+        }
+      ],
+      "title": "Scourge of Aqshy - Kruleboyz"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2427872,
+        "checksum": "ea732415f11fc3b8d4953d0e710b1124fae5403f5c718e85000e48266e4f870c",
+        "etag": "\"ccbc39c96815be313dd9025221606910\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_lumineth_realmlords-1vnpx6n9ay-rkjxiqzzb4.pdf",
+        "lastModified": "Fri, 26 Jun 2026 08:08:13 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_lumineth_realmlords-1vnpx6n9ay-rkjxiqzzb4.pdf",
+        "retrievedAt": "2026-07-28T03:05:41.859Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:ea732415f11fc3b8d4953d0e710b1124fae5403f5c718e85000e48266e4f870c%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "b858341d221199e9f21dcebeb6167cffa06da75dc992cbd192f2c82ca6e26e2e"
+        },
+        {
+          "id": "source-record:games-workshop:ea732415f11fc3b8d4953d0e710b1124fae5403f5c718e85000e48266e4f870c%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "64f1b6a52d3f9e0e73f88af53c857238059973047b8cf37f9ad41fc772a233aa"
+        }
+      ],
+      "title": "Scourge of Aqshy - Lumineth Realm-lords"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3020001,
+        "checksum": "f292a483f45c5cf431fb2d1f3435ba5df2c722e1db75ff6b03d3ca93059b9b3c",
+        "etag": "\"f7894bd112a7e3838f032920b9c1191c\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-07_warhammer_age_of_sigmar_scourge_of_aqshy_maggotkin_of_nurgle-wxaoylmlh1-juclicweqh.pdf",
+        "lastModified": "Fri, 26 Jun 2026 09:21:24 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-07_warhammer_age_of_sigmar_scourge_of_aqshy_maggotkin_of_nurgle-wxaoylmlh1-juclicweqh.pdf",
+        "retrievedAt": "2026-07-28T03:05:04.892Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:f292a483f45c5cf431fb2d1f3435ba5df2c722e1db75ff6b03d3ca93059b9b3c%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "0c69c2337da9d3578241ee5e67cfa717edde476a7ef8fc077458b2ad18762d9b"
+        },
+        {
+          "id": "source-record:games-workshop:f292a483f45c5cf431fb2d1f3435ba5df2c722e1db75ff6b03d3ca93059b9b3c%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "6ded4cb623e5974ab11a7410bfb67d25ef91a48402fcf4259156750938fa1923"
+        }
+      ],
+      "title": "Scourge of Aqshy - Maggotkin of Nurgle"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2634809,
+        "checksum": "28e13f649ab20a9a26033a4ed66f43efb262568628b493bfd498e3c409625752",
+        "etag": "\"0b48ef3722e23f45f3dccf76d95de98c\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_02-07_warhammer_age_of_sigmar_scourge_of_aqshy_nighthaunt-wvpxdokbdf-wascrg8yr9.pdf",
+        "lastModified": "Fri, 26 Jun 2026 09:42:38 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_02-07_warhammer_age_of_sigmar_scourge_of_aqshy_nighthaunt-wvpxdokbdf-wascrg8yr9.pdf",
+        "retrievedAt": "2026-07-28T03:05:10.791Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:28e13f649ab20a9a26033a4ed66f43efb262568628b493bfd498e3c409625752%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "14ffc0e3c0c16e8f73a5f36fa7c00f7c03fd82a85e34c18e53b6d65593e2f0c3"
+        },
+        {
+          "id": "source-record:games-workshop:28e13f649ab20a9a26033a4ed66f43efb262568628b493bfd498e3c409625752%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "a9a21c2bff2f4bb4c68249fb3929f73a4e4594f5216b428f775288dc728ee44f"
+        }
+      ],
+      "title": "Scourge of Aqshy - Nighthaunt"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 5316530,
+        "checksum": "88112372fc087c2c41a6a194fd93c77e7cbc8dbf54c5f58ded38740a688d421a",
+        "etag": "\"a0b5cc758d4fafb06a8457c7e16946ee\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_03-07_warhammer_age_of_sigmar_scourge_of_aqshy_ogor_mawtribes-fnzpmjxogs-32udmyvbim.pdf",
+        "lastModified": "Fri, 26 Jun 2026 10:15:13 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_03-07_warhammer_age_of_sigmar_scourge_of_aqshy_ogor_mawtribes-fnzpmjxogs-32udmyvbim.pdf",
+        "retrievedAt": "2026-07-28T03:05:20.012Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:88112372fc087c2c41a6a194fd93c77e7cbc8dbf54c5f58ded38740a688d421a%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "bc42424818344a5cae0084ee19918dc491efa901511183d560526dc472a8ad31"
+        },
+        {
+          "id": "source-record:games-workshop:88112372fc087c2c41a6a194fd93c77e7cbc8dbf54c5f58ded38740a688d421a%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "74231b6cd2ad2a6d2490bffa5106fdd8382291b982ebcab52963e9cfd843eaeb"
+        },
+        {
+          "id": "source-record:games-workshop:88112372fc087c2c41a6a194fd93c77e7cbc8dbf54c5f58ded38740a688d421a%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "7cbfb73ca3f6ce4747858a380b62bdbad466f3f23c90795a85e96821be8b0035"
+        }
+      ],
+      "title": "Scourge of Aqshy - Ogor Mawtribes"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2777908,
+        "checksum": "1d84d1cf50b059c428dabf3796bf7eec5449b0bcbea0111f1d702bf78a0c2c58",
+        "etag": "\"4e95eae0a05f68cfdef44b9b9462d9a6\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_02-07_warhammer_age_of_sigmar_scourge_of_aqshy_ossiarch_bonereapers-hbsdxt30lc-h1bs1gkzdy.pdf",
+        "lastModified": "Fri, 26 Jun 2026 09:48:30 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_02-07_warhammer_age_of_sigmar_scourge_of_aqshy_ossiarch_bonereapers-hbsdxt30lc-h1bs1gkzdy.pdf",
+        "retrievedAt": "2026-07-28T03:05:12.285Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:1d84d1cf50b059c428dabf3796bf7eec5449b0bcbea0111f1d702bf78a0c2c58%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "a0d8dca83b2ede6e1c25b96fb6f19df4504e19ecfd876164e2e60ee5b0723217"
+        },
+        {
+          "id": "source-record:games-workshop:1d84d1cf50b059c428dabf3796bf7eec5449b0bcbea0111f1d702bf78a0c2c58%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "34f5f357e8818e7184cad97e0c2ed618620a78c2206ee81a541e5171affd0b24"
+        }
+      ],
+      "title": "Scourge of Aqshy - Ossiarch Bonereapers"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3834842,
+        "checksum": "4c6adcc50312082904bd6c58cdf42705d3f16d33708d7d67b3a752b4ff472610",
+        "etag": "\"9ed21ef91c643917903d68d87fbcc05d\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_seraphon-lwebb0dm73-fd4bdni8wp.pdf",
+        "lastModified": "Fri, 26 Jun 2026 08:14:39 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_seraphon-lwebb0dm73-fd4bdni8wp.pdf",
+        "retrievedAt": "2026-07-28T03:05:43.442Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:4c6adcc50312082904bd6c58cdf42705d3f16d33708d7d67b3a752b4ff472610%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "5eccbec6d0912856fa859cc995fb11a9a2768593940523a69d93225731d7507c"
+        },
+        {
+          "id": "source-record:games-workshop:4c6adcc50312082904bd6c58cdf42705d3f16d33708d7d67b3a752b4ff472610%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "e256beaf0dc59b5765ad0d2c7cfc7f14322cdcba5ebe975cde28fb4dae47dfda"
+        },
+        {
+          "id": "source-record:games-workshop:4c6adcc50312082904bd6c58cdf42705d3f16d33708d7d67b3a752b4ff472610%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "fffad61203303a89d47a7ab92d651a1859bb77078743384e0708d921ce1302e9"
+        }
+      ],
+      "title": "Scourge of Aqshy - Seraphon"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2671912,
+        "checksum": "b0c1c4c58744ab5a40bd8eb6749e34270599ae533578f9d62d7ce4c4ab7efbe1",
+        "etag": "\"a2ba4aa99159be78e969ae186438a7da\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_scourge_of_aqshy_skaven-zemddcttpu-u7hsjiy30z.pdf",
+        "lastModified": "Fri, 24 Jul 2026 13:48:56 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_29-07_warhammer_age_of_sigmar_scourge_of_aqshy_skaven-zemddcttpu-u7hsjiy30z.pdf",
+        "retrievedAt": "2026-07-30T00:53:11.134Z"
+      },
+      "documentKind": "reference",
+      "effectiveDate": "2026-07-29",
+      "publicationDate": "2026-07-29",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:b0c1c4c58744ab5a40bd8eb6749e34270599ae533578f9d62d7ce4c4ab7efbe1%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "a3afa9a7d219751e4555260a4cd0c82320f3d66b051b264f0d553a97b46790d3"
+        }
+      ],
+      "title": "Scourge of Aqshy - Skaven",
+      "version": "July 2026"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2547265,
+        "checksum": "d12f678f97e4f0f6786b61b6de7da2ddb9bde93f3a2db80717e02da62105e2b4",
+        "etag": "\"10d9a3cb963bc33f9cd31011ffffef25\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-07_warhammer_age_of_sigmar_scourge_of_aqshy_slaves_to_darkness-fui91apgno-hhr5jihpgk.pdf",
+        "lastModified": "Fri, 26 Jun 2026 09:29:39 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-07_warhammer_age_of_sigmar_scourge_of_aqshy_slaves_to_darkness-fui91apgno-hhr5jihpgk.pdf",
+        "retrievedAt": "2026-07-28T03:05:07.838Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:d12f678f97e4f0f6786b61b6de7da2ddb9bde93f3a2db80717e02da62105e2b4%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "cce7bb1cd056f805936a15d0ca21e2769df8ec97b600c9e8c9ed27e94d06cc9c"
+        },
+        {
+          "id": "source-record:games-workshop:d12f678f97e4f0f6786b61b6de7da2ddb9bde93f3a2db80717e02da62105e2b4%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "b90afca992350ca93376af0494247cd1e2237244cb2a7b718d81bf218d05af4c"
+        }
+      ],
+      "title": "Scourge of Aqshy - Slaves to Darkness"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 4138859,
+        "checksum": "20b04fa511f9ecb1136613a83fe898416965eef5426f978f466cab53adc87592",
+        "etag": "\"4595477c56647ea2cf53f2f17752c004\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_03-07_warhammer_age_of_sigmar_scourge_of_aqshy_sons_of_behemat-mfhfhbwwi9-1r2mvp24r3.pdf",
+        "lastModified": "Fri, 26 Jun 2026 10:19:52 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_03-07_warhammer_age_of_sigmar_scourge_of_aqshy_sons_of_behemat-mfhfhbwwi9-1r2mvp24r3.pdf",
+        "retrievedAt": "2026-07-28T03:05:21.638Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:20b04fa511f9ecb1136613a83fe898416965eef5426f978f466cab53adc87592%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "ea11748239889a70521359e037b4c8c76cbf222069228518f069ff8a2fd388a9"
+        },
+        {
+          "id": "source-record:games-workshop:20b04fa511f9ecb1136613a83fe898416965eef5426f978f466cab53adc87592%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "728afccaf61bcb1252e8bb19fbad2649159a31394d7ce596ed7f42afde09bf9b"
+        },
+        {
+          "id": "source-record:games-workshop:20b04fa511f9ecb1136613a83fe898416965eef5426f978f466cab53adc87592%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "9228d8c578e97f33162708a7c24b47c60fa6d217133d7823958c8f030351be6d"
+        }
+      ],
+      "title": "Scourge of Aqshy - Sons of Behemat"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 4309931,
+        "checksum": "bffbeb3b887fdbad1a7599e55eb534a7da50736210e69650955fba883ccd2097",
+        "etag": "\"bb8b9349e4167b551c3a418c9c1cf403\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_02-07_warhammer_age_of_sigmar_scourge_of_aqshy_soulblight_gravelords-sdhsy4qj6l-htfbgtpxks.pdf",
+        "lastModified": "Fri, 26 Jun 2026 09:54:16 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_02-07_warhammer_age_of_sigmar_scourge_of_aqshy_soulblight_gravelords-sdhsy4qj6l-htfbgtpxks.pdf",
+        "retrievedAt": "2026-07-28T03:05:13.903Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:bffbeb3b887fdbad1a7599e55eb534a7da50736210e69650955fba883ccd2097%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "cf80e86c20b6f6e8a5e872377319cd11fa6edba91aedd780702a5ebcebd71924"
+        },
+        {
+          "id": "source-record:games-workshop:bffbeb3b887fdbad1a7599e55eb534a7da50736210e69650955fba883ccd2097%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "a41234964d3dd26b7f7e07958004b4c7b06d80bc699fd12995600ccfaefdf8fc"
+        },
+        {
+          "id": "source-record:games-workshop:bffbeb3b887fdbad1a7599e55eb534a7da50736210e69650955fba883ccd2097%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "1782fcb727ef2d1cd120e2da0f380a23b750a8dd92ca4b1c079f8d0e2a622565"
+        }
+      ],
+      "title": "Scourge of Aqshy - Soulblight Gravelords"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 4620896,
+        "checksum": "394d53c667331fe8d4b41055f5b9e595d448bcaca0b7c84907d32befcae154ac",
+        "etag": "\"5b27e851379d1b7c9a537c81fd5cdca9\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_stormcast_eternals-fvjrhzrus1-mml4oehqwo.pdf",
+        "lastModified": "Fri, 26 Jun 2026 08:42:33 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_stormcast_eternals-fvjrhzrus1-mml4oehqwo.pdf",
+        "retrievedAt": "2026-07-28T03:05:45.109Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:394d53c667331fe8d4b41055f5b9e595d448bcaca0b7c84907d32befcae154ac%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "3e96b6b525468a4241b1afb626cf5ad8df752b7115cc271d6ff35880978ddb1c"
+        },
+        {
+          "id": "source-record:games-workshop:394d53c667331fe8d4b41055f5b9e595d448bcaca0b7c84907d32befcae154ac%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "758bcc4a451740d16deb03cecbb5848af9472588c34873a172204ae7d29a627a"
+        },
+        {
+          "id": "source-record:games-workshop:394d53c667331fe8d4b41055f5b9e595d448bcaca0b7c84907d32befcae154ac%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "3e1cc09034f9ea9ff629d2eec7a61ff0b7483d73dbd4b5fcaa6a60902ee84561"
+        }
+      ],
+      "title": "Scourge of Aqshy - Stormcast Eternals"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2586563,
+        "checksum": "90c094676f9cdddd5cd956cf12c72604d01d25beba12d09c2397a466659677e2",
+        "etag": "\"96f12df7533aa0c8c82893b10f7c7336\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_sylvaneth-cpwgaoyfkm-egebdmyunr.pdf",
+        "lastModified": "Fri, 26 Jun 2026 08:48:22 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_scourge_of_aqshy_sylvaneth-cpwgaoyfkm-egebdmyunr.pdf",
+        "retrievedAt": "2026-07-28T03:05:46.603Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:90c094676f9cdddd5cd956cf12c72604d01d25beba12d09c2397a466659677e2%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "501dc5fde2c455631e23da552964fe8ee2d3e0b39dff0cf904b4c8d7647cc0de"
+        },
+        {
+          "id": "source-record:games-workshop:90c094676f9cdddd5cd956cf12c72604d01d25beba12d09c2397a466659677e2%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "671029f05526278792237c25f65fdb0b4b08a1ace9d508e4545ef68bd115e216"
+        }
+      ],
+      "title": "Scourge of Aqshy - Sylvaneth"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2636927,
+        "checksum": "42cc667c51700ab23dc859bfbaf97eb5fab3732f3fdfea3cf88834bdc751baaf",
+        "etag": "\"cbe7599eb55a3726a1ab649cc2e2dac1\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_scourge_of_ghyran_blades_of_khorne-9da0rlwtkd-1bbq27pj3d.pdf",
+        "lastModified": "Tue, 22 Jul 2025 09:09:57 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_scourge_of_ghyran_blades_of_khorne-9da0rlwtkd-1bbq27pj3d.pdf",
+        "retrievedAt": "2026-07-28T19:27:52.492Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:42cc667c51700ab23dc859bfbaf97eb5fab3732f3fdfea3cf88834bdc751baaf%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "b8bfe5c7e9c261099ad1e1a3edb33abdc77216135319f02f72903ff513058c56"
+        },
+        {
+          "id": "source-record:games-workshop:42cc667c51700ab23dc859bfbaf97eb5fab3732f3fdfea3cf88834bdc751baaf%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "4b7eefbc475d9f928dfd8b2385183f996506e882b72d05a1acda400b136c4540"
+        }
+      ],
+      "title": "Scourge of Ghyran - Blades of Khorne"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2498219,
+        "checksum": "05a37c788d639b2c8741716782d1f83fa4cd5ed1de9732f920155cb77b3863b8",
+        "etag": "\"7ddb4f8db9931728e947cfe9abd73893\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_17-12_aos_scourge_of_ghyran_cities_of_sigmar-mjw5yzazkz-qxnfbb87js.pdf",
+        "lastModified": "Mon, 15 Dec 2025 10:15:46 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_17-12_aos_scourge_of_ghyran_cities_of_sigmar-mjw5yzazkz-qxnfbb87js.pdf",
+        "retrievedAt": "2026-07-28T19:27:45.410Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:05a37c788d639b2c8741716782d1f83fa4cd5ed1de9732f920155cb77b3863b8%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "5b213c68f597438bdd3709461e4d632b8af2888cb7582188ee7c26ec1460b2ee"
+        },
+        {
+          "id": "source-record:games-workshop:05a37c788d639b2c8741716782d1f83fa4cd5ed1de9732f920155cb77b3863b8%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "9ddf1075d5e1681788dc864cc1077a1cf1405297f2e3df142c0250d7d77b5795"
+        }
+      ],
+      "title": "Scourge of Ghyran - Cities of Sigmar"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2416387,
+        "checksum": "450f19be74a6a11bde5a74222c62b122b153219841f51718b158cf7a55d59598",
+        "etag": "\"faa6ecf3c989e82d791911289893b140\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_jul25_aos_scourge_of_ghyran_daughters_of_khaine-cxho8dl0nx-zi58yev3zu.pdf",
+        "lastModified": "Tue, 22 Jul 2025 08:25:59 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_jul25_aos_scourge_of_ghyran_daughters_of_khaine-cxho8dl0nx-zi58yev3zu.pdf",
+        "retrievedAt": "2026-07-28T19:27:55.565Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:450f19be74a6a11bde5a74222c62b122b153219841f51718b158cf7a55d59598%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "d82a86bca7b127a7fcdd9eb9f9ab398d83e522b3d941c80668d150a9cae83381"
+        },
+        {
+          "id": "source-record:games-workshop:450f19be74a6a11bde5a74222c62b122b153219841f51718b158cf7a55d59598%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "b2e77c2e2e022cb122ce707a69369f4f98bfc6d16cb4338120317f99995098d7"
+        }
+      ],
+      "title": "Scourge of Ghyran - Daughters of Khaine"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3932589,
+        "checksum": "c47f4f681bbc097d5559576de5925b513d99a4ee4a1e0111150e96e1fd27de53",
+        "etag": "\"ba46eb81a59f9ef6b53c1f78460f1cff\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_18-xvksuvnnwj-flskqsuuz1.pdf",
+        "lastModified": "Mon, 12 May 2025 09:24:31 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_18-xvksuvnnwj-flskqsuuz1.pdf",
+        "retrievedAt": "2026-07-28T19:27:46.868Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:c47f4f681bbc097d5559576de5925b513d99a4ee4a1e0111150e96e1fd27de53%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "309b47e1881cb681310989e8b43ee15cbcb6d1bcfd6c2e29b68c6b6d9f54fa06"
+        },
+        {
+          "id": "source-record:games-workshop:c47f4f681bbc097d5559576de5925b513d99a4ee4a1e0111150e96e1fd27de53%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "bcb989a7e1423ddedc9d8e3f6475a3a758bc4018c7b702150d19fdf3c05bfc6c"
+        }
+      ],
+      "title": "Scourge of Ghyran - Disciples of Tzeentch"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 4574280,
+        "checksum": "6b5d234693e7e822efb548da7cbbe448635133bbcdadab64de9e29c7b60053be",
+        "etag": "\"49d2e33ce12d68465c476081ac44596e\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_17-12_aos_scourge_of_ghyran_flesh_eater_courts-ext4xhdhyx-li7cvwqsj3.pdf",
+        "lastModified": "Mon, 15 Dec 2025 10:19:07 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_17-12_aos_scourge_of_ghyran_flesh_eater_courts-ext4xhdhyx-li7cvwqsj3.pdf",
+        "retrievedAt": "2026-07-28T19:27:45.878Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:6b5d234693e7e822efb548da7cbbe448635133bbcdadab64de9e29c7b60053be%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "fe3d4b75bdc5458adae616448d34de483fbaacecc938a26d0f24fc76a79fdc69"
+        },
+        {
+          "id": "source-record:games-workshop:6b5d234693e7e822efb548da7cbbe448635133bbcdadab64de9e29c7b60053be%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "7535f75888ee001d963a5feb6ce4d17d3d13334c3f46d422e1d4efbc25e1fe6b"
+        }
+      ],
+      "title": "Scourge of Ghyran - Flesheater Courts"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3530741,
+        "checksum": "3d73096eb9a9b0b9bd729796a8a7e596952fcbea1c39e3591c349bcc29f62b2d",
+        "etag": "\"0b11100762bf39378cae0827cf157fc2\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_17-tskydeksez-ucivtfjjyq.pdf",
+        "lastModified": "Mon, 12 May 2025 09:12:42 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_17-tskydeksez-ucivtfjjyq.pdf",
+        "retrievedAt": "2026-07-28T19:27:46.378Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:3d73096eb9a9b0b9bd729796a8a7e596952fcbea1c39e3591c349bcc29f62b2d%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "3d360426ae490933ff29f22b6c6eb4afdd2a09c5b95ec137c39a508d29081b33"
+        },
+        {
+          "id": "source-record:games-workshop:3d73096eb9a9b0b9bd729796a8a7e596952fcbea1c39e3591c349bcc29f62b2d%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "7cce9a5c89e88c2aad55b0501b213027eea548f9e5fc7ec9edc7557894157da8"
+        }
+      ],
+      "title": "Scourge of Ghyran - Fyreslayers"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2883868,
+        "checksum": "147f22e0ea8f319948e5e3e79683c395965115a663728d14b31dbd52e93cd1c4",
+        "etag": "\"96fdd27a67b38c00e7f2c8fbb3ec15ae\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_25-02_aos_scourge_of_ghyran_gloomspite_gitz-xypay4sjwk-htmhuc6lwh.pdf",
+        "lastModified": "Tue, 17 Feb 2026 14:36:26 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_25-02_aos_scourge_of_ghyran_gloomspite_gitz-xypay4sjwk-htmhuc6lwh.pdf",
+        "retrievedAt": "2026-07-28T19:27:50.328Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:147f22e0ea8f319948e5e3e79683c395965115a663728d14b31dbd52e93cd1c4%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "df4cc149a3ac0bfcdb400cde6ca13a23bdc8d62b6c994ec77d260bc04d4a4f33"
+        },
+        {
+          "id": "source-record:games-workshop:147f22e0ea8f319948e5e3e79683c395965115a663728d14b31dbd52e93cd1c4%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "c19a60dcc8a82c23f93beaacba79e9c65fb4ae9af65f72ed085f030ff9357f4d"
+        }
+      ],
+      "title": "Scourge of Ghyran - Gloomspite Gitz"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2540785,
+        "checksum": "991c13020351b83aa76071a049ccb3847f7fd0503daba9a934b1d824ac0fed99",
+        "etag": "\"41bec7194054a51dbef8ba5a7812cd07\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_scourge_of_ghyran_hedonites_of_slaanesh-j2idintorf-w5cn1viauw.pdf",
+        "lastModified": "Tue, 22 Jul 2025 09:22:33 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_scourge_of_ghyran_hedonites_of_slaanesh-j2idintorf-w5cn1viauw.pdf",
+        "retrievedAt": "2026-07-28T19:27:53.053Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:991c13020351b83aa76071a049ccb3847f7fd0503daba9a934b1d824ac0fed99%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "ef69695d7e7c690d02881c1e64dd6c7aa8d2e75674fa1b2a2db8fb38599088bb"
+        },
+        {
+          "id": "source-record:games-workshop:991c13020351b83aa76071a049ccb3847f7fd0503daba9a934b1d824ac0fed99%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "23c768a68cb210e8ed2d578f7d235333200560219f2c7a4ecac138f620f739bc"
+        }
+      ],
+      "title": "Scourge of Ghyran - Hedonites of Slaanesh"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2517919,
+        "checksum": "2f471d48eba1bf405ae0a6bf8fee4fd6e8d987275d008e4fc88ed949702e665c",
+        "etag": "\"301010f0667c12456de391322fefdf95\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_2-12_aos_scourge_of_ghyran_helsmiths-msvi0macd3-vp7lsxjgt3.pdf",
+        "lastModified": "Mon, 01 Dec 2025 11:09:31 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_2-12_aos_scourge_of_ghyran_helsmiths-msvi0macd3-vp7lsxjgt3.pdf",
+        "retrievedAt": "2026-07-28T19:27:47.852Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:2f471d48eba1bf405ae0a6bf8fee4fd6e8d987275d008e4fc88ed949702e665c%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "e922803df2aae3b2b7d5f62e89e986529904620184b67b3448632be6c923f206"
+        },
+        {
+          "id": "source-record:games-workshop:2f471d48eba1bf405ae0a6bf8fee4fd6e8d987275d008e4fc88ed949702e665c%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "7d47b545d6d207cad5a0b1c9cf908e143e54536d9a08117103675f90659ab91a"
+        }
+      ],
+      "title": "Scourge of Ghyran - Helsmiths of Hashut"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2526186,
+        "checksum": "2f71586b5e3109cae58ee35474e5fb9f412613d35b879749addae42c06589a28",
+        "etag": "\"69f0b40c0941073f4d4165418863ff8d\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_19-nitx5fw10d-tevfzutq5l.pdf",
+        "lastModified": "Mon, 12 May 2025 13:52:21 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_19-nitx5fw10d-tevfzutq5l.pdf",
+        "retrievedAt": "2026-07-28T19:27:47.385Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:2f71586b5e3109cae58ee35474e5fb9f412613d35b879749addae42c06589a28%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "2f8e594bee66e701fd1607ec7b0f7a69e37ed95bc0cc26c76480123dbaeacce6"
+        },
+        {
+          "id": "source-record:games-workshop:2f71586b5e3109cae58ee35474e5fb9f412613d35b879749addae42c06589a28%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "b8ab45298a983635a48a9d51b17af4f2b5e960f260f0cea39caf6df817903bae"
+        }
+      ],
+      "title": "Scourge of Ghyran - Idoneth Deepkin"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3037269,
+        "checksum": "4eb7a492d79e69f423e07d3bfb2ce6ff4a9cdb937d4bd67591e9724dfbf4298b",
+        "etag": "\"5957aa6b5e238f76b9b98f220e5e5ad3\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_16-rjqbawyqhq-emloprl3ci.pdf",
+        "lastModified": "Mon, 12 May 2025 08:46:20 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_16-rjqbawyqhq-emloprl3ci.pdf",
+        "retrievedAt": "2026-07-28T19:27:44.959Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:4eb7a492d79e69f423e07d3bfb2ce6ff4a9cdb937d4bd67591e9724dfbf4298b%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "2627f99ec7a3d1c4fa48fd07d22901f7745eb314222c6d37b4c324ba7984c5c6"
+        },
+        {
+          "id": "source-record:games-workshop:4eb7a492d79e69f423e07d3bfb2ce6ff4a9cdb937d4bd67591e9724dfbf4298b%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "d213ec7d7f0d43465cd1ed35375a7677b465531e7b084daa70accb3f19343849"
+        }
+      ],
+      "title": "Scourge of Ghyran - Ironjawz"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2837965,
+        "checksum": "abe36b9c290611c0011ff781462ffe8a38eea8bae7b146fe40afe7df9d6f53e0",
+        "etag": "\"caf2e0a85745941e40a54f314a0db1a7\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_sept25_aos_scourge_of_ghyran_kharadron_overlords-9lt9hjshqj-3bb3nejf9s.pdf",
+        "lastModified": "Tue, 23 Sep 2025 08:51:13 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_sept25_aos_scourge_of_ghyran_kharadron_overlords-9lt9hjshqj-3bb3nejf9s.pdf",
+        "retrievedAt": "2026-07-28T19:27:57.560Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:abe36b9c290611c0011ff781462ffe8a38eea8bae7b146fe40afe7df9d6f53e0%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "c94a66b124f798d8424f4fad8e183146e682ce283e392d7b4ef60430546e3bc2"
+        },
+        {
+          "id": "source-record:games-workshop:abe36b9c290611c0011ff781462ffe8a38eea8bae7b146fe40afe7df9d6f53e0%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "c6f92180b3b1666d6b936f9856dbe493dc22de31442c22810bdb100c19f06237"
+        }
+      ],
+      "title": "Scourge of Ghyran - Kharadron Overlords"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3058869,
+        "checksum": "95b8b992f4f2af8d6714b5006e39e9993999152fbd1f38bd0a7f23bf69035317",
+        "etag": "\"8812cae7ee2c76246f085424d9a33305\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_scourge_of_ghyran_kruleboyz-5fus06ozcb-01dazapx7r.pdf",
+        "lastModified": "Tue, 22 Jul 2025 09:19:02 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_scourge_of_ghyran_kruleboyz-5fus06ozcb-01dazapx7r.pdf",
+        "retrievedAt": "2026-07-28T19:27:53.521Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:95b8b992f4f2af8d6714b5006e39e9993999152fbd1f38bd0a7f23bf69035317%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "101affde66c84ac4355c6c3feb2d684cf4decaed482dc194b397614d1a8b9823"
+        },
+        {
+          "id": "source-record:games-workshop:95b8b992f4f2af8d6714b5006e39e9993999152fbd1f38bd0a7f23bf69035317%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "43395f62b8223df6fdff67ebe3041cc029639b40b31e65bb108ec7934016c1e8"
+        }
+      ],
+      "title": "Scourge of Ghyran - Kruleboyz"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2567731,
+        "checksum": "fc6f7cea3bea9bac3d88796cf7348b8fc0a4d850c9de904f403b9d20fdd69ac7",
+        "etag": "\"39deeb09c65d34c3ae3f9ad924d37df8\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_scourge_of_ghyran_lumineth_realmlords-gsudsctyvq-i9sqd4f8ao.pdf",
+        "lastModified": "Tue, 22 Jul 2025 09:13:44 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_scourge_of_ghyran_lumineth_realmlords-gsudsctyvq-i9sqd4f8ao.pdf",
+        "retrievedAt": "2026-07-28T19:27:53.962Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:fc6f7cea3bea9bac3d88796cf7348b8fc0a4d850c9de904f403b9d20fdd69ac7%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "7ece21423c5b74c3099576380e41d86b99a9d4e3c09ed62c32c5dcfb111acdec"
+        },
+        {
+          "id": "source-record:games-workshop:fc6f7cea3bea9bac3d88796cf7348b8fc0a4d850c9de904f403b9d20fdd69ac7%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "3335449cb3338422666d179b65492c654a2d5dc6fd6dfa57bf1ba93b57c0c1ee"
+        }
+      ],
+      "title": "Scourge of Ghyran - Lumineth Realm-lords"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2948308,
+        "checksum": "b88302276b755f75d06a9d5ba5405035b512118c9ed99461cda3faf9bb2ac3a3",
+        "etag": "\"4d79ccdf873361bc593152da713afe09\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_scourge_of_ghyran_maggotkin_of_nurgle-d04dyajgfq-blza4yfj1k.pdf",
+        "lastModified": "Tue, 22 Jul 2025 09:26:17 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_scourge_of_ghyran_maggotkin_of_nurgle-d04dyajgfq-blza4yfj1k.pdf",
+        "retrievedAt": "2026-07-28T19:27:54.549Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:b88302276b755f75d06a9d5ba5405035b512118c9ed99461cda3faf9bb2ac3a3%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "07ba9d6f98d0f9923f24446a894e26fafff4296d414e6ccbf4b05d3046240341"
+        },
+        {
+          "id": "source-record:games-workshop:b88302276b755f75d06a9d5ba5405035b512118c9ed99461cda3faf9bb2ac3a3%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "d3622d4fb5b5c2eb8d4f2d7ee6783e446f22f53427f9f9f78ad4ed97f5b50029"
+        }
+      ],
+      "title": "Scourge of Ghyran - Maggotkin of Nurgle"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2412158,
+        "checksum": "be7941c0aca09a8b789b978b818fb53e001f5be47a470bfc4c40f6ed9e58875a",
+        "etag": "\"0ddf78592213ce460303a9b98cd12c1b\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_26-11_aos_scourge_of_ghyran_nighthaunt-2cuomcjp5f-sirlqdel6q.pdf",
+        "lastModified": "Mon, 24 Nov 2025 11:04:23 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_26-11_aos_scourge_of_ghyran_nighthaunt-2cuomcjp5f-sirlqdel6q.pdf",
+        "retrievedAt": "2026-07-28T19:27:50.860Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:be7941c0aca09a8b789b978b818fb53e001f5be47a470bfc4c40f6ed9e58875a%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "d09d7d52d499b25ff2026938509840664a36b2bee94706e80f26e0eac7b334df"
+        },
+        {
+          "id": "source-record:games-workshop:be7941c0aca09a8b789b978b818fb53e001f5be47a470bfc4c40f6ed9e58875a%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "4d16a2df7eb99c12ea25c34a87e549072d5f4b359f9aa2466758b7d04505e8c0"
+        }
+      ],
+      "title": "Scourge of Ghyran - Nighthaunt"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2457557,
+        "checksum": "68341e4a8a700022f8ec8a90ffd8f0e756b37b021ae3920977329d29f986c069",
+        "etag": "\"a59b9ac756c9a13b251a42a82a6e28e4\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_scourge_of_ghyran_ogor_mawtribes-ertlkjf5uz-6nqzrig13q.pdf",
+        "lastModified": "Tue, 22 Jul 2025 09:31:02 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_scourge_of_ghyran_ogor_mawtribes-ertlkjf5uz-6nqzrig13q.pdf",
+        "retrievedAt": "2026-07-28T19:27:55.016Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:68341e4a8a700022f8ec8a90ffd8f0e756b37b021ae3920977329d29f986c069%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "58768be9e5db8f88f08ed80968081fcf38e80cd8463252c3f82c387d49bc3bcd"
+        },
+        {
+          "id": "source-record:games-workshop:68341e4a8a700022f8ec8a90ffd8f0e756b37b021ae3920977329d29f986c069%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "11abd3098ef13f27d02c79487b41b89f010c24c045195e54379ee292efd622c3"
+        }
+      ],
+      "title": "Scourge of Ghyran - Ogor Mawtribes"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2881435,
+        "checksum": "fba644a9007a96e5c919c6c4f44404267e882870ed6caf2fe8ff619f01613224",
+        "etag": "\"1a246e2b8d319e542a3d445eed2ccb6d\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_29-04_aos_scourge_of_ghyran_ossiarch_bonereapers-b2i9msmbyv-a3sfhxcid3.pdf",
+        "lastModified": "Mon, 27 Apr 2026 09:59:48 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_29-04_aos_scourge_of_ghyran_ossiarch_bonereapers-b2i9msmbyv-a3sfhxcid3.pdf",
+        "retrievedAt": "2026-07-28T19:27:51.352Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:fba644a9007a96e5c919c6c4f44404267e882870ed6caf2fe8ff619f01613224%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "65e87489ed6f8dcdedb80e2d64f78f99b8ff6aaa9633b6e967b9dd75f76199fa"
+        },
+        {
+          "id": "source-record:games-workshop:fba644a9007a96e5c919c6c4f44404267e882870ed6caf2fe8ff619f01613224%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "862d7cc2f4ad5dbc795f608ad1753ad9ae17d5325ee43e6063c140093d6164f0"
+        }
+      ],
+      "title": "Scourge of Ghyran - Ossiarch Bonereapers"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 6964796,
+        "checksum": "482bf19382d887439dedd137d12480e6fbc58bbbfc4c32f2166414884de1db87",
+        "etag": "\"a789c3c1317afd6f2aa7033a068a4f7b\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_jul25_aos_scourge_of_ghyran_seraphon-znols9ag0w-0uc2pse3au.pdf",
+        "lastModified": "Tue, 22 Jul 2025 09:02:51 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_jul25_aos_scourge_of_ghyran_seraphon-znols9ag0w-0uc2pse3au.pdf",
+        "retrievedAt": "2026-07-28T19:27:56.129Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:482bf19382d887439dedd137d12480e6fbc58bbbfc4c32f2166414884de1db87%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "274fabaf65d32c123a49dd55d0538db0726c33ab12099938bafa463cb08ff066"
+        },
+        {
+          "id": "source-record:games-workshop:482bf19382d887439dedd137d12480e6fbc58bbbfc4c32f2166414884de1db87%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "35bc787f9e555c52b78b1ec6844b51dd7cb58c395f0f02360faea76c5b4c098f"
+        }
+      ],
+      "title": "Scourge of Ghyran - Seraphon"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2575825,
+        "checksum": "a5c12f4e25fb00153d881a9bd8c8d40c963b7df219cedd4b04fad15bbe95746e",
+        "etag": "\"0deabb871e7c754642aa11ced1c35b91\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_jul25_aos_scourge_of_ghyran_skaven-o2p2zexyhs-q7xa9ryzpg.pdf",
+        "lastModified": "Tue, 22 Jul 2025 08:34:16 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_jul25_aos_scourge_of_ghyran_skaven-o2p2zexyhs-q7xa9ryzpg.pdf",
+        "retrievedAt": "2026-07-28T19:27:56.623Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:a5c12f4e25fb00153d881a9bd8c8d40c963b7df219cedd4b04fad15bbe95746e%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "3fcdd2112ec96c8a87fecb83db2c1de66ce68aec24425b4af8a808e9bdab8e37"
+        },
+        {
+          "id": "source-record:games-workshop:a5c12f4e25fb00153d881a9bd8c8d40c963b7df219cedd4b04fad15bbe95746e%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "17c18e8f81aa70059e6f76dbb2c4fe055b1fdf67ff24a8dcd9008d0a0e0515fc"
+        }
+      ],
+      "title": "Scourge of Ghyran - Skaven"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2931342,
+        "checksum": "4a2a0862eab918613d3aa8722094f5d54f93a757e41fb93af928873ad48ce7e2",
+        "etag": "\"fa2233e222acba0f1244f3d12b8136b9\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_23-yfkz9bvbug-4c6zrximmg.pdf",
+        "lastModified": "Thu, 15 May 2025 07:32:34 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_23-yfkz9bvbug-4c6zrximmg.pdf",
+        "retrievedAt": "2026-07-28T19:27:48.811Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:4a2a0862eab918613d3aa8722094f5d54f93a757e41fb93af928873ad48ce7e2%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "5b04ad293d4fa4fda92d6e94d90ef06011bd18f4d3e9809f18f6b14b4401404d"
+        },
+        {
+          "id": "source-record:games-workshop:4a2a0862eab918613d3aa8722094f5d54f93a757e41fb93af928873ad48ce7e2%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "7a3e327690324df85702d21201ebc29779091b14afcbefb3ea93bd4bce0027a7"
+        }
+      ],
+      "title": "Scourge of Ghyran - Slaves to Darkness"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3205651,
+        "checksum": "db30e7a4f25e6e1fbf1e0e187c6c59a358f00475733db1da9f84daa51bdd0a1d",
+        "etag": "\"f5d16fbf6afddd6932596acef7ad3162\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_20-i549znmfzg-c9i1aq7c4q.pdf",
+        "lastModified": "Thu, 15 May 2025 07:16:36 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_20-i549znmfzg-c9i1aq7c4q.pdf",
+        "retrievedAt": "2026-07-28T19:27:48.328Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:db30e7a4f25e6e1fbf1e0e187c6c59a358f00475733db1da9f84daa51bdd0a1d%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "a4798d20e3197fe86d63a982027b7e8c80a887c83e736712410643f99257fa67"
+        },
+        {
+          "id": "source-record:games-workshop:db30e7a4f25e6e1fbf1e0e187c6c59a358f00475733db1da9f84daa51bdd0a1d%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "fc98f388722f1b783d289c779346e569dcc7d17d5e0aa88bb9ede5e3e83af9d3"
+        }
+      ],
+      "title": "Scourge of Ghyran - Sons of Behemat"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2366432,
+        "checksum": "2159557463e20ac33614afdbebdf697ce13158d7610cf7a9ee8e74ce42f9e859",
+        "etag": "\"9a31358ef3e079b796c04cf1f32dee98\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_24-09_aos_scourge_of_ghyran_soulblight_gravelords-7qdtzfg9ac-4sjxodyk5b.pdf",
+        "lastModified": "Tue, 23 Sep 2025 10:34:26 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_24-09_aos_scourge_of_ghyran_soulblight_gravelords-7qdtzfg9ac-4sjxodyk5b.pdf",
+        "retrievedAt": "2026-07-28T19:27:49.314Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:2159557463e20ac33614afdbebdf697ce13158d7610cf7a9ee8e74ce42f9e859%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "6d8f11672d9c8fdd5b045277a6add0bce24bf3f0e3d105f6a40a983fa8874431"
+        },
+        {
+          "id": "source-record:games-workshop:2159557463e20ac33614afdbebdf697ce13158d7610cf7a9ee8e74ce42f9e859%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "fdf157780c4b4331017c10dc75a002c2398a21994212bca51d0ec3b0aeb4c724"
+        }
+      ],
+      "title": "Scourge of Ghyran - Soulblight Gravelords"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 4074551,
+        "checksum": "970f1eb4ea669798efec6743862a3a9dd9f9e160ae6bd7343b03644bd855e569",
+        "etag": "\"e8f1ce5707bd25871f36b6521ad22d3e\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_07-8zq4ka3qga-luzqgfyu6x.pdf",
+        "lastModified": "Mon, 05 May 2025 08:48:30 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_07-8zq4ka3qga-luzqgfyu6x.pdf",
+        "retrievedAt": "2026-07-28T19:27:43.929Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:970f1eb4ea669798efec6743862a3a9dd9f9e160ae6bd7343b03644bd855e569%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "2785b71c3407c00979d4cf5872d04d2f2391675f49eb8b3dad33f86caf2c775c"
+        },
+        {
+          "id": "source-record:games-workshop:970f1eb4ea669798efec6743862a3a9dd9f9e160ae6bd7343b03644bd855e569%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "118a5fdb582a9ffea26f335fa426ff39317ee8241a07e1a5851fadd9e419f47e"
+        }
+      ],
+      "title": "Scourge of Ghyran - Stormcast Eternals"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2604098,
+        "checksum": "364cd67380a60b661c16846cc47a180d9311a820c6f7a6050f41cc7bdf704de7",
+        "etag": "\"a21e3ba2e15f56e03abe48a2f0f27c87\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_29-04_aos_scourge_of_ghyran_sylvaneth-ghwkpsrc2f-ccxtamjcyd.pdf",
+        "lastModified": "Mon, 27 Apr 2026 09:53:49 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_29-04_aos_scourge_of_ghyran_sylvaneth-ghwkpsrc2f-ccxtamjcyd.pdf",
+        "retrievedAt": "2026-07-28T19:27:51.945Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:364cd67380a60b661c16846cc47a180d9311a820c6f7a6050f41cc7bdf704de7%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "1080d59d2ab5507f7643a88eb64fbb0fa663e4f1d7d2f10b4f900da44f2384c3"
+        },
+        {
+          "id": "source-record:games-workshop:364cd67380a60b661c16846cc47a180d9311a820c6f7a6050f41cc7bdf704de7%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "72a4a225e55999cdf0a0697eb24dc1c085869e41fe8f85e36f71fbf9ba3fdbfc"
+        }
+      ],
+      "title": "Scourge of Ghyran - Sylvaneth"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2806022,
+        "checksum": "3cb8aa7eccf66093163e8a8e098965ff0b44828ee01e9bcc3dc7cb2ce58c3041",
+        "etag": "\"e92d19b3274f2672f4a371824a1fc366\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_17-12_aos_otherrule_seraphon_sunblood_pack_warscroll-uir9vw325p-9wfuqbkexw.pdf",
+        "lastModified": "Mon, 15 Dec 2025 10:10:05 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_17-12_aos_otherrule_seraphon_sunblood_pack_warscroll-uir9vw325p-9wfuqbkexw.pdf",
+        "retrievedAt": "2026-07-28T17:49:49.180Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:3cb8aa7eccf66093163e8a8e098965ff0b44828ee01e9bcc3dc7cb2ce58c3041%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "3891052b7468575a9eca283e7adbe910320996a0d98230755b9e86f0c3f0d85b"
+        }
+      ],
+      "title": "Seraphon - Sunblood Pack Warscroll"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 11003127,
+        "checksum": "84dbeb45fa14de8538d54e690f49fcb75868e716193e1aec5985403450e8b186",
+        "etag": "\"8c3431c51d0c5ca5231c92e36075cf16\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_14-12_aos_spearhead_doubles-0mbddn5ccu-8rp55iunvh.pdf",
+        "lastModified": "Tue, 09 Dec 2025 15:04:29 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_14-12_aos_spearhead_doubles-0mbddn5ccu-8rp55iunvh.pdf",
+        "retrievedAt": "2026-07-28T17:49:49.470Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:84dbeb45fa14de8538d54e690f49fcb75868e716193e1aec5985403450e8b186%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "7d368fa422f7cd17cc54b238c7cbbab9bf7672191d117929a574a337ad596f99"
+        },
+        {
+          "id": "source-record:games-workshop:84dbeb45fa14de8538d54e690f49fcb75868e716193e1aec5985403450e8b186%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "8198e10474f95fa4ac6744e94f06a199bd7283bf54f6df9d8082e465108866a8"
+        },
+        {
+          "id": "source-record:games-workshop:84dbeb45fa14de8538d54e690f49fcb75868e716193e1aec5985403450e8b186%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "b6b79cfc96af23ce2c790fdeba607ae4ec72f3b3c550bc92d76137064e52fdcb"
+        },
+        {
+          "id": "source-record:games-workshop:84dbeb45fa14de8538d54e690f49fcb75868e716193e1aec5985403450e8b186%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "18b137d7091b1553eff9f56d34a928864d1a21977bbfd767a1a357a7ad11b8bf"
+        }
+      ],
+      "title": "Spearhead Doubles"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 9143626,
+        "checksum": "4637427e906238a5c5ac38e52f7b7f8b3d6f646d2af2c85717eb8aaf16c95fd0",
+        "etag": "\"9732475e873d84b67286626aa01ebc6b-2\"",
+        "finalUrl": "https://assets.warhammer-community.com/ageofsigmar_corerules&keydownloads_spearheadreferece_eng_24.09-jrpbcnzwuu.pdf",
+        "lastModified": "Wed, 25 Sep 2024 15:38:13 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/ageofsigmar_corerules&keydownloads_spearheadreferece_eng_24.09-jrpbcnzwuu.pdf",
+        "retrievedAt": "2026-07-28T17:49:49.835Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:4637427e906238a5c5ac38e52f7b7f8b3d6f646d2af2c85717eb8aaf16c95fd0%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "ea7093640abfa98b5f852500c39be0009cc5e9769c2e8354c206d86f10891b9f"
+        },
+        {
+          "id": "source-record:games-workshop:4637427e906238a5c5ac38e52f7b7f8b3d6f646d2af2c85717eb8aaf16c95fd0%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "0ed0fb18c3f3f186e60b34c47d164f7c1c94eec2589a5ae4c8b106edd4b99f69"
+        }
+      ],
+      "title": "Spearhead Reference"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 4051753,
+        "checksum": "6a2afe7edb780a60833a2d20575b63494e1fd57a798ade293d5037266c5b290f",
+        "etag": "\"e25f871f58be70349c7ea251d05b618c\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_08-08_aos_other_rules_spearhead_rules_module_desolation_of_the_mortal_realms-ttpg1obflk-vw3epzd1yc.pdf",
+        "lastModified": "Fri, 08 Aug 2025 10:37:22 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_08-08_aos_other_rules_spearhead_rules_module_desolation_of_the_mortal_realms-ttpg1obflk-vw3epzd1yc.pdf",
+        "retrievedAt": "2026-07-28T17:49:50.062Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:6a2afe7edb780a60833a2d20575b63494e1fd57a798ade293d5037266c5b290f%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "cf30cfe9423f30be5de18f7137e95c9eb61dc124b3e73d9f75945006732d83cb"
+        }
+      ],
+      "title": "Spearhead Rules Module: Desolation of the Mortal Realms"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 10531975,
+        "checksum": "1cb0c7efde39ae35c19fb9d82083f7625ab14e5c5be5ecb329cd3db7fc3609af",
+        "etag": "\"fa9d4c14ba90ee9dbc5dd090da39ad71\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_blades_of_khorne_fangs_of_the_blood_god-ka6n0z20jt-aeqz1vbnku.pdf",
+        "lastModified": "Mon, 30 Mar 2026 10:46:41 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_blades_of_khorne_fangs_of_the_blood_god-ka6n0z20jt-aeqz1vbnku.pdf",
+        "retrievedAt": "2026-07-28T17:49:50.336Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:1cb0c7efde39ae35c19fb9d82083f7625ab14e5c5be5ecb329cd3db7fc3609af%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "5d880906dbdcefbc90274042a3c5c9d43b13aad58ab4f5f6faf5dc638b3deb6f"
+        },
+        {
+          "id": "source-record:games-workshop:1cb0c7efde39ae35c19fb9d82083f7625ab14e5c5be5ecb329cd3db7fc3609af%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "13278a2581edada502e4ded5f294f044d547c4d8a6a9218351de8463cb220dfb"
+        },
+        {
+          "id": "source-record:games-workshop:1cb0c7efde39ae35c19fb9d82083f7625ab14e5c5be5ecb329cd3db7fc3609af%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "0f116881b0414d40e8aef19207987ed34be5e1841258d41bc77a9068a1f676e7"
+        },
+        {
+          "id": "source-record:games-workshop:1cb0c7efde39ae35c19fb9d82083f7625ab14e5c5be5ecb329cd3db7fc3609af%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "77dbf404bfb5a99aa7b83476432b1dac9b5defdc8d0eea220fdec2e2e6e2c01c"
+        }
+      ],
+      "title": "Spearhead: Blades of Khorne - Fangs of the Blood God"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 23191812,
+        "checksum": "72f95be84d13b0b65b9e9529e61cc18525755eafb4f39ed925cceb7618711545",
+        "etag": "\"2e090b02e760dd0d20ea8dea0d2dfe1c\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_blades_of_khorne_bloodbound_gore_pilgrims-r1xwzo5jaf-hkweqb74wl.pdf",
+        "lastModified": "Mon, 30 Mar 2026 10:51:51 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_blades_of_khorne_bloodbound_gore_pilgrims-r1xwzo5jaf-hkweqb74wl.pdf",
+        "retrievedAt": "2026-07-28T17:49:50.946Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:72f95be84d13b0b65b9e9529e61cc18525755eafb4f39ed925cceb7618711545%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "40cc6832980f8619b3faaf38186bd0160bd1620e7795d879530cdbf7b12725f8"
+        },
+        {
+          "id": "source-record:games-workshop:72f95be84d13b0b65b9e9529e61cc18525755eafb4f39ed925cceb7618711545%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "f921d2b6888bdae151176cfb8d431b6133ea7adc7e7863dc1aa9e128cd7408d5"
+        },
+        {
+          "id": "source-record:games-workshop:72f95be84d13b0b65b9e9529e61cc18525755eafb4f39ed925cceb7618711545%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "83859e76efa6a912fb03f70df7beafb9ce156931fa9b10d274d6bbbae4984410"
+        },
+        {
+          "id": "source-record:games-workshop:72f95be84d13b0b65b9e9529e61cc18525755eafb4f39ed925cceb7618711545%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "a2b6c76382f0392ac46bb1675da2e00c1355375541fdacb39301a21bd1c3aecc"
+        },
+        {
+          "id": "source-record:games-workshop:72f95be84d13b0b65b9e9529e61cc18525755eafb4f39ed925cceb7618711545%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "a2b6c76382f0392ac46bb1675da2e00c1355375541fdacb39301a21bd1c3aecc"
+        },
+        {
+          "id": "source-record:games-workshop:72f95be84d13b0b65b9e9529e61cc18525755eafb4f39ed925cceb7618711545%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "fb8d0cec52527366e76f03408eae795399697a197f51f518ec0c7b293150d3b2"
+        },
+        {
+          "id": "source-record:games-workshop:72f95be84d13b0b65b9e9529e61cc18525755eafb4f39ed925cceb7618711545%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "8807868f3e9dbdde0b3e2c37011d92030b7cbbcce7235f7036dfb6fc58257a19"
+        }
+      ],
+      "title": "Spearhead: Blades of Khorne - Gore Pilgrims"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 12055228,
+        "checksum": "aa33f06b5fbbf848db3ab65a7bc0d7dc9144288d7ecd6c867c432a328ab8d884",
+        "etag": "\"f0f9dbaa273aeeced719c41f57f7c7bf\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_cities_of_sigmar_castelite_company-nthmiu00z3-olrqpo2lat.pdf",
+        "lastModified": "Mon, 30 Mar 2026 11:12:45 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_cities_of_sigmar_castelite_company-nthmiu00z3-olrqpo2lat.pdf",
+        "retrievedAt": "2026-07-28T17:49:51.449Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:aa33f06b5fbbf848db3ab65a7bc0d7dc9144288d7ecd6c867c432a328ab8d884%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "c4b62d686c4b9d05807b3327ae04d74db5ff61fbf5220a28c081a6107fe546ef"
+        },
+        {
+          "id": "source-record:games-workshop:aa33f06b5fbbf848db3ab65a7bc0d7dc9144288d7ecd6c867c432a328ab8d884%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "d09ac76afdd9d82cfcd65284165f077f179eaa159dcb15617b738094978d00af"
+        },
+        {
+          "id": "source-record:games-workshop:aa33f06b5fbbf848db3ab65a7bc0d7dc9144288d7ecd6c867c432a328ab8d884%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "9d1c6794c2d9fa2d1c810dc6205ac1174274794a922dd5bd5b2830e701cacec1"
+        },
+        {
+          "id": "source-record:games-workshop:aa33f06b5fbbf848db3ab65a7bc0d7dc9144288d7ecd6c867c432a328ab8d884%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "92ed98a221d5d138362d3059b5480eb87a2aadc3e1c826626a2225f321b2ee3b"
+        },
+        {
+          "id": "source-record:games-workshop:aa33f06b5fbbf848db3ab65a7bc0d7dc9144288d7ecd6c867c432a328ab8d884%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "b064e99e0132a97d460243583ef941bb983ab20bbd7c0da655df2fac94af3562"
+        },
+        {
+          "id": "source-record:games-workshop:aa33f06b5fbbf848db3ab65a7bc0d7dc9144288d7ecd6c867c432a328ab8d884%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "7dce82d784a06ca39adc5f129b3567fb4e141ae6946dcbb7588e28668ebb82a1"
+        },
+        {
+          "id": "source-record:games-workshop:aa33f06b5fbbf848db3ab65a7bc0d7dc9144288d7ecd6c867c432a328ab8d884%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "6f5642c6fae478677e5c32c1abc24c04eaadbb4888184adf154cff625340b09b"
+        }
+      ],
+      "title": "Spearhead: Cities of Sigmar - Castelite Company"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 20966117,
+        "checksum": "58233b4000f567a5231474822a5ec0124c57a04c1d1d2544418d1e5575ca76db",
+        "etag": "\"50a8a641b8cc1930eeded7c31ce5d7b9\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_cities_of_sigmar_fusil_platoon-ps3dhpiflc-3fboq1inns.pdf",
+        "lastModified": "Tue, 31 Mar 2026 07:37:40 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_cities_of_sigmar_fusil_platoon-ps3dhpiflc-3fboq1inns.pdf",
+        "retrievedAt": "2026-07-28T17:49:52.029Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:58233b4000f567a5231474822a5ec0124c57a04c1d1d2544418d1e5575ca76db%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "132ac33d95fa3a61571996af4e125b62692314878cf5cb87d405a77f694ae716"
+        },
+        {
+          "id": "source-record:games-workshop:58233b4000f567a5231474822a5ec0124c57a04c1d1d2544418d1e5575ca76db%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "a3b47c03d1d7f2542a69bf954efb4bfe84e93e57e0cc3e8689eeb350dff54123"
+        },
+        {
+          "id": "source-record:games-workshop:58233b4000f567a5231474822a5ec0124c57a04c1d1d2544418d1e5575ca76db%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "021be45fd772360e4cdd3cf16ed3908d8310d3cd4d405c525b7e825465c88786"
+        },
+        {
+          "id": "source-record:games-workshop:58233b4000f567a5231474822a5ec0124c57a04c1d1d2544418d1e5575ca76db%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "f98e3bd8c9893cc5429a294e14f1904774c490f4536050ed3b86aecb0859a614"
+        }
+      ],
+      "title": "Spearhead: Cities of Sigmar - Fusil Platoon"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3003954,
+        "checksum": "57dd24b01270ab5fa01b1860db2f30c229016c5e1c4b3e27076ef3e3920942c6",
+        "etag": "\"4bcc39640eae3713d0b3f88ff55babca\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_13-05_aos_spearhead_cities_of_sigmar_zenestra-s_zealots-jiv98kvc9n-nhjktzu4pc.pdf",
+        "lastModified": "Mon, 11 May 2026 13:48:51 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_13-05_aos_spearhead_cities_of_sigmar_zenestra-s_zealots-jiv98kvc9n-nhjktzu4pc.pdf",
+        "retrievedAt": "2026-07-28T17:49:52.304Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:57dd24b01270ab5fa01b1860db2f30c229016c5e1c4b3e27076ef3e3920942c6%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "fa5a36b667d9c237ccc945101b6d7d55ce6c23b8c2e8405437a78f37cc943178"
+        },
+        {
+          "id": "source-record:games-workshop:57dd24b01270ab5fa01b1860db2f30c229016c5e1c4b3e27076ef3e3920942c6%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "81051545bbc93068c365678d9e1cf9224229200be8cd46cbe464cae4571d4c1c"
+        },
+        {
+          "id": "source-record:games-workshop:57dd24b01270ab5fa01b1860db2f30c229016c5e1c4b3e27076ef3e3920942c6%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "660439e70eab9ca5de7a9d9c3342efaf041fbf93a2c7e07894a809a5d0d3ae84"
+        },
+        {
+          "id": "source-record:games-workshop:57dd24b01270ab5fa01b1860db2f30c229016c5e1c4b3e27076ef3e3920942c6%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "0e3cfc24fae1af5d15846852fa8361eddcd9c932f7bd93799d848708467e55e9"
+        }
+      ],
+      "title": "Spearhead: Cities of Sigmar - Zenestra's Zealots"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 10043744,
+        "checksum": "0883493fe1ce0f29066070905a5021f4b7e91caf55be1cad64d714bc99a723d1",
+        "etag": "\"0e2893ba399e2d2ac2c8ec9bca4ad3b7\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_15-04_aos_spearhead_city_of_ash_gaming_pack-0mp6ikgdep-heefiiargp.pdf",
+        "lastModified": "Mon, 13 Apr 2026 09:48:53 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_15-04_aos_spearhead_city_of_ash_gaming_pack-0mp6ikgdep-heefiiargp.pdf",
+        "retrievedAt": "2026-07-28T17:49:52.630Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:0883493fe1ce0f29066070905a5021f4b7e91caf55be1cad64d714bc99a723d1%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "cf4c34728d11dfc5a83c701095f0088f9ac1f16869f44c2f8f5c91a08f86439a"
+        },
+        {
+          "id": "source-record:games-workshop:0883493fe1ce0f29066070905a5021f4b7e91caf55be1cad64d714bc99a723d1%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "5481c8e23eecc9c8cb6c0b705479d8534c124af08c9f6d531b597b8349971cb0"
+        },
+        {
+          "id": "source-record:games-workshop:0883493fe1ce0f29066070905a5021f4b7e91caf55be1cad64d714bc99a723d1%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "538028f64c9d05ad517c9bdd2e747e98ce3a09848e6a460b62d32e5e4c5395a1"
+        },
+        {
+          "id": "source-record:games-workshop:0883493fe1ce0f29066070905a5021f4b7e91caf55be1cad64d714bc99a723d1%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "5bbe1ca77435dfc2cdf960403cb1fb560935e4d6d5439006d56fa7c68d79c5cb"
+        },
+        {
+          "id": "source-record:games-workshop:0883493fe1ce0f29066070905a5021f4b7e91caf55be1cad64d714bc99a723d1%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "579c96fc11c8f1fcef6319d5e114e97c5a029fcfcb204c98b7cc6d4ff57e4f28"
+        },
+        {
+          "id": "source-record:games-workshop:0883493fe1ce0f29066070905a5021f4b7e91caf55be1cad64d714bc99a723d1%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "4441d1628680931ac019d3356a753c8c0c0df48a900b9c657a7913ba3794fc11"
+        },
+        {
+          "id": "source-record:games-workshop:0883493fe1ce0f29066070905a5021f4b7e91caf55be1cad64d714bc99a723d1%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "0af2527e310bee0d6fd13390498270c80cb16711d0a4b34e9fcf71e9b6e34f02"
+        },
+        {
+          "id": "source-record:games-workshop:0883493fe1ce0f29066070905a5021f4b7e91caf55be1cad64d714bc99a723d1%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "515e744a89829d362563cdab35022191b5ba0b2d45765a949c4733d3c8250465"
+        }
+      ],
+      "title": "Spearhead: City of Ash"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 27737403,
+        "checksum": "7153de6330d3827f8c86c491f62250470e964feef93145b0fd1cd113e20825be",
+        "etag": "\"74d3090d0763f2c1ced21abb2327989f\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_daughters_of_khaine_heartflayer_troupe-f0gnypscvv-4htucb5fsr.pdf",
+        "lastModified": "Mon, 30 Mar 2026 13:05:46 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_daughters_of_khaine_heartflayer_troupe-f0gnypscvv-4htucb5fsr.pdf",
+        "retrievedAt": "2026-07-28T17:49:53.360Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:7153de6330d3827f8c86c491f62250470e964feef93145b0fd1cd113e20825be%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "b70e4624725861786a97c59c1add17622431ef0229f1615f1c9dc5181556ab7c"
+        },
+        {
+          "id": "source-record:games-workshop:7153de6330d3827f8c86c491f62250470e964feef93145b0fd1cd113e20825be%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "634805bbf5874ce8c7fd89b040b42052b773a770f2d0060159b16bd0458e7a6c"
+        },
+        {
+          "id": "source-record:games-workshop:7153de6330d3827f8c86c491f62250470e964feef93145b0fd1cd113e20825be%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "634805bbf5874ce8c7fd89b040b42052b773a770f2d0060159b16bd0458e7a6c"
+        },
+        {
+          "id": "source-record:games-workshop:7153de6330d3827f8c86c491f62250470e964feef93145b0fd1cd113e20825be%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "3c1fc4f24b7b00f0a52ff9e20beb21ea05f2f2769780e8c8cae0b8e9a164d7e8"
+        },
+        {
+          "id": "source-record:games-workshop:7153de6330d3827f8c86c491f62250470e964feef93145b0fd1cd113e20825be%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "149b174fe16084bdb83baf08e7e89e679e71284d0f4eac907aaee7e035265505"
+        },
+        {
+          "id": "source-record:games-workshop:7153de6330d3827f8c86c491f62250470e964feef93145b0fd1cd113e20825be%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "27eaa68b543f8aea33e2e8d4b65b68d05cc4b13fa00c0bb519f4ccd9860c9ebd"
+        },
+        {
+          "id": "source-record:games-workshop:7153de6330d3827f8c86c491f62250470e964feef93145b0fd1cd113e20825be%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "7cfcb7e6adc2d59732858f2ea216351c3e225a2bd14d906cb0a2a4dcc3bbb29f"
+        }
+      ],
+      "title": "Spearhead: Daughters of Khaine - Heartflayer Troupe"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 4874479,
+        "checksum": "1e341ef2e67d10c46cf51d3c3138bc48621407b0850d9b65f10192b2499d52ef",
+        "etag": "\"2ac190321ebc5677ab4351647fd3de76\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_25-03_aos_spearhead_daughters_of_khaine_khainite_shadow_coven-kcxewlylck-jc3xxv1v2v.pdf",
+        "lastModified": "Thu, 19 Mar 2026 09:59:47 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_25-03_aos_spearhead_daughters_of_khaine_khainite_shadow_coven-kcxewlylck-jc3xxv1v2v.pdf",
+        "retrievedAt": "2026-07-28T17:49:53.710Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:1e341ef2e67d10c46cf51d3c3138bc48621407b0850d9b65f10192b2499d52ef%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "3ae8099df71ad48e757ead5b6b96639fce1e48a3b29dafced4e0b0f90f83e34b"
+        },
+        {
+          "id": "source-record:games-workshop:1e341ef2e67d10c46cf51d3c3138bc48621407b0850d9b65f10192b2499d52ef%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "3e6d8a9383e1573ab40eaae25dc61f15aba3836ea81d0d08cb60725c20232a9e"
+        },
+        {
+          "id": "source-record:games-workshop:1e341ef2e67d10c46cf51d3c3138bc48621407b0850d9b65f10192b2499d52ef%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "f9bcb26633bbf3b2e3cae8b95face8f92558fba8adbb21b11155ac33d4622372"
+        },
+        {
+          "id": "source-record:games-workshop:1e341ef2e67d10c46cf51d3c3138bc48621407b0850d9b65f10192b2499d52ef%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "39fb43e13c03e54b5d094c8dc784288d6165f36012a5da26a442694beef96467"
+        }
+      ],
+      "title": "Spearhead: Daughters of Khaine - Khainite Shadow Coven"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 20810006,
+        "checksum": "6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c",
+        "etag": "\"2b1ac19b88688b808fd9005f15839ef1\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_disciples_of_tzeentch_fluxblade_coven-maph6dtofo-iasdohuesc.pdf",
+        "lastModified": "Mon, 30 Mar 2026 13:37:35 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_disciples_of_tzeentch_fluxblade_coven-maph6dtofo-iasdohuesc.pdf",
+        "retrievedAt": "2026-07-28T17:49:54.188Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "26d6762c143bf9b0d4ce8e94e47cddb936c14279a45854fbe2dd6f46d995bc5e"
+        },
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "1a2d6f3792eccac20869229910563dfa5bb6e1569bab5b2817e755e0fab20472"
+        },
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "26d6762c143bf9b0d4ce8e94e47cddb936c14279a45854fbe2dd6f46d995bc5e"
+        },
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "463fe358d0701227165ed5394e18332dd319b17cef2883f3f0b3fc27511973bb"
+        },
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "c3c0c6b149036ddea8f434225edcdbe55a369e6e6b4153bda120605eb83b9b89"
+        },
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "6d22fd00759aad2d0a70c456680ee0ce87ec1c9cb5ff1c2d2052df22923e58c8"
+        },
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "bb20bf6859e3456be2c3cc931948d0e0524a089cd09315ba61e6ecca9e6e0be9"
+        },
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "0a2b402d3712af6706ea9af67a008539fed239170535d368696000814edee7c8"
+        },
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "f1bb0a204c48ec871fa18eb2f3a66ff2fabf9444aba458f1a5b22064076d4141"
+        },
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "8fbe64c6b9a9ba037d2a60494bcf7414f349aa9e77a582417b6188f458dd1e15"
+        },
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "af8889a9fc8131d83c0b0943dd3e5d4979eeaf182c0a3d10bee026eadc92c8ed"
+        },
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "80addf9f82ffbf78b25de9b9a1bfea1ac8e889a2923952e522cac3bd0cf380ef"
+        },
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "988f3963fc6d3a61b9609d3d49cd8efefdda703a8fff137108bd878b2b3e15a1"
+        },
+        {
+          "id": "source-record:games-workshop:6b70e56d2cb0afa7febfc26f4290147a6b39b35263c12a9b09069885a6aa455c%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "8fbe64c6b9a9ba037d2a60494bcf7414f349aa9e77a582417b6188f458dd1e15"
+        }
+      ],
+      "title": "Spearhead: Disciples of Tzeentch - Fluxblade Coven"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2507209,
+        "checksum": "d6c38781ac6f38b48adc0add92977c6326720e67301e2bad4a472a2d0a1c275e",
+        "etag": "\"cc5fda48fff94a5358b221bb2883cda7\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_04-02_aos_spearhead_disciples_of_tzeentch-4mldohmkit-qcunidsq7c.pdf",
+        "lastModified": "Mon, 02 Feb 2026 11:16:00 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_04-02_aos_spearhead_disciples_of_tzeentch-4mldohmkit-qcunidsq7c.pdf",
+        "retrievedAt": "2026-07-28T17:49:54.645Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:d6c38781ac6f38b48adc0add92977c6326720e67301e2bad4a472a2d0a1c275e%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "491a17f6a762e6184e3eff6a21048dfa85496f1db20605a25d99af574476b503"
+        },
+        {
+          "id": "source-record:games-workshop:d6c38781ac6f38b48adc0add92977c6326720e67301e2bad4a472a2d0a1c275e%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "7639e293b33bba1b3e867feaf82120670cec0c178fd9f7895ca37af8db35aa1d"
+        },
+        {
+          "id": "source-record:games-workshop:d6c38781ac6f38b48adc0add92977c6326720e67301e2bad4a472a2d0a1c275e%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "7ce0f016cfda108162c72acd32d89b917ee01485375db99a1538cbd5ce1e318c"
+        },
+        {
+          "id": "source-record:games-workshop:d6c38781ac6f38b48adc0add92977c6326720e67301e2bad4a472a2d0a1c275e%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "03c1b5c60f6fbd2169ee5d388e66fb1324600baa41a6f2779949145749aac114"
+        }
+      ],
+      "title": "Spearhead: Disciples of Tzeentch - Tzaangor Warflocks"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2821088,
+        "checksum": "3bb9117c7e4d1c4c7f5b9f5d2d95ee8e84fa2d0e4dda596728ab640fc296ed1d",
+        "etag": "\"0ecfbf088dec5e20a30db55e343388c8\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_12-11_aos_spearhead_flesh_eater_courts_carrion_retainers-p8mhioxip3-ugpcbnaxvq.pdf",
+        "lastModified": "Mon, 10 Nov 2025 14:10:21 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_12-11_aos_spearhead_flesh_eater_courts_carrion_retainers-p8mhioxip3-ugpcbnaxvq.pdf",
+        "retrievedAt": "2026-07-28T17:49:54.823Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:3bb9117c7e4d1c4c7f5b9f5d2d95ee8e84fa2d0e4dda596728ab640fc296ed1d%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "874c71d0b5a087c0ad03788f250be70a11589df7cd554e2ba486f4aa3c38a8a0"
+        },
+        {
+          "id": "source-record:games-workshop:3bb9117c7e4d1c4c7f5b9f5d2d95ee8e84fa2d0e4dda596728ab640fc296ed1d%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "93983b6234a4052b5ceb1641e30fc6f663f72467384f7557841f1b18bf4ac781"
+        },
+        {
+          "id": "source-record:games-workshop:3bb9117c7e4d1c4c7f5b9f5d2d95ee8e84fa2d0e4dda596728ab640fc296ed1d%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "874c71d0b5a087c0ad03788f250be70a11589df7cd554e2ba486f4aa3c38a8a0"
+        },
+        {
+          "id": "source-record:games-workshop:3bb9117c7e4d1c4c7f5b9f5d2d95ee8e84fa2d0e4dda596728ab640fc296ed1d%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "93983b6234a4052b5ceb1641e30fc6f663f72467384f7557841f1b18bf4ac781"
+        },
+        {
+          "id": "source-record:games-workshop:3bb9117c7e4d1c4c7f5b9f5d2d95ee8e84fa2d0e4dda596728ab640fc296ed1d%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "d60946eebe1aa1d5fb47db047835441fb62b119c98ff1f1223dae626843086bb"
+        },
+        {
+          "id": "source-record:games-workshop:3bb9117c7e4d1c4c7f5b9f5d2d95ee8e84fa2d0e4dda596728ab640fc296ed1d%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "761c15af0fb89c4882e0293f11cb4e9ba5f655f70bc6384642fdcfe84bfdd57a"
+        },
+        {
+          "id": "source-record:games-workshop:3bb9117c7e4d1c4c7f5b9f5d2d95ee8e84fa2d0e4dda596728ab640fc296ed1d%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "af05ab7b246cf5e93b0744b2e260159e9aa8eb5d6e70b992e1548a9206e02f5d"
+        },
+        {
+          "id": "source-record:games-workshop:3bb9117c7e4d1c4c7f5b9f5d2d95ee8e84fa2d0e4dda596728ab640fc296ed1d%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "8fadbc7a7cc84d7919a7d295ccdd0eaa92d6b8e5a2482d2b669680a0886fff73"
+        }
+      ],
+      "title": "Spearhead: Flesh Eater-Courts - Carrion Retainers"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 6307171,
+        "checksum": "78e67dedc50816c4fbc1b8a3f317e75f9aa7f4e84b81e2ad7a59651b371ce804",
+        "etag": "\"452f2297b1c8a6b6810c4579c75ecf03\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aug25_aos_spearhead_rules_fec-2e0llsv3kw-gnsahcoz34.pdf",
+        "lastModified": "Tue, 26 Aug 2025 07:01:25 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aug25_aos_spearhead_rules_fec-2e0llsv3kw-gnsahcoz34.pdf",
+        "retrievedAt": "2026-07-28T17:49:55.129Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:78e67dedc50816c4fbc1b8a3f317e75f9aa7f4e84b81e2ad7a59651b371ce804%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "0552204b063b8244c4cc6da87f72ab929ee66a800ee3e349a0c8c08765a24d6c"
+        },
+        {
+          "id": "source-record:games-workshop:78e67dedc50816c4fbc1b8a3f317e75f9aa7f4e84b81e2ad7a59651b371ce804%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "21b56e09c6d2558fdf08d514c7bc28823231a1063a6fbf77af57c18a0bd4c6a6"
+        },
+        {
+          "id": "source-record:games-workshop:78e67dedc50816c4fbc1b8a3f317e75f9aa7f4e84b81e2ad7a59651b371ce804%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "ea9e0cdad0e1e47abb32df277427f7a29b8b4c33cd0ac32d361064057f2ee537"
+        },
+        {
+          "id": "source-record:games-workshop:78e67dedc50816c4fbc1b8a3f317e75f9aa7f4e84b81e2ad7a59651b371ce804%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "3594fd1dc8f746e3b36b311bec65c2a2f9370605a1c02c85f52c9139244b14ae"
+        }
+      ],
+      "title": "Spearhead: Flesh-eater Courts - Charnel Watch"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 20295762,
+        "checksum": "32312388e377ced6c4389fe9837e38d8033a205b5a09d04233fd3a316c719650",
+        "etag": "\"1c0dab5b3ae93265bb2d834990643f45\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_fyreslayers_saga_axeband-9bngjzbzg0-d3q2qoqm5r.pdf",
+        "lastModified": "Tue, 14 Apr 2026 09:21:32 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_fyreslayers_saga_axeband-9bngjzbzg0-d3q2qoqm5r.pdf",
+        "retrievedAt": "2026-07-28T17:49:55.615Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:32312388e377ced6c4389fe9837e38d8033a205b5a09d04233fd3a316c719650%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "f6cf9faa82a5cc1ac497ce32026a839bbe80a5d98ca2975ae31f2a433e79c92f"
+        },
+        {
+          "id": "source-record:games-workshop:32312388e377ced6c4389fe9837e38d8033a205b5a09d04233fd3a316c719650%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "62e4d80f152a389e3aee8b4bbbc672ae24772910b4312bb5e123defc2c929959"
+        },
+        {
+          "id": "source-record:games-workshop:32312388e377ced6c4389fe9837e38d8033a205b5a09d04233fd3a316c719650%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "9d143c3e19d7f24b6e54ddb4b124227d53dc1782c58c86a98788472143d35497"
+        },
+        {
+          "id": "source-record:games-workshop:32312388e377ced6c4389fe9837e38d8033a205b5a09d04233fd3a316c719650%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "4a26a61f4b409ca76fa16bd95629017ed1893cb250134c0e94013c056a143604"
+        }
+      ],
+      "title": "Spearhead: Fyreslayers - Saga Axeband"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 15730753,
+        "checksum": "e8bf035b01b53db3b69ca7334b622cdb2a260210ea03384801e29efb32735cea",
+        "etag": "\"eed6fff8892735026ec19567efba31e7\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_gloomspite_gitz_bad_moon_madmob-x8uml0kiyo-xpyifmywuh.pdf",
+        "lastModified": "Mon, 30 Mar 2026 14:38:01 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_gloomspite_gitz_bad_moon_madmob-x8uml0kiyo-xpyifmywuh.pdf",
+        "retrievedAt": "2026-07-28T17:49:56.094Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:e8bf035b01b53db3b69ca7334b622cdb2a260210ea03384801e29efb32735cea%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "df33b1ef5e9420a91b803a6c0c528fc412837a0093dfdfaeadd382e57cf71efc"
+        },
+        {
+          "id": "source-record:games-workshop:e8bf035b01b53db3b69ca7334b622cdb2a260210ea03384801e29efb32735cea%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "899ec8d3a9d35e25e6b734861bed9749edb01577503c44bcc1d8d5584c9547f4"
+        },
+        {
+          "id": "source-record:games-workshop:e8bf035b01b53db3b69ca7334b622cdb2a260210ea03384801e29efb32735cea%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "6bcdf1a28b5300ef6fda96bed6b28081b5837981e99bbb64b66d05978486f305"
+        },
+        {
+          "id": "source-record:games-workshop:e8bf035b01b53db3b69ca7334b622cdb2a260210ea03384801e29efb32735cea%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "4e5d383af2ad6ef26e732f532c320e2a0caacdc23e446e2c0cc0f46298b3e000"
+        },
+        {
+          "id": "source-record:games-workshop:e8bf035b01b53db3b69ca7334b622cdb2a260210ea03384801e29efb32735cea%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "8c716151b0b66be8a9f1ad7e236711fd488752dd4203973d9b25a3d1ec2fbbd1"
+        },
+        {
+          "id": "source-record:games-workshop:e8bf035b01b53db3b69ca7334b622cdb2a260210ea03384801e29efb32735cea%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "8c716151b0b66be8a9f1ad7e236711fd488752dd4203973d9b25a3d1ec2fbbd1"
+        },
+        {
+          "id": "source-record:games-workshop:e8bf035b01b53db3b69ca7334b622cdb2a260210ea03384801e29efb32735cea%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "735df587ecc7d037dca2223c37448e605e16ecfd539a64ae9f4ac1129b1f7026"
+        },
+        {
+          "id": "source-record:games-workshop:e8bf035b01b53db3b69ca7334b622cdb2a260210ea03384801e29efb32735cea%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "715fa0f4060efb502d7cfdc9ec08b791d00e23e714e4cb0848d00f482991b4eb"
+        }
+      ],
+      "title": "Spearhead: Gloomspite Gitz - Bad Moon Madmob"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 12888800,
+        "checksum": "84b8b1b4f82ee92372a7214989b418b128608edd571d2985e6cf8ea65ad9b845",
+        "etag": "\"69bfa2fac0d2eddc571b0d84e6c3f647\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_gloomspite_gitz_snarlpack_hunters-dk3amzdenf-1dhez0axxu.pdf",
+        "lastModified": "Mon, 30 Mar 2026 14:30:08 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_gloomspite_gitz_snarlpack_hunters-dk3amzdenf-1dhez0axxu.pdf",
+        "retrievedAt": "2026-07-28T17:49:56.686Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:84b8b1b4f82ee92372a7214989b418b128608edd571d2985e6cf8ea65ad9b845%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "c81d8df7f963ccebaff2dfdc606963f2b5696de61978935ac19a992a53de04cf"
+        },
+        {
+          "id": "source-record:games-workshop:84b8b1b4f82ee92372a7214989b418b128608edd571d2985e6cf8ea65ad9b845%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "aa5c7e2179cd269c48818966822114136d3df28c3f48c24c28f15ab122cc5362"
+        },
+        {
+          "id": "source-record:games-workshop:84b8b1b4f82ee92372a7214989b418b128608edd571d2985e6cf8ea65ad9b845%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "58266ab57bbeac3c648da46ada12c297521aff83b47eb07238e3ef64b7fd5985"
+        },
+        {
+          "id": "source-record:games-workshop:84b8b1b4f82ee92372a7214989b418b128608edd571d2985e6cf8ea65ad9b845%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "37a9406fa46d57e3ebf44fc084203488919416e38c3fe1489b17ebb94e634f2e"
+        }
+      ],
+      "title": "Spearhead: Gloomspite Gitz - Snarlpack Huntaz"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 21108322,
+        "checksum": "607775cab94d2176d4a96c8d30de367fbcecea62cdbe50862dbd129e8a7a83f9",
+        "etag": "\"a036d6b7125c20ef49c08dd90d5ad010\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_29-06_aos_spearhead_hedonites_of_slaanesh_blades_of_the_lurid_dream-pz0rmwhqem-kdikh1iuy5.pdf",
+        "lastModified": "Thu, 25 Jun 2026 10:03:44 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_29-06_aos_spearhead_hedonites_of_slaanesh_blades_of_the_lurid_dream-pz0rmwhqem-kdikh1iuy5.pdf",
+        "retrievedAt": "2026-07-28T17:49:57.208Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:607775cab94d2176d4a96c8d30de367fbcecea62cdbe50862dbd129e8a7a83f9%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "f889367fd1f0f3b5c2e481fd5cea613b7ed179a58e34009b77fec6522cc25d44"
+        },
+        {
+          "id": "source-record:games-workshop:607775cab94d2176d4a96c8d30de367fbcecea62cdbe50862dbd129e8a7a83f9%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "3890232dc083e0378be69cdb28dd61192824ec784e349f21efe99807dce86dc4"
+        },
+        {
+          "id": "source-record:games-workshop:607775cab94d2176d4a96c8d30de367fbcecea62cdbe50862dbd129e8a7a83f9%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "022c85d4f168507c5a94f4748575d2a607ce2d83d3d3725ccd15834ccd1fb776"
+        },
+        {
+          "id": "source-record:games-workshop:607775cab94d2176d4a96c8d30de367fbcecea62cdbe50862dbd129e8a7a83f9%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "3b6b9f7cd4ef2adc94793ebfd3e25ccd65788e8f3abdd7d84cb6574f3630443a"
+        }
+      ],
+      "title": "Spearhead: Hedonites of Slaanesh - Blades of The Lurid Dream"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 25378065,
+        "checksum": "38acbc1a70d0b5b993666fa24011a3e9491ca9c14f9735fddaa56adae15b04be",
+        "etag": "\"6c66ed8683d25b3a011b4f0e09467e0c\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_17-06_aos_spearhead_hedonites_of_slaanesh_epicurean_revellers-h8enq2lijh-3uxfyepywh.pdf",
+        "lastModified": "Mon, 15 Jun 2026 07:51:45 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_17-06_aos_spearhead_hedonites_of_slaanesh_epicurean_revellers-h8enq2lijh-3uxfyepywh.pdf",
+        "retrievedAt": "2026-07-28T17:49:57.822Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:38acbc1a70d0b5b993666fa24011a3e9491ca9c14f9735fddaa56adae15b04be%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "8fa1af7673637c119f413632d064d5420dd5c8d4d92a79746670a88a223abcfb"
+        },
+        {
+          "id": "source-record:games-workshop:38acbc1a70d0b5b993666fa24011a3e9491ca9c14f9735fddaa56adae15b04be%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "a7f06e1bdb8624dbaedb720a8f515796606283044bac8f7a15c21031417c9414"
+        },
+        {
+          "id": "source-record:games-workshop:38acbc1a70d0b5b993666fa24011a3e9491ca9c14f9735fddaa56adae15b04be%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "16f327b729996efcc1127944c1720573f4ff827e2d4e30990b5e828deda42764"
+        },
+        {
+          "id": "source-record:games-workshop:38acbc1a70d0b5b993666fa24011a3e9491ca9c14f9735fddaa56adae15b04be%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "3c3b87fd736bcb8f438bc75a0fa082a6ffe2949b12a7d272661ce30ba8aa426b"
+        }
+      ],
+      "title": "Spearhead: Hedonites of Slaanesh - Epicurean Revellers"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 12973820,
+        "checksum": "22fa2463399f831fa11e8bb83b1df1210a9d1382d2d5441ab0bd1035292eb711",
+        "etag": "\"a94ff0ed3c941e3602fd56bdf209650e\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_helsmiths_of_hashut_helforge_host-f9jrp14new-ugnb0veptj.pdf",
+        "lastModified": "Tue, 31 Mar 2026 07:40:59 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_helsmiths_of_hashut_helforge_host-f9jrp14new-ugnb0veptj.pdf",
+        "retrievedAt": "2026-07-28T17:49:58.364Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:22fa2463399f831fa11e8bb83b1df1210a9d1382d2d5441ab0bd1035292eb711%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "e4cb65189ee5b5cf56d0a1281c096a31093e76647c81b530b6b28b6c22b4a853"
+        },
+        {
+          "id": "source-record:games-workshop:22fa2463399f831fa11e8bb83b1df1210a9d1382d2d5441ab0bd1035292eb711%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "dfbdc478e39d3474068e8aad760e6f9ff95066b16f5627a307497e38099b0252"
+        },
+        {
+          "id": "source-record:games-workshop:22fa2463399f831fa11e8bb83b1df1210a9d1382d2d5441ab0bd1035292eb711%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "da694ddfc32f5e055c8398f93680cc38758a6d9e7a59060f29952a2835e87e86"
+        },
+        {
+          "id": "source-record:games-workshop:22fa2463399f831fa11e8bb83b1df1210a9d1382d2d5441ab0bd1035292eb711%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "fa351a248cc6d10788017ef6805b33394b91deb6d63eaf4eca45a1117b9b61fb"
+        }
+      ],
+      "title": "Spearhead: Helsmiths of Hashut - Helforge Host"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 10418630,
+        "checksum": "7275407dbcd7945ab74fde6e1735282b842cfb67ed205b2b11187b8e3c3d1444",
+        "etag": "\"094dffa0552f746f370de8cb0f9edb8f\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos4_idoneth_deepkin_spearhead_rules-wa1tiv6csl-bndmddnja9.pdf",
+        "lastModified": "Tue, 15 Jul 2025 11:59:56 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos4_idoneth_deepkin_spearhead_rules-wa1tiv6csl-bndmddnja9.pdf",
+        "retrievedAt": "2026-07-28T17:49:58.811Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:7275407dbcd7945ab74fde6e1735282b842cfb67ed205b2b11187b8e3c3d1444%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "123b0a2c9400627eccea7993ac87df42048b48e17ca26db9607347575439e6f6"
+        },
+        {
+          "id": "source-record:games-workshop:7275407dbcd7945ab74fde6e1735282b842cfb67ed205b2b11187b8e3c3d1444%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "cf2ed23be9306095a5705aaf74dd440f4185f08adeb6e62ae91265f96b61d158"
+        },
+        {
+          "id": "source-record:games-workshop:7275407dbcd7945ab74fde6e1735282b842cfb67ed205b2b11187b8e3c3d1444%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "087901dd1b4e96b3c85955fafd2157b66335c212a02357b2be8624d8f6add555"
+        },
+        {
+          "id": "source-record:games-workshop:7275407dbcd7945ab74fde6e1735282b842cfb67ed205b2b11187b8e3c3d1444%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "2bece85f8c12eeac844551210948939b49f0de079f9b60f004e478114dffd83a"
+        }
+      ],
+      "title": "Spearhead: Idoneth Deepkin - Akhelian Tide Guard"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 16735093,
+        "checksum": "809b80ad5db07f193a33312132e2caae0dae8dc47ff604fc3519edfedeafe015",
+        "etag": "\"8aa8a3301b8cbd4440b6e92f5e0e1ca3\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_idoneth_deepkin_soulraid_hunt-ymkq3pu04e-aymk0cvmbn.pdf",
+        "lastModified": "Tue, 31 Mar 2026 07:46:28 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_idoneth_deepkin_soulraid_hunt-ymkq3pu04e-aymk0cvmbn.pdf",
+        "retrievedAt": "2026-07-28T17:49:59.281Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:809b80ad5db07f193a33312132e2caae0dae8dc47ff604fc3519edfedeafe015%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "36c1d95f54d3459d47ee90e1ffc318db7dc08347715f86848a48248dfb419a19"
+        },
+        {
+          "id": "source-record:games-workshop:809b80ad5db07f193a33312132e2caae0dae8dc47ff604fc3519edfedeafe015%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "cfce6d91e65a2fd32c4ed3443c32ad9a817fe56a390404489f276210de366654"
+        },
+        {
+          "id": "source-record:games-workshop:809b80ad5db07f193a33312132e2caae0dae8dc47ff604fc3519edfedeafe015%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "f6620fdd7550f2a3ea86554942a7105d04914f6a3e1147698096749c86902305"
+        },
+        {
+          "id": "source-record:games-workshop:809b80ad5db07f193a33312132e2caae0dae8dc47ff604fc3519edfedeafe015%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "3ec00a1f2984b94376c7024f640255edd4213d2a966fa3736324c8bda7f7a4d2"
+        },
+        {
+          "id": "source-record:games-workshop:809b80ad5db07f193a33312132e2caae0dae8dc47ff604fc3519edfedeafe015%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "c19d4cf061dafff598878ba89798c8db05a331966278e2f59b1a40e066555abe"
+        },
+        {
+          "id": "source-record:games-workshop:809b80ad5db07f193a33312132e2caae0dae8dc47ff604fc3519edfedeafe015%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "61cb19379ac11c2c66e4f0dc34ad50104199b9a821e0d193e715bd406bf3db83"
+        },
+        {
+          "id": "source-record:games-workshop:809b80ad5db07f193a33312132e2caae0dae8dc47ff604fc3519edfedeafe015%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "6dabc91e42640326c42f6a5574be49831616f3703679d25f0680147e1ba3a463"
+        }
+      ],
+      "title": "Spearhead: Idoneth Deepkin - Soulraid Hunt"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 12065749,
+        "checksum": "9b053b0fabb3f8fb59c4e208c109a6b806622735e7c24e9a8566e46c4ad53142",
+        "etag": "\"e354ac9c0a18e58f8c45f5fa05ee4a02\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_kharadron_overlords_grundstok_trailblazers-sthwiusou1-9tilsswcap.pdf",
+        "lastModified": "Tue, 31 Mar 2026 07:55:34 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_kharadron_overlords_grundstok_trailblazers-sthwiusou1-9tilsswcap.pdf",
+        "retrievedAt": "2026-07-28T17:49:59.741Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:9b053b0fabb3f8fb59c4e208c109a6b806622735e7c24e9a8566e46c4ad53142%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "1decf32bd45fe665d1d3858952fc0092707c1a6ff96cf4f0177f8a173b8e9299"
+        },
+        {
+          "id": "source-record:games-workshop:9b053b0fabb3f8fb59c4e208c109a6b806622735e7c24e9a8566e46c4ad53142%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "824cc7f30fe91c09dd203688a83f532ff93a383a84f5f0c635d70953eb2c740e"
+        },
+        {
+          "id": "source-record:games-workshop:9b053b0fabb3f8fb59c4e208c109a6b806622735e7c24e9a8566e46c4ad53142%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "ab9facc1601fa2ae7a8d0eeafc330ca00d8a12027535950b215769e2c92f6c84"
+        },
+        {
+          "id": "source-record:games-workshop:9b053b0fabb3f8fb59c4e208c109a6b806622735e7c24e9a8566e46c4ad53142%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "59d6b3af201abf9f61d6a77087bedc06c914adaa4b726c597b5d95abffae0d95"
+        }
+      ],
+      "title": "Spearhead: Kharadron Overlords - Grundstok Trailblazers"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3089865,
+        "checksum": "bd35cd9cad654c66b0ce625ad7f5512727d45acf79b66c79412ed00f34b07853",
+        "etag": "\"6115f805c244be7bd73809dfc6024dd2\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_12-11_aos_spearhead_kharadron_overlords_skyhammer_task_force-juxkvk8zj2-scpnhbxwwv.pdf",
+        "lastModified": "Mon, 10 Nov 2025 14:33:03 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_12-11_aos_spearhead_kharadron_overlords_skyhammer_task_force-juxkvk8zj2-scpnhbxwwv.pdf",
+        "retrievedAt": "2026-07-28T17:49:59.980Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:bd35cd9cad654c66b0ce625ad7f5512727d45acf79b66c79412ed00f34b07853%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "beaa92802202fad9f387697d4c64762f2fcbf9157fc68e5b8b55b846290983fb"
+        },
+        {
+          "id": "source-record:games-workshop:bd35cd9cad654c66b0ce625ad7f5512727d45acf79b66c79412ed00f34b07853%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "6fa3228f15557ad4009e43f73e94e0e745a598d60889ef76f91394ff204d89f7"
+        },
+        {
+          "id": "source-record:games-workshop:bd35cd9cad654c66b0ce625ad7f5512727d45acf79b66c79412ed00f34b07853%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "beaa92802202fad9f387697d4c64762f2fcbf9157fc68e5b8b55b846290983fb"
+        },
+        {
+          "id": "source-record:games-workshop:bd35cd9cad654c66b0ce625ad7f5512727d45acf79b66c79412ed00f34b07853%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "1059a3dcde1cd41516dfeeb66d428acf6b8f930a6f204147a05858e1791d4bba"
+        },
+        {
+          "id": "source-record:games-workshop:bd35cd9cad654c66b0ce625ad7f5512727d45acf79b66c79412ed00f34b07853%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "01f7c49258f415c7bef0996846c4944cafde67c01c6069b27905c4f683a7b751"
+        },
+        {
+          "id": "source-record:games-workshop:bd35cd9cad654c66b0ce625ad7f5512727d45acf79b66c79412ed00f34b07853%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "95c3be9b3d9791ee743aa28abfffc0b26e2008cd69edbcc9bf723fdac75202c4"
+        },
+        {
+          "id": "source-record:games-workshop:bd35cd9cad654c66b0ce625ad7f5512727d45acf79b66c79412ed00f34b07853%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "c39af2088360d81c480302c7b09e4a4d52a949a0abb03953dd0aeed3715f275b"
+        },
+        {
+          "id": "source-record:games-workshop:bd35cd9cad654c66b0ce625ad7f5512727d45acf79b66c79412ed00f34b07853%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "11cd4df0c9c68d91caa595b7d5ce92561bc6e201b0cfc0007bcafb68d7e4f95c"
+        }
+      ],
+      "title": "Spearhead: Kharadron Overlords - Skyhammer Task Force"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 17808047,
+        "checksum": "fce9460066978d148d0e10913fdfed1740c8eabbc8751e3bccad6650e32fd43e",
+        "etag": "\"3433106e46e82d766273826560c95031\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_lumineth_realmlords_glittering_phalanx-vc5h4mvert-lcmzbvmqq9.pdf",
+        "lastModified": "Tue, 31 Mar 2026 08:00:23 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_lumineth_realmlords_glittering_phalanx-vc5h4mvert-lcmzbvmqq9.pdf",
+        "retrievedAt": "2026-07-28T17:50:00.630Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:fce9460066978d148d0e10913fdfed1740c8eabbc8751e3bccad6650e32fd43e%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "03150a9656f61867b6b1cf777f50f5905e68c0bfd98c23b058fe44e32ebe6225"
+        },
+        {
+          "id": "source-record:games-workshop:fce9460066978d148d0e10913fdfed1740c8eabbc8751e3bccad6650e32fd43e%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "7653e433277297dc2185ad450897b77314c93eaab8935ff48075b28592fe90b5"
+        },
+        {
+          "id": "source-record:games-workshop:fce9460066978d148d0e10913fdfed1740c8eabbc8751e3bccad6650e32fd43e%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "18d8bb131cf1b39fecd17d973a7b731c5a0653b0aea6bfeb5b30c84f59a34a1e"
+        },
+        {
+          "id": "source-record:games-workshop:fce9460066978d148d0e10913fdfed1740c8eabbc8751e3bccad6650e32fd43e%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "e437ee14507201fb46185a10b8ddbfcb65e9cab0fed29932260086825acda8a5"
+        },
+        {
+          "id": "source-record:games-workshop:fce9460066978d148d0e10913fdfed1740c8eabbc8751e3bccad6650e32fd43e%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "e437ee14507201fb46185a10b8ddbfcb65e9cab0fed29932260086825acda8a5"
+        },
+        {
+          "id": "source-record:games-workshop:fce9460066978d148d0e10913fdfed1740c8eabbc8751e3bccad6650e32fd43e%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "a3106aea88b85f504b33a4e8aba624e58a087e815ae5fb2bf939aa0f20e9e10b"
+        },
+        {
+          "id": "source-record:games-workshop:fce9460066978d148d0e10913fdfed1740c8eabbc8751e3bccad6650e32fd43e%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "a3106aea88b85f504b33a4e8aba624e58a087e815ae5fb2bf939aa0f20e9e10b"
+        }
+      ],
+      "title": "Spearhead: Lumineth Realm-lords - Glittering Phalanx"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2520378,
+        "checksum": "14ad0ed8091ba6a01a6cee4b7d226898561ad7be01855fce3e1708af741ee9b1",
+        "etag": "\"ceea5d33cb7f9c6c73773d49ca5acb27\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_04-02_aos_spearhead_lumineth_realmlords-5ruf50utef-0atmxv5lpx.pdf",
+        "lastModified": "Mon, 02 Feb 2026 13:28:34 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_04-02_aos_spearhead_lumineth_realmlords-5ruf50utef-0atmxv5lpx.pdf",
+        "retrievedAt": "2026-07-28T17:50:00.907Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:14ad0ed8091ba6a01a6cee4b7d226898561ad7be01855fce3e1708af741ee9b1%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "249533824b16c3054da9badac98724a503cbe1ee932ca78482b7a7f30d555422"
+        },
+        {
+          "id": "source-record:games-workshop:14ad0ed8091ba6a01a6cee4b7d226898561ad7be01855fce3e1708af741ee9b1%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "d9889f314df7fe53b6bd524d61a986627b048dffb3e1cf3b56ca3036402b2fb0"
+        },
+        {
+          "id": "source-record:games-workshop:14ad0ed8091ba6a01a6cee4b7d226898561ad7be01855fce3e1708af741ee9b1%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "6c1b80ec0301e5ee8e5badd00417ec08360d53bd5b538dfc80d7632c92834293"
+        },
+        {
+          "id": "source-record:games-workshop:14ad0ed8091ba6a01a6cee4b7d226898561ad7be01855fce3e1708af741ee9b1%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "c032cfb2ff141e50349795664bafb7527ffeb564d847377d37d7e41a8569e7d8"
+        }
+      ],
+      "title": "Spearhead: Lumineth Realm-lords - Hurakan Vanguard"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 14786173,
+        "checksum": "68635a5a3a857bfd88a023951e9223f4d40f5bc20c81cd2dc4f3dd01f150cbf7",
+        "etag": "\"c9cc5e4521809787995518baffaf91b9\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_maggotkin_of_nurgle_bleak_host-anonar5akg-es9llpugle.pdf",
+        "lastModified": "Tue, 31 Mar 2026 08:09:52 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_maggotkin_of_nurgle_bleak_host-anonar5akg-es9llpugle.pdf",
+        "retrievedAt": "2026-07-28T17:50:01.288Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:68635a5a3a857bfd88a023951e9223f4d40f5bc20c81cd2dc4f3dd01f150cbf7%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "53ccea62ebf398b01bfd6342b8d6bb0ccab8267b20f08370638312f635a1796b"
+        },
+        {
+          "id": "source-record:games-workshop:68635a5a3a857bfd88a023951e9223f4d40f5bc20c81cd2dc4f3dd01f150cbf7%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "4054b793baf7a0cb468e5d631bff2d43641085d4faee4105970b76831492556f"
+        },
+        {
+          "id": "source-record:games-workshop:68635a5a3a857bfd88a023951e9223f4d40f5bc20c81cd2dc4f3dd01f150cbf7%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "2c3ebee48880fa986b793093adeed668b791addfcd0e41065f6561c9043e823c"
+        },
+        {
+          "id": "source-record:games-workshop:68635a5a3a857bfd88a023951e9223f4d40f5bc20c81cd2dc4f3dd01f150cbf7%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "50eed1a9f2326b2b3c561a7a34d1c42d80970403a5372c0e0060206d6e0519bf"
+        },
+        {
+          "id": "source-record:games-workshop:68635a5a3a857bfd88a023951e9223f4d40f5bc20c81cd2dc4f3dd01f150cbf7%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "50eed1a9f2326b2b3c561a7a34d1c42d80970403a5372c0e0060206d6e0519bf"
+        },
+        {
+          "id": "source-record:games-workshop:68635a5a3a857bfd88a023951e9223f4d40f5bc20c81cd2dc4f3dd01f150cbf7%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "fa155549aa4dfb80f4a46a89b0833baefdce8fc04d5d88a6c6ff097a38a63b4b"
+        },
+        {
+          "id": "source-record:games-workshop:68635a5a3a857bfd88a023951e9223f4d40f5bc20c81cd2dc4f3dd01f150cbf7%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "fa155549aa4dfb80f4a46a89b0833baefdce8fc04d5d88a6c6ff097a38a63b4b"
+        }
+      ],
+      "title": "Spearhead: Maggotkin of Nurgle - Bleak Host"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 7990992,
+        "checksum": "718c39109e6a3ddb1ffe54f9bc84531dda70d06d13e6098d917340f37794b431",
+        "etag": "\"5374e216f9edd43c858e9977293479af\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_14-01_aos_spearhead_maggotkin_of_nurgle_bubonic_cell-pzrkznb841-nra7t3b9st.pdf",
+        "lastModified": "Mon, 12 Jan 2026 12:12:29 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_14-01_aos_spearhead_maggotkin_of_nurgle_bubonic_cell-pzrkznb841-nra7t3b9st.pdf",
+        "retrievedAt": "2026-07-28T17:50:01.665Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:718c39109e6a3ddb1ffe54f9bc84531dda70d06d13e6098d917340f37794b431%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "520c29ff7cd7e65d4cae00dee6591266109c523694ee41baa782654a46bd2e74"
+        },
+        {
+          "id": "source-record:games-workshop:718c39109e6a3ddb1ffe54f9bc84531dda70d06d13e6098d917340f37794b431%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "fe0343641594131924773b8c6a27f5f0a6e931daca4c2058076fe648e8d6857a"
+        },
+        {
+          "id": "source-record:games-workshop:718c39109e6a3ddb1ffe54f9bc84531dda70d06d13e6098d917340f37794b431%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "e027e88d0b2b1f3fbca3170be5fa3082064fafb381afdbe0b4027608b2235c5a"
+        },
+        {
+          "id": "source-record:games-workshop:718c39109e6a3ddb1ffe54f9bc84531dda70d06d13e6098d917340f37794b431%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "97a2df5cb56cb8bd9d5b85a11f559ce7a593694aaff9d5c9e19a8153d34b97e1"
+        }
+      ],
+      "title": "Spearhead: Maggotkin of Nurgle - Bubonic Cell"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 8686555,
+        "checksum": "ffde34191ec7b50a4bcf98e2e2372205c9b48a1c433eb3fc05d234df81f9c3ef",
+        "etag": "\"05a99820263fea1d9655f983ababed09\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_29-04_aos_spearhead_nighthaunt_cursed_shacklehorde-br9d6bfwzt-4k0qp3is9x.pdf",
+        "lastModified": "Mon, 27 Apr 2026 09:24:50 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_29-04_aos_spearhead_nighthaunt_cursed_shacklehorde-br9d6bfwzt-4k0qp3is9x.pdf",
+        "retrievedAt": "2026-07-28T17:50:02.060Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:ffde34191ec7b50a4bcf98e2e2372205c9b48a1c433eb3fc05d234df81f9c3ef%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "058aa58065b93b469be4f7e05c1e37c11a2cecef987cc84116a4e406cb66771f"
+        },
+        {
+          "id": "source-record:games-workshop:ffde34191ec7b50a4bcf98e2e2372205c9b48a1c433eb3fc05d234df81f9c3ef%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "e76c3aee4533f8dd31784214d0175e9cce0fa7a6a3a63bb2d5bacadcdb04fd42"
+        },
+        {
+          "id": "source-record:games-workshop:ffde34191ec7b50a4bcf98e2e2372205c9b48a1c433eb3fc05d234df81f9c3ef%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "6c8b4535004ec4cc4808e99c8d877dc331089d77e00c9a1323fe8e83f3971045"
+        },
+        {
+          "id": "source-record:games-workshop:ffde34191ec7b50a4bcf98e2e2372205c9b48a1c433eb3fc05d234df81f9c3ef%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "df3f37d51c8a9ea7574f8fc69e48ef3e8e8529d3d3ddad195ae5a64f64b738b7"
+        }
+      ],
+      "title": "Spearhead: Nighthaunt - Cursed Shacklehorde"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 2575267,
+        "checksum": "5d05c0feae5aceded233544447b5b65075ccb6b42b83e3c0d7fa917b37229c96",
+        "etag": "\"a7eef04704b0c72e7a01c047069303d7\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_12-11_aos_spearhead_nighthaunt_slasher_host-5basg9ujlw-xowsazitxv.pdf",
+        "lastModified": "Mon, 10 Nov 2025 14:41:57 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_12-11_aos_spearhead_nighthaunt_slasher_host-5basg9ujlw-xowsazitxv.pdf",
+        "retrievedAt": "2026-07-28T17:50:02.281Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:5d05c0feae5aceded233544447b5b65075ccb6b42b83e3c0d7fa917b37229c96%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "9b0bde2ba316d52d5075bedbfb5821173886e9efb448c1436b1dc0bb33e6469b"
+        },
+        {
+          "id": "source-record:games-workshop:5d05c0feae5aceded233544447b5b65075ccb6b42b83e3c0d7fa917b37229c96%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "f22d4ad8fbcbfce62cfb807a3a8f4058fc0d75f141e6c32ece5cdb08b47034e1"
+        },
+        {
+          "id": "source-record:games-workshop:5d05c0feae5aceded233544447b5b65075ccb6b42b83e3c0d7fa917b37229c96%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "9b0bde2ba316d52d5075bedbfb5821173886e9efb448c1436b1dc0bb33e6469b"
+        },
+        {
+          "id": "source-record:games-workshop:5d05c0feae5aceded233544447b5b65075ccb6b42b83e3c0d7fa917b37229c96%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "f22d4ad8fbcbfce62cfb807a3a8f4058fc0d75f141e6c32ece5cdb08b47034e1"
+        },
+        {
+          "id": "source-record:games-workshop:5d05c0feae5aceded233544447b5b65075ccb6b42b83e3c0d7fa917b37229c96%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "8b9084c7e6b1f30472f98ddf43670c394601028f961ed0dc2b2f136fe5dab102"
+        },
+        {
+          "id": "source-record:games-workshop:5d05c0feae5aceded233544447b5b65075ccb6b42b83e3c0d7fa917b37229c96%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "f5a91ad353f8d8d196daa213c96247abeab5e509a5b925a315e25cc139090106"
+        },
+        {
+          "id": "source-record:games-workshop:5d05c0feae5aceded233544447b5b65075ccb6b42b83e3c0d7fa917b37229c96%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "bf19a913dae342d87917cae775dd8eebecd70b267f10679ac24ae0ffdd15b134"
+        },
+        {
+          "id": "source-record:games-workshop:5d05c0feae5aceded233544447b5b65075ccb6b42b83e3c0d7fa917b37229c96%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "b3c6a18cf350b38990e352df6cab2e4d64829436a21afd72a1f48f1f1aa565f6"
+        }
+      ],
+      "title": "Spearhead: Nighthaunt - Slasher Host"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 18208263,
+        "checksum": "2e4490a3a02581d685878f49373974e465570437d5e3838b25c4de21e9e84027",
+        "etag": "\"1ae12cecef3f52a8250a5e7cb8383a76\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_ogor_mawtribes_scrapglutt-rscn8zyfsn-ersmm4yxe3.pdf",
+        "lastModified": "Tue, 31 Mar 2026 07:39:48 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_ogor_mawtribes_scrapglutt-rscn8zyfsn-ersmm4yxe3.pdf",
+        "retrievedAt": "2026-07-28T17:50:02.900Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:2e4490a3a02581d685878f49373974e465570437d5e3838b25c4de21e9e84027%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "b3307981620a052541c2236c5d2b1086369bbf8823d5402febdc052b02e2bdfd"
+        },
+        {
+          "id": "source-record:games-workshop:2e4490a3a02581d685878f49373974e465570437d5e3838b25c4de21e9e84027%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "649de9ede02d6d7f8eaf190c7dfdc5624ccb3568e6aedea1a0c35fcc16013506"
+        },
+        {
+          "id": "source-record:games-workshop:2e4490a3a02581d685878f49373974e465570437d5e3838b25c4de21e9e84027%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "d66784215557f2d6aae34a96ce8f66ae500c8c65cc7026adf3c9856c50aed07f"
+        },
+        {
+          "id": "source-record:games-workshop:2e4490a3a02581d685878f49373974e465570437d5e3838b25c4de21e9e84027%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "0ba538d7ac49e747010b989435df0a70dc83547ad43804ba1427fcde17eb20fe"
+        }
+      ],
+      "title": "Spearhead: Ogor Mawtribes - Scrapglutt"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 20499001,
+        "checksum": "c210be1999d6a29de4da02744fe03cb87bf5c84a194a7a8a6631800cc4796633",
+        "etag": "\"476fcafcc6699625d4ad56b67b1b1dd6\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_ogor_tyrant-s_bellow-2x4dua4hul-ybq3296fth.pdf",
+        "lastModified": "Tue, 14 Apr 2026 08:56:37 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_ogor_tyrant-s_bellow-2x4dua4hul-ybq3296fth.pdf",
+        "retrievedAt": "2026-07-28T17:50:03.483Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:c210be1999d6a29de4da02744fe03cb87bf5c84a194a7a8a6631800cc4796633%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "e7eeed64312a608f26285fbf68226b3d7c091b6a138170b22f8930e3969cf58d"
+        },
+        {
+          "id": "source-record:games-workshop:c210be1999d6a29de4da02744fe03cb87bf5c84a194a7a8a6631800cc4796633%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "1a835efb9d29b5e6f450e19c5608cf1cf9aadf805ab19919d2fdd9ad347122a7"
+        },
+        {
+          "id": "source-record:games-workshop:c210be1999d6a29de4da02744fe03cb87bf5c84a194a7a8a6631800cc4796633%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "ba670492f58cdcb5b6d6fce37f9212ff7d45f30a848b13df6d1f036458efdfa9"
+        },
+        {
+          "id": "source-record:games-workshop:c210be1999d6a29de4da02744fe03cb87bf5c84a194a7a8a6631800cc4796633%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "548b1a95658c43bd314fe95047eafd8c84a86ad98c813e0678d39621c7e0eb3c"
+        }
+      ],
+      "title": "Spearhead: Ogor Mawtribes - Tyrant's Bellow"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 14983414,
+        "checksum": "e04b8c1239d45585ff2fe96aa930fb5dfed7507909699a8435a17aa72a3cc797",
+        "etag": "\"e590be6beb24fd60333d5e60da2e4e10\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_15-07_aos_spearhead_ogor_mawtribes_warglutt_marauders-l0ewnuqqj7-sqi5tjabsr.pdf",
+        "lastModified": "Thu, 09 Jul 2026 08:48:39 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_15-07_aos_spearhead_ogor_mawtribes_warglutt_marauders-l0ewnuqqj7-sqi5tjabsr.pdf",
+        "retrievedAt": "2026-07-28T17:50:04.008Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:e04b8c1239d45585ff2fe96aa930fb5dfed7507909699a8435a17aa72a3cc797%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "0fd3543f3146b72d8355ac72d076298acb963f6a0d1759805bc10d3f85062c7a"
+        },
+        {
+          "id": "source-record:games-workshop:e04b8c1239d45585ff2fe96aa930fb5dfed7507909699a8435a17aa72a3cc797%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "58f58c680ba3a4c1508e8861e02fd62ba74941124a15b55423a0c9f5e63404c5"
+        },
+        {
+          "id": "source-record:games-workshop:e04b8c1239d45585ff2fe96aa930fb5dfed7507909699a8435a17aa72a3cc797%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "b11ae20b79fc6baec3b507299f86bb077c095f5770b331ed52889d8bf2921b88"
+        },
+        {
+          "id": "source-record:games-workshop:e04b8c1239d45585ff2fe96aa930fb5dfed7507909699a8435a17aa72a3cc797%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "843376212f73bce2b683a96f08488c850e66c3f1a8f4eec2a786c1d7450015a0"
+        },
+        {
+          "id": "source-record:games-workshop:e04b8c1239d45585ff2fe96aa930fb5dfed7507909699a8435a17aa72a3cc797%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "12e67018b81a63ed8051724866eba62288bff31a69fa85a39bcf0096ce73f820"
+        },
+        {
+          "id": "source-record:games-workshop:e04b8c1239d45585ff2fe96aa930fb5dfed7507909699a8435a17aa72a3cc797%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "50115da7d79e994bd9553708f883431fcb52496cba213bbbf7850b37291f7a13"
+        },
+        {
+          "id": "source-record:games-workshop:e04b8c1239d45585ff2fe96aa930fb5dfed7507909699a8435a17aa72a3cc797%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "0b15e3e5e57f2d891a81f5b8dbe124ce81773e822ffe63c0fb29a17aa7a4a7f1"
+        },
+        {
+          "id": "source-record:games-workshop:e04b8c1239d45585ff2fe96aa930fb5dfed7507909699a8435a17aa72a3cc797%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "e22aa15cacab84401f65d8a2b79e302b49a68c957aed12490c878eea823564f3"
+        }
+      ],
+      "title": "Spearhead: Ogor Mawtribes - Warglutt Marauders"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 19791056,
+        "checksum": "277f2ab8972c6dc43d73960074bbad3c1cac9b21f99f488614f3a39efefc2c60",
+        "etag": "\"d5fb8dffd4dff44eddb1d7dfcc75018f\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_orruk_warclans_ironjawz_bigmob-ihpwqzmdpv-nkwwjlzs0m.pdf",
+        "lastModified": "Tue, 31 Mar 2026 07:51:43 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_orruk_warclans_ironjawz_bigmob-ihpwqzmdpv-nkwwjlzs0m.pdf",
+        "retrievedAt": "2026-07-28T17:50:04.639Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:277f2ab8972c6dc43d73960074bbad3c1cac9b21f99f488614f3a39efefc2c60%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "76086e25171f6863a1a7f2d8c07624b3d130abb3a270ff180ed55d467cf6824e"
+        },
+        {
+          "id": "source-record:games-workshop:277f2ab8972c6dc43d73960074bbad3c1cac9b21f99f488614f3a39efefc2c60%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "20713641d2c592aa09f89bc46eeff7e20f8bf723471a856d4e9f5fb5b13edc21"
+        },
+        {
+          "id": "source-record:games-workshop:277f2ab8972c6dc43d73960074bbad3c1cac9b21f99f488614f3a39efefc2c60%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "d7adb81516b25cb9464ec38f43012bd79c5c77d8fb709a58faf4fe24cfad755d"
+        },
+        {
+          "id": "source-record:games-workshop:277f2ab8972c6dc43d73960074bbad3c1cac9b21f99f488614f3a39efefc2c60%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "4b4e5e3b619f0af8c0b36fe12d143addcea79fffadbff36af4730d5a8383c85b"
+        }
+      ],
+      "title": "Spearhead: Orruk Warclans - Ironjawz Bigmob"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3213977,
+        "checksum": "92cdb032db024f69674f71c583d51166f268829b733c3a81ff6bc8f26e009af2",
+        "etag": "\"bb8bc124f4d6828af2f049bb8072749e\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_12-11_aos_spearhead_swampskulka_gang_orruk_warclans-w8fpypteaj-ekuw00scka.pdf",
+        "lastModified": "Mon, 10 Nov 2025 14:25:37 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_12-11_aos_spearhead_swampskulka_gang_orruk_warclans-w8fpypteaj-ekuw00scka.pdf",
+        "retrievedAt": "2026-07-28T17:50:04.908Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:92cdb032db024f69674f71c583d51166f268829b733c3a81ff6bc8f26e009af2%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "aab4f52b5b6e6c239d918e166c11bba6cee827eac0d320c2a57c35b2adbf28e5"
+        },
+        {
+          "id": "source-record:games-workshop:92cdb032db024f69674f71c583d51166f268829b733c3a81ff6bc8f26e009af2%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "1f57b5e4150d8a7a2f85a5401e5eb6aeea3b53f7dd75e424a9cfd404d94ccd54"
+        },
+        {
+          "id": "source-record:games-workshop:92cdb032db024f69674f71c583d51166f268829b733c3a81ff6bc8f26e009af2%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "aab4f52b5b6e6c239d918e166c11bba6cee827eac0d320c2a57c35b2adbf28e5"
+        },
+        {
+          "id": "source-record:games-workshop:92cdb032db024f69674f71c583d51166f268829b733c3a81ff6bc8f26e009af2%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "1f57b5e4150d8a7a2f85a5401e5eb6aeea3b53f7dd75e424a9cfd404d94ccd54"
+        },
+        {
+          "id": "source-record:games-workshop:92cdb032db024f69674f71c583d51166f268829b733c3a81ff6bc8f26e009af2%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "8f9ee1dded3fec086b7965c5d3b6c4e2f24127fb5aac6ecf01a9d1410df8246a"
+        },
+        {
+          "id": "source-record:games-workshop:92cdb032db024f69674f71c583d51166f268829b733c3a81ff6bc8f26e009af2%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "171a2ae5cf718b01f9e473dc866fbe04b1658482f650cdfd74156f4916b936f0"
+        },
+        {
+          "id": "source-record:games-workshop:92cdb032db024f69674f71c583d51166f268829b733c3a81ff6bc8f26e009af2%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "ea8ce53802c9144bb607c62aaa13905ffb59496850dbd5c844b3435ae4f2f5bf"
+        },
+        {
+          "id": "source-record:games-workshop:92cdb032db024f69674f71c583d51166f268829b733c3a81ff6bc8f26e009af2%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "24b85bdac57e2f8edc3c51ea6317b8af68746e639eb094f8ae10d1b55591c415"
+        },
+        {
+          "id": "source-record:games-workshop:92cdb032db024f69674f71c583d51166f268829b733c3a81ff6bc8f26e009af2%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "ec0b4b8019d2a3ca1525bfe373dfaa234dad01b5a921ef76bfb7fd0bbee339fa"
+        }
+      ],
+      "title": "Spearhead: Orruk Warclans - Swampskulka Gang"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 9568278,
+        "checksum": "75b197b4afd0d1be2850190dd56e2e43958e4c56ce788cf951634bfc036a81a5",
+        "etag": "\"927e37e9c162cc087227091a1116975e\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_18-02_aos_spearhead_ossiarch_bonereapers_kavalos_vanguard-jbqptot5r8-wv7o91pzot.pdf",
+        "lastModified": "Mon, 16 Feb 2026 11:52:08 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_18-02_aos_spearhead_ossiarch_bonereapers_kavalos_vanguard-jbqptot5r8-wv7o91pzot.pdf",
+        "retrievedAt": "2026-07-28T17:50:05.285Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:75b197b4afd0d1be2850190dd56e2e43958e4c56ce788cf951634bfc036a81a5%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "45ceb7b26f9d0e04e22d057b20816c943bc3cf51712357cf67f230a93ac999d7"
+        },
+        {
+          "id": "source-record:games-workshop:75b197b4afd0d1be2850190dd56e2e43958e4c56ce788cf951634bfc036a81a5%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "5b2027c08b068e810fb1fd8ec4fd10baae50f5f6476932125a7fdf1dc7ca2089"
+        },
+        {
+          "id": "source-record:games-workshop:75b197b4afd0d1be2850190dd56e2e43958e4c56ce788cf951634bfc036a81a5%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "e0a3e0fcc86d28d0f9d404b4b764f8f9c8963b7ea25e7671b3a5f2a2b45c4f7e"
+        },
+        {
+          "id": "source-record:games-workshop:75b197b4afd0d1be2850190dd56e2e43958e4c56ce788cf951634bfc036a81a5%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "d96cd42fb4c04124bf3ab2051214a7a2f5ac857676fd99ce4765f2dc85b7ecb5"
+        }
+      ],
+      "title": "Spearhead: Ossiarch Bonereapers - Kavalos Vanguard"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 6367637,
+        "checksum": "a0d45622e6406975fa31df32ffe56176bfe0473579160cf5a3eab63f65924ca5",
+        "etag": "\"4266f5fa9be06251ed477ce50a527ef5\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_jun25_aos_spearhead_ossiarchbr_rules-oyqrmemltw-ba87liamqd.pdf",
+        "lastModified": "Tue, 10 Jun 2025 09:56:16 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_jun25_aos_spearhead_ossiarchbr_rules-oyqrmemltw-ba87liamqd.pdf",
+        "retrievedAt": "2026-07-28T17:50:05.560Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:a0d45622e6406975fa31df32ffe56176bfe0473579160cf5a3eab63f65924ca5%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "80943cf845389c30e6fae0733475870d88f88c93a27d638b6d226c0eec75a3db"
+        },
+        {
+          "id": "source-record:games-workshop:a0d45622e6406975fa31df32ffe56176bfe0473579160cf5a3eab63f65924ca5%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "6a2c01d242615ced9ec5ef49fbfb7fa36ebf781b7a3eb236ecfe80f7f931fe33"
+        },
+        {
+          "id": "source-record:games-workshop:a0d45622e6406975fa31df32ffe56176bfe0473579160cf5a3eab63f65924ca5%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "9236ddd379c3c9a2d9c5fa6718a3a7fb90d51090ef83bccc83dd0612ae613fcc"
+        },
+        {
+          "id": "source-record:games-workshop:a0d45622e6406975fa31df32ffe56176bfe0473579160cf5a3eab63f65924ca5%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "6c816862c369edf9f73aaf5fab7387f70ff3f6c516a35c920d304340cbfd09f3"
+        }
+      ],
+      "title": "Spearhead: Ossiarch Bonereapers - Mortisan Elite"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 18007865,
+        "checksum": "3f9b6818767a57a08c08d010ad72c5f10e984fdbac7de041cdf448a976ae0445",
+        "etag": "\"564e8c80e2f44c4ef6ade11df638e64b\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_fire_and_jade_obr-x8j1lrc6kr-slfvyoftwm.pdf",
+        "lastModified": "Tue, 14 Apr 2026 08:27:53 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_fire_and_jade_obr-x8j1lrc6kr-slfvyoftwm.pdf",
+        "retrievedAt": "2026-07-28T17:50:06.039Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:3f9b6818767a57a08c08d010ad72c5f10e984fdbac7de041cdf448a976ae0445%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "3876d021a2fd60f6b614f393e3bcad55ade60f082e3dc98eb1409348c8e672b8"
+        },
+        {
+          "id": "source-record:games-workshop:3f9b6818767a57a08c08d010ad72c5f10e984fdbac7de041cdf448a976ae0445%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "11c7759689e080c75ce22f2dff276931487df2e1333d495f559593ebe3ffe3f2"
+        },
+        {
+          "id": "source-record:games-workshop:3f9b6818767a57a08c08d010ad72c5f10e984fdbac7de041cdf448a976ae0445%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "a259ccea636f0243f7c6d583961eb3a59e64e3a4ade8c98c5259ecaee8839846"
+        },
+        {
+          "id": "source-record:games-workshop:3f9b6818767a57a08c08d010ad72c5f10e984fdbac7de041cdf448a976ae0445%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "469334767fa2f6ce376e46685981f936df496d3be9e8a04283489ee9b6b578a1"
+        }
+      ],
+      "title": "Spearhead: Ossiarch Bonereapers - Tithe-Reaper Echelon"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 29238078,
+        "checksum": "8cfee3adca0901d6fb08a84ec2e03205f1050cf3cfdb573de7f8cb0ff0c751bc",
+        "etag": "\"6410d52144455275b679623f4a1ba6b4\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_seraphon_starscale_warhost-4ipgg8d3kx-kpmzdbylav.pdf",
+        "lastModified": "Tue, 14 Apr 2026 08:50:32 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_seraphon_starscale_warhost-4ipgg8d3kx-kpmzdbylav.pdf",
+        "retrievedAt": "2026-07-28T17:50:06.791Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:8cfee3adca0901d6fb08a84ec2e03205f1050cf3cfdb573de7f8cb0ff0c751bc%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "155ade5f8ff532f4b732a038d8bed1c372421885f6269659093959e9cc1d9127"
+        },
+        {
+          "id": "source-record:games-workshop:8cfee3adca0901d6fb08a84ec2e03205f1050cf3cfdb573de7f8cb0ff0c751bc%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "2c27a899b485024090528fa209266323cd8c5291525fc8b01577ddd8266515d7"
+        },
+        {
+          "id": "source-record:games-workshop:8cfee3adca0901d6fb08a84ec2e03205f1050cf3cfdb573de7f8cb0ff0c751bc%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "d742f1f00d7e541413ffd3b0722d88b003da79b45e17886ae4a600d83f263fd2"
+        },
+        {
+          "id": "source-record:games-workshop:8cfee3adca0901d6fb08a84ec2e03205f1050cf3cfdb573de7f8cb0ff0c751bc%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "52307f2bb30edf11c69f09573878a3bf0a6cab97f88f236076b81c8607409208"
+        }
+      ],
+      "title": "Spearhead: Seraphon - Starscale Warhost"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 19472559,
+        "checksum": "58ec318574e274125ead3e001dcbf9965df6b4f4dbd9286c5feb380420565330",
+        "etag": "\"d119054a7359cd7871b20529a70930c5\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_seraphon_sunblooded_prowlers-ijqpegpobv-fpafdma7w8.pdf",
+        "lastModified": "Tue, 31 Mar 2026 07:52:48 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_seraphon_sunblooded_prowlers-ijqpegpobv-fpafdma7w8.pdf",
+        "retrievedAt": "2026-07-28T17:50:07.390Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:58ec318574e274125ead3e001dcbf9965df6b4f4dbd9286c5feb380420565330%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "9f38d106b2ac6c9cc40bbeec19382df90d2ed1ec69461edd56926d9138fc9770"
+        },
+        {
+          "id": "source-record:games-workshop:58ec318574e274125ead3e001dcbf9965df6b4f4dbd9286c5feb380420565330%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "4f5023f1c3a141b1da7df6513db079dab69450dca24b0b339694abc467a92261"
+        },
+        {
+          "id": "source-record:games-workshop:58ec318574e274125ead3e001dcbf9965df6b4f4dbd9286c5feb380420565330%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "f92ef83231f1958388f3bb5ae07c03e50df58688c9d153968ee1fcd1b37fb568"
+        },
+        {
+          "id": "source-record:games-workshop:58ec318574e274125ead3e001dcbf9965df6b4f4dbd9286c5feb380420565330%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "436af63c3ee7051d789bb6b71dfb97a16aa16b792e0443e1d6de68bd7f2c2f2b"
+        }
+      ],
+      "title": "Spearhead: Seraphon - Sunblooded Prowlers"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 30798981,
+        "checksum": "6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465",
+        "etag": "\"0f8df8655bf4a81da82d158b487e180d\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_skaven_gnawfeast_clawpack-zorddipson-dpnghi1nvc.pdf",
+        "lastModified": "Mon, 30 Mar 2026 14:21:11 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_skaven_gnawfeast_clawpack-zorddipson-dpnghi1nvc.pdf",
+        "retrievedAt": "2026-07-28T17:50:08.076Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "139e3358ecc31dc4ae05661e0631b6dbf4fa0947412097ab92e16486c3cb559b"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "8d13bac131796c3c28247813accf5c1d26c4e252d45f877250190193413aaed7"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "8d13bac131796c3c28247813accf5c1d26c4e252d45f877250190193413aaed7"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "45ec13c5d8f89a0de3b569ab4432b70a85902d783263b124e66de38825560659"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "45ec13c5d8f89a0de3b569ab4432b70a85902d783263b124e66de38825560659"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "c4f27567f22800d9de8f7d66c7b738e06d2f874662d85bb73fdcc7c16d4d0ef1"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "c4f27567f22800d9de8f7d66c7b738e06d2f874662d85bb73fdcc7c16d4d0ef1"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "c4f27567f22800d9de8f7d66c7b738e06d2f874662d85bb73fdcc7c16d4d0ef1"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "6b321d846eeb57ff1f802a91cf10ac7e8bc1d618c975755413c08a078a219712"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "adae440e166e91459be2a55293dde0db9e3647585a988a272ebec79ad6f90bf4"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "1c50e1719a128f485d28542bffd4c6147bfca54ac6d88c6d1de4ff47214fe674"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "68ea2702b8b446673f16ff896053035a82e75bbab76fa13a02af7729fd893704"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "68ea2702b8b446673f16ff896053035a82e75bbab76fa13a02af7729fd893704"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "0900a0e7880186edaf42b93ad9dd7e05d5490f28fc10caa7c9293a10663495eb"
+        },
+        {
+          "id": "source-record:games-workshop:6bc1df76393af8b42f3ca7b9ee29ead2cef8a045acb31bb799f6709ae6184465%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "0900a0e7880186edaf42b93ad9dd7e05d5490f28fc10caa7c9293a10663495eb"
+        }
+      ],
+      "title": "Spearhead: Skaven – Gnawfeast Clawpack and Warpspark Clawpack"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3337066,
+        "checksum": "41ef536af8eb36243e322daf3038a72abe0b10906e5b64c17c829dfd616ff229",
+        "etag": "\"1592c8b5096abcf6726618257f339692\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_spearhead_slaves_to_darkness.27-dqd6t0o4ny.pdf",
+        "lastModified": "Tue, 19 Nov 2024 13:37:34 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_spearhead_slaves_to_darkness.27-dqd6t0o4ny.pdf",
+        "retrievedAt": "2026-07-28T17:50:08.530Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:41ef536af8eb36243e322daf3038a72abe0b10906e5b64c17c829dfd616ff229%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "851e1babaa0681fc90b58633255f636a69dabe54fc24397e0d19bcd15282e92a"
+        },
+        {
+          "id": "source-record:games-workshop:41ef536af8eb36243e322daf3038a72abe0b10906e5b64c17c829dfd616ff229%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "31b65dbd441b0ba96de3ff799353437ea7323e1782f56a711985c922fb97e81b"
+        },
+        {
+          "id": "source-record:games-workshop:41ef536af8eb36243e322daf3038a72abe0b10906e5b64c17c829dfd616ff229%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "1f204b5fc0f61d89c249591af37f90330c6a6f0581dc7aace2b9b7f07fd44fa9"
+        },
+        {
+          "id": "source-record:games-workshop:41ef536af8eb36243e322daf3038a72abe0b10906e5b64c17c829dfd616ff229%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "0fde1d221460c0a4ba569c3d3565967dd19cce5d1ddaccbbf170e82b83c83d96"
+        },
+        {
+          "id": "source-record:games-workshop:41ef536af8eb36243e322daf3038a72abe0b10906e5b64c17c829dfd616ff229%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "bd2f276c7e8604c92b2c5b37650a688f0c6d75c5fa0077d04a2fc90d67c34fcb"
+        },
+        {
+          "id": "source-record:games-workshop:41ef536af8eb36243e322daf3038a72abe0b10906e5b64c17c829dfd616ff229%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "038bb2d8a5fe2072151e47ba9adc279377f9f6a8996b8083c4fe4142b35090b4"
+        },
+        {
+          "id": "source-record:games-workshop:41ef536af8eb36243e322daf3038a72abe0b10906e5b64c17c829dfd616ff229%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "789c3329ce4eb61c6623ccb46ae9a5a973fcb1a07852fda3ad5242d17d8cc19e"
+        }
+      ],
+      "title": "Spearhead: Slaves to Darkness - Bloodwind Legion"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 22785871,
+        "checksum": "c7cb83cc6f631c6599b6f777c5600c8dbe8e0aa0fcc93feb52d8cec29ea9e65b",
+        "etag": "\"c6b6b42a847ab7a34f3faaca8159fd6e\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_slaves_to_darkness_darkoath_raiders-mcmbaocpba-1o87y80z16.pdf",
+        "lastModified": "Mon, 30 Mar 2026 14:25:46 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_slaves_to_darkness_darkoath_raiders-mcmbaocpba-1o87y80z16.pdf",
+        "retrievedAt": "2026-07-28T17:50:09.077Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:c7cb83cc6f631c6599b6f777c5600c8dbe8e0aa0fcc93feb52d8cec29ea9e65b%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "97d55e17e0eb7d7138219fa5d168cd1b8d2781b71f3259fe4f1738b0523e1a70"
+        },
+        {
+          "id": "source-record:games-workshop:c7cb83cc6f631c6599b6f777c5600c8dbe8e0aa0fcc93feb52d8cec29ea9e65b%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "d56d16bfb692a0d94eccb6faae544671a42bcb334c192b4acbe4f7b8d4490d62"
+        },
+        {
+          "id": "source-record:games-workshop:c7cb83cc6f631c6599b6f777c5600c8dbe8e0aa0fcc93feb52d8cec29ea9e65b%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "3bb1e59aa40c5feda27d38c501f9ca8c657fa505f3cea43d2f43be7e1b1a3b6c"
+        },
+        {
+          "id": "source-record:games-workshop:c7cb83cc6f631c6599b6f777c5600c8dbe8e0aa0fcc93feb52d8cec29ea9e65b%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "4d49b1446df1bb712046991160513d6ccc5e61d24bee2028109f969e006d63db"
+        }
+      ],
+      "title": "Spearhead: Slaves To Darkness - Darkoath Raiders"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 19473290,
+        "checksum": "c653c64e7f74aff0b550bfe9693b1dadcf9451c80e11af0bf7486d867444e781",
+        "etag": "\"24bd8bce2ffbbd1c1a613672d50a56e0\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_sons_of_behemat_wallsmasher_stomp-pixgkvvzk0-hh6q2dgl7y.pdf",
+        "lastModified": "Tue, 14 Apr 2026 09:36:54 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_sons_of_behemat_wallsmasher_stomp-pixgkvvzk0-hh6q2dgl7y.pdf",
+        "retrievedAt": "2026-07-28T17:50:09.636Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:c653c64e7f74aff0b550bfe9693b1dadcf9451c80e11af0bf7486d867444e781%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "87562ff2a5cb1b53866fcd4529160326708c4ef5a570822d548cd4b57c8ce1a8"
+        },
+        {
+          "id": "source-record:games-workshop:c653c64e7f74aff0b550bfe9693b1dadcf9451c80e11af0bf7486d867444e781%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "d382cecdb85fae9d06c5ca80d1d65511d6d321b8038661344e6c9ca9638f7bf5"
+        }
+      ],
+      "title": "Spearhead: Sons of Behemat - Wallsmasher Stomp"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 16214015,
+        "checksum": "eaaab843dbb2f434c6bb983da9aee18a284ae466d5daa81e918c62b8da4c03f0",
+        "etag": "\"6692ba3c7190781f7a11fbdead46ee83\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_soulblight_gravelords_bloodcrave_hunt-vdg57qq6dt-h7hylvvtke.pdf",
+        "lastModified": "Tue, 31 Mar 2026 07:33:05 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_soulblight_gravelords_bloodcrave_hunt-vdg57qq6dt-h7hylvvtke.pdf",
+        "retrievedAt": "2026-07-28T17:50:10.147Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:eaaab843dbb2f434c6bb983da9aee18a284ae466d5daa81e918c62b8da4c03f0%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "a7377ac17ac65c8288f46cea652928b5caa7b6b58a15bfdda878f61f2db0137c"
+        },
+        {
+          "id": "source-record:games-workshop:eaaab843dbb2f434c6bb983da9aee18a284ae466d5daa81e918c62b8da4c03f0%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "3edbb5cd629bb4227f4652c730d4bdcd7b9fadb08d7427ec7d9cd5757e41ccef"
+        },
+        {
+          "id": "source-record:games-workshop:eaaab843dbb2f434c6bb983da9aee18a284ae466d5daa81e918c62b8da4c03f0%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "7054e4f463170fb99ca9195bf98a80ff01f24dacb0b8f0bc2260a569e8a1af94"
+        },
+        {
+          "id": "source-record:games-workshop:eaaab843dbb2f434c6bb983da9aee18a284ae466d5daa81e918c62b8da4c03f0%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "661508c5e2bfcd3c4be89dc7721856c390c511b2e649a5274e510474e0e55a5f"
+        },
+        {
+          "id": "source-record:games-workshop:eaaab843dbb2f434c6bb983da9aee18a284ae466d5daa81e918c62b8da4c03f0%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "661508c5e2bfcd3c4be89dc7721856c390c511b2e649a5274e510474e0e55a5f"
+        },
+        {
+          "id": "source-record:games-workshop:eaaab843dbb2f434c6bb983da9aee18a284ae466d5daa81e918c62b8da4c03f0%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "48350623383500e6ccf6fb3ead3c212112b6ccfd5f84bd45e8fd72748a5edc20"
+        },
+        {
+          "id": "source-record:games-workshop:eaaab843dbb2f434c6bb983da9aee18a284ae466d5daa81e918c62b8da4c03f0%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "1e2d41c33d15c6828e4f1bc99a16c221404169ce26c3793c60a53dff035d8817"
+        }
+      ],
+      "title": "Spearhead: Soulblight Gravelords - Bloodcrave Hunt"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 13280820,
+        "checksum": "19d1a5a884ffff7c2cbc11b21db71a560880c541ac21830f2c608f5492f3fada",
+        "etag": "\"39b902549c4a55efc763820ee7af2a01\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_soulblight_gravelords_deathrattle_tomb_host-yfcq06h2aq-h5hdzqs0hi.pdf",
+        "lastModified": "Mon, 30 Mar 2026 14:33:12 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_01-04_aos_spearhead_soulblight_gravelords_deathrattle_tomb_host-yfcq06h2aq-h5hdzqs0hi.pdf",
+        "retrievedAt": "2026-07-28T17:50:10.635Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:19d1a5a884ffff7c2cbc11b21db71a560880c541ac21830f2c608f5492f3fada%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "bae3fcfcbd23750e1619d31b0615671464daef1873cd88ff5dca135832e7396e"
+        },
+        {
+          "id": "source-record:games-workshop:19d1a5a884ffff7c2cbc11b21db71a560880c541ac21830f2c608f5492f3fada%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "13278cf020d03bb060c4bbf3e065f30625ce1398a6ad1bf2df2e576a32930aff"
+        },
+        {
+          "id": "source-record:games-workshop:19d1a5a884ffff7c2cbc11b21db71a560880c541ac21830f2c608f5492f3fada%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "6159642fc8294cf8f978eba12401444f71b108b759f270a30319c2b8ed7cc8ff"
+        },
+        {
+          "id": "source-record:games-workshop:19d1a5a884ffff7c2cbc11b21db71a560880c541ac21830f2c608f5492f3fada%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "9ffc84009ef7bdff340ae100723e05c419e65a11de8e5bd27253f149d8788c72"
+        }
+      ],
+      "title": "Spearhead: Soulblight Gravelords – Deathrattle Tomb Host"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 4195596,
+        "checksum": "3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2",
+        "etag": "\"758ce673f97ef145cb0d44775a0097ad\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_stormcast_eternals_dec_24-jyo1gqr2pm-0e3gf5ydzh.pdf",
+        "lastModified": "Fri, 13 Dec 2024 08:12:02 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_stormcast_eternals_dec_24-jyo1gqr2pm-0e3gf5ydzh.pdf",
+        "retrievedAt": "2026-07-28T17:50:10.873Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "a14aad5e360fbb22c9941fc0dcb11431129283c9216f3c4d28ed9148c2191dcb"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "2133c404bd5995b9f845de4ca92550ca8d2c5f83fcf07fff9425a04a7f3eeb5b"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "2133c404bd5995b9f845de4ca92550ca8d2c5f83fcf07fff9425a04a7f3eeb5b"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "29bc57892b87d8078af1a14fa58b5643647b6fd24d355b17e08a797a966c60c7"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "60862c567c5db2245d371d4e0a25055985817a1b8c8e55313e94e4590ab92d97"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "6ea6e0fc4e8944780b241def943cacaf6e9fcfaddc084af9753c7a89fb4cbfa6"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "4e43cf389b7853cccf61169c69c5aec56da087d14cc69657493d3b39a3cd81df"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "eaf63b8f168fd9e56ad6243c34c18f348a636804c791abcede1fac8653aeab0e"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "fb35f4b41f832e751e85260e94be16ded9c7f3860eedf25fc382d2fec489ce39"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "a459162d5ac16dec131b5d2055371593be8484db678a82fff30ce7e1e3968a78"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "4c8e21fc221e31feb4423bbc34a2e57d337773d98c98ee8f3d1e50b4bfd303ac"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "b2bf0b887d7dff3ce48d0d5719701b1367cb388e4e4e4b3db4135414b7603283"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "b9cf45787e7b9a27d49e84dbc2056f47bc87f7abdae0d86b086127073768a943"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "b74ba7a081ba2b9e0e4373ae8583169952641decaa8ab089f0b9b7a23044554e"
+        },
+        {
+          "id": "source-record:games-workshop:3a3c901779b5fb74d3f6dc11882838a2dd3f96cc664ca0537197c9ad57c987c2%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "2b234d58655da8ddd9aae02acef2a5d73afe3638f9d40d0c8872f36d43889183"
+        }
+      ],
+      "title": "Spearhead: Stormcast Eternals - Yndrasta’s Spearhead and Vigilant Brotherhood"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 22420115,
+        "checksum": "d7d82cb235abe41d8691b87d3cddf06766007d7aad40481c20cfd1d6f3fe6f79",
+        "etag": "\"11b0f8c291a0e0e72699fc44b57eb9cb\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_sylvaneth_bitterbark-copse-jqmpmca0ca-baul2djdaq.pdf",
+        "lastModified": "Tue, 14 Apr 2026 08:34:56 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_spearhead_sylvaneth_bitterbark-copse-jqmpmca0ca-baul2djdaq.pdf",
+        "retrievedAt": "2026-07-28T17:50:11.574Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:d7d82cb235abe41d8691b87d3cddf06766007d7aad40481c20cfd1d6f3fe6f79%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "b56be58d3f90a256057d85270b1c8fdcd97da8fe5563e81b45b009f0b5609908"
+        },
+        {
+          "id": "source-record:games-workshop:d7d82cb235abe41d8691b87d3cddf06766007d7aad40481c20cfd1d6f3fe6f79%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "e9c0c06231fe11209cb9dcc1c250ff274f641069b3ad7876a4820544f9b334ca"
+        },
+        {
+          "id": "source-record:games-workshop:d7d82cb235abe41d8691b87d3cddf06766007d7aad40481c20cfd1d6f3fe6f79%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "45580649cf8df1f474b7077b79180886327c934dada753a5cfdd7dc707c87033"
+        },
+        {
+          "id": "source-record:games-workshop:d7d82cb235abe41d8691b87d3cddf06766007d7aad40481c20cfd1d6f3fe6f79%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "488747ce2e6b5de3f675bd562fd2df32ef427ee15801dbef1c50814d8f7ae233"
+        }
+      ],
+      "title": "Spearhead: Sylvaneth - Bitterbark Copse"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 6702317,
+        "checksum": "00f6bad3cd8b976d412f7d9f9029e75051517677cb6e5074cf0b675470f44ca1",
+        "etag": "\"20d703e7f68a6be54ed65cdfa91cd05a\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_25-03_aos_spearhead_spitewing_flight_sylvaneth-rtiguzvyhx-f7di7yhcim.pdf",
+        "lastModified": "Thu, 19 Mar 2026 09:52:36 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_25-03_aos_spearhead_spitewing_flight_sylvaneth-rtiguzvyhx-f7di7yhcim.pdf",
+        "retrievedAt": "2026-07-28T17:50:11.939Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000002"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:00f6bad3cd8b976d412f7d9f9029e75051517677cb6e5074cf0b675470f44ca1%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "ddbeef8c7118f102f64bc7dd2612000e99eaf6256def57f2ef367d29c01f65b5"
+        },
+        {
+          "id": "source-record:games-workshop:00f6bad3cd8b976d412f7d9f9029e75051517677cb6e5074cf0b675470f44ca1%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "01ee2aec9cb276bfe913392cc2057c8ff6edb92e3d7d49ec2c83886448379c01"
+        },
+        {
+          "id": "source-record:games-workshop:00f6bad3cd8b976d412f7d9f9029e75051517677cb6e5074cf0b675470f44ca1%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "2fde522671bbe360b532886315e44c025c9e25c828d72ee66d63c852aee5f56b"
+        },
+        {
+          "id": "source-record:games-workshop:00f6bad3cd8b976d412f7d9f9029e75051517677cb6e5074cf0b675470f44ca1%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "bfb3eb71a21723ae8b05e58b7e58c64c5e162e48ed2d26ccc56ebc425cf97b8f"
+        }
+      ],
+      "title": "Spearhead: Sylvaneth - Spitewing Flight"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 3709823,
+        "checksum": "9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a",
+        "etag": "\"56756190b43c9eb933a79555bf3e0144\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_29-04_aos_other_rules_universal_manifestations_warscroll-j4l57m8ikh-asbcd2gzks.pdf",
+        "lastModified": "Mon, 27 Apr 2026 08:57:59 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_29-04_aos_other_rules_universal_manifestations_warscroll-j4l57m8ikh-asbcd2gzks.pdf",
+        "retrievedAt": "2026-07-28T17:50:12.217Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "70a5eeb32a9f7413f1bcf7dd2c44e7f3b87ab9f1528150bffac51a9ff3161eaa"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "23eabc944a2a83e3c3aa5495c440a59233fad19e057695f010b6334f92d09955"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "b91798ddae70476555c2fb55dde9cf2793fad8e7009b01af4067044a7abf36ca"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "149f6096225538f4aa14ec7fdaf3de5ac80c168aecffd4e98a6419eb05d400e5"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "130771f24e21be162e7f027649b993b8e6dfdfd2206e91a9b1d91bd9d932c8db"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "02f54a4b141c024fb933afcd5cd59bbb955c38e5fdf23b8d612c5ac57dd733fa"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "2e8b9add322b2cd7faa0ff28b47e5382d0bdbe8fbfccb6ae61107ab1df451b9a"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "727866432a6cdab95b935d448cb51dad78b1f1a06e816bb6cc392ea7c6cb2d23"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "13e64b8a7461432907088763a072a0f266fba339cebb0cb8b80089b4bc214852"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "1e2526771ef9c6fb91baca83188619b7e5040cca3fa4f31063c2c02bb0b42398"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "7471fcc76d9819527aa871c97e5a27b957f70c443a8ef56d50ca166902b73ea2"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "d6ae8eb1cd08688e2a59c65e6b68bb2dfc8f5097c43293b94cbf56d73c9bd227"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "474a81048c869d1798a9ae8e1af9e16b443c0b5b3a45657f5c708eebe4374e4e"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "a85df55726b07b77fd8fc92db3191a2073b30fbc716d81bf4b63f68197dee51b"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "5403fa1f2ff8d160d067b1082506823a9706fa446373f0d5a9c5681b8c3d4546"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "6bd9c1bafccb81b294be4b353f8164361e40a74b273a96b3966b3cddc3ba6e0d"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "b8bede52f7052007f2b8cd794a150a76d7ced9310b1a5158a0ed15f0eb4282cd"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "05df3da87a2885230db4a7b25f398158928e2b98af7401f706d369664ee482e0"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "2cc2eec97131011f47d6c0c3e809793ffb2577ef92cacf4265e5befce22c1d97"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "fbf27362dcba3b61a893ce6281ed0927a71f6d2825689229ea8e25b04e0d84e4"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A21",
+          "page": 21,
+          "recordChecksum": "6ec17d45b6047cc24dd81010ac0ccdbaa22769d776686186082c462fd9a26bbb"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A22",
+          "page": 22,
+          "recordChecksum": "1ff7556649770981318d35a40f60532548dba36bb1ced8fef27b04604e667050"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A23",
+          "page": 23,
+          "recordChecksum": "1c8ee37ac5e148380a0dccdb0f13f7dbab6ced40add3278d1e98c4ac01d12fac"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A24",
+          "page": 24,
+          "recordChecksum": "b97add05de7aa88e17d7fe62972229b05845cdb2b1cb28469af6e7f1f3169391"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A25",
+          "page": 25,
+          "recordChecksum": "f5db695b253702107463a951a8da1276308675823c66c6d560df3779675f73a4"
+        },
+        {
+          "id": "source-record:games-workshop:9399e542477af8e5abb4d6b384acb123aa7de79c0de6a31d16e6851eb318ad0a%3Apage%3A26",
+          "page": 26,
+          "recordChecksum": "2e4ad486792e32c929d522aa8cb9688abaaa9eed3c237f81e7789009c5752eee"
+        }
+      ],
+      "title": "Universal Manifestations"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 1525706,
+        "checksum": "97377f04cf2935ede8d31ed969982f23384875cb097c327eb0a52d06804e6375",
+        "etag": "\"ebbbce4b3a30655a429ed8a123645dd2\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_using_the_scourge_of_aqshy_rules-mfzsg5z6eg-twfmfgwynu.pdf",
+        "lastModified": "Mon, 29 Jun 2026 11:23:39 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_30-06_warhammer_age_of_sigmar_using_the_scourge_of_aqshy_rules-mfzsg5z6eg-twfmfgwynu.pdf",
+        "retrievedAt": "2026-07-28T03:05:47.978Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:97377f04cf2935ede8d31ed969982f23384875cb097c327eb0a52d06804e6375%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "d08762e862768a1d9e7084d563dfeb7fcab3ddc47b94ca5568999f81d927abc0"
+        }
+      ],
+      "title": "Using the Scourge of Aqshy Rules"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 1217168,
+        "checksum": "9bded144a62e6b3404e51c5d903f5212b324bcdfd8048eeb68a2e77e4ac6f0a9",
+        "etag": "\"e064df71fb1972ac68d37b5370f2d0c7\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_scourge_of_ghyran-schqapm2tm-oshtzpsidi.pdf",
+        "lastModified": "Thu, 08 May 2025 13:28:02 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_scourge_of_ghyran-schqapm2tm-oshtzpsidi.pdf",
+        "retrievedAt": "2026-07-28T19:27:57.056Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000003"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:9bded144a62e6b3404e51c5d903f5212b324bcdfd8048eeb68a2e77e4ac6f0a9%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "9fcc96efed7fbe94ba548422818e04ee60e949d5ded57af91cb4a966ee4c9e4c"
+        }
+      ],
+      "title": "Using the Scourge of Ghyran Rules"
+    },
+    {
+      "artifact": {
+        "adapterVersion": "games-workshop-pdf/1",
+        "byteLength": 44885400,
+        "checksum": "be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798",
+        "etag": "\"b4d9cba9024efa6e3821f19cca9ddc0b\"",
+        "finalUrl": "https://assets.warhammer-community.com/eng_aos_core&key_the-rules_apr25-t7q3fbv0zb-bit50crc5k.pdf",
+        "lastModified": "Mon, 31 Mar 2025 07:49:59 GMT",
+        "mediaType": "application/pdf",
+        "redirectChain": [],
+        "requestUrl": "https://assets.warhammer-community.com/eng_aos_core&key_the-rules_apr25-t7q3fbv0zb-bit50crc5k.pdf",
+        "retrievedAt": "2026-07-28T03:05:51.885Z"
+      },
+      "documentKind": "reference",
+      "rulesContextIds": [
+        "rules-context:90000000-0000-4000-8000-000000000001",
+        "rules-context:90000000-0000-4000-8000-000000000002",
+        "rules-context:90000000-0000-4000-8000-000000000003",
+        "rules-context:90000000-0000-4000-8000-000000000004",
+        "rules-context:90000000-0000-4000-8000-000000000006"
+      ],
+      "sourceRecords": [
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A1",
+          "page": 1,
+          "recordChecksum": "b308bb8762437f6362c56fa8add993f6ec31806c07b34dfbc3d0ee69fe2aa3ff"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A2",
+          "page": 2,
+          "recordChecksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A3",
+          "page": 3,
+          "recordChecksum": "fe10faf860d50db5f7f8ac610a0cb7c0fdc2391f88d405339784314c6882c6d7"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A4",
+          "page": 4,
+          "recordChecksum": "8bf7af03e1282ce8d561e2a9c6d6b8acbbffb1a0ca1a7acffb2622d42b4e568b"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A5",
+          "page": 5,
+          "recordChecksum": "1ae6fdb147f9e4b36774d92094d5d73a7bca4d44fbbbe20e75a8343d491616e1"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A6",
+          "page": 6,
+          "recordChecksum": "4397ff56ed347fb13831576a56ff4d1a7ac47fbcbc5055a8c852eca3e0470637"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A7",
+          "page": 7,
+          "recordChecksum": "15ade31c9db0a7ea2f356655ce8cc3a63f62c51f05ac08d7c5b7a8479626c5db"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A8",
+          "page": 8,
+          "recordChecksum": "8133a2be6a811c62ad4bfa26035031165dcf3aef27836a886009527c6960a14d"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A9",
+          "page": 9,
+          "recordChecksum": "e28070aad799cf3b8a1b9a7dcf210d42f48d8a7a185d57da2aa694b0a96f0922"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A10",
+          "page": 10,
+          "recordChecksum": "56c0c5712d706fdb652e91323a3b34695631e75e91e4763094b7ca8b21611174"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A11",
+          "page": 11,
+          "recordChecksum": "c99b966e702b3767af1e9f92d65c79835e4fa2bc96a5adf2a64874adbd1c2ba6"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A12",
+          "page": 12,
+          "recordChecksum": "662956f6764393f06392139f94a732b00e76875c5416ae1fd6da9307050067ce"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A13",
+          "page": 13,
+          "recordChecksum": "11f9f0d756061102605d7747126a9da598abff7c3782d6da294584da179f3d55"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A14",
+          "page": 14,
+          "recordChecksum": "b475ff054897d944beaf54b393ee78e9a800105b380786cb6e06ab68aeaac498"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A15",
+          "page": 15,
+          "recordChecksum": "c4b4a5c1cf7f50f75fd86c740cc191f9ce994068dfa9482b19aac7c49e2a11a5"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A16",
+          "page": 16,
+          "recordChecksum": "4152d52c69bc129ea3ec7b1a53333d5352988acdd39baaeee4b24354e87b78be"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A17",
+          "page": 17,
+          "recordChecksum": "95511d8cac09c445c328ec859b0ff0eac529029d2d937ada9c8980ec65027735"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A18",
+          "page": 18,
+          "recordChecksum": "3fc8437c238b28d5455a530a90b73c0a28135fea47bcdc1481dedb95f8dcb08b"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A19",
+          "page": 19,
+          "recordChecksum": "604c49594f84af7de9fceaf111c06df431d1bb384bcc0d6d112fd58552817b86"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A20",
+          "page": 20,
+          "recordChecksum": "bdbe2fd9999faaba64daba2661fdb0f8554db0e5799d8bf4caa3b77a2577892d"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A21",
+          "page": 21,
+          "recordChecksum": "6cab05b4b5efd78aaeb38f7dcc10586ec10aa6d6acacd82f6935a0860ee0516f"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A22",
+          "page": 22,
+          "recordChecksum": "b8c8ca5218a809bc08545104540b2e26d92c24008eca481f8f246ed2118408fe"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A23",
+          "page": 23,
+          "recordChecksum": "3ecfcb45fcd04390f45e3f6cea212c4f926157bd5f4ba0b0387a3941690daa64"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A24",
+          "page": 24,
+          "recordChecksum": "ad10c64d99bdd383b02670546b3c7deaff6ba36ca68a8029f14cddd3b3368132"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A25",
+          "page": 25,
+          "recordChecksum": "3296b988768b35242325991ec5015a45b6c4136d6721a099a2ff2e00da61d09a"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A26",
+          "page": 26,
+          "recordChecksum": "ad22592e75b0fda4285a94898694f844374b0c3d4c432b4c49ee38a81fda792e"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A27",
+          "page": 27,
+          "recordChecksum": "b6564052e06d8e0e867a47f7dce6b8bf0c59e7e2c58b40c548709de616f2cfe4"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A28",
+          "page": 28,
+          "recordChecksum": "8e553fa6b9a1f052b9c2db0c8e5a67d438b706273decdcb0415ada2f00ef7179"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A29",
+          "page": 29,
+          "recordChecksum": "2a1711867387635fd7e62be9225fd0ce0eff442f871a1835898728be62b62f7e"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A30",
+          "page": 30,
+          "recordChecksum": "514e711a90973f6515ff2889d27dbae099a03e7e269e1ca8e682796785b555e9"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A31",
+          "page": 31,
+          "recordChecksum": "c8978eea70875b74934979330d214bf300fd85de126166ddd3f840f576875574"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A32",
+          "page": 32,
+          "recordChecksum": "a42ddd427600d8134a6aac7e3678f525ffe946de896c27cfa01558415ab745fa"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A33",
+          "page": 33,
+          "recordChecksum": "0147d59a51177d26b97670b87e06483bb24ba6c8421fd3dffbeada2b559c463e"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A34",
+          "page": 34,
+          "recordChecksum": "aae55064bd50b39a14060540a9cd6f38d93cc867c3c94014ede0df17621f5510"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A35",
+          "page": 35,
+          "recordChecksum": "4e1cdf30b3f023301f185fbb2c4ed4313300c71da59228398f1027578fab0ed0"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A36",
+          "page": 36,
+          "recordChecksum": "0e36a14de73761c9048d296e629cfa185e74a08a0bee876b40aacc61aec9e455"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A37",
+          "page": 37,
+          "recordChecksum": "593622c63bba2782416b809b1795e8b936b498d1f8cc4fbab0bc77be275841cc"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A38",
+          "page": 38,
+          "recordChecksum": "d25bf41984c2edbf676ecff3860e770ba93e54d0c80c0f5fe5a97c7f6cfb3de4"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A39",
+          "page": 39,
+          "recordChecksum": "159aba9c7a22c346baaeeb698cc436b9f50a04bb66857c0e0d0e494a0aba3839"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A40",
+          "page": 40,
+          "recordChecksum": "e7b9d8bd0c30f8c127c039db9a6107ae8ee1af8e8f245da4a3dcb0aab35a2509"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A41",
+          "page": 41,
+          "recordChecksum": "3c2650136d4c7fd05802fc345ae1da59dbbaf3810c84e1e445641757216b0ccd"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A42",
+          "page": 42,
+          "recordChecksum": "9fbab4abf61fd7dfa1642a0fba26a32dc5189f997009f694a63adf21359443a0"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A43",
+          "page": 43,
+          "recordChecksum": "d41cb1e03832bf8f1e4c27417e3744b99bad16748ac3478e32c563faa7474910"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A44",
+          "page": 44,
+          "recordChecksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A45",
+          "page": 45,
+          "recordChecksum": "de9704eeb7dc7d6679039809ee0a6ff6fa52999926306f3ea6e5451366af36e3"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A46",
+          "page": 46,
+          "recordChecksum": "bef595c7458bfba9c51f169cbc2db83ac0d3219b84f2634dc6a00cd1efaaa97f"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A47",
+          "page": 47,
+          "recordChecksum": "81b46289823c5a913fd55aa5d3eebc6675d83c7ca475c32afc3ce752fb6dc688"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A48",
+          "page": 48,
+          "recordChecksum": "0f6f554fd3134e853b175fa042f6c653a977b1011201a7a2002a50599ff67e6d"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A49",
+          "page": 49,
+          "recordChecksum": "488ab0607501ff8ded1df7323fe70771017518888a28d0c028f2ea9f6fd0ec89"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A50",
+          "page": 50,
+          "recordChecksum": "87fa6efa3ed25895f1b078f6747b38ec4e00d24435394b4f8fbc0b24125a926b"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A51",
+          "page": 51,
+          "recordChecksum": "3f7e80ed9c78030ebdcc3bab40618fa9f5e016f1f3b36f83f99ff2714ef39c9b"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A52",
+          "page": 52,
+          "recordChecksum": "e0299eaecdde3e30b295d0e278a3028fcf124550c06566f4c1ed992e13111cba"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A53",
+          "page": 53,
+          "recordChecksum": "def55cb18ed322dff14289c0484e159ccbf116e85f07ac60401ff5d4ffd48d99"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A54",
+          "page": 54,
+          "recordChecksum": "5651d77cbbfe8ed9038329417d92330aa57758eae43e83bbb461647ecfb27fff"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A55",
+          "page": 55,
+          "recordChecksum": "050b9a6dab45441b1fff35a325d9da25502dac3571e40eaba550482bacb750ca"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A56",
+          "page": 56,
+          "recordChecksum": "78c717851875738e3f85f8e8bb4d903aaf9365b6e2873d99fab92045e921cd2b"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A57",
+          "page": 57,
+          "recordChecksum": "9c7c27a61a0c009c2b3308e379fb530025e228f0912bb2536aca48b114fb12f9"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A58",
+          "page": 58,
+          "recordChecksum": "6dd349c5dbb8dff48a6dcecc076b4c61402cb7d48601215bf399187bfaf7f16d"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A59",
+          "page": 59,
+          "recordChecksum": "7deb6ff5eaa3a106168b4552451688080721cb676ed8b408e9d398cb210fc338"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A60",
+          "page": 60,
+          "recordChecksum": "918f23723106ee5b74a6e5bd4da3c6682bf2c821500105f2f763845a7b619263"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A61",
+          "page": 61,
+          "recordChecksum": "74861def457fa8ec8b0562b97256bed9019cf5a0d36d401ce2a257b0ea63978d"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A62",
+          "page": 62,
+          "recordChecksum": "ae63c939a1eadd6ba5dec37ed5e857230e0a295afec8d197cb4b9c1487c6fc44"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A63",
+          "page": 63,
+          "recordChecksum": "0d888ed9a78ce97afae3f0831f3e556cc3c476688e222daf63a1c756f4aa7d79"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A64",
+          "page": 64,
+          "recordChecksum": "125f4e328a8c1c9eb00860d844ec20fc7c71a0ab8c29ceb117181628facbfc25"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A65",
+          "page": 65,
+          "recordChecksum": "e488028ee4c8041f6c98a63dd8a7411b827396d6f643c9cd4b1d627d1601b0b0"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A66",
+          "page": 66,
+          "recordChecksum": "e8c9c0ad7405a83c76e34ba726d05c807f9e99f7a61ca01fff50a80278e0e926"
+        },
+        {
+          "id": "source-record:games-workshop:be0b9d4f32135d45f9dfff251beb4940afddb154cfe3416cd8e6ac56994a0798%3Apage%3A67",
+          "page": 67,
+          "recordChecksum": "8d8741d74c8ca946672e83075b2e158ca98a82436f6ca81261f2a1342b66004f"
+        }
+      ],
+      "title": "Warhammer Age of Sigmar Core Rules, Spearhead Rules, Terrain List and Glossary"
+    }
+  ],
+  "revision": "aos4-corpus-2026-07-31",
+  "rulesContext": {
+    "id": "rules-context:90000000-0000-4000-8000-000000000001",
+    "mode": "standard",
+    "name": "Age of Sigmar Fourth Edition",
+    "status": "current",
+    "validFrom": "2024-07-13"
+  },
+  "schemaVersion": 1,
+  "supersededSourceRecords": {
+    "checksum": "31a9e711d23800deb3e0fb23bd686e9e4a85e82ef264aea806911adb506281ef",
+    "expectedCount": 18897,
+    "reason": "Current reviewed Wahapedia HTML replaces the accepted May 2026 bulk warscroll and faction-rule records; superseded rows remain dispositioned for audit but cannot enter the current runtime."
+  },
+  "timingOverrides": [
+    {
+      "abilityKind": "active",
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A39"
+      ],
+      "reason": "The July 2026 Blades of Khorne update replaces Sigil of Doom with a Your Hero Phase timing and no usage limit.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fblades-of-khorne%2Fwarscrolls.html%23datasheet%3ABleeding-Icon%2Fability%3A1",
+      "timings": [
+        {
+          "kind": "active",
+          "perspective": "your",
+          "raw": "Your Hero Phase",
+          "window": {
+            "kind": "turn-phase",
+            "phase": "hero"
+          }
+        }
+      ]
+    },
+    {
+      "abilityKind": "passive",
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A57"
+      ],
+      "reason": "The June 2026 Games Workshop Rules Updates explicitly restores the omitted Passive timing for Sanctum of Amyntok's Multiple Parts ability.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Flumineth-realm-lords%2Fwarscrolls.html%23datasheet%3ASanctum-of-Amyntok%2Fability%3A2",
+      "timings": [
+        {
+          "kind": "passive",
+          "perspective": "neutral",
+          "raw": "Passive",
+          "window": {
+            "kind": "always"
+          }
+        }
+      ]
+    },
+    {
+      "abilityKind": "passive",
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A61"
+      ],
+      "reason": "The July 2026 Nighthaunt update replaces Damned Vessel reaction timing with Passive.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fnighthaunt%2F%23faction-ability%3AHeroic-Traits-2%3Aability%3A1",
+      "timings": [
+        {
+          "kind": "passive",
+          "perspective": "neutral",
+          "raw": "Passive",
+          "window": {
+            "kind": "always"
+          }
+        }
+      ]
+    }
+  ],
+  "universalFactionContent": [
+    {
+      "factionId": "EnS",
+      "reason": "Endless Spells is a Wahapedia container row, not an army. The universal manifestation lores it carries (Aetherwrought Machineries, Forbidden Power, Krondspine Incarnate, Morbid Conjuration, Primal Energy, Twilit Sorceries) and their manifestation warscrolls may be taken by any army, so they are offered to every approved faction rather than to the container alone."
+    }
+  ],
+  "warscrollKeywordOverrides": [
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:f22149076e05dd6c450a5390c8d11dd72a8bf62663dd9a4df6ab99dad621acd2%3Apage%3A33"
+      ],
+      "reason": "The July 2026 Other Digital Downloads update removes the Hero keyword.",
+      "remove": [
+        "HERO"
+      ],
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Flumineth-realm-lords%2Fwarscrolls.html%23datasheet%3AThyrielle-s-Zephyrites-1%2Fwarscroll"
+    }
+  ],
+  "weaponProfileOverrides": [
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A17"
+      ],
+      "profile": {
+        "damage": "See below",
+        "rend": "See below",
+        "wound": "See below"
+      },
+      "reason": "The Games Workshop supplement shows one merged 'See below' value spanning Wound, Rend, and Damage.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fcities-of-sigmar%2Fwarscrolls.html%23datasheet%3ABattlemage-on-Luminark-of-Hysh%2Fweapon%3A1"
+    },
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:031051d7669cc9441cd9ab2b5b137ffff6547089c4568f9233ea5331f7e89a75%3Apage%3A17"
+      ],
+      "profile": {
+        "damage": "See below",
+        "rend": "See below",
+        "wound": "See below"
+      },
+      "reason": "The Games Workshop supplement shows one merged 'See below' value spanning Wound, Rend, and Damage.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fcities-of-sigmar%2Fwarscrolls.html%23datasheet%3ALuminark-of-Hysh%2Fweapon%3A1"
+    },
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:64cbf4bd20cd400f4e609236e1f16d53d73f6b74ced10f0ca34192c0f08b47be%3Apage%3A39"
+      ],
+      "profile": {
+        "hit": "4+",
+        "wound": "4+"
+      },
+      "reason": "The Games Workshop Legends warscroll includes the target-number suffixes omitted by the secondary HTML profile.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fgloomspite-gitz%2Fwarscrolls.html%23datasheet%3ABorgit-s-Beastgrabbaz%2Fweapon%3A1"
+    },
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:64cbf4bd20cd400f4e609236e1f16d53d73f6b74ced10f0ca34192c0f08b47be%3Apage%3A39"
+      ],
+      "profile": {
+        "rend": "-",
+        "wound": "3+"
+      },
+      "reason": "The Games Workshop Legends warscroll supplies the no-Rend dash and target-number suffix omitted by the secondary HTML profile.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fgloomspite-gitz%2Fwarscrolls.html%23datasheet%3ABorgit-s-Beastgrabbaz%2Fweapon%3A2"
+    },
+    {
+      "officialSourceRecordIds": [
+        "source-record:games-workshop:64cbf4bd20cd400f4e609236e1f16d53d73f6b74ced10f0ca34192c0f08b47be%3Apage%3A39"
+      ],
+      "profile": {
+        "rend": "-",
+        "wound": "5+"
+      },
+      "reason": "The Games Workshop Legends warscroll supplies the no-Rend dash and target-number suffix omitted by the secondary HTML profile.",
+      "sourceRecordId": "source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Ffactions%2Fgloomspite-gitz%2Fwarscrolls.html%23datasheet%3ABorgit-s-Beastgrabbaz%2Fweapon%3A3"
+    }
+  ]
+}

--- a/docs/data/aos4-maintenance.md
+++ b/docs/data/aos4-maintenance.md
@@ -77,6 +77,25 @@ The strict generation gate and the checksum-bound machine review are green for t
 snapshot. See [`aos4-accuracy-review.md`](./aos4-accuracy-review.md) for the review, correction,
 verification, and staleness workflow.
 
+### Pending review revision: corpus-2026-07-31
+
+`data/aos4/reviews/corpus-2026-07-31.json` is a prepared, not-yet-accepted revision. It carries the
+2026-07-30 review forward and additionally dispositions six Wahapedia rules-page source records as
+ignored: the illustrative `EXAMPLE SPELL` (Mystic Shield) and `EXAMPLE PRAYER` (Resurrection) cards
+that the core rules and the 2024-25/2025-26 General's Handbook pages reproduce to show the
+ability-card format. They are not playable abilities, and the universal core-rules wiring was
+surfacing them as reminders for every army (customer report 2026-07-31). Sacred Rites is not
+excluded ("All PRIESTS know the following prayer"), and the Ascension page's Mystic Shield and
+Resurrection are genuine Path rank rewards on an already reference-only page, so they stay.
+
+Accepting this revision requires an operator with the accepted 2026-07-30 immutable artifact cache
+(`.cache/aos4/artifacts`): run `yarn data:aos4:generate:write` against the new review, then the
+full certification campaign and `beta.json` re-point described in
+[`aos4-accuracy-review.md`](./aos4-accuracy-review.md). Until then the accepted 2026-07-30 products
+remain byte-for-byte reproducible and the beta gate stays bound to them.
+`src/tests/aos4/coreRulesExampleAbilities.test.ts` guards the exclusion list and proves the
+resulting selection graph drops exactly the example cards.
+
 The older `candidate-*`, `cohort-*`, and `official-rules-*` reports are provenance for the review
 journey. Their `blocked` or `candidate-review-required` statuses describe pre-acceptance inputs, not
 the current runtime.

--- a/src/tests/aos4/coreRulesExampleAbilities.test.ts
+++ b/src/tests/aos4/coreRulesExampleAbilities.test.ts
@@ -1,0 +1,156 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { armyFactions, type Aos4Catalog, type Faction } from '../../aos4/domain'
+import { AOS4_CATALOG } from '../../aos4/generated'
+import { projectReminders } from '../../aos4/reminders'
+import { resolveSelection } from '../../aos4/select'
+
+/**
+ * Customer report 2026-07-31: reminders for ordinary armies showed "Mystic Shield" and
+ * "Resurrection", which are not playable AoS 4 abilities. Wahapedia's core rules page (and the
+ * General's Handbook 2024-25 / 2025-26 rules pages) reproduce the core rulebook's illustrative
+ * EXAMPLE SPELL card (Mystic Shield) and EXAMPLE PRAYER card (Resurrection) to show the
+ * ability-card format, and the bounded rules-page parser ingested those example cards as real
+ * abilities inside the universal "Spells" / "Prayers" groups.
+ *
+ * The correction is a reviewed input: `data/aos4/reviews/corpus-2026-07-31.json` dispositions the
+ * six example-card source records as ignored. The Ascension page's Mystic Shield and Resurrection
+ * are deliberately NOT excluded: there they are genuine Path of the Mage / Path of the Devout
+ * rank rewards ("ELITE: When a HERO on this Path gains this rank, pick 1 of the following
+ * abilities"), and that page is already reference-only. Sacred Rites is likewise kept: the core
+ * rules state "All PRIESTS know the following prayer", so it is a real universal ability.
+ */
+
+interface PendingReview {
+  revision: string
+  ignoredSourceRecords: Array<{ sourceRecordId: string; reason: string }>
+}
+
+const wahapediaRulesAbilityRecordId = (page: string, section: string, index: number): string =>
+  `source-record:wahapedia:html%3Ahttps%3A%2F%2Fwahapedia.ru%2Faos4%2Fthe-rules%2F${page}%2F%23rules-ability%3A${section}%3Aability%3A${index}`
+
+const EXAMPLE_CARD_SOURCE_RECORD_IDS = [
+  wahapediaRulesAbilityRecordId('the-core-rules', 'Spells', 1),
+  wahapediaRulesAbilityRecordId('the-core-rules', 'Prayers', 2),
+  wahapediaRulesAbilityRecordId('general-s-handbook-2024-25', 'Spells', 1),
+  wahapediaRulesAbilityRecordId('general-s-handbook-2024-25', 'Prayers', 1),
+  wahapediaRulesAbilityRecordId('general-s-handbook-2025-26', 'Spells', 1),
+  wahapediaRulesAbilityRecordId('general-s-handbook-2025-26', 'Prayers', 2),
+]
+
+const EXAMPLE_CARD_NAMES = ['MYSTIC SHIELD', 'RESURRECTION']
+
+const pendingReview = JSON.parse(
+  readFileSync(path.join(process.cwd(), 'data', 'aos4', 'reviews', 'corpus-2026-07-31.json'), 'utf8')
+) as PendingReview
+
+const exampleRecordIdSet = new Set(EXAMPLE_CARD_SOURCE_RECORD_IDS)
+
+/** Entities the generator will drop once the pending review is regenerated. */
+const excludedEntityIds = new Set(
+  AOS4_CATALOG.entities
+    .filter(
+      entity =>
+        entity.sourceRefs.length > 0 &&
+        entity.sourceRefs.every(reference => exampleRecordIdSet.has(reference.sourceRecordId))
+    )
+    .map(entity => entity.id)
+)
+
+/** The catalog as deterministic regeneration will produce it from the pending review. */
+const correctedCatalog: Aos4Catalog = {
+  ...AOS4_CATALOG,
+  entities: AOS4_CATALOG.entities.filter(entity => !excludedEntityIds.has(entity.id)),
+  relationships: AOS4_CATALOG.relationships.filter(
+    relationship => !excludedEntityIds.has(relationship.from) && !excludedEntityIds.has(relationship.to)
+  ),
+}
+
+const reminderNames = (
+  catalog: Aos4Catalog,
+  faction: Faction,
+  rulesContextId: string,
+  overlays: { allowsLegends?: boolean; allowsHistorical?: boolean } = {}
+): string[] => {
+  const selection = resolveSelection(catalog, {
+    explicitIds: [faction.id],
+    rulesContextId: rulesContextId as never,
+    ...overlays,
+  })
+  return projectReminders(catalog, selection).map(reminder => reminder.name)
+}
+
+describe('core-rules example ability cards stay out of reminders (customer report 2026-07-31)', () => {
+  it('dispositions every example-card source record as ignored in the pending review revision', () => {
+    expect(pendingReview.revision).toBe('aos4-corpus-2026-07-31')
+    const ignoredById = new Map(
+      pendingReview.ignoredSourceRecords.map(record => [record.sourceRecordId, record.reason])
+    )
+    EXAMPLE_CARD_SOURCE_RECORD_IDS.forEach(sourceRecordId => {
+      expect(ignoredById.has(sourceRecordId)).toBe(true)
+      expect(ignoredById.get(sourceRecordId)).toMatch(/example/i)
+      expect(String(ignoredById.get(sourceRecordId)).trim()).not.toBe('')
+    })
+    // The previously accepted disposition is carried forward, not replaced.
+    expect(
+      ignoredById.has('source-record:wahapedia:Faction_abilities.csv%3ACoS%3A000000529%3A000002058%3A2')
+    ).toBe(true)
+    // The class fix must not overreach onto real universal abilities or the genuine Ascension
+    // Path of the Mage / Path of the Devout rank rewards.
+    pendingReview.ignoredSourceRecords.forEach(record =>
+      expect(record.sourceRecordId).not.toMatch(/ascension/)
+    )
+    // Sacred Rites is a real universal prayer ("All PRIESTS know the following prayer").
+    expect(ignoredById.has(wahapediaRulesAbilityRecordId('the-core-rules', 'Prayers', 1))).toBe(false)
+  })
+
+  it('targets only the illustrative Mystic Shield and Resurrection cards', () => {
+    const targeted = AOS4_CATALOG.entities.filter(entity =>
+      entity.sourceRefs.some(reference => exampleRecordIdSet.has(reference.sourceRecordId))
+    )
+    // Before regeneration the six example entities are present; afterwards the list is empty.
+    // Either way, nothing except the two example cards may be touched by the exclusions.
+    targeted.forEach(entity => {
+      expect(entity.kind).toBe('ability')
+      expect(EXAMPLE_CARD_NAMES).toContain(entity.name)
+      expect(entity.sourceRefs.every(reference => exampleRecordIdSet.has(reference.sourceRecordId))).toBe(
+        true
+      )
+    })
+    expect(targeted.length).toBeLessThanOrEqual(EXAMPLE_CARD_SOURCE_RECORD_IDS.length)
+  })
+
+  it('keeps the example cards out of every army reminder view in every context and overlay', () => {
+    const armies = armyFactions(correctedCatalog)
+    expect(armies.length).toBeGreaterThan(0)
+    armies.forEach(faction => {
+      faction.rulesContextIds.forEach(rulesContextId => {
+        const names = reminderNames(correctedCatalog, faction, rulesContextId, {
+          allowsLegends: true,
+          allowsHistorical: true,
+        })
+        EXAMPLE_CARD_NAMES.forEach(name => expect(names).not.toContain(name))
+      })
+    })
+  })
+
+  it('loses nothing except the example cards from a representative army', () => {
+    const stormcast = AOS4_CATALOG.entities.find(
+      (entity): entity is Faction => entity.kind === 'faction' && entity.name === 'Stormcast Eternals'
+    )
+    expect(stormcast).toBeDefined()
+    stormcast!.rulesContextIds.forEach(rulesContextId => {
+      const before = reminderNames(AOS4_CATALOG, stormcast!, rulesContextId)
+      const after = reminderNames(correctedCatalog, stormcast!, rulesContextId)
+      expect(after).toEqual(before.filter(name => !EXAMPLE_CARD_NAMES.includes(name)))
+      EXAMPLE_CARD_NAMES.forEach(name => expect(after).not.toContain(name))
+    })
+
+    // The real universal abilities from the same core-rules page survive the exclusion.
+    const seasonal = AOS4_CATALOG.rulesContexts.find(context => context.status === 'seasonal')!
+    const seasonalNames = reminderNames(correctedCatalog, stormcast!, seasonal.id)
+    ;['SACRED RITES', 'UNBIND', 'BANISH MANIFESTATION', 'ALL-OUT ATTACK', 'RALLY'].forEach(name =>
+      expect(seasonalNames).toContain(name)
+    )
+  })
+})


### PR DESCRIPTION
## Customer report (2026-07-31)

Reminders shown for a normal army include **Mystic Shield** and **Resurrection** — abilities that are not things in the AoS 4 game. The customer believed they are illustrative examples from the core rule book. Confirmed.

## Root cause

Wahapedia's rules pages reproduce the core rulebook's illustrative ability cards to show the ability-card format, and the bounded rules-page parser ingested them as real abilities:

- `https://wahapedia.ru/aos4/the-rules/the-core-rules/` — section **Spells** carries an **EXAMPLE SPELL** card (Mystic Shield: *"The caster's allies are bathed in an unearthly glow…"*), section **Prayers** carries an **EXAMPLE PRAYER** card (Resurrection). Verified against the live page: the cards sit directly under `EXAMPLE SPELL` / `EXAMPLE PRAYER` headings.
- The same two example cards recur on the `general-s-handbook-2024-25` and `general-s-handbook-2025-26` pages.

The parsed records landed in the universal core-rules content groups (`2.0 Spells`, `3.0 Prayers`), and the reviewed relationship graph wires **The Core Rules** group into every faction via `includes` (auto-select). The core-rules copies are applicable in the Legends and current-seasonal contexts — and the app's default rules context is GHB 2026-27 (seasonal) — so every ordinary army's reminder view showed both cards.

Affected source records (entity IDs from `src/aos4/generated/corpus/runtime.json` / `data/aos4/catalog/catalog.json`):

| Source record (page `#` locator) | Entity | Name |
| --- | --- | --- |
| `the-core-rules` `#rules-ability:Spells:ability:1` | `ability:3d47e0f4-fbaf-5134-a3e2-69c9894df057` | MYSTIC SHIELD |
| `the-core-rules` `#rules-ability:Prayers:ability:2` | `ability:e2f9619f-62c2-5288-83b2-5669e14d5662` | RESURRECTION |
| `general-s-handbook-2024-25` `#rules-ability:Spells:ability:1` | `ability:a11482dd-8fa2-5319-87a1-afc4b3585255` | MYSTIC SHIELD |
| `general-s-handbook-2024-25` `#rules-ability:Prayers:ability:1` | `ability:66f43b1a-20b4-578c-bff9-c98ea046ecaf` | RESURRECTION |
| `general-s-handbook-2025-26` `#rules-ability:Spells:ability:1` | `ability:381657a5-a62d-53ec-a495-3cf601fb6e2c` | MYSTIC SHIELD |
| `general-s-handbook-2025-26` `#rules-ability:Prayers:ability:2` | `ability:aa24d745-11b2-5f29-87f9-dd3b477cb11e` | RESURRECTION |

### Class sweep — what is deliberately NOT excluded

- **SACRED RITES** (`the-core-rules` `#rules-ability:Prayers:ability:1`) is a real universal ability — the live page states *"All PRIESTS know the following prayer: SACRED RITES"* — and it also appears as a normal card in the quick-start guide. Kept.
- **UNBIND**, **BANISH MANIFESTATION** and the command/phase cards from the same page are real universal ability cards. Kept.
- The **Ascension** page's Mystic Shield (`Path-of-the-Mage:ability:3`) and Resurrection (`Path-of-the-Devout:ability:4`) are genuine Path rank rewards (*"ELITE: When a HERO on this Path gains this rank, pick 1 of the following abilities"*), on a page the review already holds at `application: reference` with no wiring into armies. Kept.
- No other rules page (quick-start-guide, GHB 2026-27, battlepack/battleplan pages) contributes an example-labelled card to the corpus.

## The reviewed-input change

Per `docs/data/aos4-maintenance.md` / `docs/data/aos4-accuracy-review.md`, no generated file is hand-edited. The correction is a new reviewed-input revision, **`data/aos4/reviews/corpus-2026-07-31.json`**: a carry-forward of the accepted `corpus-2026-07-30.json` whose only differences are `revision`, `generatedAt`, and six new `ignoredSourceRecords` entries (1 → 7), each with the rationale that the record is an illustrative example card from the rules page, not a playable ability.

## Before / after (deterministic effect of the exclusions, measured with the real `resolveSelection` + `projectReminders`)

```
ability entities before: 4898
ability entities after : 4892   (exactly the 6 example entities removed)
army/context strata checked: 127 (27 armies x their applicable contexts, overlays on)
example-card reminders across all strata before: 254
example-card reminders across all strata after : 0
Stormcast Eternals, default context (GHB 2026-27):
  reminders before: 39 containing [ 'MYSTIC SHIELD', 'RESURRECTION' ]
  reminders after : 37 containing []
  removed reminders: [ 'MYSTIC SHIELD', 'RESURRECTION' ]  (nothing else lost)
  real universal cards retained (SACRED RITES, UNBIND, BANISH MANIFESTATION, ALL-OUT ATTACK, RALLY): true
```

`src/tests/aos4/coreRulesExampleAbilities.test.ts` locks this in: the pending review must disposition all six records (and only this class — Ascension and Sacred Rites are asserted untouched), and applying the exclusions to the catalog must drop the two example reminders from every army/context/overlay combination while changing nothing else. The test is written to keep passing after regeneration.

## Gate results

- `yarn test --run` (full suite): **73 files, 1114 tests passed**
- `yarn data:aos4:verify:beta`: **pass — 79598 pass, 0 finding, 0 cannot-verify**
- `tsc --noEmit`: clean; `eslint src --max-warnings 0`: clean

## Stopping point — operator action required

Deterministic regeneration (`yarn data:aos4:generate:write`) fails closed without the accepted 2026-07-30 immutable artifact cache (`.cache/aos4/artifacts`, 242 artifacts pinned by SHA-256). That cache is not present on this machine, and it cannot be rebuilt from the network: the live Wahapedia pages have already drifted from the pinned checksums (e.g. `the-core-rules` is now 703,797 bytes / `89eeff53…` vs the pinned 702,011 bytes / `c2807953…`).

This PR therefore stops at a fully-prepared state, exactly as the docs prescribe: the accepted 2026-07-30 snapshot stays byte-for-byte reproducible and the beta certification stays green and bound to it. An operator with the accepted cache (or a fresh accepted candidate cycle) needs to:

1. `yarn data:aos4:generate --candidate --write --review data/aos4/reviews/corpus-2026-07-31.json` (plus the acceptance-commit path updates), which will drop the 6 entities and record the 6 new `ignored` dispositions;
2. run the certification campaign (`data:aos4:review:prepare` → `data:aos4:review:adversarial` → `data:aos4:certify:prepare`) and re-point `data/aos4/certifications/beta.json`;
3. re-run `yarn data:aos4:verify:beta`.

The regeneration commit will also need the expected-count literals in `src/tests/aos4/catalogIntegrity.test.ts` (abilities 4898 → 4892, dispositions no longer empty) reconciled — that test failing loudly on regeneration is intentional. A note documenting the pending revision and these steps was added to `docs/data/aos4-maintenance.md`.

https://claude.ai/code/session_015nfmMygHX8CizzD6vQT8UG