### PR TITLE
fix(links): deep-link reminder sources to their unit's Wahapedia page (#1860)

### DIFF
--- a/src/aos4/view/index.ts
+++ b/src/aos4/view/index.ts
@@ -1,2 +1,3 @@
 export * from './builder'
 export * from './reminders'
+export * from './sourceLinks'

--- a/src/aos4/view/sourceLinks.ts
+++ b/src/aos4/view/sourceLinks.ts
@@ -1,0 +1,88 @@
+import type { Aos4Catalog, SourceArtifact, SourceLocator } from '../domain'
+
+/** A source citation on a reminder card, shaped for the card's dropdown menu. */
+export interface Aos4ReminderSourceLink {
+  id: string
+  label: string
+  href?: string
+  official: boolean
+}
+
+/**
+ * A Wahapedia faction page: either the faction root (`.../factions/kruleboyz/`) or its warscroll
+ * collection (`.../factions/kruleboyz/warscrolls.html`). Only these artifact URLs carry datasheet
+ * sections whose anchors this module can deep-link.
+ */
+const WAHAPEDIA_FACTION_PAGE = /^https:\/\/wahapedia\.ru\/aos4\/factions\/[^/]+\/(?:warscrolls\.html)?$/
+
+/**
+ * The anchored datasheet a section locator names. Datasheet sections look like
+ * `datasheet:Killaboss-with-Stab-grot/ability:1`; the leading segment is the page's own
+ * `<a name>` anchor for that datasheet. A nested section
+ * (`datasheet:Swampskulka-Gang:Beast-skewer-Killbow/...`) names an un-anchored child inside an
+ * anchored parent, so the parent anchor is the closest linkable location.
+ */
+const datasheetAnchor = (locator: SourceLocator): string | undefined =>
+  locator.kind === 'section' ? /^datasheet:([^/:]+)/.exec(locator.section)?.[1] : undefined
+
+/**
+ * Where a source record lives, as a browser destination (issue #1860). The artifact URL alone is
+ * the page a record was read from, and for warscroll abilities that page is the faction-wide
+ * `warscrolls.html` index — every unit's "view source" link landed at the top of the same index.
+ * The record's section locator carries the unit's datasheet anchor, so:
+ *
+ * - on a `warscrolls.html` collection the anchor is also the slug of the unit's standalone page
+ *   (`.../factions/kruleboyz/Killaboss-with-Stab-grot`) — link that page;
+ * - on a faction root the anchored datasheets (regiment and Spearhead groups) have no standalone
+ *   page, so link the root with the anchor as a fragment;
+ * - anything else (rules pages, CSV exports, PDFs, non-datasheet sections) keeps the artifact URL.
+ */
+export const sourceRecordUrl = (
+  artifact: Pick<SourceArtifact, 'publisher' | 'sourceUrl'>,
+  locator: SourceLocator
+): string => {
+  const anchor =
+    artifact.publisher === 'wahapedia' && WAHAPEDIA_FACTION_PAGE.test(artifact.sourceUrl)
+      ? datasheetAnchor(locator)
+      : undefined
+  if (!anchor) return artifact.sourceUrl
+  return artifact.sourceUrl.endsWith('/warscrolls.html')
+    ? new URL(anchor, artifact.sourceUrl).toString()
+    : `${artifact.sourceUrl}#${anchor}`
+}
+
+const sourceLabel = (artifact: SourceArtifact): string => {
+  if (artifact.publisher === 'games-workshop') return artifact.title || 'Games Workshop'
+  if (artifact.publisher === 'wahapedia') return artifact.title || 'Wahapedia'
+  return artifact.title || 'Source'
+}
+
+/**
+ * Resolves a reminder's source records to the links its card offers. One link per distinct
+ * destination: a reminder citing several records of the same artifact still shows a single entry,
+ * but records of one artifact that resolve to different unit pages stay distinct.
+ */
+export const createAos4ReminderSourceLinkResolver = (
+  catalog: Aos4Catalog
+): ((reminder: { sourceRecordIds: string[] }) => Aos4ReminderSourceLink[]) => {
+  const artifactById = new Map(catalog.sourceArtifacts.map(artifact => [artifact.id, artifact]))
+  const recordById = new Map(catalog.sourceRecords.map(record => [String(record.id), record]))
+  return reminder =>
+    Array.from(
+      new Map(
+        reminder.sourceRecordIds.flatMap(id => {
+          const record = recordById.get(id)
+          const artifact = record ? artifactById.get(record.artifactId) : undefined
+          if (!record || !artifact) return []
+          const url = sourceRecordUrl(artifact, record.locator)
+          const link: Aos4ReminderSourceLink = {
+            id: `${artifact.id}#${url}`,
+            label: sourceLabel(artifact),
+            ...(url.startsWith('http') ? { href: url } : {}),
+            official: artifact.publisher === 'games-workshop',
+          }
+          return [[link.id, link] as const]
+        })
+      ).values()
+    )
+}

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -1,4 +1,4 @@
-import { armyFactions, type CanonicalId, type SourceArtifact } from '../../aos4/domain'
+import { armyFactions, type CanonicalId } from '../../aos4/domain'
 import { AOS4_CATALOG, AOS4_DEFAULT_FACTION_ID } from '../../aos4/generated'
 import type { PrintPageSize } from '../../aos4/print/presets'
 import type { PrintPreset } from '../../aos4/print/types'
