### PR TITLE
fix(import): reflect imported artefacts in the builder dropdown selections (#1827)

### DIFF
--- a/src/aos4/view/builder.ts
+++ b/src/aos4/view/builder.ts
@@ -1,4 +1,11 @@
-import type { Aos4Catalog, BattleProfile, CanonicalId, ContentEntity, Warscroll } from '../domain'
+import type {
+  Aos4Catalog,
+  BattleProfile,
+  CanonicalId,
+  ContentEntity,
+  ContentGroup,
+  Warscroll,
+} from '../domain'
 import { resolveSelection } from '../select'
 import type { Aos4ArmyDocument } from '../state'
 
@@ -22,6 +29,30 @@ export interface Aos4BuilderWarscroll {
     baseSizes: string[]
   }
 }
+
+/**
+ * The rules categories whose individual abilities surface as selected chips in the builder cards.
+ *
+ * Two paths feed them: an Army of Renown grants its enhancements outright, and an imported roster
+ * names the single enhancement a hero carries ("Quicksilver Draught") rather than the offering
+ * group a hand-built army selects ("Artefacts of the Tempest"). Both leave an `ability` in the
+ * selection, and the ability's card is the offering group's category.
+ */
+const ABILITY_CHIP_CATEGORIES = new Set(['artefact-of-power', 'heroic-trait', 'prayer-lore', 'spell-lore'])
+const CHIP_MINOR_WORDS = new Set(['a', 'an', 'and', 'of', 'the', 'to'])
+const chipCase = (value: string): string =>
+  value
+    .toLowerCase()
+    .split(' ')
+    .map((word, index) =>
+      index > 0 && CHIP_MINOR_WORDS.has(word)
+        ? word
+        : word.replace(
+            /(^|-)([a-z])/g,
+            (_, boundary: string, letter: string) => `${boundary}${letter.toUpperCase()}`
+          )
+    )
+    .join(' ')
 
 export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4ArmyDocument) => {
   // Every army offers its full catalog: current-standard content plus the Legends and historical
@@ -54,16 +85,42 @@ export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4A
   const available = new Set(selection.availableIds)
   const entityById = new Map(catalog.entities.map(entity => [entity.id, entity]))
 
+  /**
+   * The offering group behind each individually selectable enhancement.
+   *
+   * The catalog models the individual enhancement as an `ability` inside the content-group that
+   * offers it, and only the group is ever offered — so an imported roster's artefact or heroic
+   * trait lands in the document as an ability with no card of its own, and the builder's dropdown
+   * showed nothing selected while the reminder was plainly there (#1827). The offering group
+   * supplies what the ability cannot say for itself: the category card it belongs on, and the
+   * overlay provenance (an ability is never in `availableIds`, so deriving its overlay directly
+   * would misfile current content as historical). Where more than one group includes the same
+   * ability, the one available without an overlay wins.
+   */
+  const chipGroupByAbilityId = new Map<CanonicalId, ContentGroup>()
+  catalog.relationships.forEach(relationship => {
+    if (relationship.kind !== 'includes') return
+    const parent = entityById.get(relationship.from)
+    const child = entityById.get(relationship.to)
+    if (child?.kind !== 'ability' || parent?.kind !== 'content-group') return
+    if (!ABILITY_CHIP_CATEGORIES.has(parent.groupType)) return
+    const existing = chipGroupByAbilityId.get(child.id)
+    if (!existing || (overlayFor(existing.id) && !overlayFor(parent.id))) {
+      chipGroupByAbilityId.set(child.id, parent)
+    }
+  })
+
   const options: Aos4BuilderOption[] = Array.from(
     new Set([...document.explicitSelectionIds, ...selection.availableIds])
   ).flatMap(id => {
     const entity = entityById.get(id)
     if (!entity) return []
-    const overlay = overlayFor(id)
+    const chipGroup = entity.kind === 'ability' ? chipGroupByAbilityId.get(id) : undefined
+    const overlay = overlayFor(chipGroup?.id ?? id)
     return [
       {
         id,
-        name: entity.name,
+        name: chipGroup ? chipCase(entity.name) : entity.name,
         kind: entity.kind,
         ...(entity.kind === 'content-group'
           ? { groupType: entity.groupType }
@@ -71,7 +128,9 @@ export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4A
             ? // Manifestations are a category of unit, not roster units (CONCEPTS.md); grouping
               // them apart keeps the Units card a list of the units a player actually fields.
               { groupType: 'manifestation' }
-            : {}),
+            : chipGroup
+              ? { groupType: chipGroup.groupType }
+              : {}),
         selected: selected.has(id),
         available: available.has(id),
         ...(overlay ? { overlay } : {}),
@@ -86,21 +145,6 @@ export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4A
    * Traits, Mawmeat and Retcher under Spell Lores). Battle traits stay reminder-only, like every
    * army's battle traits.
    */
-  const GRANTED_CHIP_CATEGORIES = new Set(['artefact-of-power', 'heroic-trait', 'prayer-lore', 'spell-lore'])
-  const CHIP_MINOR_WORDS = new Set(['a', 'an', 'and', 'of', 'the', 'to'])
-  const chipCase = (value: string): string =>
-    value
-      .toLowerCase()
-      .split(' ')
-      .map((word, index) =>
-        index > 0 && CHIP_MINOR_WORDS.has(word)
-          ? word
-          : word.replace(
-              /(^|-)([a-z])/g,
-              (_, boundary: string, letter: string) => `${boundary}${letter.toUpperCase()}`
-            )
-      )
-      .join(' ')
   const armyOfRenownRootIds = new Set(
     document.explicitSelectionIds.filter(id => {
       const entity = entityById.get(id)
@@ -114,7 +158,7 @@ export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4A
       const entity = entityById.get(cause.entityId)
       if (entity?.kind !== 'ability') return
       const parent = entityById.get(cause.entityPath[cause.entityPath.length - 2])
-      if (parent?.kind !== 'content-group' || !GRANTED_CHIP_CATEGORIES.has(parent.groupType)) return
+      if (parent?.kind !== 'content-group' || !ABILITY_CHIP_CATEGORIES.has(parent.groupType)) return
       seenChipIds.add(cause.entityId)
       options.push({
         id: cause.entityId,

--- a/src/tests/aos4/importSigdex.test.ts
+++ b/src/tests/aos4/importSigdex.test.ts
@@ -1,5 +1,8 @@
 import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID } from '../../aos4/generated'
 import { resolveParsedRoster } from '../../aos4/import'
+import { projectReminders } from '../../aos4/reminders'
+import { resolveSelection } from '../../aos4/select'
+import { createAos4BuilderViewModel } from '../../aos4/view'
 import { decodeAos4TextRoster } from '../../importers'
 import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -25,10 +28,8 @@ const roster = (...body: string[]) =>
 
 const decode = (...body: string[]) => decodeAos4TextRoster(roster(...body)).parsedRoster
 
-const labelled = (
-  parsed: NonNullable<ReturnType<typeof decode>>,
-  kind: string
-): string[] => parsed.selections.filter(s => s.kindHint === kind).map(s => s.label)
+const labelled = (parsed: NonNullable<ReturnType<typeof decode>>, kind: string): string[] =>
+  parsed.selections.filter(s => s.kindHint === kind).map(s => s.label)
 
 describe('Sigdex text import', () => {
   it('parses the standard fixture', () => {
@@ -102,6 +103,58 @@ describe('Sigdex text import', () => {
     )
     expect(labelled(parsed!, 'enhancement')).toEqual(['Gnawhide Cloak', 'Endless Appetite'])
     expect(labelled(parsed!, 'warscroll')).toEqual(['Tyrant'])
+  })
+
+  /**
+   * Issue #1827: a Sigdex Stormcast list with an artefact produced the artefact's reminder but the
+   * builder's Artefacts dropdown stayed empty. The import resolves the enhancement bullet to the
+   * individual `ability` inside the offering group, and the builder view model emitted that option
+   * without the offering group's category, so the dropdown card filtered it out — and its overlay
+   * was derived from the ability itself, which is never individually offered, misfiling current
+   * content as historical. Both the reminder and the dropdown selection must show the artefact.
+   */
+  it('reflects an imported artefact and heroic trait in the builder dropdown selections', () => {
+    const parsed = decode(
+      'Stormcast Eternals',
+      'Vanguard Wing',
+      "General's Handbook 2026-27",
+      "General's Regiment",
+      'Neave Blacktalon (280)',
+      '• General',
+      '• Staunch Defender',
+      '• Quicksilver Draught',
+      'Aetherwings (80)'
+    )
+    const preview = resolveParsedRoster(AOS4_CATALOG, parsed!, {
+      defaultRulesContextId: AOS4_DEFAULT_RULES_CONTEXT_ID,
+      createDocumentId: () => 'army:sigdex-artefact',
+    })
+    expect(preview.diagnostics).toEqual([])
+    const document = preview.proposedDocument!
+    expect(document).toBeDefined()
+
+    // The artefact's rule is in the reminders...
+    const reminders = projectReminders(
+      AOS4_CATALOG,
+      resolveSelection(AOS4_CATALOG, {
+        explicitIds: document.explicitSelectionIds,
+        rulesContextId: document.rulesContextId,
+      })
+    ).map(reminder => reminder.name)
+    expect(reminders).toContain('QUICKSILVER DRAUGHT')
+    expect(reminders).toContain('STAUNCH DEFENDER')
+
+    // ...and the builder cards show the same picks as selected, filed on the right card. The
+    // dropdown component only renders ability options that carry a groupType, so these assertions
+    // are exactly what the Artefacts and Heroic Traits cards read.
+    const builder = createAos4BuilderViewModel(AOS4_CATALOG, document)
+    const selectedChips = (category: string) =>
+      builder.options.filter(option => option.groupType === category && option.selected)
+    expect(selectedChips('artefact-of-power').map(option => option.name)).toEqual(['Quicksilver Draught'])
+    expect(selectedChips('heroic-trait').map(option => option.name)).toEqual(['Staunch Defender'])
+    // Current-context enhancements must not be misfiled under an overlay group header.
+    expect(selectedChips('artefact-of-power')[0].overlay).toBeUndefined()
+    expect(selectedChips('heroic-trait')[0].overlay).toBeUndefined()
   })
 
   it('parses an Army of Renown header into faction plus formation-style selection', () => {


### PR DESCRIPTION
## Root cause

Importing a Sigdex Stormcast Eternals list with an artefact added the artefact's rule to the reminders, but the builder's Artefacts dropdown stayed empty.

The catalog models an individual enhancement as an `ability` inside the content-group that offers it ("Quicksilver Draught" lives inside "Artefacts of the Tempest"), and only the group is ever *offered*. A hand-built army selects the group; an imported roster names the single enhancement a hero carries, so the import (correctly, and deliberately) resolves the bullet to the individual ability and places it in `explicitSelectionIds`. From there the two surfaces diverged:

- **Reminders** resolve the explicit ability and project its rule — so the reminder appeared.
- **The builder view model** (`src/aos4/view/builder.ts`) emitted the ability option with no `groupType`, and the builder cards only render ability options that carry one — so the Artefacts card showed nothing selected. On top of that, the option's overlay was derived from the ability's own availability; an ability is never in `availableIds`, so a current-season artefact was tagged `historical` and would have been misfiled under the "Scourge of Ghyran" group header even if it had rendered.

The desync was not Sigdex-specific: every text importer (official app, Listbot, New Recruit, Sigdex) resolves enhancement bullets through the same shared layer, and heroic traits were affected the same way as artefacts.

## Fix

Fixed at the common layer, in the builder view model. It now maps each individually selectable enhancement ability to the content-group that includes it (for the ability-chip categories: artefacts, heroic traits, spell lores, prayer lores). A selected ability's option:

- is filed on its offering group's category card (`groupType`),
- takes its overlay provenance from the offering group instead of the never-offered ability, and
- gets the same chip-cased display name the Army-of-Renown granted chips already use (corpus ability names are ALL CAPS).

The Army-of-Renown granted-chip path now shares the hoisted `chipCase` helper and category set; its behavior is unchanged.

## Tests

- New regression test in `src/tests/aos4/importSigdex.test.ts`: imports an SCE list with `• Quicksilver Draught` (artefact) and `• Staunch Defender` (heroic trait) and asserts **both** the reminders and the builder dropdown selection state, including that neither chip is misfiled under an overlay header. Verified red before the fix, green after.
- `tsc --noEmit`, `eslint`, `prettier --check`: clean.
- `vite build` + full `vitest run`: 1346 passing; the only failures are `deploymentContract.test.ts`, the known WSL-only suite on Windows, unrelated to this change.

Fixes #1827

https://claude.ai/code/session_01FfnwSqxEgq9drUfPidpo8r
