### PR TITLE
docs: make master the documented primary branch after the Version 6 cutover

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,9 @@ name: Deployment
 
 # This workflow publishes to production (S3 + CloudFront). Keep the trigger list to `master` only.
 #
-# In particular, do NOT add `workflow_run` on "Lint, Test, and Build", and do NOT add
-# `aos4-migration` or any other integration branch here. Lint/test/build coverage for those
-# branches belongs in nodejs.yml, which holds no credentials and ships nothing.
+# In particular, do NOT add `workflow_run` on "Lint, Test, and Build", and do NOT add any
+# integration branch here. Lint/test/build coverage for those branches belongs in nodejs.yml,
+# which holds no credentials and ships nothing.
 on:
   push:
     branches:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,12 +1,10 @@
 name: Lint, Test, and Build
 
-# `aos4-migration` is the long-lived integration branch for the AoS 4 migration (see AGENTS.md).
-# Without it here, migration sub-PRs merge with no lint/test/build gate at all.
 on:
   push:
-    branches: [ master, aos4-migration ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, aos4-migration ]
+    branches: [ master ]
 
 env:
   CI: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ community trusts that experience; an AoS 4 data/domain migration does not author
 - Do not add a migration-workbench aesthetic, new visual language, or broad reskin unless the user
   explicitly requests one.
 
-The launch-hardening client on this branch retires the shared browser key and sends the user's
+The Version 6 launch-hardening client retires the shared browser key and sends the user's
 Auth0 bearer token for every subscription account operation. Production remains blocked until the
 companion subscription change in `aos-reminders-subscription-api#17` is reviewed, deployed, and
 live-verified: it must derive account ownership from verified claims, reject cross-account access,
@@ -184,17 +184,16 @@ issue #1731, and the full production smoke/operational handoff is issue #1805.
 
 ## Branch and pull-request strategy
 
