### PR TITLE
test(import): pin Sigdex Scars of War honours to the offered group (#1826)

### DIFF
--- a/src/tests/aos4/importSigdex.test.ts
+++ b/src/tests/aos4/importSigdex.test.ts
@@ -89,6 +89,49 @@ describe('Sigdex text import', () => {
     )
   })
 
+  /**
+   * Every GHB 2026-27 Scars of War honour is catalogued twice — the content-group Stormcast
+   * Eternals offers and the same-named ability inside it — so each roster bullet naming one found
+   * two candidates and warned as ambiguous instead of importing (issue #1826). The pair must
+   * collapse to the offered group: the same single pick the manual builder's dropdown presents.
+   */
+  it('resolves Scars of War enhancement bullets to the offered group, not ambiguously (issue #1826)', () => {
+    const { parsedRoster, diagnostics } = decodeAos4TextRoster(
+      roster(
+        'Stormcast Eternals',
+        'Vanguard Wing',
+        "General's Handbook 2026-27",
+        "General's Regiment",
+        'Neave Blacktalon (280)',
+        '• General',
+        '• Veterans of Amberstone Watch (20)',
+        'Aetherwings (80)',
+        '• Uncaged Lightning (10)',
+        'Dracothian Guard Desolators (170)',
+        '• Pyrotechnic Souls (10)'
+      )
+    )
+    expect(diagnostics).toEqual([])
+
+    const preview = resolveParsedRoster(AOS4_CATALOG, parsedRoster!, {
+      defaultRulesContextId: AOS4_DEFAULT_RULES_CONTEXT_ID,
+      createDocumentId: () => 'army:sigdex-scars-of-war',
+    })
+    expect(preview.diagnostics).toEqual([])
+    expect(preview.proposedDocument).toBeDefined()
+
+    const honours = ['Veterans of Amberstone Watch', 'Uncaged Lightning', 'Pyrotechnic Souls']
+    const matchedIds = new Map(preview.matches.map(match => [match.label, match.canonicalId]))
+    for (const honour of honours) {
+      const canonicalId = matchedIds.get(honour)
+      expect(canonicalId, honour).toBeDefined()
+      // The offered container, never the ability it includes — one entity per pick.
+      expect(canonicalId, honour).toMatch(/^content-group:/)
+      const entity = AOS4_CATALOG.entities.find(candidate => candidate.id === canonicalId)
+      expect(entity?.kind === 'content-group' && entity.groupType, honour).toBe('scars-of-war')
+    }
+  })
+
   it('keeps enhancement bullets and strips their points', () => {
     const parsed = decode(
       'Ogor Mawtribes',


### PR DESCRIPTION
## Root cause

Importing a Sigdex Stormcast Eternals list carrying the GHB 2026-27 Scars of War honour **Veterans of Amberstone Watch** warned `"Veterans of Amberstone Watch" matches more than one enhancement, so it was not imported` in the import preview.

Each Scars of War honour is catalogued twice, deliberately: the `content-group` the faction offers (the single pick the manual builder's dropdown presents) and the same-named `ability` inside it that carries the rules text, joined by an `includes` edge. Sigdex bullets are unlabeled, so the honour resolves under the generic enhancement hint, which accepts both abilities and content-groups — the label matched the pair and the resolver refused to choose, warning as ambiguous. All three Stormcast honours (`Veterans of Amberstone Watch`, `Uncaged Lightning`, `Pyrotechnic Souls`) had the same shape, as does any other container/content pair such as the Skaven Moulder Mutations.

## Fix

The contained-candidate collapse introduced by #1859 for the official app's unlabeled bullets (`collapseContainedCandidates` in `src/aos4/import/resolveRoster.ts`) already generalizes to this case: a candidate that `includes` another candidate wins over what it contains, so the pair resolves to the offered group — one entity per pick, matching the manual builder. That change merged on 2026-08-02, after this issue was reported against the 2026-08-01 deploy, and I confirmed the exact reported warning reproduces with the collapse disabled and resolves cleanly with it in place.

This PR pins that behaviour on the Sigdex path with a regression test: a Sigdex-format Stormcast roster carrying all three Scars of War honours must resolve each to its `scars-of-war` content-group with no diagnostics. The test fails if the collapse is removed. Genuinely ambiguous names (two unrelated same-named candidates with no containment edge) still warn — the collapse only removes candidates contained by other candidates.

## Testing

- `vitest run src/tests/aos4/importSigdex.test.ts src/tests/aos4/officialAppFixtures.test.ts src/tests/aos4/importOfficialApp.test.ts` — 201 passed
- Full suite: 1346 passed; the 14 failures are the known WSL-only `deploymentContract.test.ts` harness on Windows, unrelated
- `eslint src --max-warnings 0`, `tsc --noEmit`, `tsc && vite build` — clean
- Verified the new test fails with `collapseContainedCandidates` disabled and passes with it restored

Fixes #1826

https://claude.ai/code/session_01FfnwSqxEgq9drUfPidpo8r