### PR TITLE
fix(deploy): drop the phantom registerSW.js publication step

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -95,7 +95,6 @@ extras=("${SITE_BUILD_DIR}"/sw-extras-*.js)
 [[ ${#extras[@]} -eq 1 ]] ||
   fail "expected exactly one content-hashed sw-extras-*.js dependency, found ${#extras[@]}"
 workbox_dependencies=("${SITE_BUILD_DIR}"/workbox-*.js)
-registration_dependencies=("${SITE_BUILD_DIR}"/registerSW.js)
 
 lock_body=$(mktemp)
 lock_error=$(mktemp)
@@ -214,19 +213,13 @@ aws s3 cp "$SITE_BUILD_DIR" "$SITE_S3" \
   --exclude '*build_log.txt' --exclude '*.idea*' --exclude '*.sh' \
   --exclude '*.git*' --exclude '*.DS_Store' \
   --exclude 'assets/*' --exclude 'index.html' --exclude 'site.webmanifest' \
-  --exclude 'service-worker.js' --exclude 'workbox-*.js' --exclude 'registerSW.js' \
+  --exclude 'service-worker.js' --exclude 'workbox-*.js' \
   --exclude 'sw-extras-*.js' \
   --cache-control "$MODERATE"
 
 aws s3 cp "${SITE_BUILD_DIR}/site.webmanifest" "${SITE_S3}/site.webmanifest" \
   --cache-control "$REVALIDATE" \
   --content-type 'application/manifest+json'
-
-for dependency in "${registration_dependencies[@]}"; do
-  aws s3 cp "$dependency" "${SITE_S3}/$(basename "$dependency")" \
-    --cache-control "$REVALIDATE" \
-    --content-type 'text/javascript; charset=utf-8'
-done
 
 # The app entry point is mutable and lands only after everything it can reference.
 aws s3 cp "${SITE_BUILD_DIR}/index.html" "${SITE_S3}/index.html" \

--- a/src/tests/deploymentContract.test.ts
+++ b/src/tests/deploymentContract.test.ts
@@ -165,6 +165,13 @@ if [[ "$1 $2" == "s3api list-objects-v2" ]]; then
   exit 0
 fi
 
+# The real CLI validates local cp sources before any request; a phantom build artifact in the
+# script must fail here exactly as it would in production.
+if [[ "$1 $2" == "s3 cp" && "$3" != s3://* && ! -e "$3" ]]; then
+  echo "The user-provided path $3 does not exist." >&2
+  exit 255
+fi
+
 if [[ "$1 $2" == "s3api get-object-tagging" ]]; then
   if [[ "$*" == *"assets/already-retired.js"* || "$*" == *"workbox-already-retired.js"* ]]; then
     echo 'true'


### PR DESCRIPTION
## Summary

The first production deploy of #1809 ([run 30725274355](https://github.com/daviseford/aos-reminders/actions/runs/30725274355)) failed with `The user-provided path ./dist/registerSW.js does not exist` (exit 255).

`vite.config.mts` sets `injectRegister: false` — service-worker registration is compiled into the entry chunk via `virtual:pwa-register` — so the build never emits `dist/registerSW.js`. `deploy-production.sh` still listed it as a literal path in `registration_dependencies`; `nullglob` cannot drop a glob-free literal, and the real CLI validates local `cp` sources before any request. Nothing in the built output or at runtime references `/registerSW.js`, so the step is removed outright (array, publish loop, and the matching sync exclude).

## Failure containment (verified against live prod)

The ordered-publish design held exactly as intended: the run died after publishing immutable assets and unhashed public files but **before** `index.html` and `service-worker.js`, so production is still serving the previous coherent build. The deploy lock was conditionally released on failure (`_deploy/production.lock` HeadObject returns 404).

## Why tests missed it

`deploymentContract.test.ts` drives the script with a fake `aws` that accepted any `cp` source path. The fake now mirrors the real CLI: a nonexistent local `cp` source fails with the CLI's own error and exit code, so any future phantom build artifact in the publish sequence fails the suite the same way it fails production. The fixture intentionally does not grow a `registerSW.js`.

## Verification

- CI runs the contract suite natively on ubuntu (the suite's WSL path shim makes it unrunnable in a local Git Bash session).
- Merging to master re-triggers the production deploy, which publishes `/service-worker.js` and takes over the orphaned CRA registrations that are currently white-screening pre-V6 visitors.

https://claude.ai/code/session_01FfnwSqxEgq9drUfPidpo8r