### PR TITLE
fix(import): resolve seasonal variant warscrolls for qualified roster labels (#1862)

### DIFF
--- a/src/aos4/import/labelAliases.ts
+++ b/src/aos4/import/labelAliases.ts
@@ -82,6 +82,24 @@ export const IMPORT_LABEL_ALIASES: ImportLabelAlias[] = [
       '"Kurnoth" the other three variants show.',
   },
   {
+    from: 'Infernal Enrapturess, Herald of Slaanesh (Scourge of Aqshy)',
+    to: 'Scourge of Aqshy Infernal Enrapturess',
+    reason:
+      'Provider divergence: New Recruit marks the seasonal variant with a trailing parenthetical ' +
+      'on the full official title, while the catalog’s seasonal warscroll drops the ' +
+      '"Herald of Slaanesh" honorific that the battletome warscroll carries. Rewriting the ' +
+      'qualifier into the usual battlepack prefix therefore matches nothing without this entry.',
+  },
+  {
+    from: 'Scourge of Aqshy: Infernal Enrapturess, Herald of Slaanesh',
+    to: 'Scourge of Aqshy Infernal Enrapturess',
+    reason:
+      'Provider divergence: the official app writes the seasonal variant as a battlepack-prefixed ' +
+      'line with the full official title, while the catalog’s seasonal warscroll drops the ' +
+      '"Herald of Slaanesh" honorific. Same divergence as the New Recruit spelling above, in the ' +
+      'order the official app prints it.',
+  },
+  {
     from: 'Outlaw Conqueror Cogfort',
     to: 'Conqueror Cogfort',
     reason:

--- a/src/aos4/import/resolveRoster.ts
+++ b/src/aos4/import/resolveRoster.ts
@@ -400,14 +400,14 @@ const resolveFaction = (
 }
 
 /**
- * The parenthetical or bracketed qualifiers that merely restate the rules context being imported into.
+ * The parenthetical or bracketed qualifiers that restate the rules context being imported into.
  *
- * New Recruit distinguishes a warscroll's seasonal version in its display name — "Blood Warriors
- * (Scourge of Aqshy)" — but the catalog carries one warscroll whose seasonal differences live in
- * the rules context. Since "Scourge of Aqshy" *is* the battlepack of the context we resolved, the
- * suffix is redundant here and stripping it recovers the base warscroll.
- *
- * Listbot shortens the same battlepack qualifier to an acronym such as "[SoA]".
+ * New Recruit distinguishes a warscroll's seasonal version in its display name — "Killaboss with
+ * Stab-grot (Scourge of Aqshy)" — and Listbot shortens the same battlepack qualifier to an acronym
+ * such as "[SoA]". The catalog carries that seasonal replacement as its own warscroll named with
+ * the battlepack as a prefix ("Scourge of Aqshy Killaboss with Stab-grot"), so a qualified label
+ * is first rewritten into that prefixed form; only when no such variant exists is the qualifier
+ * treated as redundant and stripped to recover the base warscroll.
  *
  * Built from the resolved context only, so a qualifier naming some *other* season is left alone
  * and still fails closed rather than silently resolving to the wrong edition of a unit.
@@ -433,6 +433,27 @@ const stripContextQualifier = (label: string, qualifiers: Set<string>): string |
   const qualifier = parentheticalQualifier ?? bracketedQualifier
   if (!base.trim() || !qualifiers.has(normalizeImportLabel(qualifier))) return undefined
   return base.trim()
+}
+
+/**
+ * A qualified label rewritten to the catalog's name for the seasonal variant it points at.
+ *
+ * A General's Handbook replaces some warscrolls for its season, and those replacements are
+ * catalogued as distinct entities named with the battlepack prefixed — "Scourge of Aqshy
+ * Killaboss with Stab-grot" lives alongside the battletome "Killaboss with Stab-grot" in the same
+ * seasonal context. A roster that says "(Scourge of Aqshy)" or "[SoA]" means that replacement, so
+ * the qualifier is rewritten into the prefix the catalog uses. This must be attempted *before*
+ * the bare qualifier strip: stripping first resolves the battletome warscroll the variant merely
+ * shares a base name with, and the player gets the wrong unit's reminders (#1862).
+ */
+const prefixContextQualifier = (
+  label: string,
+  context: RulesContext,
+  qualifiers: Set<string>
+): string | undefined => {
+  const base = stripContextQualifier(label, qualifiers)
+  const battlepack = context.battlepack?.trim()
+  return base && battlepack ? `${battlepack} ${base}` : undefined
 }
 
 /**
@@ -530,13 +551,17 @@ const resolveRosterSelection = (
      * Labels to try, in descending order of confidence.
      *
      * The roster's own wording always wins. A reviewed alias is consulted only when that finds
-     * nothing, and the seasonal-qualifier strip last, so a name the catalog knows verbatim can
-     * never be diverted by a correction meant for a different spelling.
+     * nothing, then the seasonal qualifier rewritten as the catalog's battlepack prefix, and the
+     * bare qualifier strip last — so a name the catalog knows verbatim can never be diverted by a
+     * correction meant for a different spelling, and a seasonal replacement warscroll is preferred
+     * over the base warscroll it shares a name with.
      */
+    const qualifiers = contextQualifiers(context)
     const attempts = [
       selection.label,
       aliasedImportLabel(selection.label),
-      stripContextQualifier(selection.label, contextQualifiers(context)),
+      prefixContextQualifier(selection.label, context, qualifiers),
+      stripContextQualifier(selection.label, qualifiers),
     ].filter((label): label is string => Boolean(label))
 
     /**

--- a/src/importers/rosterTree.ts
+++ b/src/importers/rosterTree.ts
@@ -66,18 +66,6 @@ const groupKind = (group: string): ParsedRosterSelectionKind | undefined => {
   return undefined
 }
 
-const directModelName = (selection: RosterNode): string | undefined => {
-  const modelNames = new Set(
-    childrenNamed(selection, 'selections')
-      .flatMap(container => childrenNamed(container, 'selection'))
-      .filter(child => child.attribute('type') === 'model')
-      .map(child => child.attribute('name')?.trim())
-      .filter((name): name is string => Boolean(name))
-  )
-  if (modelNames.size !== 1) return undefined
-  return Array.from(modelNames)[0]
-}
-
 /**
  * New Recruit marks each retired entry with a `Legends` category on the selection itself, which is
  * a far stronger signal than recognising the name later: it says which side of the Legends
@@ -90,11 +78,19 @@ const hasLegendsCategory = (selection: RosterNode): boolean =>
     .flatMap(container => childrenNamed(container, 'category'))
     .some(category => category.attribute('name')?.trim().toLocaleLowerCase('en') === 'legends')
 
-const unitLabel = (selection: RosterNode): string => {
-  const selectedName = selection.attribute('name')?.trim() ?? ''
-  const modelName = directModelName(selection)
-  return modelName && selectedName.startsWith(`${modelName} (`) ? modelName : selectedName
-}
+/**
+ * A unit's label is the roster's own wording, parenthetical qualifier and all.
+ *
+ * This used to collapse "Killaboss with Stab-grot (Scourge of Aqshy)" to the nested model's name,
+ * on the theory that the parenthetical merely restated the season being imported into. It does
+ * not: the qualifier is New Recruit distinguishing a General's Handbook replacement warscroll —
+ * a distinct catalog entity — from the battletome one, and the same shape carries the catalog's
+ * genuine size variants ("Stormdrake Guard (1 model)"). Erasing it here resolved every such unit
+ * to the base warscroll and handed the player the wrong reminders (#1862). Interpreting a
+ * qualifier requires knowing the rules context, so that judgement belongs to resolution, not
+ * parsing.
+ */
+const unitLabel = (selection: RosterNode): string => selection.attribute('name')?.trim() ?? ''
 
 const declaredContextFromForce = (force: RosterNode): string | undefined => {
   const name = (force.attribute('name') ?? '').replace(/^[^A-Za-z0-9]+/, '').trim()

--- a/src/tests/aos4/importNewRecruit.test.ts
+++ b/src/tests/aos4/importNewRecruit.test.ts
@@ -132,7 +132,7 @@ describe('New Recruit .ros and .rosz import', () => {
       { line: 16, label: 'Lore of the Storm', kindHint: 'spell-lore' },
       { line: 28, label: 'Knight-Vexillor', kindHint: 'warscroll' },
       { line: 31, label: 'Mirrorshield', kindHint: 'artefact-of-power' },
-      { line: 38, label: 'Annihilators', kindHint: 'warscroll', count: 2 },
+      { line: 38, label: 'Annihilators (Scourge of Aqshy)', kindHint: 'warscroll', count: 2 },
     ])
     expect(plain.parsedRoster?.selections.map(selection => selection.label)).not.toEqual(
       expect.arrayContaining(['Rules prose must not import', 'A profile name is not a selection'])
@@ -385,7 +385,7 @@ describe('New Recruit .json import', () => {
       'Lore of the Storm',
       'Knight-Vexillor',
       'Mirrorshield',
-      'Annihilators',
+      'Annihilators (Scourge of Aqshy)',
     ])
   })
 

--- a/src/tests/aos4/importResolution.test.ts
+++ b/src/tests/aos4/importResolution.test.ts
@@ -1,3 +1,4 @@
+import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID } from '../../aos4/generated'
 import { normalizeImportLabel, resolveParsedRoster, type ParsedRoster } from '../../aos4/import'
 import {
   createImportFixtureCatalog,
@@ -66,7 +67,29 @@ describe('AoS 4 parsed-roster resolution', () => {
     ])
   })
 
