### PR TITLE
perf(deploy): cut steady-state publishing round trips

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,6 +21,7 @@ Every object is uploaded with an explicit `Cache-Control`.
 | Content-hashed | `assets/*`, `sw-extras-<hash>.js`, `workbox-<hash>.js` | `public, max-age=31536000, immutable` |
 | Unhashed public | icons, `favicon.ico`, `robots.txt`, `browserconfig.xml`, `safari-pinned-tab.svg`, `img/*` | `public, max-age=86400` |
 | Mutable entry points | `index.html`, `site.webmanifest`, `service-worker.js`, `registerSW.js` | `public, max-age=0, must-revalidate` |
+| Internal deploy state | `_deploy/retired-immutable-keys.txt` | `no-store` |
 
 The worker imports a content-hashed `sw-extras-<hash>.js`. Its immutable name is part of the
 worker's build identity: overwriting one fixed extras key would let an interrupted deploy change
@@ -107,7 +108,8 @@ historical object. The inventory is only an optimization: when it is absent, the
 the complete bounded S3 inventory, reconstructs the file, and preserves the same one-time
 retirement behavior. An interrupted retirement also recovers safely because the next run checks
 the real tag for every key missing from the inventory before copying it. Invalid inventory entries
-fail closed before public files are uploaded.
+fail closed before public files are uploaded, and keys removed by lifecycle expiration are pruned
+from the inventory on the next release.
 
 The production lifecycle configuration should have this shape:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -101,6 +101,14 @@ immutable files absent from the new build. A file not already retired is self-co
 `retire=true`; that resets its `LastModified` at the transition and starts a full 30-day grace period.
 A file already tagged `retire=true` is untouched, so later deploys cannot extend its window.
 
