### PR TITLE
fix(import): keep the manifestation warscrolls nested under a chosen lore

### DIFF
--- a/src/importers/rosterTree.ts
+++ b/src/importers/rosterTree.ts
@@ -158,11 +158,19 @@ export const parseAos4RosterTree = (root: RosterNode): Aos4ParsedRosterResult =>
     }
 
     const container = selection.parent
-    const force = container?.parent
+    const parent = container?.parent
+    /**
+     * A `unit` nested inside another selection is normally a model or a piece of the unit above
+     * it. The exception is a manifestation: New Recruit files each manifestation warscroll as a
+     * `unit` under the chosen manifestation lore, and those are warscrolls the player summons and
+     * fields, not parts of the lore (#1854).
+     */
+    const parentGroup = parent?.name === 'selection' ? parent.attribute('group')?.trim() : undefined
+    const isManifestationUnit = Boolean(parentGroup && groupKind(parentGroup) === 'manifestation-lore')
     if (
       selection.attribute('type') !== 'unit' ||
       container?.name !== 'selections' ||
-      force?.name !== 'force'
+      (parent?.name !== 'force' && !isManifestationUnit)
     ) {
       return
     }

--- a/src/tests/aos4/importNewRecruit.test.ts
+++ b/src/tests/aos4/importNewRecruit.test.ts
@@ -174,6 +174,52 @@ describe('New Recruit .ros and .rosz import', () => {
     expect(liberators?.isLegends).toBeUndefined()
   })
 
