### PR TITLE
fix(profile): theme gift subscriptions in dark mode

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,30 @@
+## Design Context
+
+### Users
+
+Age of Sigmar players use AoS Reminders while building an army, during games with dice and models
+in hand, and when printing a compact reference for the table. They need phase-ordered rules and
+account actions to remain quickly scannable on desktop and mobile, including in poor lighting.
+
+### Brand Personality
+
+Trustworthy, utilitarian, and familiar. The interface should feel like a complete field manual: a
+quiet, dependable reference that keeps attention on the player's rules rather than on decoration.
+
+### Aesthetic Direction
+
+Preserve the established AoS Reminders interface and its Bootstrap-based visual language. Use flat
+paper or Midnight Slate surfaces, Deep Harbour and Signal Teal for structure, system typography,
+hairline borders, dense spacing, and semantic color only for actions or status. Light and dark mode
+are equal products, and every screen surface must also have an intentional print behavior. Avoid
+reskins, ornamental effects, web fonts, gradients, and new visual patterns where an existing theme
+slot or component already fits.
+
+### Design Principles
+
+1. Optimize for fast reading at the game table; content and state outrank decoration.
+2. Preserve visual and interaction continuity with the established live experience.
+3. Route every themed surface through named `ITheme` slots and verify both light and dark modes.
+4. Keep structure legible through typography, spacing, and borders so it survives print and color
+   loss.
+5. Prefer native, accessible controls and familiar project primitives over one-off components.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -526,6 +526,9 @@ first render.
   drag it past the card and scroll the page sideways), inheriting theme background and text.
 - **Dropzone:** dashed 2px, `#eeeeee` on `#fafafa` in light and Pale Gray on black in dark, with a
   `#2196f3` border on focus and drag-over.
+- **Gift purchase table:** Paper with Ink text in light theme; Midnight Slate with Paper text and
+  Pale Gray dividers in dark theme. The quantity fields use the matching page surface so the table
+  never introduces a light island on the dark profile route.
 
 ### Loading and empty states
 