+The deploy records those already-retired keys in `_deploy/retired-immutable-keys.txt`. Normal
+releases use this deployment-owned inventory to avoid one `GetObjectTagging` request for every
+historical object. The inventory is only an optimization: when it is absent, the deploy rechecks
+the complete bounded S3 inventory, reconstructs the file, and preserves the same one-time
+retirement behavior. An interrupted retirement also recovers safely because the next run checks
+the real tag for every key missing from the inventory before copying it. Invalid inventory entries
+fail closed before public files are uploaded.
+
 The production lifecycle configuration should have this shape:
 
 ```json

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -109,7 +109,9 @@ the complete bounded S3 inventory, reconstructs the file, and preserves the same
 retirement behavior. An interrupted retirement also recovers safely because the next run checks
 the real tag for every key missing from the inventory before copying it. Invalid inventory entries
 fail closed before public files are uploaded, and keys removed by lifecycle expiration are pruned
-from the inventory on the next release.
+from the inventory on the next release. If a rollback makes a retired content hash current again,
+the deploy removes it from the inventory before publishing mutable entry points. This keeps a later
+interruption from leaving stale state that could prevent the object from being retired again.
 
 The production lifecycle configuration should have this shape:
 

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -178,8 +178,6 @@ release_lock() {
   local deploy_status=$?
   local release_status=0
   trap - EXIT
-  [[ -z "$retirement_state_file" ]] || rm -f "$retirement_state_file"
-  [[ -z "$retirement_state_next_file" ]] || rm -f "$retirement_state_next_file"
   if ! aws s3api delete-object \
     --bucket "$SITE_BUCKET" \
     --key "$LOCK_OBJECT_KEY" \
@@ -187,6 +185,8 @@ release_lock() {
     echo "FATAL: failed to release production deploy lock ${DEPLOY_LOCK_ETAG}" >&2
     release_status=1
   fi
+  [[ -z "$retirement_state_file" ]] || rm -f "$retirement_state_file" || true
+  [[ -z "$retirement_state_next_file" ]] || rm -f "$retirement_state_next_file" || true
   if [[ $deploy_status -ne 0 ]]; then
     exit "$deploy_status"
   fi
@@ -224,6 +224,7 @@ is_current_immutable_object() {
 # inventory deliberately falls back to the complete S3 scan below, which bootstraps this cache and
 # also makes deleting the state object a safe recovery operation.
 known_retired_objects=()
+next_retired_objects=()
 if aws s3 cp "${SITE_S3}/${DEPLOY_RETIREMENT_STATE_KEY}" "$retirement_state_file" \
   --only-show-errors 2>/dev/null; then
   while IFS= read -r known_retired || [[ -n "$known_retired" ]]; do
@@ -256,7 +257,12 @@ is_known_retired_object() {
 
 record_retired_object() {
   local candidate="$1"
+  local recorded
   is_known_retired_object "$candidate" || known_retired_objects+=("$candidate")
+  for recorded in ${next_retired_objects[@]+"${next_retired_objects[@]}"}; do
+    [[ "$recorded" == "$candidate" ]] && return 0
+  done
+  next_retired_objects+=("$candidate")
 }
 
 # CloudFront only compresses responses up to ~10 MB, so any script above the threshold ships
@@ -356,7 +362,10 @@ while IFS= read -r remote_immutable; do
     *) continue ;;
   esac
   is_current_immutable_object "$remote_immutable" && continue
-  is_known_retired_object "$remote_immutable" && continue
+  if is_known_retired_object "$remote_immutable"; then
+    record_retired_object "$remote_immutable"
+    continue
+  fi
 
   retire_tag=$(aws s3api get-object-tagging \
     --bucket "$SITE_BUCKET" \
@@ -397,8 +406,8 @@ while IFS= read -r remote_immutable; do
 done < <(printf '%s\n' "$remote_immutable_output" | tr '\t' '\n')
 
 : > "$retirement_state_next_file"
-if [[ ${#known_retired_objects[@]} -gt 0 ]]; then
-  printf '%s\n' "${known_retired_objects[@]}" | LC_ALL=C sort -u > "$retirement_state_next_file"
+if [[ ${#next_retired_objects[@]} -gt 0 ]]; then
+  printf '%s\n' "${next_retired_objects[@]}" | LC_ALL=C sort -u > "$retirement_state_next_file"
 fi
 aws s3 cp "$retirement_state_next_file" "${SITE_S3}/${DEPLOY_RETIREMENT_STATE_KEY}" \
   --cache-control 'no-store' \

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -225,6 +225,7 @@ is_current_immutable_object() {
 # also makes deleting the state object a safe recovery operation.
 known_retired_objects=()
 next_retired_objects=()
+reactivated_retired_object_found=0
 if aws s3 cp "${SITE_S3}/${DEPLOY_RETIREMENT_STATE_KEY}" "$retirement_state_file" \
   --only-show-errors 2>/dev/null; then
   while IFS= read -r known_retired || [[ -n "$known_retired" ]]; do
@@ -241,7 +242,10 @@ if aws s3 cp "${SITE_S3}/${DEPLOY_RETIREMENT_STATE_KEY}" "$retirement_state_file
       *) fail "retirement state contains an unmanaged key: $known_retired" ;;
     esac
     # Publishing a content hash again removes retire=true below. Do not carry stale state forward.
-    is_current_immutable_object "$known_retired" && continue
+    if is_current_immutable_object "$known_retired"; then
+      reactivated_retired_object_found=1
+      continue
+    fi
     known_retired_objects+=("$known_retired")
   done < "$retirement_state_file"
 fi
@@ -263,6 +267,17 @@ record_retired_object() {
     [[ "$recorded" == "$candidate" ]] && return 0
   done
   next_retired_objects+=("$candidate")
+}
+
+write_retirement_state() {
+  : > "$retirement_state_next_file"
+  if [[ $# -gt 0 ]]; then
+    printf '%s\n' "$@" | LC_ALL=C sort -u > "$retirement_state_next_file"
+  fi
+  aws s3 cp "$retirement_state_next_file" "${SITE_S3}/${DEPLOY_RETIREMENT_STATE_KEY}" \
+    --cache-control 'no-store' \
+    --content-type 'text/plain; charset=utf-8' \
+    --only-show-errors
 }
 
 # CloudFront only compresses responses up to ~10 MB, so any script above the threshold ships
@@ -308,6 +323,13 @@ for immutable_key in "${current_immutable_objects[@]}"; do
     --key "$immutable_key" \
     --tagging 'TagSet=[{Key=retire,Value=false}]' >/dev/null
 done
+
+# A rollback can make a previously retired content hash current again. Persist that removal before
+# publishing mutable entry points so a later state-write failure cannot leave the old inventory
+# claiming the now-live object is still retired.
+if [[ $reactivated_retired_object_found -eq 1 ]]; then
+  write_retirement_state ${known_retired_objects[@]+"${known_retired_objects[@]}"}
+fi
 
 # Unhashed public assets carry a query-version buster, not a content hash.
 aws s3 cp "$SITE_BUILD_DIR" "$SITE_S3" \
@@ -405,13 +427,6 @@ while IFS= read -r remote_immutable; do
 # exempt the last listed object from retirement on every deploy.
 done < <(printf '%s\n' "$remote_immutable_output" | tr '\t' '\n')
 
-: > "$retirement_state_next_file"
-if [[ ${#next_retired_objects[@]} -gt 0 ]]; then
-  printf '%s\n' "${next_retired_objects[@]}" | LC_ALL=C sort -u > "$retirement_state_next_file"
-fi
-aws s3 cp "$retirement_state_next_file" "${SITE_S3}/${DEPLOY_RETIREMENT_STATE_KEY}" \
-  --cache-control 'no-store' \
-  --content-type 'text/plain; charset=utf-8' \
-  --only-show-errors
+write_retirement_state ${next_retired_objects[@]+"${next_retired_objects[@]}"}
 
 echo 'Deployed to https://aosreminders.com/'

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -8,6 +8,7 @@ SITE_BUILD_DIR="${SITE_BUILD_DIR:-./dist}"
 CF_DIST_ID="${CF_DIST_ID:-E3OO9Y9QRVZ2L1}"
 DEPLOY_OWNER="${DEPLOY_OWNER:-manual:${USER:-unknown}@${HOSTNAME:-unknown}:$$}"
 DEPLOY_LOCK_KEY="${DEPLOY_LOCK_KEY:-_deploy/production.lock}"
+DEPLOY_RETIREMENT_STATE_KEY="${DEPLOY_RETIREMENT_STATE_KEY:-_deploy/retired-immutable-keys.txt}"
 # CloudFront refuses to compress objects above ~10,000,000 bytes; anything larger must be stored
 # pre-gzipped. Overridable so the contract suite can exercise the path with small fixtures.
 PRECOMPRESS_THRESHOLD_BYTES="${PRECOMPRESS_THRESHOLD_BYTES:-9500000}"
@@ -24,6 +25,10 @@ fail() {
 [[ "$SITE_S3" == s3://* ]] || fail "SITE_S3 must be an s3:// URI"
 [[ "$DEPLOY_OWNER" =~ ^[A-Za-z0-9._:/@+-]+$ ]] ||
   fail "DEPLOY_OWNER contains characters that cannot be stored safely in lock metadata"
+[[ "$DEPLOY_RETIREMENT_STATE_KEY" =~ ^[A-Za-z0-9._/-]+$ &&
+  "$DEPLOY_RETIREMENT_STATE_KEY" != /* &&
+  "$DEPLOY_RETIREMENT_STATE_KEY" != *../* ]] ||
+  fail "DEPLOY_RETIREMENT_STATE_KEY must be a safe relative S3 key"
 command -v aws >/dev/null 2>&1 || fail "aws CLI is required"
 
 site_location="${SITE_S3#s3://}"
@@ -167,10 +172,14 @@ fi
 cleanup_local_lock_files
 trap - EXIT
 
+retirement_state_file=''
+retirement_state_next_file=''
 release_lock() {
   local deploy_status=$?
   local release_status=0
   trap - EXIT
+  [[ -z "$retirement_state_file" ]] || rm -f "$retirement_state_file"
+  [[ -z "$retirement_state_next_file" ]] || rm -f "$retirement_state_next_file"
   if ! aws s3api delete-object \
     --bucket "$SITE_BUCKET" \
     --key "$LOCK_OBJECT_KEY" \
@@ -184,6 +193,8 @@ release_lock() {
   exit "$release_status"
 }
 trap release_lock EXIT
+retirement_state_file=$(mktemp)
+retirement_state_next_file=$(mktemp)
 
 # An indexed array rather than an associative one: macOS ships bash 3.2, so `declare -A` would
 # break the manual deploy in upload.sh. The membership scan below is linear over the build's
@@ -206,6 +217,46 @@ is_current_immutable_object() {
     [[ "$known" == "$candidate" ]] && return 0
   done
   return 1
+}
+
+# Retirement is append-only until a content hash becomes current again. Keep a deployment-owned
+# inventory so normal releases do not re-read the retire tag on every historical object. A missing
+# inventory deliberately falls back to the complete S3 scan below, which bootstraps this cache and
+# also makes deleting the state object a safe recovery operation.
+known_retired_objects=()
+if aws s3 cp "${SITE_S3}/${DEPLOY_RETIREMENT_STATE_KEY}" "$retirement_state_file" \
+  --only-show-errors 2>/dev/null; then
+  while IFS= read -r known_retired || [[ -n "$known_retired" ]]; do
+    [[ -n "$known_retired" ]] || continue
+    [[ -z "$SITE_PREFIX" || "$known_retired" == "$SITE_PREFIX"* ]] ||
+      fail "retirement state contains a key outside the site prefix: $known_retired"
+    relative_retired="${known_retired#"$SITE_PREFIX"}"
+    case "$relative_retired" in
+      assets/*) ;;
+      sw-extras-*.js | workbox-*.js)
+        [[ "$relative_retired" != */* ]] ||
+          fail "retirement state contains an unmanaged key: $known_retired"
+        ;;
+      *) fail "retirement state contains an unmanaged key: $known_retired" ;;
+    esac
+    # Publishing a content hash again removes retire=true below. Do not carry stale state forward.
+    is_current_immutable_object "$known_retired" && continue
+    known_retired_objects+=("$known_retired")
+  done < "$retirement_state_file"
+fi
+
+is_known_retired_object() {
+  local candidate="$1"
+  local known
+  for known in ${known_retired_objects[@]+"${known_retired_objects[@]}"}; do
+    [[ "$known" == "$candidate" ]] && return 0
+  done
+  return 1
+}
+
+record_retired_object() {
+  local candidate="$1"
+  is_known_retired_object "$candidate" || known_retired_objects+=("$candidate")
 }
 
 # CloudFront only compresses responses up to ~10 MB, so any script above the threshold ships
@@ -305,13 +356,17 @@ while IFS= read -r remote_immutable; do
     *) continue ;;
   esac
   is_current_immutable_object "$remote_immutable" && continue
+  is_known_retired_object "$remote_immutable" && continue
 
   retire_tag=$(aws s3api get-object-tagging \
     --bucket "$SITE_BUCKET" \
     --key "$remote_immutable" \
     --query "TagSet[?Key=='retire'].Value | [0]" \
     --output text)
-  [[ "$retire_tag" == 'true' ]] && continue
+  if [[ "$retire_tag" == 'true' ]]; then
+    record_retired_object "$remote_immutable"
+    continue
+  fi
 
   # S3 rejects a self-copy whose only change is tags, so the write needs the REPLACE metadata
   # directive to be legal — and REPLACE drops the object's stored headers unless they are restated.
@@ -336,8 +391,18 @@ while IFS= read -r remote_immutable; do
     ${retire_headers[@]+"${retire_headers[@]}"} \
     --tagging-directive REPLACE \
     --tagging 'retire=true' >/dev/null
+  record_retired_object "$remote_immutable"
 # %s\n, not %s: read never runs its body for a final unterminated line, which would silently
 # exempt the last listed object from retirement on every deploy.
 done < <(printf '%s\n' "$remote_immutable_output" | tr '\t' '\n')
+
+: > "$retirement_state_next_file"
+if [[ ${#known_retired_objects[@]} -gt 0 ]]; then
+  printf '%s\n' "${known_retired_objects[@]}" | LC_ALL=C sort -u > "$retirement_state_next_file"
+fi
+aws s3 cp "$retirement_state_next_file" "${SITE_S3}/${DEPLOY_RETIREMENT_STATE_KEY}" \
+  --cache-control 'no-store' \
+  --content-type 'text/plain; charset=utf-8' \
+  --only-show-errors
 
 echo 'Deployed to https://aosreminders.com/'

--- a/scripts/measureDeploymentPublishing.ts
+++ b/scripts/measureDeploymentPublishing.ts
@@ -1,0 +1,382 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const repoRoot = process.cwd()
+
+const bashPath = (path: string) => {
+  if (process.platform !== 'win32') return path
+
+  const match = path.match(/^([A-Za-z]):\\(.*)$/)
+  if (!match) throw new Error(`Cannot convert ${path} to a WSL path`)
+
+  return `/mnt/${match[1].toLowerCase()}/${match[2].replaceAll('\\', '/')}`
+}
+
+const shellQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`
+const optionValue = (line: string, option: string) => {
+  const match = line.match(new RegExp(`${option.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} ([^ ]+)`))
+  return match?.[1]
+}
+
+const lifecyclePreflightQuery =
+  '[length(Rules), length(Rules[0]), Rules[0].ID, Rules[0].Status,' +
+  ' length(Rules[0].Filter), length(Rules[0].Filter.Tag), Rules[0].Filter.Tag.Key,' +
+  ' Rules[0].Filter.Tag.Value, length(Rules[0].Expiration), Rules[0].Expiration.Days]'
+const cloudFrontPreflightQuery =
+  'DistributionConfig.[DefaultCacheBehavior.MinTTL, DefaultCacheBehavior.DefaultTTL,' +
+  ' DefaultCacheBehavior.MaxTTL, DefaultCacheBehavior.CachePolicyId,' +
+  ' DefaultCacheBehavior.ResponseHeadersPolicyId, CacheBehaviors.Quantity]'
+
+const directory = mkdtempSync(join(tmpdir(), 'aos-reminders-deployment-measurement-'))
+
+try {
+  const buildDirectory = join(directory, 'dist')
+  const fakeBin = join(directory, 'bin')
+  const logPath = join(directory, 'aws.log')
+  const attemptsPath = join(directory, 'lock-attempts')
+  const retiredTagsPath = join(directory, 'retired-tags')
+  const stateObjectPath = join(directory, 'retirement-state-object')
+  mkdirSync(join(buildDirectory, 'assets'), { recursive: true })
+  mkdirSync(fakeBin)
+
+  for (const [path, contents] of [
+    ['assets/current-123.js', 'current'],
+    ['assets/aos4-catalog-data-abc123.js', `const catalogCorpus = ${'"x"'.repeat(64)}`],
+    ['index.html', '<!doctype html>'],
+    ['site.webmanifest', '{}'],
+    ['service-worker.js', 'importScripts("sw-extras-abc123.js")'],
+    ['sw-extras-abc123.js', 'const catalog = true'],
+    ['workbox-abc123.js', 'const workbox = true'],
+    ['favicon.ico', 'icon'],
+  ]) {
+    writeFileSync(join(buildDirectory, path), contents)
+  }
+
+  const alreadyRetiredAssets = Array.from(
+    { length: 120 },
+    (_, index) => `assets/retired-${String(index + 1).padStart(3, '0')}.js`
+  )
+  const newlySuperseded = ['assets/newly-superseded.js', 'sw-extras-old.js', 'workbox-old.js']
+  const currentImmutable = [
+    'assets/current-123.js',
+    'assets/aos4-catalog-data-abc123.js',
+    'sw-extras-abc123.js',
+    'workbox-abc123.js',
+  ]
+  writeFileSync(retiredTagsPath, `${alreadyRetiredAssets.join('\n')}\n`)
+
+  const fakeAws = join(fakeBin, 'aws')
+  writeFileSync(
+    fakeAws,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$AWS_LOG"
+
+option_value() {
+  local wanted="$1"
+  shift
+  while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "$wanted" ]]; then
+      printf '%s' "\${2:-}"
+      return 0
+    fi
+    shift
+  done
+  return 1
+}
+
+require_exact_option() {
+  local contract="$1"
+  local option="$2"
+  local expected="$3"
+  shift 3
+
+  local actual=''
+  local count=0
+  while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "$option" ]]; then
+      count=$((count + 1))
+      actual="\${2:-}"
+      shift 2
+    else
+      shift
+    fi
+  done
+
+  if [[ "$count" -ne 1 || "$actual" != "$expected" ]]; then
+    echo "Unexpected $contract $option argument" >&2
+    exit 64
+  fi
+}
+
+s3_key() {
+  local location="\${1#s3://}"
+  printf '%s' "\${location#*/}"
+}
+
+remove_retired_key() {
+  local key="$1"
+  local next_tags="\${AWS_RETIRED_TAGS}.next"
+  grep -Fvx "$key" "$AWS_RETIRED_TAGS" > "$next_tags" || true
+  mv "$next_tags" "$AWS_RETIRED_TAGS"
+}
+
+append_retired_key() {
+  local key="$1"
+  grep -Fqx "$key" "$AWS_RETIRED_TAGS" 2>/dev/null || printf '%s\\n' "$key" >> "$AWS_RETIRED_TAGS"
+}
+
+if [[ "$1 $2" == "s3api put-object" && "$*" == *"--if-none-match *"* ]]; then
+  attempts=0
+  [[ -f "$AWS_LOCK_ATTEMPTS" ]] && attempts=$(cat "$AWS_LOCK_ATTEMPTS")
+  attempts=$((attempts + 1))
+  printf '%s' "$attempts" > "$AWS_LOCK_ATTEMPTS"
+  echo '"acquired-etag"'
+  exit 0
+fi
+
+if [[ "$1 $2" == "s3api get-bucket-lifecycle-configuration" ]]; then
+  require_exact_option 'lifecycle preflight' '--query' ${shellQuote(lifecyclePreflightQuery)} "$@"
+  require_exact_option 'lifecycle preflight' '--output' 'text' "$@"
+  printf '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' \\
+    '1' '4' 'retire-superseded-assets' 'Enabled' '1' '2' 'retire' 'true' '1' '30'
+  exit 0
+fi
+
+if [[ "$1 $2" == "cloudfront get-distribution-config" ]]; then
+  require_exact_option 'CloudFront preflight' '--query' ${shellQuote(cloudFrontPreflightQuery)} "$@"
+  require_exact_option 'CloudFront preflight' '--output' 'text' "$@"
+  printf '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' '0' '86400' '31536000' 'None' 'None' '0'
+  exit 0
+fi
+
+if [[ "$1 $2" == "s3api list-objects-v2" ]]; then
+  if [[ "$*" == *"--prefix assets/"* ]]; then
+    printf '%s\\n' "$AWS_REMOTE_ASSET_KEYS"
+  elif [[ "$*" == *"--prefix sw-extras-"* ]]; then
+    printf '%s\\n' "$AWS_REMOTE_EXTRAS_KEYS"
+  elif [[ "$*" == *"--prefix workbox-"* ]]; then
+    printf '%s\\n' "$AWS_REMOTE_WORKBOX_KEYS"
+  else
+    echo 'Unexpected list prefix' >&2
+    exit 65
+  fi
+  exit 0
+fi
+
+if [[ "$1 $2" == "s3api get-object-tagging" ]]; then
+  key=$(option_value '--key' "$@")
+  if grep -Fqx "$key" "$AWS_RETIRED_TAGS"; then
+    echo 'true'
+  else
+    echo 'false'
+  fi
+  exit 0
+fi
+
+if [[ "$1 $2" == "s3api put-object-tagging" ]]; then
+  key=$(option_value '--key' "$@")
+  if [[ "$*" == *"Value=false"* ]]; then
+    remove_retired_key "$key"
+    exit 0
+  fi
+  echo 'Only retire=false object tagging is accepted by this benchmark' >&2
+  exit 65
+fi
+
+if [[ "$1 $2" == "s3api head-object" && "$*" == *"CacheControl"* ]]; then
+  printf '%s\\t%s\\n' 'public, max-age=31536000, immutable' 'text/javascript; charset=utf-8'
+  exit 0
+fi
+
+if [[ "$1 $2" == "s3api copy-object" ]]; then
+  [[ "$*" == *"--metadata-directive REPLACE"* ]] || exit 66
+  [[ "$*" == *"--tagging retire=true"* ]] || exit 66
+  key=$(option_value '--key' "$@")
+  append_retired_key "$key"
+  exit 0
+fi
+
+if [[ "$1 $2" == "s3 cp" ]]; then
+  source_path="$3"
+  destination="$4"
+
+  if [[ "$source_path" == s3://* ]]; then
+    key=$(s3_key "$source_path")
+    if [[ "$key" == "$AWS_STATE_KEY" && -f "$AWS_STATE_OBJECT" ]]; then
+      cp "$AWS_STATE_OBJECT" "$destination"
+      exit 0
+    fi
+    echo 'NoSuchKey' >&2
+    exit 44
+  fi
+
+  [[ -e "$source_path" ]] || {
+    echo "The user-provided path $source_path does not exist." >&2
+    exit 255
+  }
+
+  if [[ "$destination" == s3://* ]]; then
+    destination_key=$(s3_key "$destination")
+    if [[ "$destination_key" == "$AWS_STATE_KEY" ]]; then
+      cp "$source_path" "$AWS_STATE_OBJECT"
+      exit 0
+    fi
+
+    if [[ "$*" == *"--recursive"* ]]; then
+      while IFS= read -r -d '' uploaded_file; do
+        relative_file="\${uploaded_file#"\${source_path%/}/"}"
+        remove_retired_key "\${destination_key%/}/$relative_file"
+      done < <(find "$source_path" -type f -print0)
+    else
+      remove_retired_key "$destination_key"
+    fi
+    exit 0
+  fi
+fi
+
+if [[ "$1 $2" == "s3api delete-object" || "$1 $2" == "cloudfront create-invalidation" ]]; then
+  exit 0
+fi
+
+echo "Unsupported fake AWS call: $*" >&2
+exit 65
+`,
+    'utf8'
+  )
+  chmodSync(fakeAws, 0o755)
+
+  const assetKeys = [currentImmutable[0], currentImmutable[1], newlySuperseded[0], ...alreadyRetiredAssets]
+  const baseEnvironment = {
+    AWS_LOCK_ATTEMPTS: bashPath(attemptsPath),
+    AWS_LOG: bashPath(logPath),
+    AWS_REMOTE_ASSET_KEYS: assetKeys.join('\t'),
+    AWS_REMOTE_EXTRAS_KEYS: `${currentImmutable[2]}\t${newlySuperseded[1]}`,
+    AWS_REMOTE_WORKBOX_KEYS: `${currentImmutable[3]}\t${newlySuperseded[2]}`,
+    AWS_RETIRED_TAGS: bashPath(retiredTagsPath),
+    AWS_STATE_KEY: '_deploy/retired-immutable-keys.txt',
+    AWS_STATE_OBJECT: bashPath(stateObjectPath),
+    CF_DIST_ID: 'distribution-id',
+    DEPLOY_OWNER: 'deployment-measurement',
+    PRECOMPRESS_THRESHOLD_BYTES: '100',
+    SITE_BUILD_DIR: bashPath(buildDirectory),
+    SITE_S3: 's3://test-bucket',
+  }
+  const assignments = Object.entries(baseEnvironment)
+    .map(([key, value]) => `${key}=${shellQuote(value)}`)
+    .join(' ')
+  const fakeBinPath = bashPath(fakeBin)
+  const run = () =>
+    spawnSync(
+      'bash',
+      [
+        '-c',
+        `chmod +x ${shellQuote(`${fakeBinPath}/aws`)}; ` +
+          `PATH=${shellQuote(fakeBinPath)}:/usr/local/bin:/usr/bin:/bin ${assignments} ` +
+          'bash scripts/deploy-production.sh',
+      ],
+      { cwd: repoRoot, encoding: 'utf8' }
+    )
+  const readLog = () =>
+    existsSync(logPath) && readFileSync(logPath, 'utf8').trim()
+      ? readFileSync(logPath, 'utf8').trim().split('\n')
+      : []
+
+  const warmResult = run()
+  const warmLog = readLog()
+  writeFileSync(logPath, '')
+  writeFileSync(attemptsPath, '0')
+
+  const measuredStart = performance.now()
+  const measuredResult = run()
+  const measuredWallMs = performance.now() - measuredStart
+  const measuredLog = readLog()
+  const combinedLog = [...warmLog, ...measuredLog]
+
+  const assetUpload = measuredLog.findIndex(line => line.startsWith('s3 cp ') && line.includes('/assets'))
+  const extrasUpload = measuredLog.findIndex(
+    line => line.startsWith('s3 cp ') && line.includes('sw-extras-abc123.js')
+  )
+  const indexUpload = measuredLog.findIndex(line => line.startsWith('s3 cp ') && line.includes('/index.html'))
+  const workerUpload = measuredLog.findIndex(
+    line => line.startsWith('s3 cp ') && line.includes('/service-worker.js')
+  )
+  const publicWritesAfterWorker = measuredLog
+    .slice(workerUpload + 1)
+    .filter(
+      line =>
+        line.startsWith('s3 cp ') && !line.includes('s3://test-bucket/_deploy/retired-immutable-keys.txt')
+    )
+  const publicationOrderValid =
+    assetUpload >= 0 &&
+    extrasUpload > assetUpload &&
+    indexUpload > extrasUpload &&
+    workerUpload > indexUpload &&
+    publicWritesAfterWorker.length === 0
+
+  const copiesFor = (key: string) =>
+    combinedLog.filter(line => line.startsWith('s3api copy-object ') && optionValue(line, '--key') === key)
+  const liveImmutableRetired = currentImmutable.reduce((total, key) => total + copiesFor(key).length, 0)
+  const newlyRetiredExactlyOnce = newlySuperseded.every(key => copiesFor(key).length === 1)
+  const oldRetirementUntouched = alreadyRetiredAssets.every(key => copiesFor(key).length === 0)
+  const retirementCopiesKeepMetadata = combinedLog
+    .filter(line => line.startsWith('s3api copy-object '))
+    .every(
+      line =>
+        line.includes('--metadata-directive REPLACE') &&
+        line.includes('public, max-age=31536000, immutable') &&
+        line.includes('text/javascript; charset=utf-8')
+    )
+  const retirementContractValid =
+    newlyRetiredExactlyOnce && oldRetirementUntouched && retirementCopiesKeepMetadata
+
+  const lockAcquisitions = combinedLog.filter(
+    line => line.startsWith('s3api put-object ') && line.includes('--if-none-match *')
+  )
+  const lockReleases = combinedLog.filter(
+    line => line.startsWith('s3api delete-object ') && line.includes('--if-match "acquired-etag"')
+  )
+  const lockContractValid = lockAcquisitions.length === 2 && lockReleases.length === 2
+
+  const isReadCall = (line: string) =>
+    line.startsWith('s3api get-') ||
+    line.startsWith('s3api head-') ||
+    line.startsWith('s3api list-') ||
+    line.startsWith('cloudfront get-') ||
+    (line.startsWith('s3 cp s3://') && !line.includes(' s3://', 6))
+  const awsReadCalls = measuredLog.filter(isReadCall).length
+  const currentTaggingCalls = measuredLog.filter(
+    line => line.startsWith('s3api put-object-tagging ') && line.includes('Value=false')
+  ).length
+  const retirementMetadataReads = measuredLog.filter(
+    line => line.startsWith('s3api head-object ') && line.includes('CacheControl')
+  ).length
+  const immutableUploads = measuredLog.filter(
+    line =>
+      line.startsWith('s3 cp ') &&
+      (line.includes('s3://test-bucket/assets') ||
+        line.includes('s3://test-bucket/sw-extras-') ||
+        line.includes('s3://test-bucket/workbox-'))
+  ).length
+
+  const metrics = {
+    aws_cli_calls: measuredLog.length,
+    publish_succeeded: warmResult.status === 0 && measuredResult.status === 0 ? 1 : 0,
+    publication_order_valid: publicationOrderValid ? 1 : 0,
+    live_immutable_retired: liveImmutableRetired,
+    retirement_contract_valid: retirementContractValid ? 1 : 0,
+    lock_contract_valid: lockContractValid ? 1 : 0,
+    aws_read_calls: awsReadCalls,
+    aws_write_calls: measuredLog.length - awsReadCalls,
+    current_tagging_calls: currentTaggingCalls,
+    retirement_metadata_reads: retirementMetadataReads,
+    immutable_uploads: immutableUploads,
+    measured_wall_ms: Math.round(measuredWallMs * 100) / 100,
+  }
+
+  console.log(JSON.stringify(metrics))
+} finally {
+  rmSync(directory, { recursive: true, force: true })
+}

--- a/src/tests/deploymentContract.test.ts
+++ b/src/tests/deploymentContract.test.ts
@@ -189,6 +189,10 @@ if [[ "$1 $2" == "s3 cp" && "$3" == s3://*/_deploy/retired-immutable-keys.txt ]]
 fi
 
 if [[ "$1 $2" == "s3 cp" && "$4" == s3://*/_deploy/retired-immutable-keys.txt ]]; then
+  if [[ "\${AWS_FAIL_RETIREMENT_STATE_UPLOAD:-0}" == "1" ]]; then
+    echo 'Injected retirement state upload failure' >&2
+    exit 42
+  fi
   cp "$3" "$AWS_RETIREMENT_STATE"
   exit 0
 fi
@@ -430,6 +434,23 @@ echo '{}'
     expect(result.stderr).toMatch(/retirement state/i)
     const log = harness.log()
     expect(log.some(line => line.includes('/assets --recursive'))).toBe(false)
+    expect(
+      log.some(line => line.startsWith('s3api delete-object ') && line.includes('--if-match "acquired-etag"'))
+    ).toBe(true)
+  })
+
+  it('persists a reactivated key removal before publishing mutable entry points', () => {
+    const harness = createHarness()
+    writeFileSync(harness.retirementStatePath, 'assets/current-123.js\nassets/already-retired.js\n')
+
+    const result = harness.run({ AWS_FAIL_RETIREMENT_STATE_UPLOAD: '1' })
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toMatch(/retirement state upload failure/i)
+    const log = harness.log()
+    expect(log.some(line => line.includes('/assets --recursive'))).toBe(true)
+    expect(log.some(line => line.includes('/index.html'))).toBe(false)
+    expect(log.some(line => line.includes('/service-worker.js'))).toBe(false)
     expect(
       log.some(line => line.startsWith('s3api delete-object ') && line.includes('--if-match "acquired-etag"'))
     ).toBe(true)

--- a/src/tests/deploymentContract.test.ts
+++ b/src/tests/deploymentContract.test.ts
@@ -394,6 +394,10 @@ echo '{}'
     const firstResult = harness.run()
     expect(firstResult.status, firstResult.stderr).toBe(0)
     const firstLogLength = harness.log().length
+    writeFileSync(
+      harness.retirementStatePath,
+      `${readFileSync(harness.retirementStatePath, 'utf8')}assets/expired-and-removed.js\n`
+    )
 
     const secondResult = harness.run()
     expect(secondResult.status, secondResult.stderr).toBe(0)
@@ -413,6 +417,7 @@ echo '{}'
       )
     ).toHaveLength(4)
     expect(readFileSync(harness.retirementStatePath, 'utf8')).toContain('assets/newly-superseded.js')
+    expect(readFileSync(harness.retirementStatePath, 'utf8')).not.toContain('assets/expired-and-removed.js')
   })
 
   it('fails closed before publication when the retired-key inventory contains an unmanaged key', () => {

--- a/src/tests/deploymentContract.test.ts
+++ b/src/tests/deploymentContract.test.ts
@@ -42,6 +42,7 @@ describe('production deployment contract', () => {
     const fakeBin = join(directory, 'bin')
     const logPath = join(directory, 'aws.log')
     const attemptsPath = join(directory, 'lock-attempts')
+    const retirementStatePath = join(directory, 'retired-immutable-keys.txt')
     mkdirSync(join(buildDirectory, 'assets'), { recursive: true })
     mkdirSync(fakeBin)
 
@@ -178,6 +179,20 @@ if [[ "$1 $2" == "s3api list-objects-v2" ]]; then
   exit 0
 fi
 
+if [[ "$1 $2" == "s3 cp" && "$3" == s3://*/_deploy/retired-immutable-keys.txt ]]; then
+  if [[ ! -f "$AWS_RETIREMENT_STATE" ]]; then
+    echo 'NoSuchKey' >&2
+    exit 254
+  fi
+  cp "$AWS_RETIREMENT_STATE" "$4"
+  exit 0
+fi
+
+if [[ "$1 $2" == "s3 cp" && "$4" == s3://*/_deploy/retired-immutable-keys.txt ]]; then
+  cp "$3" "$AWS_RETIREMENT_STATE"
+  exit 0
+fi
+
 # The real CLI validates local cp sources before any request; a phantom build artifact in the
 # script must fail here exactly as it would in production.
 if [[ "$1 $2" == "s3 cp" && "$3" != s3://* && ! -e "$3" ]]; then
@@ -209,6 +224,7 @@ echo '{}'
         // A retirement-eligible key deliberately sits last: an unterminated final line from the
         // key listing must still be processed, or the last object silently escapes retirement.
         AWS_REMOTE_WORKBOX_KEYS: 'workbox-abc123.js\tworkbox-already-retired.js\tworkbox-old.js',
+        AWS_RETIREMENT_STATE: bashPath(retirementStatePath),
         CF_DIST_ID: 'distribution-id',
         DEPLOY_OWNER: 'deployment-test',
         PRECOMPRESS_THRESHOLD_BYTES: '100',
@@ -237,6 +253,7 @@ echo '{}'
         existsSync(logPath) && readFileSync(logPath, 'utf8').trim()
           ? readFileSync(logPath, 'utf8').trim().split('\n')
           : [],
+      retirementStatePath,
       run,
     }
   }
@@ -298,7 +315,11 @@ echo '{}'
     expect(log[extrasUpload]).toContain('public, max-age=31536000, immutable')
     expect(indexUpload).toBeGreaterThan(extrasUpload)
     expect(workerUpload).toBeGreaterThan(indexUpload)
-    expect(log.slice(workerUpload + 1).some(line => line.startsWith('s3 cp '))).toBe(false)
+    expect(
+      log
+        .slice(workerUpload + 1)
+        .some(line => line.startsWith('s3 cp ') && !line.includes('_deploy/retired-immutable-keys.txt'))
+    ).toBe(false)
     expect(
       log.some(line => line.startsWith('s3api delete-object ') && line.includes('--if-match "acquired-etag"'))
     ).toBe(true)
@@ -366,6 +387,47 @@ echo '{}'
         expect(line).toContain('public, max-age=31536000, immutable')
         expect(line).toContain('text/javascript; charset=utf-8')
       })
+  })
+
+  it('reuses the retired-key inventory instead of re-reading every historical object tag', () => {
+    const harness = createHarness()
+    const firstResult = harness.run()
+    expect(firstResult.status, firstResult.stderr).toBe(0)
+    const firstLogLength = harness.log().length
+
+    const secondResult = harness.run()
+    expect(secondResult.status, secondResult.stderr).toBe(0)
+    const secondLog = harness.log().slice(firstLogLength)
+
+    expect(
+      secondLog.some(
+        line =>
+          line.startsWith('s3 cp s3://test-bucket/_deploy/retired-immutable-keys.txt ') &&
+          line.includes('--only-show-errors')
+      )
+    ).toBe(true)
+    expect(secondLog.some(line => line.startsWith('s3api get-object-tagging '))).toBe(false)
+    expect(
+      secondLog.filter(
+        line => line.startsWith('s3api put-object-tagging ') && line.includes('retire,Value=false')
+      )
+    ).toHaveLength(4)
+    expect(readFileSync(harness.retirementStatePath, 'utf8')).toContain('assets/newly-superseded.js')
+  })
+
+  it('fails closed before publication when the retired-key inventory contains an unmanaged key', () => {
+    const harness = createHarness()
+    writeFileSync(harness.retirementStatePath, 'index.html\n')
+
+    const result = harness.run()
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toMatch(/retirement state/i)
+    const log = harness.log()
+    expect(log.some(line => line.includes('/assets --recursive'))).toBe(false)
+    expect(
+      log.some(line => line.startsWith('s3api delete-object ') && line.includes('--if-match "acquired-etag"'))
+    ).toBe(true)
   })
 
   it('stores oversized scripts gzipped so CloudFront size limits cannot ship them raw', () => {


### PR DESCRIPTION
## Summary

Steady-state production publishes no longer spend one AWS request per historical immutable asset. A disposable retirement inventory cuts measured AWS CLI calls by 84.6% while preserving the deployment lock, immutable-first publication, service-worker-last release, and one-time 30-day retirement contract.

| Metric | Before | After |
|---|---:|---:|
| AWS CLI calls | 143 | 22 |
| AWS read calls | 128 | 6 |
| Current immutable tag writes | 4 | 4 |

The first deploy after merge, or after the state object is deleted, performs the full bounded S3 scan and reconstructs the inventory. Expired keys are pruned on later releases. A rollback that reactivates a retired content hash removes that stale entry before mutable entry points are published, so an interrupted follow-up cannot prevent future retirement.

Related: #1869

## Production impact

The first successful production publish writes `_deploy/retired-immutable-keys.txt` with `Cache-Control: no-store`. No lifecycle or CloudFront configuration change is required, and no companion service is involved. This branch did not access or mutate live AWS; the deployment contract was exercised against the strict local AWS model.

No AoS 4 generated files, accepted inputs, rules sources, or effective dates changed.

## Verification

- Deployment benchmark: 143 -> 22 AWS CLI calls; all publication-order, retirement, current-object, and lock gates pass
- `bash -n scripts/deploy-production.sh`
- `yarn vitest run src/tests/deploymentContract.test.ts src/tests/deploymentConfig.test.ts` (31 tests)
- `yarn lint`
- `yarn tsc --noEmit`
- `yarn build`
- `yarn test --run` (1,441 tests)
- `yarn data:aos4:verify:beta` (81,560 pass; 0 findings; 0 cannot-verify)

Known coverage gap: the new state protocol is verified by the deterministic fake-AWS contract and benchmark, not by a live production deployment.
