### PR TITLE
fix: make the production deploy script and Listbot corpus tests portable to macOS

### DIFF
--- a/docs/solutions/workflow-learnings/deploy-script-fidelity-gaps.md
+++ b/docs/solutions/workflow-learnings/deploy-script-fidelity-gaps.md
@@ -1,0 +1,196 @@
+---
+title: "deploy-production.sh: the contract test's fake aws and CI's bash are not production"
+date: 2026-08-01
+category: workflow-learnings
+module: deployment
+problem_type: workflow_issue
+component: shell_script
+severity: high
+applies_when:
+  - "Changing scripts/deploy-production.sh or any AWS call it makes"
+  - "Adding or relaxing a case in the fake `aws` inside src/tests/deploymentContract.test.ts"
+  - "A deploy-contract test passes but you have not asked what the real CLI, real S3, or real CloudFront would do"
+  - "Adding a new build artifact the deploy script must publish, or removing one it still references"
+  - "Relying on a bash construct that is not in bash 3.2 (macOS ships 3.2; upload.sh runs /bin/bash)"
+symptoms:
+  - "Production deploy fails partway with a nonzero exit while the full contract suite is green"
+  - "Deploy succeeds but the live site is missing or eventually loses an asset it references"
+  - "A guard in the script has no test that fails when the guard is inverted or deleted"
+  - "A behaviour only reproduces on a macOS operator's manual deploy, never in GitHub Actions"
+root_cause: environment_mismatch
+resolution_type: process_change
+related_components:
+  - "scripts/deploy-production.sh"
+  - "src/tests/deploymentContract.test.ts"
+  - "upload.sh"
+  - "CI-build.sh"
+  - ".github/workflows/deploy.yml"
+  - "docs/deployment.md"
+tags: [deploy-script, contract-test-fidelity, fake-aws, bash-portability, s3-semantics, cloudfront, mutation-testing, test-doubles]
+---
+
+# `deploy-production.sh`: the contract test's fake `aws` and CI's bash are not production
+
+## Context
+
+`scripts/deploy-production.sh` was introduced on 2026-08-01 in PR #1809 as the single owner of every
+AWS mutation, so manual (`upload.sh`), standalone-CI (`CI-build.sh`), and GitHub Actions deploys
+could not drift. It shipped with `src/tests/deploymentContract.test.ts`, a contract suite that runs
+the **real script** against a **fake `aws`** on `PATH` and asserts on the logged calls.
+
+That design is sound, and the suite is genuinely good — it catches ordering, header, tagging, and
+lock-protocol regressions. But in the first day of its life the script took **four** corrective PRs,
+and every one of them was a defect the suite could not see, because the defect lived in the gap
+between a stand-in and the real thing:
+
+| PR | Defect | What the stand-in got wrong |
+| --- | --- | --- |
+| #1839 | Published a phantom `dist/registerSW.js` that `injectRegister: false` means the build never emits. First production deploy of #1809 died at exit 255 after publishing immutable assets, before `index.html`. | The fake `aws` accepted **any** `cp` source; the real CLI validates local paths first. |
+| #1841 | Tag-only self-copy used `--metadata-directive COPY`, which real S3 rejects with `InvalidRequest`. Separately, `printf '%s' \| read` silently skipped the **last** retirement-eligible object on every deploy. | The fake never enforced S3's self-copy rule and never answered `head-object`; no fixture put an eligible key last. |
+| #1843 | The ~12 MB catalog chunk shipped uncompressed to every visitor (12.25 MiB on the wire). | Nothing modelled CloudFront's ~10,000,000-byte compression ceiling — the behaviour is not an `aws` call at all. |
+| #1842 | `declare -A` (bash 4+) made the **manual** deploy impossible on macOS, which ships bash 3.2. Review then found `workbox_dependencies` had no count check, so a workbox-less build would deploy "successfully" and tag the live runtime for deletion. | The suite spawns whatever `bash` is on `PATH`; CI is `ubuntu-latest`, so only bash 5 is ever exercised. |
+
+Note the shape: **every commit that has ever touched the script also touched the contract test.**
+That is the tell. The suite is not wrong — it is a model, and each defect was a place the model had
+not yet been taught about reality.
+
+## Guidance
+
+When you change `scripts/deploy-production.sh`, do not ask "do the contract tests pass?" Ask the
+four fidelity questions:
+
+**1. Would the real `aws` CLI accept this?** The fake is permissive by default — it logs the call
+and exits 0. Before trusting a green run, check whether the real CLI validates something the fake
+does not. It already learned two lessons: local `cp` sources must exist (#1839), and a self-copy
+changing only tags needs `--metadata-directive REPLACE` (#1841). If your change relies on any other
+CLI-side validation, **teach the fake that rule in the same PR** — that is the established pattern,
+not an optional extra.
+
+**2. Would the real AWS *service* behave this way?** Distinct from the CLI. S3's self-copy rule and
+CloudFront's compression ceiling are service behaviours with no local proxy at all. #1843's fix
+exists entirely because a service limit was invisible to every test in the repo. When your change
+depends on a service threshold or quota, write it down in `docs/deployment.md` and, where possible,
+make it a named overridable variable so the suite can exercise the path with small fixtures — the
+way `PRECOMPRESS_THRESHOLD_BYTES` does.
+
+**3. Would this run on bash 3.2?** macOS has shipped bash 3.2.57 since 2007 for GPLv3 reasons, and
+`upload.sh` — the manual production deploy — invokes `bash scripts/deploy-production.sh`, which
+resolves to `/bin/bash`. Every workflow is `ubuntu-latest`, so **CI can never catch a bash-4-ism.**
+Concretely, avoid `declare -A`, `mapfile`/`readarray`, `${var,,}` / `${var^^}`, and negative array
+indices. Guard element-expansions of possibly-empty arrays with `${arr[@]+"${arr[@]}"}` — bash 3.2
+treats a bare `"${arr[@]}"` on an empty array as an unbound variable under `set -u`, while bash 5
+does not. (Length expansions like `${#arr[@]}` are safe on both.) The cheap local check is
+`/bin/bash -n scripts/deploy-production.sh` on a Mac.
+
+**4. Would a test fail if this guard were wrong?** A guard whose inversion leaves the suite green is
+decoration. Two separate reviewers found exactly this in #1842: stubbing `is_current_immutable_object`
+to always report "not current" — the failure that tags every live asset for 30-day deletion — left
+all 14 tests passing. **Mutate the guard and re-run.** If the suite stays green, the assertion you
+need does not exist yet. This is the single highest-yield check on this file, because the script's
+worst failures are silent and delayed: a wrong retirement tag does nothing visible for 30 days.
+
+### The verification that actually works here
+
+For any behaviour-preserving change (refactors especially), run the real script against a stubbed
+`aws` under both bash majors and diff the emitted calls. #1842 used a throwaway harness that creates
+a fake `dist/`, puts a logging stub on `PATH`, and runs the script; comparing sorted logs from
+bash 3.2 and bash 5.2 — and against the pre-change script — is what made a rewrite of the
+production deploy path reviewable. Compare the **sorted** log for set equality and say so; iteration
+order is not always preserved (that rewrite changed `put-object-tagging` from associative-array hash
+order to `find` order, which is inert but real).
+
+## Why This Matters
+
+- **The blast radius is production and it is delayed.** This script publishes to a live site, holds
+  a distributed lock, and tags objects for a lifecycle rule that deletes them 30 days later. The
+  ordered-publish design contains the damage — a mid-deploy failure leaves prod on the previous
+  coherent build and releases the lock — but a *wrong* retirement tag is not a failure at all until
+  a month later.
+- **Four same-day fixes is a pattern, not bad luck.** Each was a competent change that passed a
+  competent test suite. The recurring cause is structural: a test double is a hypothesis about the
+  real system, and this script's real system is three services, a CLI, and two shell majors.
+- **CI's platform coverage is narrower than the script's.** `upload.sh` is a supported entry point
+  and runs on the maintainer's Mac. Anything the deploy contract asserts is asserted only under
+  Linux + bash 5 until someone runs the suite locally.
+
+## When to Apply
+
+- Before merging any change to `scripts/deploy-production.sh` — walk the four questions above.
+- When adding a case to the fake `aws`: prefer teaching it to **reject** what the real thing rejects
+  over teaching it to accept what you need.
+- When a deploy fails in production: check whether the contract suite could have caught it, and if
+  not, add the missing fidelity in the same PR as the fix. That is how the fake accumulated its
+  current rules.
+- When adding a build artifact the script must publish, or a `dist/` file it references: add a
+  fixture and, if absence is fatal, a fail-closed guard with a test that fails without it.
+
+## Examples
+
+### Teaching the fake to reject what the real CLI rejects (#1839)
+
+```bash
+# The real CLI validates local cp sources before any request; a phantom build artifact in the
+# script must fail here exactly as it would in production.
+if [[ "$1 $2" == "s3 cp" && "$3" != s3://* && ! -e "$3" ]]; then
+  echo "The user-provided path $3 does not exist." >&2
+  exit 255
+fi
+```
+
+### Teaching the fake a service rule (#1841)
+
+```bash
+# Real S3 refuses an in-place copy that changes nothing but tags; only the REPLACE metadata
+# directive makes a self-copy legal. Enforce it so the script cannot regress to COPY.
+if [[ "$1 $2" == "s3api copy-object" && "$*" == *"--metadata-directive COPY"* ]]; then
+  echo 'An error occurred (InvalidRequest) when calling the CopyObject operation: illegal self-copy without metadata change' >&2
+  exit 254
+fi
+```
+
+### The assertion a mutation test demanded (#1842)
+
+Before, the suite asserted that *superseded* keys get retired but never that *live* keys do not, so
+an always-false membership check passed 14/14:
+
+```ts
+// The live build's own keys must never be tagged for retirement: the lifecycle rule would
+// delete them 30 days later. Without these, a membership check that always reported "not
+// current" would still pass every other assertion in this suite.
+expect(copiesFor('assets/current-123.js')).toHaveLength(0)
+expect(copiesFor('sw-extras-abc123.js')).toHaveLength(0)
+expect(copiesFor('workbox-abc123.js')).toHaveLength(0)
+```
+
+### Fail closed on a missing artifact rather than deploying a broken site (#1842)
+
+`dist/service-worker.js` opens with `define(["./workbox-<hash>"])`, so a build with no workbox chunk
+is broken — but without this the deploy succeeds, never uploads the chunk, and tags the live one for
+deletion:
+
+```bash
+[[ ${#workbox_dependencies[@]} -ge 1 ]] ||
+  fail "expected at least one content-hashed workbox-*.js runtime, found 0"
+```
+
+Placed beside its `extras` sibling, before the lock is acquired — a precondition failure should
+never reach the point of holding the deploy lock.
+
+## Known gaps
+
+- **No CI job runs this script under bash 3.2.** Until one exists, bash-4-isms ship green and only
+  surface on a manual macOS deploy. A pinned `bash:3.2` container step running the deployment
+  contract suite, or a lint step banning the constructs listed above, would close it.
+- **No `shellcheck` step** anywhere in the repo.
+- The fake `aws` models the calls this script makes today; it is not a general AWS simulator, and
+  should not be mistaken for one.
+
+## Related
+
+- GitHub #1809 — feat(pwa): introduced the script and its contract suite
+- GitHub #1839 — fix(deploy): drop the phantom registerSW.js publication step
+- GitHub #1841 — fix(deploy): make asset retirement survive real S3 semantics
+- GitHub #1843 — perf: pre-gzip assets above CloudFront's compression ceiling
+- GitHub #1840 / PR #1842 — bash 3.2 portability, plus the workbox guard and retirement coverage this review surfaced
+- docs/deployment.md — the S3/CloudFront header contract, asset retention, and worker rollback
+- docs/pwa.md — how the service worker, install, and offline behaviour fit together

--- a/docs/solutions/workflow-learnings/deploy-script-fidelity-gaps.md
+++ b/docs/solutions/workflow-learnings/deploy-script-fidelity-gaps.md
@@ -79,8 +79,23 @@ resolves to `/bin/bash`. Every workflow is `ubuntu-latest`, so **CI can never ca
 Concretely, avoid `declare -A`, `mapfile`/`readarray`, `${var,,}` / `${var^^}`, and negative array
 indices. Guard element-expansions of possibly-empty arrays with `${arr[@]+"${arr[@]}"}` — bash 3.2
 treats a bare `"${arr[@]}"` on an empty array as an unbound variable under `set -u`, while bash 5
-does not. (Length expansions like `${#arr[@]}` are safe on both.) The cheap local check is
-`/bin/bash -n scripts/deploy-production.sh` on a Mac.
+does not. (Length expansions like `${#arr[@]}` are safe on both.)
+
+`bash -n` is **not** the check for this. It only parses, and every construct above fails bash 3.2 at
+*run* time, not at parse time: `declare -A` is an invalid option to a builtin that exists, `mapfile`
+is a builtin that does not exist, `${var,,}` is applied during expansion, and `${arr[-1]}` is
+evaluated as a subscript. `bash -n` exits 0 on all four, so it certifies exactly the defect it would
+be run to find. The cheap local check that can actually fail is a construct grep:
+
+```bash
+grep -nE '^[^#]*(declare -A|mapfile|readarray|\$\{[A-Za-z_][A-Za-z0-9_]*(,,|\^\^)|\[ *-[0-9])' \
+  scripts/deploy-production.sh
+```
+
+Expect no hits (the `^[^#]*` prefix keeps the comment that *names* `declare -A` from matching).
+Verified against #1842: it hits `declare -A` on the pre-fix script and is clean on the fixed one,
+while `bash -n` exits 0 on both. For real coverage, run the deployment-contract suite against a
+pinned `bash:3.2` container — see Known gaps below. Keep `bash -n` only as a syntax smoke test.
 
 **4. Would a test fail if this guard were wrong?** A guard whose inversion leaves the suite green is
 decoration. Two separate reviewers found exactly this in #1842: stubbing `is_current_immutable_object`

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -98,6 +98,11 @@ extras=("${SITE_BUILD_DIR}"/sw-extras-*.js)
 [[ ${#extras[@]} -eq 1 ]] ||
   fail "expected exactly one content-hashed sw-extras-*.js dependency, found ${#extras[@]}"
 workbox_dependencies=("${SITE_BUILD_DIR}"/workbox-*.js)
+# dist/service-worker.js opens with define(["./workbox-<hash>"]), so a build with no workbox
+# runtime is broken. Without this check the deploy succeeds while never uploading the chunk the
+# worker requires, and then tags the live one retire=true for the lifecycle rule to delete.
+[[ ${#workbox_dependencies[@]} -ge 1 ]] ||
+  fail "expected at least one content-hashed workbox-*.js runtime, found 0"
 
 lock_body=$(mktemp)
 lock_error=$(mktemp)
@@ -181,8 +186,8 @@ release_lock() {
 trap release_lock EXIT
 
 # An indexed array rather than an associative one: macOS ships bash 3.2, so `declare -A` would
-# break the manual deploy in upload.sh. The membership scan below is linear over a few hundred
-# build artifacts, which costs nothing next to the AWS calls it guards.
+# break the manual deploy in upload.sh. The membership scan below is linear over the build's
+# immutable artifacts (~32 today), which costs nothing next to the per-object AWS calls it guards.
 current_immutable_objects=()
 while IFS= read -r -d '' local_asset; do
   relative_asset="${local_asset#"${SITE_BUILD_DIR%/}/"}"

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -180,16 +180,28 @@ release_lock() {
 }
 trap release_lock EXIT
 
-declare -A current_immutable_objects=()
+# An indexed array rather than an associative one: macOS ships bash 3.2, so `declare -A` would
+# break the manual deploy in upload.sh. The membership scan below is linear over a few hundred
+# build artifacts, which costs nothing next to the AWS calls it guards.
+current_immutable_objects=()
 while IFS= read -r -d '' local_asset; do
   relative_asset="${local_asset#"${SITE_BUILD_DIR%/}/"}"
-  current_immutable_objects["${SITE_PREFIX}${relative_asset}"]=1
+  current_immutable_objects+=("${SITE_PREFIX}${relative_asset}")
 done < <(find "${SITE_BUILD_DIR}/assets" -type f -print0)
 [[ ${#current_immutable_objects[@]} -gt 0 ]] || fail "${SITE_BUILD_DIR}/assets contains no files"
 
-for dependency in "${extras[@]}" "${workbox_dependencies[@]}"; do
-  current_immutable_objects["${SITE_PREFIX}$(basename "$dependency")"]=1
+for dependency in "${extras[@]}" ${workbox_dependencies[@]+"${workbox_dependencies[@]}"}; do
+  current_immutable_objects+=("${SITE_PREFIX}$(basename "$dependency")")
 done
+
+is_current_immutable_object() {
+  local candidate="$1"
+  local known
+  for known in "${current_immutable_objects[@]}"; do
+    [[ "$known" == "$candidate" ]] && return 0
+  done
+  return 1
+}
 
 # CloudFront only compresses responses up to ~10 MB, so any script above the threshold ships
 # uncompressed to every visitor unless it is stored gzipped with an explicit Content-Encoding.
@@ -222,13 +234,13 @@ for oversized_script in ${oversized_scripts[@]+"${oversized_scripts[@]}"}; do
   rm -f "$compressed_script"
 done
 
-for dependency in "${extras[@]}" "${workbox_dependencies[@]}"; do
+for dependency in "${extras[@]}" ${workbox_dependencies[@]+"${workbox_dependencies[@]}"}; do
   aws s3 cp "$dependency" "${SITE_S3}/$(basename "$dependency")" \
     --cache-control "$IMMUTABLE" \
     --content-type 'text/javascript; charset=utf-8'
 done
 
-for immutable_key in "${!current_immutable_objects[@]}"; do
+for immutable_key in "${current_immutable_objects[@]}"; do
   aws s3api put-object-tagging \
     --bucket "$SITE_BUCKET" \
     --key "$immutable_key" \
@@ -287,7 +299,7 @@ while IFS= read -r remote_immutable; do
       ;;
     *) continue ;;
   esac
-  [[ -n "${current_immutable_objects[$remote_immutable]:-}" ]] && continue
+  is_current_immutable_object "$remote_immutable" && continue
 
   retire_tag=$(aws s3api get-object-tagging \
     --bucket "$SITE_BUCKET" \

--- a/src/tests/aos4/listbotCorpusCommand.test.ts
+++ b/src/tests/aos4/listbotCorpusCommand.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, readdir, rename, rm, symlink, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, readdir, realpath, rename, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { writeListbotCorpus } from '../support/listbotCorpusCommand'
@@ -9,7 +9,10 @@ describe('Listbot corpus publication', () => {
   let output: string
 
   beforeEach(async () => {
-    workspaceRoot = await mkdtemp(path.join(tmpdir(), 'aos-listbot-corpus-'))
+    // Canonicalized so the paths these tests compare match the ones publication reports back.
+    // macOS os.tmpdir() sits under /var, a symlink to /private/var; the symlinked-root case is
+    // covered deliberately below rather than left to depend on the host's temp layout.
+    workspaceRoot = await realpath(await mkdtemp(path.join(tmpdir(), 'aos-listbot-corpus-')))
     outputRoot = path.join(workspaceRoot, 'data', 'aos4', 'import-corpus')
     output = path.join(outputRoot, 'listbot')
   })
@@ -37,6 +40,34 @@ describe('Listbot corpus publication', () => {
     await writeCorpus(true, 'replacement')
     await expect(readFile(path.join(output, 'armies', 'alpha.txt'), 'utf8')).resolves.toBe('replacement')
     expect((await readdir(outputRoot)).filter(name => name.includes('.backup'))).toEqual([])
+  })
+
+  it('publishes into a workspace root reached through a symbolic link', async () => {
+    const realWorkspace = path.join(workspaceRoot, 'real')
+    const linkedWorkspace = path.join(workspaceRoot, 'linked')
+    await mkdir(realWorkspace)
+    await symlink(realWorkspace, linkedWorkspace, process.platform === 'win32' ? 'junction' : 'dir')
+    const linkedOutputRoot = path.join(linkedWorkspace, 'data', 'aos4', 'import-corpus')
+
+    await writeListbotCorpus({
+      workspaceRoot: linkedWorkspace,
+      outputRoot: linkedOutputRoot,
+      output: path.join(linkedOutputRoot, 'listbot'),
+      force: false,
+      files: [{ file: 'armies/alpha.txt', text: 'new roster' }],
+      manifest: { schemaVersion: 1 },
+    })
+
+    const publishedThroughRealPath = path.join(
+      realWorkspace,
+      'data',
+      'aos4',
+      'import-corpus',
+      'listbot',
+      'armies',
+      'alpha.txt'
+    )
+    await expect(readFile(publishedThroughRealPath, 'utf8')).resolves.toBe('new roster')
   })
 
   it('refuses to traverse a junction outside the configured output root', async () => {

--- a/src/tests/deploymentContract.test.ts
+++ b/src/tests/deploymentContract.test.ts
@@ -232,6 +232,7 @@ echo '{}'
     }
 
     return {
+      buildDirectory,
       log: () =>
         existsSync(logPath) && readFileSync(logPath, 'utf8').trim()
           ? readFileSync(logPath, 'utf8').trim().split('\n')
@@ -303,6 +304,18 @@ echo '{}'
     ).toBe(true)
   })
 
+  it('fails before publication when the build emits no workbox runtime', () => {
+    const harness = createHarness()
+    rmSync(join(harness.buildDirectory, 'workbox-abc123.js'))
+    const result = harness.run()
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toMatch(/workbox/i)
+    const log = harness.log()
+    expect(log.some(line => line.startsWith('s3 cp ') || line.startsWith('s3 sync '))).toBe(false)
+    expect(log.some(line => line.startsWith('s3api put-object '))).toBe(false)
+  })
+
   it('keeps live assets ineligible and starts retirement exactly once', () => {
     const harness = createHarness()
     const result = harness.run()
@@ -340,6 +353,12 @@ echo '{}'
     expect(copiesFor('workbox-old.js')).toHaveLength(1)
     expect(copiesFor('assets/already-retired.js')).toHaveLength(0)
     expect(copiesFor('workbox-already-retired.js')).toHaveLength(0)
+    // The live build's own keys must never be tagged for retirement: the lifecycle rule would
+    // delete them 30 days later. Without these, a membership check that always reported "not
+    // current" would still pass every other assertion in this suite.
+    expect(copiesFor('assets/current-123.js')).toHaveLength(0)
+    expect(copiesFor('sw-extras-abc123.js')).toHaveLength(0)
+    expect(copiesFor('workbox-abc123.js')).toHaveLength(0)
     log
       .filter(line => line.startsWith('s3api copy-object '))
       .forEach(line => {

--- a/src/tests/support/listbotCorpusCommand.ts
+++ b/src/tests/support/listbotCorpusCommand.ts
@@ -206,6 +206,10 @@ const isContainedPath = (root: string, target: string): boolean => {
   )
 }
 
+// Returns the canonical form of `target`. `target` must be expressed against the same form of
+// `root` that the caller passed in: this function canonicalizes, so feeding its own result back in
+// as a root while keeping a lexical target compares two spellings of one directory and rejects it.
+// That is not hypothetical — on macOS os.tmpdir() sits under /var, a symlink to /private/var.
 const ensureDirectoryInside = async (root: string, target: string): Promise<string> => {
   const absoluteRoot = path.resolve(root)
   const absoluteTarget = path.resolve(target)
@@ -214,7 +218,7 @@ const ensureDirectoryInside = async (root: string, target: string): Promise<stri
   }
   const canonicalRoot = await realpath(absoluteRoot)
   const relative = path.relative(absoluteRoot, absoluteTarget)
-  let cursor = absoluteRoot
+  let cursor = canonicalRoot
   for (const segment of relative.split(path.sep).filter(Boolean)) {
     cursor = path.join(cursor, segment)
     if (!(await pathExists(cursor))) await mkdir(cursor)
@@ -228,7 +232,7 @@ const ensureDirectoryInside = async (root: string, target: string): Promise<stri
       throw new Error(`Resolved output path escapes ${canonicalRoot}: ${cursor}`)
     }
   }
-  return realpath(absoluteTarget)
+  return realpath(cursor)
 }
 
 interface WriteListbotCorpusOptions {
@@ -257,8 +261,11 @@ export const writeListbotCorpus = async (options: WriteListbotCorpusOptions): Pr
   }
 
   const canonicalOutputRoot = await ensureDirectoryInside(options.workspaceRoot, outputRoot)
-  const outputParent = await ensureDirectoryInside(canonicalOutputRoot, path.dirname(output))
-  const safeOutput = path.join(outputParent, path.basename(output))
+  // Re-express the output against the canonical root before descending again, so both arguments
+  // share one spelling. The lexical relative path is already validated as non-escaping above.
+  const canonicalOutput = path.join(canonicalOutputRoot, lexicalRelative)
+  const outputParent = await ensureDirectoryInside(canonicalOutputRoot, path.dirname(canonicalOutput))
+  const safeOutput = path.join(outputParent, path.basename(canonicalOutput))
   const outputExists = await pathExists(safeOutput)
   if (outputExists) {
     const stats = await lstat(safeOutput)

--- a/src/tests/support/listbotCorpusCommand.ts
+++ b/src/tests/support/listbotCorpusCommand.ts
@@ -263,9 +263,9 @@ export const writeListbotCorpus = async (options: WriteListbotCorpusOptions): Pr
   const canonicalOutputRoot = await ensureDirectoryInside(options.workspaceRoot, outputRoot)
   // Re-express the output against the canonical root before descending again, so both arguments
   // share one spelling. The lexical relative path is already validated as non-escaping above.
-  const canonicalOutput = path.join(canonicalOutputRoot, lexicalRelative)
-  const outputParent = await ensureDirectoryInside(canonicalOutputRoot, path.dirname(canonicalOutput))
-  const safeOutput = path.join(outputParent, path.basename(canonicalOutput))
+  const canonicalOutputTarget = path.join(canonicalOutputRoot, lexicalRelative)
+  const outputParent = await ensureDirectoryInside(canonicalOutputRoot, path.dirname(canonicalOutputTarget))
+  const safeOutput = path.join(outputParent, path.basename(canonicalOutputTarget))
   const outputExists = await pathExists(safeOutput)
   if (outputExists) {
     const stats = await lstat(safeOutput)


### PR DESCRIPTION
Fixes #1840.

Eight tests failed on a clean macOS checkout of `master` while CI stayed green. Investigating the
first cause turned up something bigger than a test problem: **the manual production deploy has been
broken on macOS**, and the test failure was the symptom.

## `scripts/deploy-production.sh` could not run on bash 3.2

`declare -A` needs bash 4+. macOS has shipped bash 3.2 since 2007 for GPLv3 reasons, and `upload.sh`
— the manual production deploy — invokes `bash scripts/deploy-production.sh`, which resolves to
`/bin/bash`. So a manual deploy from a Mac died at line 180.

Where it died matters, and it is the reassuring part: line 180 sits after the deploy lock is
acquired but before the first `aws s3 cp`. Reproducing it against a stubbed `aws` shows the whole
observable effect — two preflight reads, the lock acquisition, and the EXIT trap releasing it:

```
s3api get-bucket-lifecycle-configuration ...
cloudfront get-distribution-config ...
s3api put-object --key _deploy/production.lock ... --if-none-match *
s3api delete-object --key _deploy/production.lock --if-match "acquired-etag"
```

Nothing was ever published and no lock was stranded. The failure was loud and clean, which is
presumably why it went unnoticed — the GitHub Actions path (`ubuntu-latest`, bash 5) was unaffected.

The fix swaps the associative array for an indexed array plus a linear membership helper, and guards
the `workbox_dependencies` expansion — that one is a real glob that `nullglob` can empty, and bash
3.2 rejects an empty `"${arr[@]}"` under `set -u`. That is the same guard idiom #1841 independently
reached for on `retire_headers`, so the two are consistent.

### Verification

Beyond the suite, I ran the actual script against a stubbed `aws` under both interpreters and
compared the emitted AWS calls:

| Comparison | Result |
| --- | --- |
| this branch on bash 3.2 vs bash 5.2 | identical, exit 0 |
| this branch on bash 5.2 vs **current `master`** on bash 5.2 | identical **set** of calls, exit 0 |
| current `master` on bash 3.2 | exit 2 at line 180 |

The second row is the one that matters for production: on the interpreter CI and Actions actually
use, this rewrite issues the same AWS calls as `master`.

**One deliberate ordering change.** These comparisons are on the *sorted* call log, so they
establish set equality, not sequence equality. There is one real difference in sequence: the
`put-object-tagging` exemption pass iterated associative-array hash order before and iterates
`find` order now, so `sw-extras-*` and `workbox-*` are deterministically last instead of
arbitrarily placed. Each of those calls is independent and idempotent, and the ordering that the
deploy's coherence contract actually depends on — immutable assets → extras → public files →
`index.html` → `service-worker.js` → invalidation → retirement — is unchanged. Verified separately
against the real 30-file `dist/assets`: 62 calls on each side, sorted diff empty.

Rebased onto `master` after #1839 and #1841, and all three rows above were re-verified against the
rebased tree. The stub was extended to match the stricter semantics those two PRs introduced — it
now answers `head-object` header reads and rejects a self-copy that keeps `--metadata-directive
COPY`. #1839 removed the `registration_dependencies` loop outright, which subsumes the one
expansion in that area I had deliberately left alone.

## A defect the review caught: no workbox runtime = silent broken deploy

`workbox_dependencies` had no count check, unlike the `extras` sibling right above it that asserts
exactly one `sw-extras-*.js`. `dist/service-worker.js` opens with `define(["./workbox-<hash>"])`,
so a build emitting no workbox chunk is broken — but the deploy would **succeed**: it would never
upload the chunk the worker requires, and would then tag the currently-live one `retire=true` for
the lifecycle rule to delete 30 days later.

This is reachable on `master` today (bash 5 expands an empty array to nothing without complaint);
it is not introduced here. But this branch is what makes the bash-3.2 path behave the same way, so
it belongs with this change. The script now fails before the lock is acquired:

```
[[ ${#workbox_dependencies[@]} -ge 1 ]] ||
  fail "expected at least one content-hashed workbox-*.js runtime, found 0"
```

A contract test covers it, and I confirmed the test fails when the guard is removed.

## A second gap the review caught: the exemption pass had no negative coverage

Stubbing `is_current_immutable_object` to always report "not current" — the failure that tags every
live asset for deletion — left all 14 deployment-contract tests green. Nothing asserted that the
live build's own keys stay out of the retirement `copy-object` path. Added those three assertions
and verified they fail against that mutant.

That gap predates this branch, but the rewrite is exactly the kind of change it would have failed
to catch, so it is fixed here.

## `ensureDirectoryInside` mixed canonical and lexical paths

The other three failures were in `src/tests/support/listbotCorpusCommand.ts`. `ensureDirectoryInside`
returns `realpath`-canonicalized paths, but `writeListbotCorpus` fed its own canonical result back in
as the *root* while leaving the *target* lexical. Wherever an ancestor is a symlink those spell the
same directory two ways, and the containment guard rejected the corpus root as an escape:

```
/var/folders/…/import-corpus must stay below /private/var/folders/…/import-corpus
```

Both paths there are the same directory. macOS `os.tmpdir()` lives under `/var`, a symlink to
`/private/var`, which is all it took to trip.

My first attempt was to let the guard accept a target expressed against either form of the root.
That does not work, and the error message above is why: the target is not *nested* under the other
spelling, it is the *same* directory spelled differently, so no choice of root makes it "contained".
The fix belongs at the call site — re-express the output against the canonical root before descending
again, so both arguments share one spelling. The already-validated lexical relative path does that
directly.

This is a latent bug rather than a macOS quirk: any caller whose configured output root sits under a
symlink would hit it on any platform. So the regression test creates an explicit symlink rather than
relying on the host's temp layout, and it fails on the pre-fix code with exactly the original error.
I also canonicalized the suite's temp workspace, because one test's `renamePath` hook compares
against the destination publication reports back, and that comparison has to be apples-to-apples.

The symlink-refusal semantics are unchanged — a symlink *inside* the corpus path is still refused,
which the existing junction test continues to prove.

## Checks

`yarn lint`, `yarn tsc --noEmit`, `yarn build`, `yarn test --run` (85 files, 1286 tests — the 1284
previously on `master` plus a symlink regression test and a workbox-runtime contract test), and
`yarn data:aos4:verify:beta` (79,962 pass, 0 findings, 0 cannot-verify) all pass locally on macOS.
No change to the accepted corpus, generated runtime data, domain code, or UI.

Worth flagging for review: this touches production deploy scripting. The behavioural diff above is
the evidence I would want a reviewer to weigh, and it is reproducible — the harness stubs `aws` and
logs every call, so the comparison can be re-run independently.

## Known gaps, not addressed here

- **No CI job runs this script under bash 3.2.** Every workflow is `ubuntu-latest`, and the contract
  suite spawns whatever `bash` is on `PATH`, so bash-3.2 behaviour is only exercised when someone
  runs the suite on a Mac. A reintroduced `declare -A` / `mapfile` / `${var,,}` would ship green. A
  pinned `bash:3.2` container job, or a lint step banning bash-4-isms, would lock the property in.
- **`ensureDirectoryInside`'s canonical/lexical invariant is enforced by a comment.** Making the
  signature take a validated relative segment would make the misuse unrepresentable, but that is a
  wider refactor than this fix warrants.
- Two of the three `ensureDirectoryInside` edits (`cursor = canonicalRoot`, `return realpath(cursor)`)
  are defensive rather than load-bearing — reverting either individually still passes the suite. Only
  the call-site re-expression is proven by a test.