--- a/src/components/payment/giftSubscriptions.tsx
+++ b/src/components/payment/giftSubscriptions.tsx
@@ -138,7 +138,7 @@ const PurchaseTable = () => {
   return (
     <div className="row d-flex justify-content-center">
       <div className={COL_SIZE}>
-        <table className={`table ${theme.text} ${isMobile ? 'table-sm' : ''}`}>
+        <table className={`table ${theme.purchaseTable} ${isMobile ? 'table-sm' : ''}`}>
           <thead>
             <tr>
               <th scope="col">Plan</th>
@@ -186,6 +186,7 @@ const PlanComponent = ({ supportPlan }: { supportPlan: IGiftedSubscriptionPlans 
   const origin = `${supportPlan.title}-GiftedSubscription`
   const { user, isAuthenticated } = useAuth0()
   const { login } = useLogin({ origin })
+  const { theme } = useTheme()
   const stripe = useStripe()
   const { isMobile } = useWindowSize()
   const [quantity, setQuantity] = useState(1)
@@ -245,7 +246,7 @@ const PlanComponent = ({ supportPlan }: { supportPlan: IGiftedSubscriptionPlans 
       <td>
         <input
           style={{ maxWidth: '60px' }}
-          className="form-control"
+          className={`form-control ${theme.bgColor} ${theme.text}`}
           type="number"
           min={1}
           max={MAX_GIFT_QUANTITY}

--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -323,6 +323,23 @@ small,
     border-bottom: calc(var(--bs-border-width) * 2) solid var(--bs-table-border-color);
 }
 
+/*
+ * Bootstrap 5 paints every table cell from table-local CSS variables, so the inherited ITheme text
+ * class cannot theme this surface by itself. Keep the gift table on Paper in light mode and on the
+ * page's Midnight Slate in dark mode, with the Pale Gray divider used by other dark surfaces.
+ */
+.GiftPurchaseTable-Light {
+    --bs-table-color: #{$body-color};
+    --bs-table-bg: #{$white};
+    --bs-table-border-color: #{$table-border-color};
+}
+
+.GiftPurchaseTable-Dark {
+    --bs-table-color: #{$white};
+    --bs-table-bg: #{$themeDarkBlueSecondary};
+    --bs-table-border-color: #{$themeLightGray};
+}
+
 select.form-control {
     appearance: auto;
     /* 4.6 gave .form-control an explicit height; 5.x lets content size it, and a native select

--- a/src/tests/aos4/giftSubscriptions.test.tsx
+++ b/src/tests/aos4/giftSubscriptions.test.tsx
@@ -4,6 +4,8 @@
 import { GiftSubscriptions } from 'components/payment/giftSubscriptions'
 import { act } from 'react'
 import { render, Simulate, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
+import DarkTheme from 'theme/dark'
+import LightTheme from 'theme/light'
 import { GiftedSubscriptionPlans } from 'utils/plans'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -14,6 +16,16 @@ const stripe = vi.hoisted(() => ({
 const analytics = vi.hoisted(() => ({
   logBeginCheckout: vi.fn(),
   logClick: vi.fn(),
+}))
+
+const themeContext = vi.hoisted(() => ({
+  isDark: false,
+  theme: {
+    bgColor: 'bg-white',
+    genericButtonBlock: '',
+    purchaseTable: 'GiftPurchaseTable-Light',
+    text: 'text-dark',
+  },
 }))
 
 vi.mock('utils/analytics', () => analytics)
@@ -42,13 +54,7 @@ vi.mock('context/useSubscription', () => ({
 }))
 
 vi.mock('context/useTheme', () => ({
-  useTheme: () => ({
-    isDark: false,
-    theme: {
-      genericButtonBlock: '',
-      text: '',
-    },
-  }),
+  useTheme: () => themeContext,
 }))
 
 vi.mock('utils/hooks/useLogin', () => ({
@@ -64,6 +70,8 @@ describe('gift subscription checkout', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    themeContext.isDark = false
+    themeContext.theme = LightTheme
     stripe.redirectToCheckout.mockResolvedValue({})
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -119,6 +127,25 @@ describe('gift subscription checkout', () => {
       mode: 'payment',
       successUrl:
         'https://aosreminders.com/profile?gifted=true&checkout_kind=gift_subscription&quantity=3&plan=1%20Month&checkout_session_id={CHECKOUT_SESSION_ID}',
+    })
+  })
+
+  it('uses dark-theme surfaces for the purchase table and quantity fields', async () => {
+    themeContext.isDark = true
+    themeContext.theme = DarkTheme
+
+    await act(async () => {
+      render(<GiftSubscriptions />, container)
+    })
+
+    const table = container.querySelector('table')
+    const quantities = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="number"]'))
+
+    expect(table?.classList.contains('GiftPurchaseTable-Dark')).toBe(true)
+    expect(quantities).toHaveLength(GiftedSubscriptionPlans.length)
+    quantities.forEach(quantity => {
+      expect(quantity.classList.contains('bg-themeDarkBlueSecondary')).toBe(true)
+      expect(quantity.classList.contains('text-white')).toBe(true)
     })
   })
 })

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -80,6 +80,7 @@ const DarkTheme: ITheme = {
    * the Signal Teal headers everywhere else. Dark supplies its own opaque value instead.
    */
   profileCardHeader: `card-header bg-profileHeader-dark text-white`,
+  purchaseTable: `GiftPurchaseTable-Dark`,
   reminderHeader: `bg-themeLightBlue`,
   reminderHr: `ReminderHr-Dark`,
   reminderTags: `ReminderTags-Dark`,

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -16,6 +16,7 @@ const LightTheme: ITheme = {
   modalSuccessClass: `btn btn-success`,
   noteBorder: `NoteBorder`,
   profileCardHeader: `card-header bg-profileHeader text-dark`,
+  purchaseTable: `GiftPurchaseTable-Light`,
   reminderHeader: `bg-themeDarkBluePrimary`,
   reminderHr: `ReminderHr`,
   reminderTags: `ReminderTags-Light`,

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -12,6 +12,8 @@ export interface ITheme {
   modalSuccessClass: string
   noteBorder: string
   profileCardHeader: string
+  /** The gift-purchase table's surface, text, and divider treatment. */
+  purchaseTable: string
   reminderHeader: string
   reminderHr: string
   reminderTags: string


### PR DESCRIPTION
## Summary

In dark mode, **Gift a Subscription** no longer appears as a bright white panel against the profile
page. The purchase table and quantity fields now use the established Midnight Slate surface, Paper
text, and Pale Gray dividers while light mode keeps its existing Paper-and-Ink treatment.

The repository's existing Field Manual design context is also persisted for future design tooling;
this records the direction already documented in `DESIGN.md` and does not change runtime behavior.
No rules data, generated files, production configuration, or companion services change.

## Verification

- GitHub Actions `Lint, Test, and Build` — pass
- `yarn lint`
- `yarn tsc --noEmit`
- `yarn build`
- `yarn vitest run src/tests/aos4/giftSubscriptions.test.tsx`
- `yarn data:aos4:verify:beta` — 81,560 pass, 0 findings, 0 cannot-verify
- Manual local CSS render at 390px and 1280px — dark and light palettes matched their theme tokens
  with no horizontal overflow

Direct browser QA of the authenticated `/profile` route required credentials, so the exact
component markup and production stylesheet were exercised in a temporary local preview instead.
