### PR TITLE
fix(builder): own card for manifestations, quiet core-rules provenance, and no bogus Army of Renown cards

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -359,7 +359,7 @@ three-up grid on desktop (`col-md-6 col-lg-4`) and the toolbar is a seven-button
 
 **Mobile is a different layout, not a narrower one.** Below 576px: collapsed builder cards drop to
 `col w-50` and tile two-up so the whole builder is visible without scrolling; group titles switch
-to shorter `mobileTitle` variants ("Formations", "Artefacts", "Manifestations"); card header
+to shorter `mobileTitle` variants ("Formations", "Artefacts", "Manif. Lores"); card header
 padding grows from `0.5rem 1.25rem` to a uniform `1rem`; reminder cards start collapsed rather than
 expanded, so the player lands on a list of phases instead of a wall of text.
 

--- a/src/aos4/view/builder.ts
+++ b/src/aos4/view/builder.ts
@@ -23,6 +23,63 @@ export interface Aos4BuilderWarscroll {
   }
 }
 
+/**
+ * Battletome and Legends Armies of Renown that the corpus has not yet classified (issue #1844).
+ * Each is a Wahapedia faction-page army package whose subgroups (Battle Traits, lores, artefacts)
+ * decode as pickable options under a bogus card named after the army. Offering them piecemeal is
+ * rules-wrong — an Army of Renown replaces the faction's rules, and without the reviewed
+ * classification there are no exclusion edges, so a picked subgroup would apply additively.
+ * They are withheld from the builder until the corpus types them `army-of-renown`; at that point
+ * generation renames the group type and the matching entry here goes dead. A subgroup already
+ * selected in the player's document stays visible so the active rules can be seen and removed.
+ */
+const UNCLASSIFIED_ARMY_PACKAGE_GROUP_TYPES = new Set([
+  'aelementiri-conclave',
+  'allies-of-the-free-cities',
+  'astral-templars',
+  'barrow-legion',
+  'big-waaagh',
+  'champions-of-the-arena',
+  'change-cult-uprising',
+  'court-of-the-godlings',
+  'cycle-of-corruption',
+  'da-kings-gitz',
+  'droggzs-gitmob',
+  'gorechosen-champions',
+  'heroes-of-the-first-forged',
+  'ironsunz',
+  'knights-of-the-crimson-keep',
+  'legion-of-the-first-prince',
+  'lords-of-the-clan',
+  'murkvast-menagerie',
+  'petrifex-elite',
+  'pioneer-outpost',
+  'ruination-brotherhood',
+  'soulpod-guardians',
+  'taars-grand-forgehost',
+  'thanquols-mutated-menagerie',
+  'the-baleful-lords',
+  'the-clattering-procession',
+  'the-decadent-host',
+  'the-duardin-ascendant',
+  'the-equinox-feast',
+  'the-eternal-nightmare',
+  'the-first-phalanx-of-ionrach',
+  'the-gardeners-of-nurgle',
+  'the-great-grand-gnawhorde',
+  'the-iron-march',
+  'the-knights-of-new-summercourt',
+  'the-lance-of-ossia',
+  'the-magnates-crew',
+  'the-null-myriad',
+  'the-oracles-of-fate',
+  'vanari-paragons',
+  'wardens-of-the-chorrileum',
+  'zainthar-kai',
+  'ziggurat-stampede',
+  'zoggroks-ironmongerz',
+])
+
 export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4ArmyDocument) => {
   // Every army offers its full catalog: current-standard content plus the Legends and historical
   // (Scourge of Ghyran) overlays. Options carry an `overlay` marker so the UI can group them
@@ -59,6 +116,13 @@ export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4A
   ).flatMap(id => {
     const entity = entityById.get(id)
     if (!entity) return []
+    if (
+      entity.kind === 'content-group' &&
+      UNCLASSIFIED_ARMY_PACKAGE_GROUP_TYPES.has(entity.groupType) &&
+      !selected.has(id)
+    ) {
+      return []
+    }
     const overlay = overlayFor(id)
     return [
       {

--- a/src/aos4/view/builder.ts
+++ b/src/aos4/view/builder.ts
@@ -65,7 +65,13 @@ export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4A
         id,
         name: entity.name,
         kind: entity.kind,
-        ...(entity.kind === 'content-group' ? { groupType: entity.groupType } : {}),
+        ...(entity.kind === 'content-group'
+          ? { groupType: entity.groupType }
+          : entity.kind === 'warscroll' && entity.keywords.includes('MANIFESTATION')
+            ? // Manifestations are a category of unit, not roster units (CONCEPTS.md); grouping
+              // them apart keeps the Units card a list of the units a player actually fields.
+              { groupType: 'manifestation' }
+            : {}),
         selected: selected.has(id),
         available: available.has(id),
         ...(overlay ? { overlay } : {}),
@@ -89,7 +95,10 @@ export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4A
       .map((word, index) =>
         index > 0 && CHIP_MINOR_WORDS.has(word)
           ? word
-          : word.replace(/(^|-)([a-z])/g, (_, boundary: string, letter: string) => `${boundary}${letter.toUpperCase()}`)
+          : word.replace(
+              /(^|-)([a-z])/g,
+              (_, boundary: string, letter: string) => `${boundary}${letter.toUpperCase()}`
+            )
       )
       .join(' ')
   const armyOfRenownRootIds = new Set(

--- a/src/aos4/view/reminders.ts
+++ b/src/aos4/view/reminders.ts
@@ -190,6 +190,9 @@ export interface Aos4ReminderViewModel {
   note?: string
   order?: number
   sourceRecordIds: string[]
+  /** The game-wide rules module carrying this reminder, when one does. Provenance data only —
+   * never rendered as a tag (see `rulesModuleName`). */
+  rulesModule?: string
   projected: ProjectedReminder
 }
 
@@ -239,6 +242,28 @@ const sourceTags = (
     .sort((left, right) => left.label.localeCompare(right.label))
 }
 
+/**
+ * Names the game-wide rules module (The Core Rules, a General's Handbook) that carries a
+ * faction-rooted reminder. MUSICIAN and STANDARD BEARER are not faction rules — they arrive
+ * through a rules-module container every army includes. Deliberately data, not a tag: stamping
+ * THE CORE RULES on every core reminder read as noise, but the provenance stays available for
+ * future surfaces (filtering, an explainer, print grouping).
+ */
+const rulesModuleName = (
+  reminder: ProjectedReminder,
+  entityById: Map<CanonicalId, ContentEntity>
+): string | undefined => {
+  for (const cause of reminder.causes) {
+    for (const ancestorId of cause.entityPath.slice(0, -1)) {
+      const ancestor = entityById.get(ancestorId)
+      if (ancestor?.kind === 'content-group' && ancestor.groupType === 'rules-module') {
+        return ancestor.name
+      }
+    }
+  }
+  return undefined
+}
+
 const withPreferences = (
   reminder: ProjectedReminder,
   document: Aos4ArmyDocument,
@@ -248,6 +273,7 @@ const withPreferences = (
   const details = timingDetails(reminder.timing)
   const label = windowLabel(reminder.timing)
   const grantedBy = sourceTags(reminder, entityById)
+  const rulesModule = rulesModuleName(reminder, entityById)
   return {
     id: reminder.id,
     name: reminder.name,
@@ -269,6 +295,7 @@ const withPreferences = (
     ...(preference?.note ? { note: preference.note } : {}),
     ...(preference?.order !== undefined ? { order: preference.order } : {}),
     sourceRecordIds: reminder.sourceRefs.map(reference => String(reference.sourceRecordId)),
+    ...(rulesModule ? { rulesModule } : {}),
     projected: reminder,
   }
 }

--- a/src/components/input/army_builder.tsx
+++ b/src/components/input/army_builder.tsx
@@ -33,7 +33,8 @@ const titles: Record<string, { title: string; mobileTitle?: string; order: numbe
   'artefact-of-power': { title: 'Artefacts of Power', mobileTitle: 'Artefacts', order: 2 },
   'spell-lore': { title: 'Spell Lores', order: 3 },
   'prayer-lore': { title: 'Prayer Lores', order: 4 },
-  'manifestation-lore': { title: 'Manifestation Lores', mobileTitle: 'Manifestations', order: 5 },
+  'manifestation-lore': { title: 'Manifestation Lores', mobileTitle: 'Manif. Lores', order: 5 },
+  manifestation: { title: 'Manifestations', order: 6 },
   'regiment-of-renown': {
     title: 'Regiment Of Renown',
     mobileTitle: 'Regiments',
@@ -92,9 +93,7 @@ const SelectionCard = ({
   // but sits under its own group header so its provenance stays visible.
   const currentOptions = group.options.filter(option => !option.overlay).map(toOption)
   const legendsOptions = group.options.filter(option => option.overlay === 'legends').map(toOption)
-  const historicalOptions = group.options
-    .filter(option => option.overlay === 'historical')
-    .map(toOption)
+  const historicalOptions = group.options.filter(option => option.overlay === 'historical').map(toOption)
   const options: Option[] = [...currentOptions, ...legendsOptions, ...historicalOptions]
   const groupedOptions = [
     ...currentOptions,

--- a/src/tests/aos4/armyPackageTriage.test.ts
+++ b/src/tests/aos4/armyPackageTriage.test.ts
@@ -1,4 +1,4 @@
-import type { ContentGroup, Faction } from '../../aos4/domain'
+import type { CanonicalId, ContentGroup, Faction } from '../../aos4/domain'
 import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID } from '../../aos4/generated'
 import { createAos4ArmyDocument } from '../../aos4/state'
 import { createAos4BuilderViewModel } from '../../aos4/view'
@@ -20,7 +20,7 @@ const factionByName = (name: string): Faction => {
   return entity as Faction
 }
 
-const builderFor = (explicitSelectionIds: Faction['id'][]) =>
+const builderFor = (explicitSelectionIds: CanonicalId[]) =>
   createAos4BuilderViewModel(
     AOS4_CATALOG,
     createAos4ArmyDocument({

--- a/src/tests/aos4/armyPackageTriage.test.ts
+++ b/src/tests/aos4/armyPackageTriage.test.ts
@@ -1,0 +1,84 @@
+import type { ContentGroup, Faction } from '../../aos4/domain'
+import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID } from '../../aos4/generated'
+import { createAos4ArmyDocument } from '../../aos4/state'
+import { createAos4BuilderViewModel } from '../../aos4/view'
+
+/**
+ * Battletome and Legends Armies of Renown await their reviewed `armiesOfRenown` classification
+ * (issue #1844). Until the corpus types them `army-of-renown`, their subgroups decode as pickable
+ * options under a bogus builder card named after the army — and picking one would apply the
+ * variant's rules additively, which is rules-wrong. The builder view model withholds them, except
+ * for subgroups already selected in the document, which stay visible so the player can see and
+ * remove the active rules.
+ */
+
+const factionByName = (name: string): Faction => {
+  const entity = AOS4_CATALOG.entities.find(
+    candidate => candidate.kind === 'faction' && candidate.name === name
+  )
+  if (!entity) throw new Error(`No faction named ${name} in the catalog`)
+  return entity as Faction
+}
+
+const builderFor = (explicitSelectionIds: Faction['id'][]) =>
+  createAos4BuilderViewModel(
+    AOS4_CATALOG,
+    createAos4ArmyDocument({
+      id: 'army:test-package-triage',
+      name: 'Package Triage Test',
+      rulesContextId: AOS4_DEFAULT_RULES_CONTEXT_ID,
+      explicitSelectionIds,
+    })
+  )
+
+describe('unclassified Army of Renown package triage (#1844)', () => {
+  it('withholds unclassified army packages from the builder options', () => {
+    const packageTypes = {
+      'Stormcast Eternals': ['heroes-of-the-first-forged', 'ruination-brotherhood', 'astral-templars'],
+      'Maggotkin of Nurgle': ['cycle-of-corruption', 'the-gardeners-of-nurgle'],
+      'Flesh-eater Courts': ['the-equinox-feast', 'the-knights-of-new-summercourt'],
+    }
+    Object.entries(packageTypes).forEach(([factionName, groupTypes]) => {
+      const builder = builderFor([factionByName(factionName).id])
+      const offeredTypes = new Set(
+        builder.options.filter(option => option.kind === 'content-group').map(option => option.groupType)
+      )
+      groupTypes.forEach(groupType => {
+        expect(offeredTypes).not.toContain(groupType)
+      })
+    })
+  })
+
+  it('keeps regular category groups and classified Armies of Renown on offer', () => {
+    const stormcast = builderFor([factionByName('Stormcast Eternals').id])
+    const stormcastTypes = new Set(
+      stormcast.options.filter(option => option.kind === 'content-group').map(option => option.groupType)
+    )
+    ;['battle-formation', 'artefact-of-power', 'spell-lore', 'heroic-trait', 'scars-of-war'].forEach(
+      groupType => {
+        expect(stormcastTypes).toContain(groupType)
+      }
+    )
+
+    // The Roving Maw carries the reviewed army-of-renown classification and must keep surfacing.
+    const ogor = builderFor([factionByName('Ogor Mawtribes').id])
+    const armyOfRenownNames = ogor.options
+      .filter(option => option.kind === 'content-group' && option.groupType === 'army-of-renown')
+      .map(option => option.name)
+    expect(armyOfRenownNames).toContain('The Roving Maw')
+  })
+
+  it('keeps an already-selected package subgroup visible so it can be removed', () => {
+    const stormcast = factionByName('Stormcast Eternals')
+    const packageSubgroup = AOS4_CATALOG.entities.find(
+      (entity): entity is ContentGroup =>
+        entity.kind === 'content-group' && entity.groupType === 'ruination-brotherhood'
+    )
+    expect(packageSubgroup).toBeDefined()
+
+    const builder = builderFor([stormcast.id, packageSubgroup!.id])
+    const offered = builder.options.find(option => option.id === packageSubgroup!.id)
+    expect(offered).toBeDefined()
+    expect(offered!.selected).toBe(true)
+  })
+})

--- a/src/tests/aos4/homePresentation.test.tsx
+++ b/src/tests/aos4/homePresentation.test.tsx
@@ -224,6 +224,47 @@ describe('AoS 4 home presentation', () => {
     expect(offered).not.toContain('Endless Spells')
   })
 
+  /**
+   * Manifestations are a category of unit, not roster units (CONCEPTS.md). Mixing them into the
+   * Units card buried the units a player actually fields, so they get their own builder card.
+   */
+  it('offers manifestations in their own builder card rather than under Units', async () => {
+    const cardTitles = Array.from(container.querySelectorAll('.CardHeaderTitle')).map(
+      title => title.textContent
+    )
+    expect(cardTitles).toContain('Units')
+    expect(cardTitles).toContain('Manifestations')
+
+    const optionsOf = async (label: string) => {
+      const input = container.querySelector<HTMLInputElement>(`input[aria-label="${label}"]`)
+      expect(input).not.toBeNull()
+      const open = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
+      const close = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+      await act(async () => {
+        input!.dispatchEvent(open)
+        await new Promise(resolve => setTimeout(resolve, 0))
+      })
+      const offered = Array.from(container.querySelectorAll('[role="option"]')).map(option =>
+        option.textContent?.trim()
+      )
+      await act(async () => {
+        input!.dispatchEvent(close)
+        await new Promise(resolve => setTimeout(resolve, 0))
+      })
+      return offered
+    }
+
+    const unitOptions = await optionsOf('Units')
+    expect(unitOptions).toContain('Aetherwings')
+    expect(unitOptions).not.toContain('Aethervoid Pendulum')
+    expect(unitOptions).not.toContain('Celestian Vortex')
+
+    const manifestationOptions = await optionsOf('Manifestations')
+    expect(manifestationOptions).toContain('Aethervoid Pendulum')
+    expect(manifestationOptions).toContain('Celestian Vortex')
+    expect(manifestationOptions).not.toContain('Aetherwings')
+  })
+
   it('opens on a skip link that reaches the reminders, and a real footer landmark', () => {
     const skip = container.querySelector('a.SkipLink')
     expect(skip).not.toBeNull()

--- a/src/tests/aos4/reminderAttribution.test.ts
+++ b/src/tests/aos4/reminderAttribution.test.ts
@@ -57,6 +57,24 @@ describe('reminder source attribution (#1836)', () => {
     })
   })
 
+  /**
+   * Game-wide rules keep their module provenance as data, never as a tag: MUSICIAN is not an Ogor
+   * rule, but stamping THE CORE RULES on every core reminder read as noise on the reminder cards.
+   */
+  it('records the rules module on game-wide reminders without surfacing a tag', () => {
+    const reminders = remindersFor([['faction', 'Ogor Mawtribes']])
+    const coreReminders = ['MUSICIAN', 'STANDARD BEARER']
+    coreReminders.forEach(name => {
+      const reminder = reminders.find(candidate => candidate.name === name)
+      expect(reminder).toBeDefined()
+      expect(reminder!.rulesModule).toBe('The Core Rules')
+      expect(sourceLabels(reminder!)).toEqual([])
+    })
+    const battleTrait = reminders.find(reminder => reminder.name === 'TRAMPLING CHARGE')
+    expect(battleTrait).toBeDefined()
+    expect(battleTrait!.rulesModule).toBeUndefined()
+  })
+
   it('tags a warscroll-native spell with its unit', () => {
     const kroak = entityByName('warscroll', 'Lord Kroak')
     expect(kroak).toBeDefined()


### PR DESCRIPTION
Three related cleanups to what the army builder offers and how reminders carry provenance.

## Manifestations get their own builder card

Endless spells and invocations are technically warscrolls, so they landed in the **Units** card — burying the units a player actually fields under Aethervoid Pendulum, Chronomantic Cogs, and 75 friends. Warscrolls carrying the `MANIFESTATION` keyword (77 in the corpus: 71 endless spells, 6 invocations) now group under a **Manifestations** card ordered beside Manifestation Lores. The name follows CONCEPTS.md ("a category of unit, not an army" — and it covers invocations, which "Endless Spells" would not).

Knock-on: the lore card's mobile title was already "Manifestations", so it becomes **"Manif. Lores"** on phones to keep the two tiles distinguishable (DESIGN.md updated).

## Rules-module provenance is data, not a tag

MUSICIAN and STANDARD BEARER reminders carried no source attribution because #1838 deliberately leaves faction-rooted content untagged — but they aren't faction rules; they arrive through the rules-module container every army includes. Rendering that as a THE CORE RULES tag on every core reminder read as noise, so the reminder view model now records the module name as `rulesModule` without surfacing a tag. The provenance is ready for future surfaces (filtering, an explainer, print grouping).

## Unclassified Armies of Renown no longer render as bogus cards

A sweep of all 27 factions found **44 battletome and Legends Armies of Renown** (Heroes Of The First Forged, Ruination Brotherhood, Astral Templars, Big Waaagh!, Cycle of Corruption, …) decoding as generic content-groups, each rendered as a title-cased builder card offering *piecemeal* picks of its Battle Traits / lores / artefacts. That's rules-wrong, not just ugly: an Army of Renown replaces the faction's rules, and without the reviewed `armiesOfRenown` classification there are no exclusion edges, so a picked subgroup applied additively.

The builder view model withholds those 44 package group types. A subgroup already selected in a document stays visible so its active rules can be seen and removed. The proper fix is reviewed corpus classification — tracked with the full sweep and official-evidence notes in #1844; once a package is typed `army-of-renown`, generation renames its group type and the matching triage entry goes dead.

## Verification

- `yarn lint`, `yarn tsc --noEmit`, `yarn build` pass
- Full suite: 1281/1289 pass — the 8 failures are the pre-existing macOS portability ones fixed by #1842 (`deploymentContract`, `listbotCorpusCommand`), reproduced on bare `origin/master`
- New coverage: manifestations offered in their own card and absent from Units (`homePresentation`), module provenance recorded without a tag (`reminderAttribution`), package triage with selected-subgroup escape hatch (`armyPackageTriage`)
- Screenshot-compared against production at desktop and 390px widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy4mVPh65rFMLAp552DqXC
