### PR TITLE
feat(builder): remove the Reset Army toolbar button

### DIFF
--- a/src/components/input/toolbar/toolbar.tsx
+++ b/src/components/input/toolbar/toolbar.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from 'context/useTheme'
 import { FaTrash } from 'react-icons/fa'
-import { MdFileDownload, MdFileUpload, MdRefresh, MdSave, MdShare, MdVisibility } from 'react-icons/md'
+import { MdFileDownload, MdFileUpload, MdSave, MdShare, MdVisibility } from 'react-icons/md'
 
 interface ToolbarProps {
   hiddenCount: number
@@ -8,7 +8,6 @@ interface ToolbarProps {
   onDownloadPdf: () => void
   onImportArmy: () => void
   onOpenSavedArmies: () => void
-  onResetArmy: () => void
   onShareArmy: () => void
   onShowAll: () => void
   subscriberActionDisabled?: boolean
@@ -35,7 +34,6 @@ const Toolbar = ({
   onDownloadPdf,
   onImportArmy,
   onOpenSavedArmies,
-  onResetArmy,
   onShareArmy,
   onShowAll,
   subscriberActionDisabled,
@@ -46,12 +44,6 @@ const Toolbar = ({
         <ToolbarButton onClick={onClearArmy}>
           <FaTrash className="me-2" />
           Clear Army
-        </ToolbarButton>
-      </div>
-      <div className={buttonWrapperClass}>
-        <ToolbarButton onClick={onResetArmy}>
-          <MdRefresh className="me-2" />
-          Reset Army
         </ToolbarButton>
       </div>
       <div className={buttonWrapperClass}>

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -340,7 +340,6 @@ const HomeContent = () => {
           onDownloadPdf={() => setPrintModalIsOpen(true)}
           onImportArmy={() => setImportModalIsOpen(true)}
           onOpenSavedArmies={savedArmiesAction.run}
-          onResetArmy={() => setDocument(createDefaultAos4ArmyDocument())}
           onShareArmy={shareAction.run}
           onShowAll={showAll}
           subscriberActionDisabled={savedArmiesAction.disabled || shareAction.disabled}


### PR DESCRIPTION
## Summary

Removes the **Reset Army** button from the builder toolbar.

Reset Army replaced the whole army document with the factory-default Stormcast Eternals army. That overlapped confusingly with **Clear Army** (which empties the current army but keeps the selected faction), and with no confirmation prompt it was a one-tap way to lose a build. Clear Army remains as the single destructive action.

## Changes

- `src/components/input/toolbar/toolbar.tsx` — remove the Reset Army button, its `onResetArmy` prop, and the unused `MdRefresh` import
- `src/components/routes/Home.tsx` — drop the `onResetArmy` wiring (`createDefaultAos4ArmyDocument` is still used for the first-load fallback)

## Testing

- `npx tsc --noEmit` clean
- `src/tests/aos4/homePresentation.test.tsx` passes (9/9)

https://claude.ai/code/session_01FfnwSqxEgq9drUfPidpo8r