-PR #1717 is the final long-lived AoS 4 integration PR.
+`master` is the primary development branch and the normal PR target. The Version 6 release
+(PR #1717, `AoS Reminders 6.0.0 — Age of Sigmar fourth-edition release`) merged the retired
+`aos4-migration` integration branch into `master` on 2026-07-31; do not base new work on
+`aos4-migration` or target PRs at it.
 
-- Until PR #1717 lands, base final release work on the latest `origin/aos4-migration` and target
-  release sub-PRs at `aos4-migration`.
-- PR #1717 is named `AoS Reminders 6.0.0 — Age of Sigmar fourth-edition release` and targets
-  `master`.
-- After PR #1717 lands, base normal work on the latest `origin/master` and target PRs at `master`
-  unless the user explicitly establishes another integration branch.
+- Base normal work on the latest `origin/master` and target PRs at `master` unless the user
+  explicitly establishes another integration branch.
 - Local commits and pushes to non-`master` branches are authorized.
-- Merging PRs, pushing `master`, deploying, or changing production services requires explicit
-  direction.
+- A push to `master` triggers production deployment. Merging PRs, pushing `master`, deploying, or
+  changing production services requires explicit direction.
 
 ### Issue tracking
 
@@ -548,8 +547,7 @@ unit-test prerequisite.
    production-build checks.
 7. Repeat the checksum-bound machine review and update the beta-readiness pointer; a prior result
    is never inherited by a changed corpus.
-8. Until PR #1717 lands, commit and push only to a release sub-PR targeting `aos4-migration`.
-   After launch, use normal PRs targeting `master`; never push `master` directly without explicit
+8. Use normal PRs targeting `master`; never push `master` directly without explicit
    authorization.
 9. Reconcile beta-tester rules reports against official sources and add regression coverage for
    confirmed corrections.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -128,9 +128,9 @@ Preserve it; do not change it as a side effect of other work.
   generate pipeline, including corrections prompted by beta feedback.
 - **Names are display text, never durable identity.** Everything resolves through stable canonical
   IDs.
-- **A push to `master` deploys production.** Final Version 6 launch preparation targets
-  `aos4-migration`; after PR #1717 lands, ordinary work targets `master` unless a new integration
-  branch is explicitly established. Merging or pushing `master` requires explicit authorization.
+- **A push to `master` deploys production.** Ordinary work targets `master` unless a new
+  integration branch is explicitly established. Merging or pushing `master` requires explicit
+  authorization.
 
 ### Known launch gates
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ AoS Reminders turns an Age of Sigmar army configuration into phase-ordered remin
 
 ## Version 6 and Age of Sigmar fourth edition
 
-Version 6.0.0 is the clean cutover to Age of Sigmar fourth edition. The release candidate is
-assembled on `aos4-migration` in [PR #1717](https://github.com/daviseford/aos-reminders/pull/1717);
-`master` remains the production branch, and every push to it deploys the site.
+Version 6.0.0 is the clean cutover to Age of Sigmar fourth edition. The release was assembled in
+[PR #1717](https://github.com/daviseford/aos-reminders/pull/1717) and merged to `master` on
+2026-07-31; `master` is the primary development and production branch, and every push to it
+deploys the site.
 
 The release provides:
 
@@ -124,10 +125,9 @@ These companion repositories are private.
 
 ## Pull requests and deployment
 
-Until PR #1717 lands, final Version 6 release changes target `aos4-migration`. After launch, normal
-pull requests target `master` unless a new integration branch is explicitly established. Every
-push to `master` builds and deploys the production site to S3/CloudFront, so merging or pushing it
-requires explicit project-owner authorization.
+Normal pull requests target `master` unless a new integration branch is explicitly established.
+Every push to `master` builds and deploys the production site to S3/CloudFront, so merging or
+pushing it requires explicit project-owner authorization.
 
 See [the release runbook](docs/release.md) for production gates and post-deploy validation, and
 [CONTRIBUTING.md](docs/CONTRIBUTING.md) for the normal contribution workflow.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,10 +13,9 @@ pipeline, add regression coverage, and produce a new checksum-bound certificatio
 
 ## Branching
 
-- Until release PR #1717 lands, base final Version 6 work on `origin/aos4-migration` and target
-  release sub-PRs at `aos4-migration`.
-- After #1717 lands, base ordinary work on `origin/master` and target pull requests at `master`
-  unless a new integration branch is explicitly established.
+- Base ordinary work on `origin/master` and target pull requests at `master` unless a new
+  integration branch is explicitly established. The retired `aos4-migration` integration branch
+  merged into `master` with release PR #1717; do not base new work on it.
 - Never push `master` directly. A merge or push to `master` deploys production and requires explicit
   project-owner authorization.
 - Keep rules/data corrections separate from Phase 2 package modernization where practical.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,8 +1,9 @@
 # Release and production operations
 
 AoS Reminders 6.0.0 is the clean Age of Sigmar fourth-edition launch. Release PR
-[#1717](https://github.com/daviseford/aos-reminders/pull/1717) merges `aos4-migration` into
-`master`; a push to `master` starts the S3/CloudFront production deployment.
+[#1717](https://github.com/daviseford/aos-reminders/pull/1717) merged the `aos4-migration`
+integration branch into `master` on 2026-07-31; a push to `master` starts the S3/CloudFront
+production deployment.
 
 This runbook records the launch gates separately from the migration's implementation history. It
 does not authorize a merge, API deployment, or production configuration change.


### PR DESCRIPTION
Closes #1806.

PR #1717 merged on 2026-07-31 and `master` is the repository default branch, so this updates the live guidance:

- **AGENTS.md** — branch strategy names `master` as the primary development branch and normal PR target; the retired `aos4-migration` integration branch is explicitly not a base or target; working-sequence step 8 loses its pre-launch clause; the launch-hardening paragraph drops its "on this branch" phrasing (the #1720/#1804 gate claims themselves are unchanged — those issues are still open).
- **README.md / PRODUCT.md / docs/CONTRIBUTING.md / docs/release.md** — cutover wording moves to past tense; contribution guidance targets `master`.
- **.github/workflows/nodejs.yml** — CI triggers drop `aos4-migration`; **deploy.yml** keeps its master-only trigger and generalizes the comment. `src/tests/deploymentConfig.test.ts` passes.

Left intact as historical artifacts: `docs/plans/`, `docs/handoffs/`, `docs/design/` audits, the `vite.config.mts` budget-history comment, and the `army:aos4-migration-preview` document ID (a durable identifier, not guidance).

Not done here (owner decisions per the issue):
- Deleting or retaining the remote `aos4-migration` branch — the issue says decide only after the rollback window closes.
- #1805 (production smoke/handoff) is still open; the issue's acceptance note that #1717/#1805 identify the deployed revision is tracked there.

## Testing

- `yarn vitest run src/tests/deploymentConfig.test.ts` — 10/10 pass
- `grep -rn aos4-migration` over AGENTS/README/PRODUCT/CONTRIBUTING/release/workflows shows only historical or "do not use" references

https://claude.ai/code/session_01FfnwSqxEgq9drUfPidpo8r