### PR TITLE
perf: cut the catalog's first-load cost by 11x on the wire

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -8,6 +8,9 @@ SITE_BUILD_DIR="${SITE_BUILD_DIR:-./dist}"
 CF_DIST_ID="${CF_DIST_ID:-E3OO9Y9QRVZ2L1}"
 DEPLOY_OWNER="${DEPLOY_OWNER:-manual:${USER:-unknown}@${HOSTNAME:-unknown}:$$}"
 DEPLOY_LOCK_KEY="${DEPLOY_LOCK_KEY:-_deploy/production.lock}"
+# CloudFront refuses to compress objects above ~10,000,000 bytes; anything larger must be stored
+# pre-gzipped. Overridable so the contract suite can exercise the path with small fixtures.
+PRECOMPRESS_THRESHOLD_BYTES="${PRECOMPRESS_THRESHOLD_BYTES:-9500000}"
 
 IMMUTABLE='public, max-age=31536000, immutable'
 MODERATE='public, max-age=86400'
@@ -188,11 +191,36 @@ for dependency in "${extras[@]}" "${workbox_dependencies[@]}"; do
   current_immutable_objects["${SITE_PREFIX}$(basename "$dependency")"]=1
 done
 
+# CloudFront only compresses responses up to ~10 MB, so any script above the threshold ships
+# uncompressed to every visitor unless it is stored gzipped with an explicit Content-Encoding.
+# The ~12 MB catalog chunk is the case that matters: 12.25 MiB raw vs 1.09 MiB gzipped.
+oversized_scripts=()
+while IFS= read -r -d '' oversized_script; do
+  oversized_scripts+=("$oversized_script")
+done < <(find "${SITE_BUILD_DIR}/assets" -type f -name '*.js' \
+  -size +"${PRECOMPRESS_THRESHOLD_BYTES}"c -print0)
+
 # Immutable content is published first. Current files are explicitly removed from the retirement
 # lifecycle before either mutable entry point can reference them.
+oversized_excludes=()
+for oversized_script in ${oversized_scripts[@]+"${oversized_scripts[@]}"}; do
+  oversized_excludes+=(--exclude "${oversized_script#"${SITE_BUILD_DIR%/}/assets/"}")
+done
 aws s3 cp "${SITE_BUILD_DIR}/assets" "${SITE_S3}/assets" \
   --recursive \
+  ${oversized_excludes[@]+"${oversized_excludes[@]}"} \
   --cache-control "$IMMUTABLE"
+
+for oversized_script in ${oversized_scripts[@]+"${oversized_scripts[@]}"}; do
+  relative_script="${oversized_script#"${SITE_BUILD_DIR%/}/assets/"}"
+  compressed_script=$(mktemp)
+  gzip -9 -c "$oversized_script" > "$compressed_script"
+  aws s3 cp "$compressed_script" "${SITE_S3}/assets/${relative_script}" \
+    --content-encoding gzip \
+    --content-type 'text/javascript; charset=utf-8' \
+    --cache-control "$IMMUTABLE"
+  rm -f "$compressed_script"
+done
 
 for dependency in "${extras[@]}" "${workbox_dependencies[@]}"; do
   aws s3 cp "$dependency" "${SITE_S3}/$(basename "$dependency")" \

