### PR TITLE
fix(data): confirm the artifact store bucket before transferring blobs

### DIFF
--- a/docs/data/aos4-maintenance.md
+++ b/docs/data/aos4-maintenance.md
@@ -420,17 +420,20 @@ Offline replay fails when any checksum-addressed cache entry is missing or corru
 
 ### Restore the private immutable artifact cache
 
-Repeated refreshes should not download bytes that are already pinned by checksum. Configure a
-dedicated private S3 bucket or prefix, authenticate the AWS CLI with least-privilege `GetObject`
-and `PutObject` access, and set:
+Repeated refreshes should not download bytes that are already pinned by checksum. The store is
+provisioned as `aos-reminders-aos4-artifact-cache` in `us-east-1` under the `aos4-artifacts`
+prefix. Authenticate the AWS CLI with least-privilege `GetObject` and `PutObject` access, and set:
 
 ```powershell
-$env:AOS4_ARTIFACT_STORE_BUCKET = '<private-bucket>'
+$env:AOS4_ARTIFACT_STORE_BUCKET = 'aos-reminders-aos4-artifact-cache'
 $env:AOS4_ARTIFACT_STORE_EXPECTED_OWNER = '<12-digit-aws-account-id>'
-$env:AOS4_ARTIFACT_STORE_PREFIX = 'aos4-artifacts' # optional
+$env:AOS4_ARTIFACT_STORE_PREFIX = 'aos4-artifacts'
+$env:AWS_REGION = 'us-east-1'
 $env:AWS_PROFILE = '<profile>'                     # optional
-$env:AWS_REGION = '<region>'                       # or AWS_DEFAULT_REGION
 ```
+
+These are per-shell and do not persist. A shell without them falls back to the local cache alone,
+which is why a bare `cache:pull` reports that the bucket is required rather than doing nothing.
 
 Restore or seed the bytes pinned by a reviewed manifest:
 
@@ -452,11 +455,22 @@ before an atomic local publish. Push verifies local bytes and uses a create-only
 so an existing checksum key is never silently replaced. A corrupt local or private object blocks
 the command.
 
-The bucket is operational infrastructure, not provisioned or seeded by this repository. Enable S3
-Block Public Access, require the expected owner, retain checksum objects with an appropriate
-lifecycle policy, and do not put credentials, pre-signed URLs, or bucket inventory in logs or PRs.
-To test recovery, pull into a new temporary cache with `--cache <temporary-directory>`, replay the
-accepted manifest offline from that cache, then remove only that verified temporary directory.
+Both commands confirm the bucket with `head-bucket` before transferring anything. S3 answers
+`head-object` with a bare 404 when a bucket is missing or inaccessible — it will not say
+`NoSuchBucket`, because that would leak whether a bucket the caller cannot reach exists. Without
+the preflight a typo'd bucket, a wrong `--expected-owner`, or an unprovisioned store all reported
+as `Remote artifact <sha256> is missing`, pointing at the manifest instead of the configuration.
+A pull whose local cache already satisfies the manifest still contacts nothing.
+
+The bucket is operational infrastructure, not provisioned or seeded by this repository. It is
+configured with S3 Block Public Access on all four settings, `BucketOwnerEnforced` ownership,
+default SSE-S3 encryption with a bucket key, and a bucket policy denying both non-TLS requests and
+principals outside the owner account. Its lifecycle rule aborts incomplete multipart uploads after
+seven days and expires nothing — pinned checksum objects are retained indefinitely, since deleting
+one makes every manifest that names it unreplayable. Do not put credentials, pre-signed URLs, or
+bucket inventory in logs or PRs. To test recovery, pull into a new temporary cache with
+`--cache <temporary-directory>`, replay the accepted manifest offline from that cache, then remove
+only that verified temporary directory.
 
 Incremental certification overlays are also immutable dependency chains. Retain every certification
 directory named by a current descendant's `reuseSource`; deleting or relocating one makes the

--- a/src/aos4/data/artifactStore.ts
+++ b/src/aos4/data/artifactStore.ts
@@ -21,6 +21,7 @@ export type ArtifactStoreErrorCode =
   | 'remote-corrupt'
   | 'remote-conflict'
   | 'remote-command-failed'
+  | 'remote-unreachable'
   | 'local-missing'
   | 'local-corrupt'
 
