### PR TITLE
fix(import): read GHB 2026-27 official app exports with a General's Regiment and asterisk bullets

### DIFF
--- a/src/aos4/import/resolveRoster.ts
+++ b/src/aos4/import/resolveRoster.ts
@@ -539,10 +539,40 @@ const resolveRosterSelection = (
       stripContextQualifier(selection.label, contextQualifiers(context)),
     ].filter((label): label is string => Boolean(label))
 
-    const contextCandidates = [
-      ...attempts.map(label => () => matchLabel(label)),
-      ...attempts.map(label => () => matchQualifiedLabel(label)),
-    ].reduce<ContentEntity[]>((found, attempt) => (found.length ? found : attempt()), [])
+    /**
+     * Collapse a container and its own content matched under one name.
+     *
+     * A Moulder Mutation such as "Anabolic Accelerators" is modelled twice: a content-group the
+     * faction offers, and the ability inside it carrying the rules text. A roster line naming it
+     * means that one pick, not two rivals, so a candidate that `includes` another wins over what
+     * it contains — the same shape a hand-built army holds, where the offered group is the
+     * selectable and brings its ability along.
+     */
+    const collapseContainedCandidates = (found: ContentEntity[]): ContentEntity[] => {
+      if (found.length < 2) return found
+      const ids = new Set(found.map(entity => entity.id))
+      const contained = new Set(
+        catalog.relationships
+          .filter(
+            relationship =>
+              relationship.kind === 'includes' &&
+              relationshipIsApplicable(relationship, rulesContextId) &&
+              ids.has(relationship.from) &&
+              ids.has(relationship.to)
+          )
+          .map(relationship => relationship.to)
+      )
+      if (!contained.size) return found
+      const containers = found.filter(entity => !contained.has(entity.id))
+      return containers.length ? containers : found
+    }
+
+    const contextCandidates = collapseContainedCandidates(
+      [
+        ...attempts.map(label => () => matchLabel(label)),
+        ...attempts.map(label => () => matchQualifiedLabel(label)),
+      ].reduce<ContentEntity[]>((found, attempt) => (found.length ? found : attempt()), [])
+    )
     return { contextCandidates, candidates: contextCandidates.filter(entity => reachableIds.has(entity.id)) }
   }
 