@@ -12,11 +12,12 @@ import { resolveSelection } from '../../aos4/select'
 import { createAos4ArmyDocument, setAos4ReminderPreference, type Aos4ArmyDocument } from '../../aos4/state'
 import {
   createAos4BuilderViewModel,
+  createAos4ReminderSourceLinkResolver,
   createAos4ReminderViewModel,
   type Aos4ReminderViewModel,
 } from '../../aos4/view'
 import AppBanner from 'components/info/banners/app_banner'
-import Reminders, { REMINDERS_ANCHOR_ID, type ReminderSourceLink } from 'components/info/reminders'
+import Reminders, { REMINDERS_ANCHOR_ID } from 'components/info/reminders'
 import ArmyBuilder from 'components/input/army_builder'
 import { useSubscriberAction } from 'components/input/importArmy/subscriberAction'
 import Toolbar from 'components/input/toolbar/toolbar'
@@ -41,40 +42,12 @@ const loadDocument = (): Aos4ArmyDocument => {
   }
 }
 
-const sourceArtifactById = new Map(AOS4_CATALOG.sourceArtifacts.map(artifact => [artifact.id, artifact]))
-const sourceArtifactByRecordId = new Map(
-  AOS4_CATALOG.sourceRecords.flatMap(record => {
-    const artifact = sourceArtifactById.get(record.artifactId)
-    return artifact ? [[String(record.id), artifact] as const] : []
-  })
-)
-
-const sourceLabel = (artifact: SourceArtifact): string => {
-  if (artifact.publisher === 'games-workshop') return artifact.title || 'Games Workshop'
-  if (artifact.publisher === 'wahapedia') return artifact.title || 'Wahapedia'
-  return artifact.title || 'Source'
-}
-
-const reminderSources = (reminder: Aos4ReminderViewModel): ReminderSourceLink[] =>
-  Array.from(
-    new Map(
-      reminder.sourceRecordIds.flatMap(id => {
-        const artifact = sourceArtifactByRecordId.get(id)
-        if (!artifact) return []
-        return [
-          [
-            artifact.id,
-            {
-              id: artifact.id,
-              label: sourceLabel(artifact),
-              ...(artifact.sourceUrl.startsWith('http') ? { href: artifact.sourceUrl } : {}),
-              official: artifact.publisher === 'games-workshop',
-            },
-          ] as const,
-        ]
-      })
-    ).values()
-  )
+/*
+ * Warscroll-ability records deep-link to their unit's own Wahapedia page rather than the
+ * faction-wide warscrolls index they were read from (issue #1860). The resolver owns that URL
+ * derivation; see src/aos4/view/sourceLinks.ts.
+ */
+const reminderSources = createAos4ReminderSourceLinkResolver(AOS4_CATALOG)
 
 /*
  * Every decoded faction can name itself, but only the ones that field units are offered. A stored

--- a/src/tests/aos4/reminderSourceLinks.test.ts
+++ b/src/tests/aos4/reminderSourceLinks.test.ts
@@ -1,0 +1,142 @@
+import type { Faction, SourceLocator, Warscroll } from '../../aos4/domain'
+import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID } from '../../aos4/generated'
+import { createAos4ArmyDocument } from '../../aos4/state'
+import {
+  createAos4ReminderSourceLinkResolver,
+  createAos4ReminderViewModel,
+  sourceRecordUrl,
+  type Aos4ReminderViewModel,
+} from '../../aos4/view'
+
+/**
+ * Reminder source links point at the unit the record describes (issue #1860). Warscroll abilities
+ * are read from the faction-wide Wahapedia `warscrolls.html` index, and linking that artifact URL
+ * sent every unit's "source" link to the top of the same index page. The record's datasheet
+ * locator names the unit's anchor, which on a warscroll collection is also the slug of the unit's
+ * standalone page.
+ */
+
+const entityByName = (kind: 'faction' | 'warscroll', name: string): Faction | Warscroll => {
+  const entity = AOS4_CATALOG.entities.find(candidate => candidate.kind === kind && candidate.name === name)
+  if (!entity) throw new Error(`No ${kind} named ${name} in the catalog`)
+  return entity as Faction | Warscroll
+}
+
+const remindersFor = (explicitNames: Array<['faction' | 'warscroll', string]>): Aos4ReminderViewModel[] =>
+  createAos4ReminderViewModel(
+    AOS4_CATALOG,
+    createAos4ArmyDocument({
+      id: 'army:test-source-links',
+      name: 'Source Link Test',
+      rulesContextId: AOS4_DEFAULT_RULES_CONTEXT_ID,
+      explicitSelectionIds: explicitNames.map(([kind, name]) => entityByName(kind, name).id),
+    })
+  )
+
+const resolveLinks = createAos4ReminderSourceLinkResolver(AOS4_CATALOG)
+
+const wahapediaHrefs = (reminder: Aos4ReminderViewModel): string[] =>
+  resolveLinks(reminder).flatMap(link =>
+    !link.official && link.href?.includes('wahapedia.ru') ? [link.href] : []
+  )
+
+describe('reminder source links (#1860)', () => {
+  it("links a warscroll ability to its unit's own Wahapedia page, not the warscrolls index", () => {
+    const reminders = remindersFor([
+      ['faction', 'Kruleboyz'],
+      ['warscroll', 'Killaboss with Stab-grot'],
+    ])
+    const reminder = reminders.find(candidate => candidate.name === 'UNLEASH THE STAB-GROT!')
+    expect(reminder).toBeDefined()
+    expect(wahapediaHrefs(reminder!)).toEqual([
+      'https://wahapedia.ru/aos4/factions/kruleboyz/Killaboss-with-Stab-grot',
+    ])
+  })
+
+  it('never leaves a reminder pointing at the bare warscrolls index', () => {
+    const reminders = remindersFor([
+      ['faction', 'Kruleboyz'],
+      ['warscroll', 'Killaboss with Stab-grot'],
+      ['warscroll', 'Gutrippaz'],
+      ['warscroll', 'Beast-skewer Killbow'],
+    ])
+    expect(reminders.length).toBeGreaterThan(0)
+    reminders.forEach(reminder => {
+      wahapediaHrefs(reminder).forEach(href => {
+        expect(href).not.toMatch(/\/warscrolls\.html$/)
+      })
+    })
+  })
+
+  it('resolves one link per destination, so shared-artifact records do not duplicate', () => {
+    const reminders = remindersFor([
+      ['faction', 'Kruleboyz'],
+      ['warscroll', 'Gutrippaz'],
+    ])
+    reminders.forEach(reminder => {
+      const hrefs = wahapediaHrefs(reminder)
+      expect(new Set(hrefs).size).toBe(hrefs.length)
+    })
+  })
+})
+
+describe('sourceRecordUrl', () => {
+  const locator = (section: string): SourceLocator => ({ kind: 'section', section })
+
+  it('turns a warscroll-collection datasheet section into the standalone unit page', () => {
+    expect(
+      sourceRecordUrl(
+        {
+          publisher: 'wahapedia',
+          sourceUrl: 'https://wahapedia.ru/aos4/factions/kruleboyz/warscrolls.html',
+        },
+        locator('datasheet:Killaboss-with-Stab-grot/ability:1')
+      )
+    ).toBe('https://wahapedia.ru/aos4/factions/kruleboyz/Killaboss-with-Stab-grot')
+  })
+
+  it('anchors a faction-root datasheet into the root page, which has no standalone unit pages', () => {
+    expect(
+      sourceRecordUrl(
+        { publisher: 'wahapedia', sourceUrl: 'https://wahapedia.ru/aos4/factions/kruleboyz/' },
+        locator('datasheet:Swampskulka-Gang/warscroll')
+      )
+    ).toBe('https://wahapedia.ru/aos4/factions/kruleboyz/#Swampskulka-Gang')
+  })
+
+  it('anchors a nested datasheet to its anchored parent group', () => {
+    expect(
+      sourceRecordUrl(
+        { publisher: 'wahapedia', sourceUrl: 'https://wahapedia.ru/aos4/factions/kruleboyz/' },
+        locator('datasheet:Swampskulka-Gang:Beast-skewer-Killbow/ability:1')
+      )
+    ).toBe('https://wahapedia.ru/aos4/factions/kruleboyz/#Swampskulka-Gang')
+  })
+
+  it('leaves non-datasheet sections on the artifact URL', () => {
+    expect(
+      sourceRecordUrl(
+        {
+          publisher: 'wahapedia',
+          sourceUrl: 'https://wahapedia.ru/aos4/factions/kruleboyz/warscrolls.html',
+        },
+        locator('keyword:1')
+      )
+    ).toBe('https://wahapedia.ru/aos4/factions/kruleboyz/warscrolls.html')
+  })
+
+  it('leaves rules pages and non-Wahapedia artifacts untouched', () => {
+    expect(
+      sourceRecordUrl(
+        { publisher: 'wahapedia', sourceUrl: 'https://wahapedia.ru/aos4/the-rules/the-core-rules/' },
+        locator('datasheet:Something/ability:1')
+      )
+    ).toBe('https://wahapedia.ru/aos4/the-rules/the-core-rules/')
+    expect(
+      sourceRecordUrl(
+        { publisher: 'games-workshop', sourceUrl: 'https://assets.warhammer-community.com/some.pdf' },
+        { kind: 'page', page: 3 }
+      )
+    ).toBe('https://assets.warhammer-community.com/some.pdf')
+  })
+})