--- a/src/tests/deploymentContract.test.ts
+++ b/src/tests/deploymentContract.test.ts
@@ -47,6 +47,8 @@ describe('production deployment contract', () => {
 
     for (const [path, contents] of [
       ['assets/current-123.js', 'current'],
+      // Longer than the harness's PRECOMPRESS_THRESHOLD_BYTES so the pre-gzip path always runs.
+      ['assets/aos4-catalog-data-abc123.js', `const catalogCorpus = ${'"x"'.repeat(64)}`],
       ['index.html', '<!doctype html>'],
       ['site.webmanifest', '{}'],
       ['service-worker.js', 'importScripts("sw-extras-abc123.js")'],
@@ -209,6 +211,7 @@ echo '{}'
         AWS_REMOTE_WORKBOX_KEYS: 'workbox-abc123.js\tworkbox-already-retired.js\tworkbox-old.js',
         CF_DIST_ID: 'distribution-id',
         DEPLOY_OWNER: 'deployment-test',
+        PRECOMPRESS_THRESHOLD_BYTES: '100',
         SITE_BUILD_DIR: bashPath(buildDirectory),
         SITE_S3: 's3://test-bucket',
         ...extraEnvironment,
@@ -344,6 +347,36 @@ echo '{}'
         expect(line).toContain('public, max-age=31536000, immutable')
         expect(line).toContain('text/javascript; charset=utf-8')
       })
+  })
+
+  it('stores oversized scripts gzipped so CloudFront size limits cannot ship them raw', () => {
+    const harness = createHarness()
+    const result = harness.run()
+
+    expect(result.status, result.stderr).toBe(0)
+    const log = harness.log()
+    const recursiveAssetsUpload = log.find(
+      line => line.startsWith('s3 cp ') && line.includes('/assets --recursive')
+    )
+    expect(recursiveAssetsUpload).toBeDefined()
+    expect(recursiveAssetsUpload).toContain('--exclude aos4-catalog-data-abc123.js')
+    const compressedUpload = log.find(
+      line =>
+        line.startsWith('s3 cp ') &&
+        line.includes('s3://test-bucket/assets/aos4-catalog-data-abc123.js') &&
+        line.includes('--content-encoding gzip')
+    )
+    expect(compressedUpload).toBeDefined()
+    expect(compressedUpload).toContain('public, max-age=31536000, immutable')
+    expect(compressedUpload).toContain('text/javascript; charset=utf-8')
+    expect(
+      log.some(
+        line =>
+          line.startsWith('s3api put-object-tagging ') &&
+          line.includes('assets/aos4-catalog-data-abc123.js') &&
+          line.includes('retire,Value=false')
+      )
+    ).toBe(true)
   })
 
   it('force-copies unhashed public files with the moderate cache header', () => {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -229,6 +229,12 @@ self.addEventListener('activate', event => {
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  /*
+   * Emit imported JSON as JSON.parse("...") instead of a JS object literal. Engines parse JSON
+   * several times faster than JS source at scale, and the corpus chunk is ~12 MB — on a phone the
+   * literal form costs whole seconds of main-thread parse before Home can render.
+   */
+  json: { stringify: true },
   build: {
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Summary

First-load on mobile still paid the full ~12 MB catalog chunk even after the PWA landed (precache only helps repeat visits). The chunk is a hard dependency of the lazily-loaded Home route, so first render blocks on downloading and parsing it. Two independent fixes:

**Delivery — 12.25 MiB → 1.11 MiB on the wire.** CloudFront refuses to compress objects above ~10,000,000 bytes, so the catalog always shipped raw. `deploy-production.sh` now stores any `assets/*.js` above a configurable threshold (default 9,500,000 bytes) pre-gzipped with an explicit `Content-Encoding: gzip`, uploaded individually with the same immutable cache header and excluded from the plain recursive copy. Every browser sends `Accept-Encoding: gzip`, and the service worker's warm/runtime-cache fetches decode transparently.

**Parse — object literal → `JSON.parse`.** Vite's `json.stringify` option makes the corpus chunk a single `JSON.parse` call instead of a 12 MB JS object literal. Engines parse JSON several times faster than JS source at this scale, which matters most on phone CPUs. All JSON imports in `src` use the default-import form stringify requires, and the 850 kB entry-chunk budget plugin guards against inlining regressions.

## Verification

- `yarn build`: catalog chunk emits as a `JSON.parse` string; entry budget passes; worker + precache generate cleanly (30 entries).
- `yarn lint`, `yarn tsc --noEmit`: clean.
- pwaBuild, bundleBoundaries, registerServiceWorker, updateAvailable suites: 46/46 pass against the fresh `dist/`.
- Deploy script exercised end-to-end in a local fake-`aws` harness: oversized fixture excluded from the recursive copy, uploaded gzipped from a temp file with immutable + `text/javascript` headers, tagged `retire=false`, exit 0.
- Contract suite hardened: oversized fixture above a lowered `PRECOMPRESS_THRESHOLD_BYTES`, with assertions on the encoding, headers, tagging, and exclusion.

## Follow-up candidates (not in this PR)

- Restructure Home so the shell renders before the catalog resolves (removes the remaining ~1 MiB from the critical path).
- Split the corpus per faction so a phone only loads what the selected army needs.

https://claude.ai/code/session_01FfnwSqxEgq9drUfPidpo8r
