### PR TITLE
fix: paint the dark theme past the fold

### DIFF
--- a/src/context/useTheme.tsx
+++ b/src/context/useTheme.tsx
@@ -9,6 +9,12 @@ import { SubscriptionApi } from '../api/subscriptionApi'
 
 const LOCAL_THEME_KEY = 'theme'
 
+/*
+ * Every page background a theme can ask for, so the effect below can clear whichever one <body> is
+ * already wearing before it applies the current one.
+ */
+const BG_CLASS_NAMES = [LightTheme.bgColor, DarkTheme.bgColor]
+
 const getLocalTheme = () => localStorage.getItem(LOCAL_THEME_KEY) as TThemeType | null
 
 const setLocalTheme = (theme: TThemeType) => localStorage.setItem(LOCAL_THEME_KEY, theme)
@@ -64,6 +70,19 @@ const ThemeProvider = ({ children }: React.PropsWithChildren<object>) => {
   useEffect(() => {
     const element = document.getElementById('root')
     if (element) element.className = theme.bgColor
+
+    /*
+     * ...and to <body>, which owns the canvas. `#root` covers the document, but the area outside it
+     * is painted from <body>: iOS rubber-band overscroll, and the gap a page shorter than the
+     * viewport leaves once a route sizes `#root` below its min-height floor. Left white, those read
+     * as a flash of the light theme.
+     *
+     * `classList` rather than `className`, which is what `#root` above can safely use: react-modal
+     * writes `ReactModal__Body--open` onto <body> for as long as a modal is open, and assigning
+     * `className` would drop it.
+     */
+    document.body.classList.remove(...BG_CLASS_NAMES)
+    document.body.classList.add(theme.bgColor)
   }, [theme.bgColor])
 
   useEffect(() => setThemeFromValue(getLocalTheme()), [setThemeFromValue])

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -2,10 +2,21 @@
 
 /* Make sure our document fills the page - important for dark theme! */
 html,
-body,
-#root {
+body {
     margin: 0;
     height: 100%;
+}
+
+/*
+ * `#root` is the element useTheme paints `theme.bgColor` onto, so its box *is* the page background.
+ * `height: 100%` bounded that box to one viewport, which is why a page taller than the fold showed
+ * the white canvas in dark theme — only the cards, which paint their own background, stayed dark.
+ * `min-height` keeps the full-viewport floor on short pages (/join, /redeem, the loading fallback)
+ * and lets the box grow with the content on long ones.
+ */
+#root {
+    margin: 0;
+    min-height: 100%;
 }
 
 /* Elements */

--- a/src/tests/aos4/subscriberTheme.test.tsx
+++ b/src/tests/aos4/subscriberTheme.test.tsx
@@ -107,4 +107,55 @@ describe('subscriber theme continuity', () => {
     expect(window.localStorage.getItem('theme')).toBe('light')
     expect(subscriptionApi.updateTheme).toHaveBeenCalledWith({ theme: 'light' }, 'audience-token')
   })
+
+  /*
+   * The canvas behind the document takes its colour from <body>, not from `#root`, so a theme that
+   * only paints `#root` leaves white in the overscroll area. The previous background has to come off
+   * as well as the new one going on, or a toggle back to light leaves both classes fighting.
+   */
+  it('paints the current theme onto <body> and clears the previous one', async () => {
+    await act(async () => {
+      render(
+        <ThemeProvider>
+          <Probe />
+        </ThemeProvider>,
+        container
+      )
+      await Promise.resolve()
+    })
+
+    expect(document.body.classList.contains('bg-themeDarkBlueSecondary')).toBe(true)
+    expect(document.body.classList.contains('bg-white')).toBe(false)
+
+    await act(async () => {
+      container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(document.body.classList.contains('bg-white')).toBe(true)
+    expect(document.body.classList.contains('bg-themeDarkBlueSecondary')).toBe(false)
+  })
+
+  /* react-modal parks `ReactModal__Body--open` on <body>; a theme change must not sweep it off. */
+  it('leaves unrelated body classes alone', async () => {
+    document.body.classList.add('ReactModal__Body--open')
+
+    await act(async () => {
+      render(
+        <ThemeProvider>
+          <Probe />
+        </ThemeProvider>,
+        container
+      )
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(document.body.classList.contains('ReactModal__Body--open')).toBe(true)
+    document.body.classList.remove('ReactModal__Body--open')
+  })
 })


### PR DESCRIPTION
## Problem

In dark mode, the page background stopped at the bottom of the viewport. Everything below the fold fell through to the white canvas, so the reminder cards — which paint their own `bg-themeDarkBlueSecondary` via `theme.cardBody` — were left floating on white gutters. The reminders screen is always taller than the fold, so this was visible on every visit.

## Cause

`#root` is the element `useTheme` paints `theme.bgColor` onto (`src/context/useTheme.tsx`), so its box *is* the page background. It sat in a shared rule with `html, body` that set `height: 100%`, which pinned it to exactly one viewport while the content overflowed past it.

## Fix

- **`src/css/index.scss`** — split `#root` out of the `html, body` rule and give it `min-height: 100%`. Keeps the full-viewport floor the short routes rely on (`.RedemptionContainer` on `/join` and `/redeem`, `.LoadingContainer`) and lets the box grow with the content elsewhere.
- **`src/context/useTheme.tsx`** — also paint the theme background onto `<body>`. `#root` covers the document but not the canvas outside it: iOS rubber-band overscroll takes its colour from `<body>`, which no theme was painting. Uses `classList` rather than `className` because react-modal parks `ReactModal__Body--open` on `<body>` while a modal is open, and assigning `className` would drop it.

No visual change to the light theme, and no change to layout, spacing, or any component — the same colours paint, over the area they were always meant to cover.

## Testing

Two cases added to `src/tests/aos4/subscriberTheme.test.tsx`: the current theme lands on `<body>` and the previous one comes off, and a theme change leaves unrelated body classes alone.

Verified in Chrome against a dev server, dark and light:

| | before | after |
|---|---|---|
| `#root` height, dark home | 1271px (= viewport) | 7255px |
| document `scrollHeight` | 7255px | 7255px |

- `<body>` carries the theme background (`rgb(24, 38, 51)` dark, `rgb(255, 255, 255)` light) with `<html>` left transparent, so it propagates to the canvas.
- Opening the Import Army modal leaves `<body>` as `bg-themeDarkBlueSecondary ReactModal__Body--open` — both classes coexist.
- `/join` still fills the viewport exactly (root 1271px = viewport 1271px). That route renders light by design; `Redeem.tsx:47` calls `setLightTheme()` on mount.

`yarn lint`, `tsc --noEmit`, `vitest run` (75 files, 1154 tests), and `vite build` all pass.
