### PR TITLE
docs(data): document the artifact store env vars for maintainers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,12 @@
 VITE_ARMY_API_URL=https://your-http-api.execute-api.us-east-1.amazonaws.com
 VITE_SUBSCRIPTION_API_URL=https://your-subscription-http-api.execute-api.us-east-1.amazonaws.com
+
+# Maintainer-only. Not needed to build, run, or test the app: the generated corpus is committed,
+# and the full src/tests/aos4 suite passes with an empty artifact cache. These configure the
+# private immutable artifact store, which only corpus regeneration reads. The store mirrors
+# third-party publications and is restricted to the owner account, so it is not readable by
+# outside contributors. See docs/data/aos4-maintenance.md.
+# vite-node loads this file into process.env; a shell variable of the same name wins over it.
+# AOS4_ARTIFACT_STORE_BUCKET=<private-bucket>
+# AOS4_ARTIFACT_STORE_EXPECTED_OWNER=<12-digit-aws-account-id>
+# AOS4_ARTIFACT_STORE_PREFIX=aos4-artifacts


### PR DESCRIPTION
Follow-up to #1881, which documented the artifact store but not how to configure it locally.

`vite-node` loads `.env` into `process.env`, including unprefixed variables — verified by probe, not assumed. So `yarn data:aos4:cache:pull|push` picks the store config up from the repo env file as well as from the shell. A shell variable of the same name wins over the file, also verified, so the two can coexist without one silently shadowing the other in a surprising direction.

This records that in `.env.example` with placeholders only — no bucket name, no account id.

The comment also states plainly that outside contributors need none of it. That is worth writing down because the opposite is easy to assume from a repo that ships an artifact-store pull command:

- The generated corpus is committed (`src/aos4/generated/corpus/runtime.json`, `defaults.json`, `data/aos4/catalog/catalog.json`).
- The full `src/tests/aos4` suite — 85 files, 1388 tests — passes with **no** `.cache` directory at all.
- Only corpus regeneration reads the pinned bytes, and the store mirrors third-party publications, so it is restricted to the owner account and cannot be opened up.

## Testing

`.env.example` is documentation; nothing loads it. Behaviour it describes was verified against the real store:

1. In a `-NoProfile` shell with no store variables set, `cache:pull` resolved bucket and expected-owner from `.env` alone, passed the `head-bucket` preflight, and failed with a per-object `Remote artifact <sha256> is missing` under a deliberately unseeded `--prefix`.
2. With the same variable set in both the shell and `.env`, the shell value is the one that resolves.
