### PR TITLE
perf(release): parallelize independent preparation gates

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,9 +4,12 @@ The production site is static files in the `aosreminders.com` S3 bucket, served 
 distribution `E3OO9Y9QRVZ2L1`.
 
 `scripts/prepare-production-release.sh` is the only production preparation contract. It validates
-the API configuration, lints, verifies the accepted AoS 4 beta corpus, type-checks, builds, tests,
-and inspects the artifact. `scripts/deploy-production.sh` is the only AWS publication contract.
-Three entry points install dependencies, run the shared preparation contract, then publish:
+the API configuration, lints, verifies the accepted AoS 4 beta corpus, type-checks and builds,
+tests, and inspects the artifact. The independent lint, beta-verification, and build gates run
+concurrently; the build's leading TypeScript compile is the single type-check. Tests and artifact
+inspection begin only after that phase completes, so the PWA tests always read a complete `dist/`
+tree. `scripts/deploy-production.sh` is the only AWS publication contract. Three entry points
+install dependencies, run the shared preparation contract, then publish:
 
 - `upload.sh` - manual deploy from a workstation
 - `CI-build.sh` - standalone CI deploy

--- a/scripts/prepare-production-release.sh
+++ b/scripts/prepare-production-release.sh
@@ -3,9 +3,29 @@
 set -euo pipefail
 
 yarn release:validate-config
-yarn lint
-yarn data:aos4:verify:beta
-yarn tsc --noEmit
-yarn build
-yarn test --run
-yarn release:inspect-artifact
+
+# These gates have no shared outputs. The build already begins with tsc, so a separate typecheck
+# would only compile the same revision twice.
+yarn lint &
+lint_pid=$!
+yarn data:aos4:verify:beta &
+beta_pid=$!
+yarn build &
+build_pid=$!
+
+gate_status=0
+wait "$lint_pid" || gate_status=1
+wait "$beta_pid" || gate_status=1
+wait "$build_pid" || gate_status=1
+[[ $gate_status -eq 0 ]] || exit "$gate_status"
+
+# Both consumers read the completed dist tree without mutating it.
+yarn test --run &
+test_pid=$!
+yarn release:inspect-artifact &
+inspection_pid=$!
+
+gate_status=0
+wait "$test_pid" || gate_status=1
+wait "$inspection_pid" || gate_status=1
+exit "$gate_status"

--- a/src/tests/deploymentConfig.test.ts
+++ b/src/tests/deploymentConfig.test.ts
@@ -1,6 +1,7 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
 import { inspectDeploymentArtifact, validateDeploymentEndpoints } from '../../scripts/deploymentConfig'
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -8,6 +9,16 @@ const validEndpoints = {
   armyApiUrl: 'https://army123.execute-api.us-east-1.amazonaws.com',
   subscriptionApiUrl: 'https://subs123.execute-api.us-east-1.amazonaws.com',
 }