+  /**
+   * New Recruit files each manifestation warscroll as a `unit` nested under the chosen
+   * manifestation lore, so the "units sit directly in a force" rule alone would drop them and the
+   * imported army would lose the manifestations' own abilities (#1854). The lore's `Summon X`
+   * upgrades stay out — the catalog's lore group already carries the summoning spells — and a
+   * `unit` nested inside an ordinary unit is still that unit's internals, not an army unit.
+   */
+  it('imports manifestation units nested under their lore, and only those', async () => {
+    const units = `
+      <selection id="manifestation-slot" name="Manifestation Lore" number="1" type="upgrade">
+        <selections>
+          <selection id="manifestation-lore" name="Manifestations of the Storm" number="1" type="upgrade"
+            from="group" group="Manifestation Lores">
+            <selections>
+              <selection id="manifestation-unit" name="Stormstrike Axe" number="1" type="unit"
+                from="group" group="Manifestations of the Storm" />
+              <selection id="manifestation-summon" name="Summon Stormstrike Axe" number="1" type="upgrade"
+                from="group" group="Manifestations of the Storm" />
+            </selections>
+          </selection>
+        </selections>
+      </selection>
+      <selection id="terrain" name="Zontari Endrin Dock" number="1" type="unit">
+        <selections>
+          <selection id="terrain-part" name="Auto-Endrin" number="1" type="unit" />
+        </selections>
+      </selection>`
+    const xml = rosterXml({ units })
+    const [fromXml, fromJson] = await Promise.all([
+      decodeAos4RosterFile(asRos(xml)),
+      decodeAos4RosterFile(asJson(xml)),
+    ])
+
+    expect(fromXml.diagnostics).toEqual([])
+    expect(fromXml.parsedRoster?.selections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Manifestations of the Storm', kindHint: 'manifestation-lore' }),
+        expect.objectContaining({ label: 'Stormstrike Axe', kindHint: 'warscroll' }),
+      ])
+    )
+    const labels = fromXml.parsedRoster?.selections.map(selection => selection.label)
+    expect(labels).not.toContain('Summon Stormstrike Axe')
+    expect(labels).not.toContain('Auto-Endrin')
+    expect(withoutLines(fromJson.parsedRoster)).toEqual(withoutLines(fromXml.parsedRoster))
+  })
+
   it('ignores harmless ZIP metadata but rejects multiple rosters and traversal names', async () => {
     const xml = strToU8(rosterXml())
     const metadata = await decodeAos4RosterFile(

--- a/src/tests/aos4/importNewRecruitCorpus.test.ts
+++ b/src/tests/aos4/importNewRecruitCorpus.test.ts
@@ -147,6 +147,32 @@ describe('New Recruit corpus through the production importer', () => {
   })
 
   /**
+   * New Recruit nests each manifestation warscroll as a `unit` under the chosen manifestation
+   * lore rather than in the force itself. Dropping them loses the manifestations' own abilities —
+   * a Foot of Gork that never stomps in the movement phase (#1854) — so the nested units have to
+   * arrive as ordinary warscroll selections and resolve against the catalog.
+   */
+  it('imports the manifestation warscrolls nested under a chosen lore', async () => {
+    const result = await decode('bok-001-all-units', 'ros')
+    const parsedRoster = result.parsedRoster
+    if (!parsedRoster) throw new Error('expected the roster to parse')
+
+    const labels = parsedRoster.selections.map(selection => selection.label)
+    for (const manifestation of ['Bleeding Icon', 'Hexgorger Skulls', 'Wrath-axe']) {
+      expect(labels).toContain(manifestation)
+    }
+
+    const preview = resolveParsedRoster(AOS4_CATALOG, parsedRoster, {
+      defaultRulesContextId: AOS4_DEFAULT_RULES_CONTEXT_ID,
+      createDocumentId: () => 'manifestations',
+    })
+    const matched = new Set(preview.matches.map(match => match.label))
+    for (const manifestation of ['Bleeding Icon', 'Hexgorger Skulls', 'Wrath-axe']) {
+      expect(matched).toContain(manifestation)
+    }
+  })
+
+  /**
    * The captures were built with New Recruit's "Allow Legends" switch on, so the opt-in has to
    * survive the import and the Legends units have to arrive. A player who deliberately opted into
    * Legends gets the army they built, in the roster's own context, and the document remembers the


### PR DESCRIPTION
Fixes #1854.

## What was wrong

A New Recruit roster files each manifestation warscroll as a `unit` selection nested under the chosen manifestation lore, not directly in the force:

```
force > Manifestation Lore (upgrade) > Manifestations of Gorkamorka (upgrade) > Foot of Gork (unit)
```

The shared roster-tree reader only accepted `unit` selections sitting directly in a force's `selections`, so the nested manifestation units were silently dropped on import. The lore's summoning spells still arrived (the catalog's lore content-group includes them), but the manifestation warscrolls' own abilities never did — the reporter's Kruleboyz list had SUMMON FOOT OF GORK in the hero phase and no WANDERING DESTRUCTION in the movement phase.

## The fix

`parseAos4RosterTree` now also keeps a `unit` selection when its parent selection is a recognised manifestation-lore group choice (`group="Manifestation Lores"`). The rule is deliberately narrow: the lore's nested `Summon X` upgrades stay out (the summoning spells already come from the catalog), and a `unit` nested inside an ordinary unit (e.g. Kharadron's `Zontari Endrin Dock > Auto-Endrin`) is still treated as that unit's internals. One change in the shared tree reader covers all three New Recruit formats (`.ros`/`.rosz`/`.json`) identically.

Verified against the attached roster from the issue: Foot of Gork, Gork-Roara, and Morkspit Marsh now import as warscroll selections, and the reminders gain WANDERING DESTRUCTION (Movement Phase) and MULTIPLE PARTS (Passive) with no new diagnostics.

## Tests

- Synthetic case in `importNewRecruit.test.ts`: nested manifestation units import in both XML and JSON forms, `Summon X` upgrades and unit-in-unit internals stay excluded.
- Corpus case in `importNewRecruitCorpus.test.ts`: `bok-001-all-units` now parses and resolves Bleeding Icon, Hexgorger Skulls, and Wrath-axe.
- `yarn lint`, `tsc --noEmit`, `yarn build`, full `vitest run` pass locally (except the known WSL-only `deploymentContract` suite on Windows). Import-related suites: 426/426 passing, fixture corpus coverage improved with 0 new unresolved names.

## Testing instructions

1. Open the app, Import, and upload the `1k krule.json` roster attached to #1854.
2. Confirm the army imports with no warnings and the Manifestations card lists Foot of Gork, Gork-Roara, and Morkspit Marsh.
3. Confirm the Movement Phase reminders include WANDERING DESTRUCTION alongside the hero-phase SUMMON abilities.

https://claude.ai/code/session_011XtRJDiGHvihSrnZTQDorB