### PR TITLE
fix(import): report warning-only roster diagnostics

### DIFF
--- a/src/components/input/importArmy/failedImportReport.ts
+++ b/src/components/input/importArmy/failedImportReport.ts
@@ -22,6 +22,7 @@ const githubAttachmentName = (fileName: string): string => {
 }
 
 const issueBody = (attachmentName: string, diagnostics: readonly Aos4ImportDiagnostic[]): string => {
+  const hasErrors = diagnostics.some(diagnostic => diagnostic.severity === 'error')
   const diagnosticLines = diagnostics
     .slice(0, MAX_ISSUE_DIAGNOSTICS)
     .map(diagnostic => {
@@ -34,15 +35,15 @@ const issueBody = (attachmentName: string, diagnostics: readonly Aos4ImportDiagn
       ? `\n- ${diagnostics.length - MAX_ISSUE_DIAGNOSTICS} more diagnostics omitted from this draft.`
       : ''
 
-  return `## Failed import
+  return `## ${hasErrors ? 'Failed import' : 'Import warning'}
 
-AoS Reminders could not import this roster.
+AoS Reminders ${hasErrors ? 'could not import this roster.' : 'imported this roster with warnings.'}
 
 ## Reproduction file
 
 Attach the downloaded \`${attachmentName}\` file to this issue before submitting it. Its contents are
-the exact roster input that failed. Its generic name and any extra \`.xml\`, \`.zip\`, or \`.txt\`
-suffix only make the file type attachable on GitHub.
+the exact roster input that produced these diagnostics. Its generic name and any extra \`.xml\`,
+\`.zip\`, or \`.txt\` suffix only make the file type attachable on GitHub.
 
 GitHub issues are public. Please remove any private information before attaching the file.
 The original filename, roster content, and diagnostic messages were not added to this draft.
@@ -58,7 +59,8 @@ const createFailedImportIssueUrl = (
   diagnostics: readonly Aos4ImportDiagnostic[]
 ): string => {
   const url = new URL(`${GITHUB_URL}/issues/new`, 'https://aosreminders.com')
-  url.searchParams.set('title', '[BUG] Failed roster import')
+  const hasErrors = diagnostics.some(diagnostic => diagnostic.severity === 'error')
+  url.searchParams.set('title', hasErrors ? '[BUG] Failed roster import' : '[BUG] Roster import warning')
   url.searchParams.set('body', issueBody(attachmentName, diagnostics))
   return url.toString()
 }

--- a/src/components/input/importArmy/importArmyModal.tsx
+++ b/src/components/input/importArmy/importArmyModal.tsx
@@ -76,7 +76,7 @@ const ImportArmyModal = ({
   ]
   const hasErrors = diagnostics.some(diagnostic => diagnostic.severity === 'error')
   const canApply = Boolean(preview?.proposedDocument) && !hasErrors
-  const canReport = Boolean(decoded && hasErrors && (mode === 'paste' ? text : droppedFile))
+  const canReport = Boolean(decoded && diagnostics.length > 0 && (mode === 'paste' ? text : droppedFile))
 
   useEffect(() => {
     if (!decoded || !hasErrors || trackedErrorRef.current === decoded) return
@@ -286,9 +286,10 @@ const ImportArmyModal = ({
         {canReport && (
           <div className="mt-3">
             <p className="small mb-2">
-              Help us reproduce this import error. This downloads an exact copy of the failed roster and opens
-              a GitHub issue draft without the roster content or original filename. Attach the downloaded file
-              before submitting. GitHub issues are public, so remove any private information first.
+              Help us investigate these import warnings or errors. This downloads an exact copy of the roster
+              and opens a GitHub issue draft without the roster content or original filename. Attach the
+              downloaded file before submitting. GitHub issues are public, so remove any private information
+              first.
             </p>
             <button
               className={`${theme.genericButton} d-block w-100`}

--- a/src/tests/aos4/importUi.test.tsx
+++ b/src/tests/aos4/importUi.test.tsx
@@ -343,7 +343,14 @@ describe('AoS 4 import modal', () => {
    * builder where the unit exists, so the useful outcome is the rest of the army plus a note about
    * what was dropped.
    */
-  it('stays confirmable when a selection cannot be placed, and names it', () => {
+  it('stays confirmable and reportable when a selection cannot be placed', () => {
+    Object.defineProperties(URL, {
+      createObjectURL: { configurable: true, value: vi.fn(() => 'blob:warning-import') },
+      revokeObjectURL: { configurable: true, value: vi.fn() },
+    })
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined)
+    const openIssue = vi.spyOn(window, 'open').mockImplementation(() => null)
+
     pasteAndPreview(officialRoster('Annihilators', false))
 
     expect(container.textContent).toContain('No rules context was declared')
@@ -352,8 +359,16 @@ describe('AoS 4 import modal', () => {
     pasteAndPreview(officialRoster('Definitely Unknown Unit'))
 
     expect(container.textContent).toContain('Definitely Unknown Unit')
-    expect(container.textContent).not.toContain('Send to devs')
     expect(findButton(container, 'Import Army').disabled).toBe(false)
+
+    act(() => {
+      Simulate.click(findButton(container, 'Send to devs'))
+    })
+
+    const issueUrl = new URL(openIssue.mock.calls[0][0] as string)
+    expect(issueUrl.searchParams.get('title')).toContain('warning')
+    expect(issueUrl.searchParams.get('body')).toContain('imported this roster with warnings')
+    expect(issueUrl.searchParams.get('body')).toContain('unknown-selection')
 
     act(() => {
       Simulate.click(findButton(container, 'Import Army'))


### PR DESCRIPTION
## Summary

Warning-only roster imports now show the existing **Send to devs** recovery action while remaining importable. Previously, the button appeared only for blocking errors, so players could not report unknown or ambiguous selections that the importer skipped. The privacy-safe flow is unchanged: it downloads the exact roster, opens a prefilled GitHub issue draft without roster content or the original filename, and now describes a successful import with warnings truthfully instead of calling it a failure.

Related: #1786

## Data and generated output

No rules sources, effective dates, accepted inputs, generated catalog files, or diagnostic dispositions changed.

## Validation

- `yarn lint`
- `yarn tsc --noEmit`
- `yarn build`
- `yarn test --run` - 86 test files passed
- `yarn data:aos4:verify:beta` - 80,004 pass, 0 findings, 0 cannot-verify
- The focused import UI regression keeps a warning-only roster importable and verifies that **Send to devs** opens a warning-specific GitHub issue draft containing the diagnostic code.

## Coverage gaps

Browser issue creation and download behavior use mocked browser APIs; validation did not submit a real public GitHub issue or attach a roster.

## Production impact

No production configuration or companion-service coordination is required.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