### PR DESCRIPTION
## Root cause

Reminder cards resolve their source links at the **artifact** level: `Home.tsx` mapped each reminder's source records to the artifact they were read from and linked `artifact.sourceUrl`. Warscroll abilities are all read from one artifact per faction — the faction-wide Wahapedia warscrolls index (`https://wahapedia.ru/aos4/factions/kruleboyz/warscrolls.html`) — so the 3-dots menu on **every** unit card linked to the top of the same index page. This affected every faction, not just Kruleboyz; the generic faction links (battle traits on the faction root page) were only correct by coincidence, because that artifact happens to be a page of its own.

The unit-specific location was already in the data: each record's section locator names the unit's datasheet anchor (`datasheet:Killaboss-with-Stab-grot/ability:1`), and on a `warscrolls.html` collection that anchor is also the slug of the unit's standalone Wahapedia page.

## Fix

New `src/aos4/view/sourceLinks.ts` resolver (no React, per the view-layer boundary) derives a per-record destination:

- **Warscroll collection records** link the unit's standalone page, e.g. `https://wahapedia.ru/aos4/factions/kruleboyz/Killaboss-with-Stab-grot` — exactly the page the reporter expected (verified live: unit, Regiment of Renown, and Spearhead-variant slugs all resolve).
- **Faction-root datasheets** (regiment groups such as `Swampskulka-Gang`, which have no standalone page — verified 404 live) link the root page with the datasheet anchor as a fragment; nested child datasheets use their anchored parent.
- **Everything else** (rules pages, CSV exports, official PDFs, non-datasheet sections) keeps the artifact URL, so the existing faction-page and official-source links are byte-identical to before.

Links now dedupe per destination rather than per artifact, so records of one artifact that resolve to different unit pages stay distinct. `Home.tsx` swaps its inline mapping for the resolver.

## Testing

- New `src/tests/aos4/reminderSourceLinks.test.ts`: the issue's Kruleboyz repro (Killaboss with Stab-grot links its own page, nothing links the bare index), dedupe behavior, and unit tests for each URL-derivation branch (collection, root anchor, nested datasheet, non-datasheet section, rules page, official PDF).
- `yarn tsc --noEmit`, eslint on changed files, `yarn build`, and the full vitest suite pass (86/87 files, 1333 tests; the one failing file is `deploymentContract.test.ts`, a pre-existing WSL-only harness limitation on Windows unrelated to this change).

Fixes #1860

https://claude.ai/code/session_01FfnwSqxEgq9drUfPidpo8r