@@ -44,6 +45,14 @@ export interface ArtifactStore {
   inspect(checksum: string): Promise<ArtifactStoreMetadata | undefined>
   read(checksum: string): Promise<Uint8Array | undefined>
   create(checksum: string, bytes: Uint8Array): Promise<'created' | 'exists'>
+  /**
+   * Confirm the configured bucket exists and is readable by the expected owner.
+   *
+   * S3 answers HeadObject with a bare 404 when the bucket is missing or inaccessible, so a
+   * misconfigured store is otherwise indistinguishable from a store that simply lacks the blob.
+   * Optional so in-memory test doubles stay valid stores.
+   */
+  assertReachable?(): Promise<void>
 }
 
 export interface ArtifactTransferSummary {
@@ -220,6 +229,28 @@ export class AwsS3ArtifactStore implements ArtifactStore {
       ...(this.configuration.profile ? ['--profile', this.configuration.profile] : []),
       ...(this.configuration.region ? ['--region', this.configuration.region] : []),
     ]
+  }
+
+  async assertReachable(): Promise<void> {
+    const result = await this.runner([
+      's3api',
+      'head-bucket',
+      '--bucket',
+      this.configuration.bucket,
+      '--expected-bucket-owner',
+      this.configuration.expectedOwner,
+      ...(this.configuration.profile ? ['--profile', this.configuration.profile] : []),
+      ...(this.configuration.region ? ['--region', this.configuration.region] : []),
+      '--output',
+      'json',
+    ])
+    if (result.exitCode === 0) return
+    throw new ArtifactStoreError(
+      'remote-unreachable',
+      `Private artifact store bucket ${this.configuration.bucket} is missing or inaccessible${
+        awsErrorCode(result) ? ` (${awsErrorCode(result)})` : ''
+      }`
+    )
   }
 
   async inspect(checksum: string): Promise<ArtifactStoreMetadata | undefined> {
@@ -467,13 +498,24 @@ export const pullArtifactManifest = async (
     reused: 0,
     missing: 0,
   }
+  const pending: ArtifactRequirement[] = []
   await mapBounded(requirements, concurrency, async requirement => {
     const local = await cache.get(requirement.checksum)
-    if (local) {
-      assertBytes(requirement, local, 'local')
-      summary.reused += 1
+    if (!local) {
+      pending.push(requirement)
       return
     }
+    assertBytes(requirement, local, 'local')
+    summary.reused += 1
+  })
+  if (!pending.length) return summary
+
+  // A complete local cache never contacts the private tier. A partial one confirms the bucket
+  // first, so a missing or misconfigured store reports itself instead of masquerading as a
+  // manifest full of absent blobs.
+  await store.assertReachable?.()
+  pending.sort((left, right) => left.checksum.localeCompare(right.checksum))
+  await mapBounded(pending, concurrency, async requirement => {
     const metadata = await store.inspect(requirement.checksum)
     if (!metadata) {
       summary.missing += 1
@@ -516,6 +558,7 @@ export const pushArtifactManifest = async (
     reused: 0,
     missing: 0,
   }
+  await store.assertReachable?.()
   await mapBounded(requirements, concurrency, async requirement => {
     const existing = await store.inspect(requirement.checksum)
     if (existing) {

--- a/src/tests/aos4/artifactStore.test.ts
+++ b/src/tests/aos4/artifactStore.test.ts
@@ -219,7 +219,9 @@ describe('AoS 4 private artifact store', () => {
     expect(calls[1]).toContain('--expected-bucket-owner')
   })
 
-  it('distinguishes a missing object from a missing or inaccessible bucket', async () => {
+  // Classification of whatever stderr the CLI returns. A bare 404 is genuinely ambiguous on this
+  // path — see the head-bucket preflight below for how a missing bucket is actually caught.
+  it('classifies per-object CLI failures by error code', async () => {
     const storeFor = (stderr: string) =>
       new AwsS3ArtifactStore(
         {
@@ -259,6 +261,67 @@ describe('AoS 4 private artifact store', () => {
       code: 'remote-conflict',
       message: expect.stringContaining('ConditionalRequestConflict'),
     })
+  })
+
+  it('reports an unreachable bucket instead of a manifest full of absent blobs', async () => {
+    // Real S3 answers HeadObject with a bare 404 when the bucket is missing or inaccessible — it
+    // never emits NoSuchBucket on that path, because doing so would leak whether a bucket the
+    // caller cannot access exists. Only the head-bucket preflight separates a misconfigured store
+    // from a store that is merely unseeded.
+    const calls: string[][] = []
+    const runner: AwsCliRunner = async arguments_ => {
+      calls.push(arguments_)
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr:
+          arguments_[1] === 'head-bucket'
+            ? 'An error occurred (404) when calling the HeadBucket operation: Not Found'
+            : 'An error occurred (404) when calling the HeadObject operation: Not Found',
+      }
+    }
+    const storeFor = () =>
+      new AwsS3ArtifactStore({ bucket: 'aos-reminders-corpus-cache', expectedOwner: '123456789012' }, runner)
+    const value = bytes('accepted bytes')
+    const manifest = manifestFor(value)
+
+    await expect(
+      pullArtifactManifest(manifest, new MemoryArtifactCache(), storeFor(), 2)
+    ).rejects.toMatchObject({
+      code: 'remote-unreachable',
+      message: expect.stringContaining('aos-reminders-corpus-cache'),
+    })
+
+    const seeded = new MemoryArtifactCache()
+    await seeded.put(artifactChecksum(value), value)
+    await expect(pushArtifactManifest(manifest, seeded, storeFor(), 2)).rejects.toMatchObject({
+      code: 'remote-unreachable',
+    })
+
+    // Both transfers stopped at the preflight rather than probing per-artifact keys.
+    expect(calls.map(call => call[1])).toEqual(['head-bucket', 'head-bucket'])
+  })
+
+  it('never contacts the private tier when the local cache already satisfies the manifest', async () => {
+    const value = bytes('already cached')
+    const cache = new MemoryArtifactCache()
+    await cache.put(artifactChecksum(value), value)
+    let invocations = 0
+    const store = new AwsS3ArtifactStore(
+      { bucket: 'aos-reminders-corpus-cache', expectedOwner: '123456789012' },
+      async () => {
+        invocations += 1
+        return { exitCode: 1, stdout: '', stderr: 'should never run' }
+      }
+    )
+
+    await expect(pullArtifactManifest(manifestFor(value), cache, store, 2)).resolves.toEqual({
+      total: 1,
+      transferred: 0,
+      reused: 1,
+      missing: 0,
+    })
+    expect(invocations).toBe(0)
   })
 
   it.each([


### PR DESCRIPTION
## Problem

A `cache:pull` against an unprovisioned artifact store failed with:

```
Remote artifact 023ec4bc25c0cd21c961768da3bd73d4278d81cec53dae50e3f84d82d99fdd73 is missing
```

That message points at the manifest, but the actual fault was configuration — there was no bucket at all. The same message appears for a mistyped `--bucket` and for a wrong `--expected-owner`.

The cause is an S3 behaviour the classifier did not account for. `head-object` answers with a bare `404` when the bucket is missing or inaccessible; it never returns `NoSuchBucket` on that path, because that would leak whether a bucket the caller cannot reach exists. So the `NoSuchBucket|AccessDenied|…` guard in `missingObject()` never matched and every failure fell through to `remote-missing`.

The existing test asserting this distinction passed only because it fed in a `NoSuchBucket` stderr that real `head-object` does not produce.

## Change

- `AwsS3ArtifactStore.assertReachable()` runs `s3api head-bucket` and throws a new `remote-unreachable` code naming the bucket.
- `pullArtifactManifest` and `pushArtifactManifest` preflight before transferring anything.
- Pull settles the local cache **first** and preflights only when a download is genuinely required, so a cache that already satisfies the manifest still contacts nothing. Adding an unconditional preflight would have broken that property, which the offline replay path depends on.
- `assertReachable` is optional on the `ArtifactStore` interface so in-memory test doubles remain valid stores.
- The misleading test is renamed to what it actually covers (stderr classification); two new tests cover the real distinction and the no-network case.
- `docs/data/aos4-maintenance.md` records the provisioned bucket, its hardening, and the preflight behaviour.

## Before / after

```
# before — every misconfiguration looked like an absent blob
Remote artifact 023ec4bc… is missing

# after — nonexistent bucket
Private artifact store bucket aos-reminders-artifact-cache-probe is missing or inaccessible (404)

# after — real bucket, wrong --expected-owner
Private artifact store bucket aos-reminders-aos4-artifact-cache is missing or inaccessible (403)

# after — reachable bucket, blob genuinely absent (unchanged)
Remote artifact 023ec4bc… is missing
```

## Testing

Automated:

```powershell
yarn vitest run src/tests/aos4/artifactStore.test.ts   # 18 passed
yarn vitest run src/tests/aos4                          # 85 files, 1388 passed
yarn tsc --noEmit
```

Manual, against real S3 (requires the store env vars):

1. Point at a bucket that does not exist and pull into an empty `--cache` directory. Expect `… is missing or inaccessible (404)` on the first call, with no per-artifact probing.
2. Point at the real bucket with a wrong `--expected-owner`. Expect `(403)`.
3. Point at the real bucket with an unseeded `--prefix`. Expect the preflight to pass and the failure to be attributed to the object: `Remote artifact <sha256> is missing`.
4. Pull with a cache that already satisfies the manifest. Expect `{"total":245,"transferred":0,"reused":245,"missing":0}` and zero AWS calls.

Full round trip verified separately: 245 blobs pushed, then pulled into an empty cache (`{"total":245,"transferred":245,"reused":0,"missing":0}`) and independently re-hashed — 245 verified, 0 corrupt, 0 missing.

## Note

The bucket referenced in the docs is now provisioned and seeded, but it remains private to the owner account by policy. It mirrors third-party publications, so it is not readable by outside contributors and should not be made public. Contributors do not need it: the full `src/tests/aos4` suite passes with an empty artifact cache. Only corpus regeneration requires the pinned bytes.
