### PR TITLE
fix(deploy): make asset retirement survive real S3 semantics

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -268,13 +268,31 @@ while IFS= read -r remote_immutable; do
     --output text)
   [[ "$retire_tag" == 'true' ]] && continue
 
+  # S3 rejects a self-copy whose only change is tags, so the write needs the REPLACE metadata
+  # directive to be legal — and REPLACE drops the object's stored headers unless they are restated.
+  # Losing Content-Type would break any straggler still loading this module from a stale shell.
+  retire_metadata=$(aws s3api head-object \
+    --bucket "$SITE_BUCKET" \
+    --key "$remote_immutable" \
+    --query '[CacheControl, ContentType]' \
+    --output text) || fail "could not read headers for $remote_immutable before retirement"
+  IFS=$'\t' read -r retire_cache_control retire_content_type <<< "$retire_metadata"
+  retire_headers=()
+  [[ -n "$retire_cache_control" && "$retire_cache_control" != 'None' ]] &&
+    retire_headers+=(--cache-control "$retire_cache_control")
+  [[ -n "$retire_content_type" && "$retire_content_type" != 'None' ]] &&
+    retire_headers+=(--content-type "$retire_content_type")
+
   aws s3api copy-object \
     --bucket "$SITE_BUCKET" \
     --key "$remote_immutable" \
     --copy-source "${SITE_BUCKET}/${remote_immutable}" \
-    --metadata-directive COPY \
+    --metadata-directive REPLACE \
+    ${retire_headers[@]+"${retire_headers[@]}"} \
     --tagging-directive REPLACE \
     --tagging 'retire=true' >/dev/null
-done < <(printf '%s' "$remote_immutable_output" | tr '\t' '\n')
+# %s\n, not %s: read never runs its body for a final unterminated line, which would silently
+# exempt the last listed object from retirement on every deploy.
+done < <(printf '%s\n' "$remote_immutable_output" | tr '\t' '\n')
 
 echo 'Deployed to https://aosreminders.com/'

--- a/src/tests/deploymentContract.test.ts
+++ b/src/tests/deploymentContract.test.ts
@@ -150,8 +150,19 @@ if [[ "$1 $2" == "cloudfront get-distribution-config" ]]; then
 fi
 
 if [[ "$1 $2" == "s3api head-object" ]]; then
+  if [[ "$*" == *"CacheControl"* ]]; then
+    printf '%s\\t%s\\n' 'public, max-age=31536000, immutable' 'text/javascript; charset=utf-8'
+    exit 0
+  fi
   printf '%s\\t%s\\t%s\\n' '"held-etag"' 'held-owner' '2026-08-01T00:00:00+00:00'
   exit 0
+fi
+
+# Real S3 refuses an in-place copy that changes nothing but tags; only the REPLACE metadata
+# directive makes a self-copy legal. Enforce it so the script cannot regress to COPY.
+if [[ "$1 $2" == "s3api copy-object" && "$*" == *"--metadata-directive COPY"* ]]; then
+  echo 'An error occurred (InvalidRequest) when calling the CopyObject operation: illegal self-copy without metadata change' >&2
+  exit 254
 fi
 
 if [[ "$1 $2" == "s3api list-objects-v2" ]]; then
@@ -193,7 +204,9 @@ echo '{}'
         AWS_LOG: bashPath(logPath),
         AWS_REMOTE_ASSET_KEYS: 'assets/current-123.js\tassets/newly-superseded.js\tassets/already-retired.js',
         AWS_REMOTE_EXTRAS_KEYS: 'sw-extras-abc123.js\tsw-extras-old.js',
-        AWS_REMOTE_WORKBOX_KEYS: 'workbox-abc123.js\tworkbox-old.js\tworkbox-already-retired.js',
+        // A retirement-eligible key deliberately sits last: an unterminated final line from the
+        // key listing must still be processed, or the last object silently escapes retirement.
+        AWS_REMOTE_WORKBOX_KEYS: 'workbox-abc123.js\tworkbox-already-retired.js\tworkbox-old.js',
         CF_DIST_ID: 'distribution-id',
         DEPLOY_OWNER: 'deployment-test',
         SITE_BUILD_DIR: bashPath(buildDirectory),
@@ -324,6 +337,13 @@ echo '{}'
     expect(copiesFor('workbox-old.js')).toHaveLength(1)
     expect(copiesFor('assets/already-retired.js')).toHaveLength(0)
     expect(copiesFor('workbox-already-retired.js')).toHaveLength(0)
+    log
+      .filter(line => line.startsWith('s3api copy-object '))
+      .forEach(line => {
+        expect(line).toContain('--metadata-directive REPLACE')
+        expect(line).toContain('public, max-age=31536000, immutable')
+        expect(line).toContain('text/javascript; charset=utf-8')
+      })
   })
 
   it('force-copies unhashed public files with the moderate cache header', () => {


### PR DESCRIPTION
## Summary

The redeploy after #1839 ([run 30725723890](https://github.com/daviseford/aos-reminders/actions/runs/30725723890)) published everything — assets, `index.html`, `/service-worker.js`, CloudFront invalidation — and then failed in the post-publication retirement phase with `InvalidRequest: This copy request is illegal because it is trying to copy an object to itself without changing the object's metadata...`. Production is live and coherent on the PWA build; only retirement housekeeping aborted (and the lock released correctly).

Two real defects:

1. **S3 rejects a tag-only self-copy.** `--metadata-directive COPY` plus `--tagging-directive REPLACE` is always illegal for an in-place copy. The copy now uses `--metadata-directive REPLACE` — the canonical way to make a self-copy legal while refreshing `LastModified` so a retired object gets its full 30-day lifecycle window — and restates the object's existing `Cache-Control`/`Content-Type` (read via `head-object` first), because REPLACE drops stored headers and losing `Content-Type` would break any straggler still loading the module from a stale shell.

2. **The last listed object always escaped retirement.** The loop was fed by `printf '%s'` with no trailing newline, and `while read` never executes its body for a final unterminated line. Now `printf '%s\n'`.

## Test hardening

The contract suite's fake `aws` accepted the illegal copy, which is how this shipped. It now enforces the real self-copy rule (exit 254 with the InvalidRequest error on `--metadata-directive COPY`), answers `head-object` header reads, and the fixture puts a retirement-eligible key last in the listing — so both defects fail the suite exactly as they failed production. The retirement test also pins the new copy shape (REPLACE directive + restated headers).

## Verification

Ran the full script end-to-end in a local harness against the hardened fake `aws`: exit 0, all three retirement-eligible fixture objects copied with preserved headers, already-retired and live objects untouched. CI runs the real suite on ubuntu.

https://claude.ai/code/session_01FfnwSqxEgq9drUfPidpo8r