--- a/src/importers/officialApp.ts
+++ b/src/importers/officialApp.ts
@@ -15,14 +15,15 @@ const contextPattern = /^(?:General['’]s Handbook|GHB)\b/i
 const officialMetadataPattern =
   /^(?:Created with Warhammer Age of Sigmar: The App|App:|Exported with App Version:|Drops?:|Total:|Auxiliaries:|Battle Tactics? Cards?:|Army of Renown\s*$)/i
 const sectionPattern =
-  /^(?:REGIMENTS?|Regiment \d+|AUXILIARIES|AUXILIARY UNITS|FACTION TERRAIN|REGIMENTS OF RENOWN)$/i
+  /^(?:REGIMENTS?|Regiment \d+|General['’]s Regiment|AUXILIARIES|AUXILIARY UNITS|FACTION TERRAIN|REGIMENTS OF RENOWN)$/i
 /** The app pads its exports with runs of dashes between blocks. They carry no roster content. */
 const separatorPattern = /^[-–—]{3,}$/
 /**
  * A `• Legends` bullet is not an enhancement — it marks the warscroll above it as Legends content.
- * The app emits it per unit rather than declaring the opt-in once in the header.
+ * The app emits it per unit rather than declaring the opt-in once in the header. Some platforms
+ * put the bullets on the clipboard as `*` instead of `•`, so both count as the marker everywhere.
  */
-const legendsBulletPattern = /^[•]\s*Legends\s*$/i
+const legendsBulletPattern = /^[•*]\s*Legends\s*$/i
 
 /**
  * A bundled sub-unit — an unpointed line directly beneath a pointed one, covered by that unit's
@@ -34,7 +35,7 @@ const legendsBulletPattern = /^[•]\s*Legends\s*$/i
  * with a list marker, and carry no sentence punctuation. Colons are allowed — `Scourge of Aqshy:
  * Mancrusher Gargant` is a unit name.
  */
-const bundledWarscrollPattern = /^[^-•][^.!?;]*$/
+const bundledWarscrollPattern = /^[^-•*][^.!?;]*$/
 const MAX_BUNDLED_LABEL_LENGTH = 60
 
 type Section = 'none' | 'units' | 'faction-terrain' | 'regiment-of-renown'
@@ -117,12 +118,14 @@ const parseBundledWarscroll = (
 }
 
 const parseBullet = (line: Aos4ImportLine): ParsedRosterSelection | undefined => {
-  const match = line.text.match(/^[•]\s*(.+)$/)
+  const match = line.text.match(/^[•*]\s*(.+)$/)
   if (!match) return undefined
   const label = match[1].trim()
   if (
     /^(?:General|Reinforced)$/i.test(label) ||
-    /^\d+\s*[x×]\s+/i.test(label) ||
+    // A leading count is a weapon loadout — `1 Shock Gauntlets`, `3 x Ratling Cannon` — which is
+    // model configuration, not an enhancement.
+    /^\d+\s*[x×]?\s+/i.test(label) ||
     /\bx\d+\b/i.test(label) ||
     label.includes(';')
   ) {

--- a/src/tests/aos4/importOfficialApp.test.ts
+++ b/src/tests/aos4/importOfficialApp.test.ts
@@ -113,6 +113,51 @@ describe('official AoS app text import', () => {
       expect(parsed?.selections.find(s => s.label === 'Squig Herd')?.isLegends).toBeUndefined()
     })
 
+    it("reads the General's Regiment section and asterisk bullets", () => {
+      // GHB 2026-27 lists open with `General's Regiment` instead of a numbered regiment, and some
+      // platforms put the bullets on the clipboard as `*` rather than `•`. Before either was
+      // handled, every unit in the general's regiment was silently dropped and each `*` line
+      // surfaced as an unknown warscroll (issue #1853).
+      const parsed = decode(
+        'Grand Alliance Chaos | Skaven | Warpcog Convocation',
+        "General's Regiment",
+        'Thanquol on Boneripper (310)',
+        '* General',
+        'Rat Ogors (290)',
+        '* Reinforced',
+        '* Anabolic Accelerators',
+        'Regiment 1',
+        'Warplock Jezzails (240)'
+      )
+      expect(labelled(parsed, 'warscroll')).toEqual([
+        'Thanquol on Boneripper',
+        'Rat Ogors',
+        'Warplock Jezzails',
+      ])
+      expect(labelled(parsed, 'enhancement')).toEqual(['Anabolic Accelerators'])
+    })
+
+    it('drops weapon-loadout bullets that lead with a model count', () => {
+      const parsed = decode(
+        'Grand Alliance Chaos | Skaven | Warpcog Convocation',
+        'Regiment 1',
+        'Stormfiends (230)',
+        '* 1 Ratling Cannons and Clubbing Blows',
+        '* 1 Shock Gauntlets',
+        '• 3 x Ratling Cannon',
+        'Warlock Engineer (100)'
+      )
+      expect(labelled(parsed, 'warscroll')).toEqual(['Stormfiends', 'Warlock Engineer'])
+      expect(labelled(parsed, 'enhancement')).toEqual([])
+    })
+
+    it('honours a * Legends bullet the same as the • form', () => {
+      const parsed = decode("Gloomspite Gitz | Da King's Gitz", 'Regiment 1', 'Loonboss (70)', '* Legends')
+      expect(parsed?.allowsLegends).toBe(true)
+      expect(parsed?.selections.find(s => s.label === 'Loonboss')?.isLegends).toBe(true)
+      expect(labelled(parsed, 'enhancement')).toEqual([])
+    })
+
     it('splits a manifestation line into one selection per manifestation', () => {
       const parsed = decode(
         'Grand Alliance Order | Cities of Sigmar | Grudgebound War Throng',

--- a/src/tests/aos4/officialAppFixtures.test.ts
+++ b/src/tests/aos4/officialAppFixtures.test.ts
@@ -168,6 +168,21 @@ describe('official app list resolution', () => {
     expect(resolveFixture(id).matched).toContain(lore)
   })
 
+  it("resolves a general's regiment and its GHB 2026-27 honours (issue #1853)", () => {
+    const { matched, preview } = resolveFixture('skv-002-generals-regiment-asterisk-bullets')
+
+    // The units that were silently dropped while `General's Regiment` was not a section header.
+    expect(matched).toContain('Thanquol on Boneripper')
+    expect(matched).toContain('Rat Ogors')
+    // The `*`-bulleted enhancements that surfaced as unknown warscrolls before the fix.
+    expect(matched).toContain('Anabolic Accelerators')
+    expect(matched).toContain('Foulhide')
+    expect(matched).toContain('Master of the Swarm')
+    // "Anabolic Accelerators" is both a content-group and the ability inside it; the pair must
+    // collapse to the offered group rather than fail as ambiguous.
+    expect(preview.diagnostics).toEqual([])
+  })
+
   /**
    * Names the corpus genuinely does not carry must keep failing closed.
    *

--- a/src/tests/fixtures/aos4/import/official-app/README.md
+++ b/src/tests/fixtures/aos4/import/official-app/README.md
@@ -80,6 +80,7 @@ Fail closed on malformed or hostile input, never on an illegal army.
 | `hh-001-renown-stress` | 18 dashless regiments of renown, 51 members, one bundle repeated four times — the densest renown case in the corpus |
 | `mon-001-singular-model-count` | `Pusgoyle Blightlords (1 model) (110)` — the singular `model`, which resolves to a different warscroll than the plural entry beside it |
 | `skv-001-renown-manifestation-members` | the largest list in the corpus (117 selections, 57 renown members), with five-member bundles whose members include manifestations |
+| `skv-002-generals-regiment-asterisk-bullets` | the GHB 2026-27 `General's Regiment` section, `*` bullets instead of `•`, weapon-loadout bullets with leading counts, and a three-dash separator (issue #1853) |
 | `std-001-duplicate-renown-bundles` | the same renown bundle bought twice with identical members, and 82 drops — the widest roster in the corpus |
 | `fec-001-size-variants` | four `(2 models)` size variants alongside their base warscrolls; the only fixture that resolves **65/65** against the shipped catalog |
 | `nh-001-emoji-name-renown` | an emoji in the roster name, and a renown bundle whose lone member repeats the container name (`Blades of the Hollow King`) |

--- a/src/tests/fixtures/aos4/import/official-app/lists/skv-002-generals-regiment-asterisk-bullets/expected.json
+++ b/src/tests/fixtures/aos4/import/official-app/lists/skv-002-generals-regiment-asterisk-bullets/expected.json
@@ -1,0 +1,95 @@
+{
+  "id": "skv-002-generals-regiment-asterisk-bullets",
+  "diagnostics": [],
+  "proposedName": "Daka Daka 2",
+  "declaredFaction": "Skaven",
+  "declaredContext": "General's Handbook 2026-27",
+  "allowsLegends": false,
+  "selections": [
+    {
+      "line": 3,
+      "kindHint": "battle-formation",
+      "label": "Warpcog Convocation"
+    },
+    {
+      "line": 6,
+      "kindHint": "spell-lore",
+      "label": "Lore of Ruin"
+    },
+    {
+      "line": 7,
+      "kindHint": "prayer-lore",
+      "label": "Noxious Prayers"
+    },
+    {
+      "line": 8,
+      "kindHint": "manifestation-lore",
+      "label": "Manifestations of Doom"
+    },
+    {
+      "line": 11,
+      "kindHint": "warscroll",
+      "label": "Thanquol on Boneripper"
+    },
+    {
+      "line": 13,
+      "kindHint": "warscroll",
+      "label": "Clanrats"
+    },
+    {
+      "line": 14,
+      "kindHint": "warscroll",
+      "label": "Clanrats"
+    },
+    {
+      "line": 15,
+      "kindHint": "warscroll",
+      "label": "Rat Ogors"
+    },
+    {
+      "line": 17,
+      "kindHint": "enhancement",
+      "label": "Anabolic Accelerators"
+    },
+    {
+      "line": 18,
+      "kindHint": "warscroll",
+      "label": "Ratling Guns"
+    },
+    {
+      "line": 21,
+      "kindHint": "warscroll",
+      "label": "Scourge of Aqshy: Grey Seer on Screaming Bell"
+    },
+    {
+      "line": 22,
+      "kindHint": "enhancement",
+      "label": "Foulhide"
+    },
+    {
+      "line": 23,
+      "kindHint": "enhancement",
+      "label": "Master of the Swarm"
+    },
+    {
+      "line": 24,
+      "kindHint": "warscroll",
+      "label": "Stormfiends"
+    },
+    {
+      "line": 28,
+      "kindHint": "warscroll",
+      "label": "Warlock Engineer"
+    },
+    {
+      "line": 29,
+      "kindHint": "warscroll",
+      "label": "Warplock Jezzails"
+    },
+    {
+      "line": 33,
+      "kindHint": "warscroll",
+      "label": "Gnawhole"
+    }
+  ]
+}

--- a/src/tests/fixtures/aos4/import/official-app/lists/skv-002-generals-regiment-asterisk-bullets/list.txt
+++ b/src/tests/fixtures/aos4/import/official-app/lists/skv-002-generals-regiment-asterisk-bullets/list.txt
@@ -1,0 +1,36 @@
+Daka Daka 2 1990/2000 pts
+-----
+Grand Alliance Chaos | Skaven | Warpcog Convocation
+General's Handbook 2026-27
+Drops: 2
+Spell Lore - Lore of Ruin
+Prayer Lore - Noxious Prayers
+Manifestation Lore - Manifestations of Doom
+-----
+General's Regiment
+Thanquol on Boneripper (310)
+* General
+Clanrats (150)
+Clanrats (150)
+Rat Ogors (290)
+* Reinforced
+* Anabolic Accelerators
+Ratling Guns (170)
+---
+Regiment 1
+Scourge of Aqshy: Grey Seer on Screaming Bell (350)
+* Foulhide
+* Master of the Swarm
+Stormfiends (230)
+* 1 Ratling Cannons and Clubbing Blows
+* 1 Shock Gauntlets
+* 1 Clubbing Blows and Warpfire Projectors
+Warlock Engineer (100)
+Warplock Jezzails (240)
+* Reinforced
+-----
+Faction Terrain
+Gnawhole
+-----
+Created with Warhammer Age of Sigmar: The App
+App: v1.36.0 (1) | Data: v466


### PR DESCRIPTION
Fixes #1853.

## What was broken

The reported roster (Skaven, Warpcog Convocation, GHB 2026-27, app v1.36.0) hit two parser gaps in the official app text importer:

1. **`General's Regiment` was not a recognized section header.** GHB 2026-27 exports open with it instead of `Regiment 1`, so the parser never entered the units section and **silently dropped** Thanquol on Boneripper, both Clanrats, Rat Ogors, and Ratling Guns — no diagnostic at all.
2. **The export uses `*` bullets, not `•`.** Every `*` line fell through the bullet parser and was misread as a bundled warscroll, producing exactly the errors in the screenshot: `Couldn't find a warscroll named "* Foulhide"` on lines 22, 23, 25–27, and 30.

## The fix

- `General's Regiment` is now a units section header (straight or curly apostrophe).
- `*` is accepted everywhere `•` is: enhancement bullets, the `General`/`Reinforced` markers, and the `Legends` mark.
- Weapon-loadout bullets that lead with a model count (`* 1 Shock Gauntlets`, `* 1 Ratling Cannons and Clubbing Blows`) are dropped as model configuration, matching how `3 x` counts were already treated.
- One resolution fix surfaced by the now-parsing enhancements: `Anabolic Accelerators` exists in the catalog as both a content-group the faction offers and the ability that group includes, so it failed as ambiguous. When one candidate `includes` the other, the pair now collapses to the offered group — the same selectable a hand-built army holds.

With all of this, the issue's roster imports with **17/17 selections matched and zero diagnostics**.

## Testing

- New fixture `skv-002-generals-regiment-asterisk-bullets` — the issue's list verbatim — with its golden, plus a README row.
- Targeted parser tests: the `General's Regiment` section, `*` bullets, count-led loadout bullets, `* Legends`.
- Resolution test pinning that the general's regiment units and the three GHB 2026-27 honours (`Foulhide`, `Master of the Swarm`, `Anabolic Accelerators`) all resolve cleanly.
- Full suite: 1323 passing; the only failures are `deploymentContract.test.ts`, which is WSL-only on Windows and untouched by this change. Lint and `tsc --noEmit` clean.

https://claude.ai/code/session_01FfnwSqxEgq9drUfPidpo8r