### PR TITLE
feat: name the granting selection on each reminder

### DIFF
--- a/src/aos4/print/presets.ts
+++ b/src/aos4/print/presets.ts
@@ -116,6 +116,7 @@ const TAG_TONES: Record<PrintTagTone, PrintTagStyle> = {
   'turn-neutral': { text: [77, 90, 99], border: [77, 90, 99] },
   priority: { text: [121, 73, 13], border: [121, 73, 13] },
   usage: { text: [91, 107, 116], border: [91, 107, 116], dashed: true },
+  source: { text: [84, 62, 122], border: [84, 62, 122] },
 }
 
 export const STANDARD_PRESET: PrintPreset = {

--- a/src/aos4/print/types.ts
+++ b/src/aos4/print/types.ts
@@ -30,6 +30,7 @@ export type PrintTagTone =
   | 'kind-active'
   | 'kind-reaction'
   | 'kind-passive'
+  | 'source'
   | 'turn-your'
   | 'turn-enemy'
   | 'turn-neutral'

--- a/src/aos4/view/reminders.ts
+++ b/src/aos4/view/reminders.ts
@@ -2,7 +2,9 @@ import {
   TURN_PHASES,
   type AbilityTiming,
   type Aos4Catalog,
+  type CanonicalId,
   type CombatPriority,
+  type ContentEntity,
   type TimingKind,
   type TimingPerspective,
   type UsageLimit,
@@ -72,6 +74,7 @@ export type Aos4ReminderTagTone =
   | 'turn-neutral'
   | 'usage'
   | 'priority'
+  | 'source'
 
 export interface Aos4ReminderTag {
   label: string
@@ -190,19 +193,71 @@ export interface Aos4ReminderViewModel {
   projected: ProjectedReminder
 }
 
-const withPreferences = (reminder: ProjectedReminder, document: Aos4ArmyDocument): Aos4ReminderViewModel => {
+/**
+ * Names the selection that put this reminder in the army, so an ability is recognizable as
+ * belonging to what the player picked (issue #1836: Well-Fed Beasts grants HORN TOSS, and nothing
+ * on the HORN TOSS reminder said so). One tag per distinct granting source:
+ *
+ * - An ability with a warscroll ancestor is that unit's own — its warscroll name wins, even when
+ *   the unit itself arrived through a group (a Regiment of Renown).
+ * - Otherwise the cause's root names the grant when the root is a picked content-group: a spell
+ *   lore, an enhancement trait, an Army of Renown. Faction-rooted content is deliberately
+ *   untagged — stamping the faction name on every automatic battle trait and core rule is noise.
+ *
+ * A tag that would repeat the reminder's own name is dropped: enhancement picks are groups named
+ * after their single ability, and "Tunnel Master — Tunnel Master" attributes nothing.
+ */
+const sourceTags = (
+  reminder: ProjectedReminder,
+  entityById: Map<CanonicalId, ContentEntity>
+): Aos4ReminderTag[] => {
+  const tagsByLabel = new Map<string, Aos4ReminderTag>()
+  reminder.causes.forEach(cause => {
+    const ancestors = cause.entityPath.slice(0, -1)
+    for (let index = ancestors.length - 1; index >= 0; index -= 1) {
+      const ancestor = entityById.get(ancestors[index])
+      if (ancestor?.kind === 'warscroll') {
+        tagsByLabel.set(ancestor.name, {
+          label: ancestor.name,
+          tone: 'source',
+          description: `Printed on the ${ancestor.name} warscroll. Only that unit uses it.`,
+        })
+        return
+      }
+    }
+    const root = entityById.get(cause.rootId)
+    if (root?.kind === 'content-group') {
+      tagsByLabel.set(root.name, {
+        label: root.name,
+        tone: 'source',
+        description: `In your army because you took ${root.name}.`,
+      })
+    }
+  })
+  return Array.from(tagsByLabel.values())
+    .filter(tag => tag.label.toLowerCase() !== reminder.name.toLowerCase())
+    .sort((left, right) => left.label.localeCompare(right.label))
+}
+
+const withPreferences = (
+  reminder: ProjectedReminder,
+  document: Aos4ArmyDocument,
+  entityById: Map<CanonicalId, ContentEntity>
+): Aos4ReminderViewModel => {
   const preference = document.reminderPreferences[reminder.id]
   const details = timingDetails(reminder.timing)
   const label = windowLabel(reminder.timing)
+  const grantedBy = sourceTags(reminder, entityById)
   return {
     id: reminder.id,
     name: reminder.name,
     windowKey: gameWindowKey(reminder.timing.window),
     windowLabel: label,
     typeLabel: details.join(' · '),
-    tags: timingTags(reminder.timing),
+    tags: [...grantedBy, ...timingTags(reminder.timing)],
     accessibleLabel: [
       reminder.name,
+      ...grantedBy.map(tag => `From ${tag.label}`),
       label,
       ...details,
       ...(reminder.text.reactionTrigger ? [`Trigger: ${reminder.text.reactionTrigger}`] : []),
@@ -228,7 +283,10 @@ export const createAos4ReminderViewModel = (
     ...(document.allowsLegends ? { allowsLegends: true } : {}),
     ...(document.allowsHistorical ? { allowsHistorical: true } : {}),
   })
-  const reminders = projectReminders(catalog, selection).map(reminder => withPreferences(reminder, document))
+  const entityById = new Map(catalog.entities.map(entity => [entity.id, entity]))
+  const reminders = projectReminders(catalog, selection).map(reminder =>
+    withPreferences(reminder, document, entityById)
+  )
   const baseOrder = new Map(reminders.map((reminder, index) => [reminder.id, index]))
   return reminders.sort((left, right) => {
     if (left.windowKey !== right.windowKey) {

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -360,7 +360,7 @@ small {
     }
 }
 
-@mixin tag-tones($active, $reaction, $passive, $your, $enemy, $neutral, $usage) {
+@mixin tag-tones($active, $reaction, $passive, $your, $enemy, $neutral, $usage, $source) {
     .ReminderTag {
         &--kind-active {
             @include tag-tone($active...);
@@ -387,6 +387,9 @@ small {
             @include tag-tone($usage...);
             border-style: dashed;
         }
+        &--source {
+            @include tag-tone($source...);
+        }
     }
 }
 
@@ -404,7 +407,8 @@ small {
         (#e6f2ea, #1f5334, #bcdcc7),
         (#f9e8e8, #7c3535, #ecc9c9),
         (#eef0f2, #4d5a63, #d8dee2),
-        (transparent, #5b6b74, #b9c5cc)
+        (transparent, #5b6b74, #b9c5cc),
+        (#efeaf7, #543e7a, #d3c6e8)
     );
 }
 
@@ -416,7 +420,8 @@ small {
         (rgba(72, 160, 105, 0.24), #92d8ac, rgba(72, 160, 105, 0.45)),
         (rgba(190, 90, 90, 0.24), #f0a6a6, rgba(190, 90, 90, 0.45)),
         (rgba(255, 255, 255, 0.08), #b3c1ca, rgba(255, 255, 255, 0.18)),
-        (transparent, #a9bac3, rgba(255, 255, 255, 0.3))
+        (transparent, #a9bac3, rgba(255, 255, 255, 0.3)),
+        (rgba(132, 100, 190, 0.24), #cbb8ee, rgba(132, 100, 190, 0.45))
     );
 }
 

--- a/src/tests/aos4/reminderAttribution.test.ts
+++ b/src/tests/aos4/reminderAttribution.test.ts
@@ -1,0 +1,109 @@
+import type { ContentGroup, Faction, Warscroll } from '../../aos4/domain'
+import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID } from '../../aos4/generated'
+import { createAos4ArmyDocument } from '../../aos4/state'
+import { createAos4ReminderViewModel, type Aos4ReminderViewModel } from '../../aos4/view'
+
+/**
+ * Reminders name the selection that granted them (issue #1836). Without attribution, a player who
+ * picks Well-Fed Beasts scans the reminders for that name and finds nothing — the granted
+ * abilities surface under their own names (HORN TOSS, GRUMPY ALPHA) with no visible tie to the
+ * trait. Every player-picked grant carries a `source` tag; faction-automatic content stays
+ * untagged so the faction name is not stamped on every core rule.
+ */
+
+type PickableKind = 'faction' | 'warscroll' | 'content-group'
+
+const entityByName = (kind: PickableKind, name: string): Faction | Warscroll | ContentGroup => {
+  const entity = AOS4_CATALOG.entities.find(candidate => candidate.kind === kind && candidate.name === name)
+  if (!entity) throw new Error(`No ${kind} named ${name} in the catalog`)
+  return entity as Faction | Warscroll | ContentGroup
+}
+
+const remindersFor = (explicitNames: Array<[PickableKind, string]>): Aos4ReminderViewModel[] =>
+  createAos4ReminderViewModel(
+    AOS4_CATALOG,
+    createAos4ArmyDocument({
+      id: 'army:test-attribution',
+      name: 'Attribution Test',
+      rulesContextId: AOS4_DEFAULT_RULES_CONTEXT_ID,
+      explicitSelectionIds: explicitNames.map(([kind, name]) => entityByName(kind, name).id),
+    })
+  )
+
+const sourceLabels = (reminder: Aos4ReminderViewModel): string[] =>
+  reminder.tags.filter(tag => tag.tone === 'source').map(tag => tag.label)
+
+describe('reminder source attribution (#1836)', () => {
+  it('tags a monstrous trait pick on each granted ability reminder', () => {
+    const wellFed = entityByName('content-group', 'Well-Fed Beasts')
+    expect(wellFed).toBeDefined()
+    const reminders = remindersFor([
+      ['faction', 'Ogor Mawtribes'],
+      ['content-group', 'Well-Fed Beasts'],
+    ])
+    const granted = ['HORN TOSS', 'GRUMPY ALPHA', 'EXTREMELY OBSTINATE']
+    granted.forEach(name => {
+      const reminder = reminders.find(candidate => candidate.name === name)
+      expect(reminder).toBeDefined()
+      expect(sourceLabels(reminder!)).toEqual(['Well-Fed Beasts'])
+    })
+  })
+
+  it('leaves faction-automatic content untagged', () => {
+    const reminders = remindersFor([['faction', 'Ogor Mawtribes']])
+    expect(reminders.length).toBeGreaterThan(0)
+    reminders.forEach(reminder => {
+      expect(sourceLabels(reminder)).toEqual([])
+    })
+  })
+
+  it('tags a warscroll-native spell with its unit', () => {
+    const kroak = entityByName('warscroll', 'Lord Kroak')
+    expect(kroak).toBeDefined()
+    const reminders = remindersFor([
+      ['faction', 'Seraphon'],
+      ['warscroll', 'Lord Kroak'],
+    ])
+    const spell = reminders.find(reminder => reminder.name === 'CELESTIAL DELIVERANCE')
+    expect(spell).toBeDefined()
+    expect(sourceLabels(spell!)).toEqual(['Lord Kroak'])
+  })
+
+  it('tags Army of Renown grants with the army root', () => {
+    const rovingMaw = entityByName('content-group', 'The Roving Maw') as ContentGroup
+    expect(rovingMaw.groupType).toBe('army-of-renown')
+    const reminders = remindersFor([
+      ['faction', 'Ogor Mawtribes'],
+      ['content-group', 'The Roving Maw'],
+    ])
+    const spell = reminders.find(reminder => reminder.name === 'MAWMEAT')
+    expect(spell).toBeDefined()
+    expect(sourceLabels(spell!)).toEqual(['The Roving Maw'])
+  })
+
+  it('never repeats the reminder name as its own attribution', () => {
+    const ogor = entityByName('faction', 'Ogor Mawtribes')
+    expect(ogor).toBeDefined()
+    const documents: Array<Array<[PickableKind, string]>> = [
+      [
+        ['faction', 'Ogor Mawtribes'],
+        ['content-group', 'Well-Fed Beasts'],
+      ],
+      [
+        ['faction', 'Ogor Mawtribes'],
+        ['content-group', 'The Roving Maw'],
+      ],
+      [
+        ['faction', 'Seraphon'],
+        ['warscroll', 'Lord Kroak'],
+      ],
+    ]
+    documents.forEach(explicit => {
+      remindersFor(explicit).forEach(reminder => {
+        sourceLabels(reminder).forEach(label => {
+          expect(label.toLowerCase()).not.toBe(reminder.name.toLowerCase())
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Fixes #1836.

## Problem

Reminders showed only the ability's own name in its phase window. A player who picked **Well-Fed Beasts** and scanned the reminders for that name found nothing — the granted abilities appear as HORN TOSS, GRUMPY ALPHA, and EXTREMELY OBSTINATE with no visible tie to the trait. Same gap for Army of Renown grants and warscroll-native spells.

## Change

Each reminder's tag row now leads with a `source` tag naming what put it in the army:

- **Warscroll ancestor wins**: a unit's own ability (including its unique spell) is tagged with the warscroll name, even when the unit arrived through a group.
- **Otherwise the picked root**: content-group roots (monstrous traits, spell lores, formations, Armies of Renown) tag their granted abilities — so The Roving Maw's battle traits, spells, and enhancements all read as its.
- **Faction-automatic content stays untagged** — no faction-name spam on every core rule and battle trait.
- A tag that would repeat the reminder's own name is dropped (enhancement groups named after their single ability).

Provenance comes from `selection.causes` — no new data, no corpus change. The tag carries a plain-language expansion (hover/tap, screen-reader label), and the PDF path gets a matching outline tone.

## Verification

- 5 new tests in `src/tests/aos4/reminderAttribution.test.ts` (trait grant, faction-untagged, warscroll spell, AoR root, no self-attribution)
- Full suite: 81 files / 1,229 tests green; lint, tsc, build clean
- Browser-verified on the running app: Well-Fed Beasts tags render on exactly the three granted reminders, core abilities untagged

https://claude.ai/code/session_01FfnwSqxEgq9drUfPidpo8r