+
+const bashPath = (path: string) => {
+  if (process.platform !== 'win32') return path
+
+  const match = path.match(/^([A-Za-z]):\\(.*)$/)
+  if (!match) throw new Error(`Cannot convert ${path} to a WSL path`)
+
+  return `/mnt/${match[1].toLowerCase()}/${match[2].replaceAll('\\', '/')}`
+}
+const shellQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`
 
 describe('production deployment configuration', () => {
   const temporaryDirectories: string[] = []
@@ -58,29 +69,91 @@ describe('production deployment configuration', () => {
   })
 
   it('defines one fail-closed release preparation contract', () => {
-    const preparation = readFileSync(
-      join(process.cwd(), 'scripts', 'prepare-production-release.sh'),
-      'utf8'
-    )
+    const preparation = readFileSync(join(process.cwd(), 'scripts', 'prepare-production-release.sh'), 'utf8')
 
     expect(preparation).toMatch(/set -euo pipefail/)
-    let previousCommandIndex = -1
     for (const command of [
       'yarn release:validate-config',
       'yarn lint',
       'yarn data:aos4:verify:beta',
-      'yarn tsc --noEmit',
       'yarn build',
       'yarn test --run',
       'yarn release:inspect-artifact',
     ]) {
-      const commandIndex = preparation.indexOf(command)
-      expect(commandIndex, `${command} is present`).toBeGreaterThan(-1)
-      expect(commandIndex, `${command} follows the previous release gate`).toBeGreaterThan(
-        previousCommandIndex
-      )
-      previousCommandIndex = commandIndex
+      expect(preparation, `${command} is present`).toContain(command)
     }
+    expect(preparation).not.toContain('yarn tsc --noEmit')
+  })
+
+  it('parallelizes independent release gates without testing an incomplete build', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'aos-reminders-release-preparation-'))
+    temporaryDirectories.push(directory)
+    const fakeBin = join(directory, 'bin')
+    const logPath = join(directory, 'gates.log')
+    mkdirSync(fakeBin)
+
+    const fakeYarn = join(fakeBin, 'yarn')
+    writeFileSync(
+      fakeYarn,
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf 'start:%s\\n' "$*" >> "$RELEASE_GATE_LOG"
+if [[ "\${RELEASE_FAIL_GATE:-}" == "$*" ]]; then
+  exit 23
+fi
+case "$*" in
+  'lint' | 'data:aos4:verify:beta' | 'build' | 'test --run' | 'release:inspect-artifact') sleep 1 ;;
+esac
+printf 'end:%s\\n' "$*" >> "$RELEASE_GATE_LOG"
+`,
+      'utf8'
+    )
+    chmodSync(fakeYarn, 0o755)
+
+    const fakeBinPath = bashPath(fakeBin)
+    const result = spawnSync(
+      'bash',
+      [
+        '-c',
+        `chmod +x ${shellQuote(`${fakeBinPath}/yarn`)}; ` +
+          `PATH=${shellQuote(fakeBinPath)}:/usr/local/bin:/usr/bin:/bin ` +
+          `RELEASE_GATE_LOG=${shellQuote(bashPath(logPath))} bash scripts/prepare-production-release.sh`,
+      ],
+      { cwd: process.cwd(), encoding: 'utf8' }
+    )
+
+    expect(result.status, result.stderr).toBe(0)
+    const log = readFileSync(logPath, 'utf8').trim().split('\n')
+    expect(log.slice(0, 2)).toEqual(['start:release:validate-config', 'end:release:validate-config'])
+
+    const phaseOne = ['lint', 'data:aos4:verify:beta', 'build']
+    const firstPhaseOneEnd = Math.min(...phaseOne.map(gate => log.indexOf(`end:${gate}`)))
+    expect(phaseOne.every(gate => log.indexOf(`start:${gate}`) < firstPhaseOneEnd)).toBe(true)
+
+    const lastPhaseOneEnd = Math.max(...phaseOne.map(gate => log.indexOf(`end:${gate}`)))
+    const phaseTwo = ['test --run', 'release:inspect-artifact']
+    expect(phaseTwo.every(gate => log.indexOf(`start:${gate}`) > lastPhaseOneEnd)).toBe(true)
+    const firstPhaseTwoEnd = Math.min(...phaseTwo.map(gate => log.indexOf(`end:${gate}`)))
+    expect(phaseTwo.every(gate => log.indexOf(`start:${gate}`) < firstPhaseTwoEnd)).toBe(true)
+
+    writeFileSync(logPath, '', 'utf8')
+    const failure = spawnSync(
+      'bash',
+      [
+        '-c',
+        `chmod +x ${shellQuote(`${fakeBinPath}/yarn`)}; ` +
+          `PATH=${shellQuote(fakeBinPath)}:/usr/local/bin:/usr/bin:/bin ` +
+          `RELEASE_GATE_LOG=${shellQuote(bashPath(logPath))} ` +
+          `RELEASE_FAIL_GATE=${shellQuote('data:aos4:verify:beta')} ` +
+          `bash scripts/prepare-production-release.sh`,
+      ],
+      { cwd: process.cwd(), encoding: 'utf8' }
+    )
+    expect(failure.status).not.toBe(0)
+    const failureLog = readFileSync(logPath, 'utf8')
+    expect(failureLog).toContain('start:data:aos4:verify:beta')
+    expect(failureLog).not.toContain('start:test --run')
+    expect(failureLog).not.toContain('start:release:inspect-artifact')
   })
 
   it('runs release preparation before publication from every production entry point', () => {
@@ -99,12 +172,8 @@ describe('production deployment configuration', () => {
       expect(installationIndex, `${entryPoint} installs dependencies`).toBeGreaterThan(-1)
       expect(preparationIndex, `${entryPoint} prepares the release`).toBeGreaterThan(-1)
       expect(publicationIndex, `${entryPoint} publishes the release`).toBeGreaterThan(-1)
-      expect(installationIndex, `${entryPoint} installs before preparation`).toBeLessThan(
-        preparationIndex
-      )
-      expect(preparationIndex, `${entryPoint} prepares before publication`).toBeLessThan(
-        publicationIndex
-      )
+      expect(installationIndex, `${entryPoint} installs before preparation`).toBeLessThan(preparationIndex)
+      expect(preparationIndex, `${entryPoint} prepares before publication`).toBeLessThan(publicationIndex)
     }
   })
 


### PR DESCRIPTION
## Summary

- run lint, accepted-corpus verification, and the production build concurrently after endpoint validation
- use the build's leading `tsc` invocation as the single TypeScript gate instead of compiling twice
- run the full test suite and artifact inspection concurrently only after the build completes
- preserve fail-closed behavior and add a behavioral contract test for phase ordering and failures

## Timing

The previous release contract serialized every gate and compiled TypeScript twice. Using the
individually measured native stages, its critical path was about 104 seconds. The new schedule's
critical path is about 76 seconds, a projected 28% reduction on that machine.

The complete optimized contract also passed under Node 22 in the slower WSL-on-NTFS verification
environment in 254 seconds. Absolute duration varies by runner; the phase relationship is covered
by a deterministic behavioral test.

## Verification

- `bash -n scripts/prepare-production-release.sh`
- `yarn vitest run src/tests/deploymentConfig.test.ts`
- full `scripts/prepare-production-release.sh` contract with production-shaped API endpoints
  - lint passed
  - accepted AoS 4 beta verification passed: 81,920 checks
  - TypeScript and production build passed
  - complete test suite passed
  - deployment artifact inspection passed

Related to #1869.