-  it("resolves Listbot's abbreviated seasonal qualifier in the selected context", () => {
+  /**
+   * A seasonal qualifier names the battlepack's replacement warscroll, not the base one.
+   *
+   * The catalog carries the replacement as its own entity with the battlepack prefixed
+   * ("Scourge of Tests Shared Guard") alongside the base warscroll in the same seasonal context.
+   * Resolving the qualified label to the base warscroll hands the player the wrong unit's
+   * reminders (#1862).
+   */
+  it("resolves New Recruit's parenthetical seasonal qualifier to the seasonal variant warscroll", () => {
+    const preview = resolve(
+      roster({
+        source: 'roster-xml',
+        selections: [{ line: 8, label: 'Shared Guard (Scourge of Tests)', kindHint: 'warscroll' }],
+      })
+    )
+
+    expect(preview.diagnostics).toEqual([])
+    expect(preview.matches).toEqual([
+      { line: 8, label: 'Shared Guard (Scourge of Tests)', canonicalId: importFixtureIds.alphaGuardSeasonal },
+    ])
+  })
+
+  it("resolves Listbot's abbreviated seasonal qualifier to the seasonal variant warscroll", () => {
     const preview = resolve(
       roster({
         source: 'listbot-text',
@@ -76,7 +99,26 @@ describe('AoS 4 parsed-roster resolution', () => {
 
     expect(preview.diagnostics).toEqual([])
     expect(preview.matches).toEqual([
-      { line: 8, label: 'Shared Guard [SoT]', canonicalId: importFixtureIds.alphaGuard },
+      { line: 8, label: 'Shared Guard [SoT]', canonicalId: importFixtureIds.alphaGuardSeasonal },
+    ])
+  })
+
+  /**
+   * Not every unit gains a seasonal replacement. When the catalog carries no battlepack-prefixed
+   * variant, the qualifier is redundant restatement of the context and stripping it recovers the
+   * one warscroll the roster can mean.
+   */
+  it('strips the seasonal qualifier when no seasonal variant warscroll exists', () => {
+    const preview = resolve(
+      roster({
+        source: 'listbot-text',
+        selections: [{ line: 8, label: 'Twin Era Guard [SoT]', kindHint: 'warscroll' }],
+      })
+    )
+
+    expect(preview.diagnostics).toEqual([])
+    expect(preview.matches).toEqual([
+      { line: 8, label: 'Twin Era Guard [SoT]', canonicalId: importFixtureIds.twinEraCurrent },
     ])
   })
 
@@ -497,5 +539,64 @@ describe('AoS 4 superseded-season resolution', () => {
 
     expect(preview.matches).toEqual([])
     expect(preview.proposedDocument?.allowsHistorical).toBeUndefined()
+  })
+})
+
+/**
+ * The report behind the fixtures: issue #1862.
+ *
+ * A New Recruit Kruleboyz roster named its hero "Killaboss with Stab-grot (Scourge of Aqshy)" and
+ * the importer stripped the qualifier straight to the battletome warscroll, so the player got the
+ * standard unit's reminders instead of the seasonal replacement's. Pinned against the shipped
+ * catalog because the fixture catalog can only prove the logic, not that the real corpus carries
+ * both warscrolls for the resolution to distinguish.
+ */
+describe('seasonal variant resolution against the shipped catalog (#1862)', () => {
+  const resolveShipped = (label: string) =>
+    resolveParsedRoster(
+      AOS4_CATALOG,
+      {
+        source: 'roster-xml',
+        proposedName: 'Issue 1862',
+        declaredContext: "General's Handbook 2026-27",
+        declaredFaction: 'Kruleboyz',
+        selections: [{ line: 1, label, kindHint: 'warscroll' }],
+      },
+      {
+        defaultRulesContextId: AOS4_DEFAULT_RULES_CONTEXT_ID,
+        createDocumentId: () => 'army:issue-1862',
+      }
+    )
+
+  const warscrollIdByName = (name: string) => {
+    const entity = AOS4_CATALOG.entities.find(
+      candidate => candidate.kind === 'warscroll' && candidate.name === name
+    )
+    if (!entity) throw new Error(`expected the shipped catalog to carry the warscroll "${name}"`)
+    return entity.id
+  }
+
+  it('resolves the qualified label to the Scourge of Aqshy replacement warscroll', () => {
+    const preview = resolveShipped('Killaboss with Stab-grot (Scourge of Aqshy)')
+
+    expect(preview.matches).toEqual([
+      {
+        line: 1,
+        label: 'Killaboss with Stab-grot (Scourge of Aqshy)',
+        canonicalId: warscrollIdByName('Scourge of Aqshy Killaboss with Stab-grot'),
+      },
+    ])
+  })
+
+  it('still resolves the unqualified label to the battletome warscroll', () => {
+    const preview = resolveShipped('Killaboss with Stab-grot')
+
+    expect(preview.matches).toEqual([
+      {
+        line: 1,
+        label: 'Killaboss with Stab-grot',
+        canonicalId: warscrollIdByName('Killaboss with Stab-grot'),
+      },
+    ])
   })
 })

--- a/src/tests/fixtures/aos4/import/catalog.ts
+++ b/src/tests/fixtures/aos4/import/catalog.ts
@@ -27,6 +27,12 @@ export const importFixtureIds = {
    */
   containerFaction: factionId('81000000-0000-4000-8000-000000000012'),
   alphaGuard: warscrollId('81000000-0000-4000-8000-000000000020'),
+  /**
+   * The seasonal replacement warscroll for `alphaGuard`, catalogued the way generation emits one:
+   * a distinct entity named with the battlepack prefixed, living in the same seasonal context as
+   * the base warscroll it replaces (#1862).
+   */
+  alphaGuardSeasonal: warscrollId('81000000-0000-4000-8000-000000000026'),
   betaGuard: warscrollId('81000000-0000-4000-8000-000000000021'),
   betaOnly: warscrollId('81000000-0000-4000-8000-000000000022'),
   /** Catalogued only in the Legends context, reachable from Alpha Hosts only there. */
@@ -99,6 +105,13 @@ export const createImportFixtureCatalog = (): Aos4Catalog => {
       from: importFixtureIds.alphaFaction,
       to: importFixtureIds.alphaRetired,
       rulesContextIds: [importFixtureContextIds.legends],
+    },
+    {
+      id: 'relationship:alpha-offers-shared-guard-seasonal',
+      kind: 'offers',
+      from: importFixtureIds.alphaFaction,
+      to: importFixtureIds.alphaGuardSeasonal,
+      rulesContextIds: [importFixtureContextIds.seasonal],
     },
     {
       id: 'relationship:alpha-offers-twin-era-current',
@@ -244,6 +257,17 @@ export const createImportFixtureCatalog = (): Aos4Catalog => {
         kind: 'warscroll',
         revision: 'import-fixture',
         name: 'Shared Guard',
+        factionIds: [importFixtureIds.alphaFaction],
+        keywords: [],
+        characteristics: { move: '5"', save: '4+', control: '1', health: '2' },
+        rulesContextIds: [importFixtureContextIds.seasonal],
+        sourceRefs,
+      },
+      {
+        id: importFixtureIds.alphaGuardSeasonal,
+        kind: 'warscroll',
+        revision: 'import-fixture',
+        name: 'Scourge of Tests Shared Guard',
         factionIds: [importFixtureIds.alphaFaction],
         keywords: [],
         characteristics: { move: '5"', save: '4+', control: '1', health: '2' },


### PR DESCRIPTION
Fixes #1862

## Root cause

The reporter's New Recruit roster names the unit `Killaboss with Stab-grot (Scourge of Aqshy)` — the General's Handbook 2026-27 replacement warscroll, which the catalog carries as its own entity, `Scourge of Aqshy Killaboss with Stab-grot`, alongside the battletome `Killaboss with Stab-grot` in the same seasonal rules context.

Two layers of the import path erased the qualifier before resolution could pick the right warscroll:

1. **Parse time** (`src/importers/rosterTree.ts`): a unit selection named `<model name> (<anything>)` was collapsed to its nested model's name, so the parsed label was already the bare `Killaboss with Stab-grot`. The same heuristic also erased the catalog's genuine size-variant qualifiers (`Stormdrake Guard (1 model)`, `Pusgoyle Blightlords (1 Model)`).
2. **Resolution** (`src/aos4/import/resolveRoster.ts`): the seasonal-qualifier handling stripped `(Scourge of Aqshy)` / Listbot's `[SoA]` straight to the base name. That policy predates the accepted corpus carrying each seasonal replacement as a distinct battlepack-prefixed warscroll, so a label that survived parsing still resolved to the battletome unit.

Either way the player silently got the standard unit's reminders — the worst failure mode the importer has, because nothing tells them it's wrong.

## Fix

- The parser now keeps the roster's own wording for a unit label. Interpreting a qualifier requires knowing the rules context, which only resolution has.
- The resolver tries a new attempt between the reviewed alias and the bare strip: the context qualifier rewritten as the catalog's battlepack prefix (`Killaboss with Stab-grot (Scourge of Aqshy)` → `Scourge of Aqshy Killaboss with Stab-grot`). Units with no seasonal replacement still fall through to the strip and resolve to their base warscroll; a qualifier naming some other season still fails closed.
- Two reviewed alias entries cover the one variant whose catalog name diverges from the `battlepack + base name` shape: the seasonal `Scourge of Aqshy Infernal Enrapturess` drops the battletome's ", Herald of Slaanesh" honorific (New Recruit and official-app spellings).

A side benefit: `(1 model)` size-variant picks now reach the resolver's exact-match path and resolve to the catalog's size-variant warscrolls instead of being collapsed to the base unit.

## Tests

- `importResolution.test.ts`: fixture-catalog coverage for the New Recruit parenthetical and Listbot acronym resolving to the seasonal variant, plus the no-variant fallback to the base warscroll; and a shipped-catalog regression pinning the issue's exact Kruleboyz labels — qualified → `Scourge of Aqshy Killaboss with Stab-grot`, unqualified → battletome warscroll.
- `importNewRecruit.test.ts`: parsed labels now keep the qualifier.
- Verified the issue's attached `1k.krule.json` end-to-end through `decodeAos4RosterFile` → `resolveParsedRoster`: the Killaboss resolves to the Scourge of Aqshy warscroll with no diagnostics, and every other selection resolves as before.
- Full run: lint, `tsc`, production build, and the vitest suite pass (the only failure is `deploymentContract.test.ts`, the WSL-only deploy harness that cannot run on this Windows machine — unrelated to this change). New Recruit corpus resolution coverage is unchanged (same six pre-existing unresolved names), with the `(Scourge of Aqshy)` labels now resolving to the seasonal variants.

https://claude.ai/code/session_01FfnwSqxEgq9drUfPidpo8r
