### PR TITLE
test(data): pin the Scourge of Aqshy Ogor variants' battletome-current text (#1850)

### DIFF
--- a/src/tests/aos4/ogorSupplementProvisional.test.ts
+++ b/src/tests/aos4/ogorSupplementProvisional.test.ts
@@ -224,6 +224,47 @@ describe('Ogor supplement units ship provisionally from BSData under the fallbac
     expect(hasProvisionalCommunityAttribution(greatMawpot!)).toBe(true)
   })
 
+  it('keeps the Scourge of Aqshy variants on Wahapedia text that already matches the battletome (#1850)', () => {
+    /**
+     * The July 2026 battletome did not rewrite the seasonal battlepack variants: verified
+     * 2026-08-03 against the commit-pinned BSData Ogor library (publication-pinned to the
+     * battletome) — characteristics, keywords, weapons, and ability texts are identical, so
+     * these two keep their preferred-secondary Wahapedia source with no provisional facts.
+     */
+    const seasonal = AOS4_CATALOG.rulesContexts.find(context => context.status === 'seasonal')!
+    const cases = [
+      {
+        name: 'Scourge of Aqshy Frostlord on Thundertusk',
+        points: 280,
+        abilities: ['BATTLE DAMAGED', 'COLD FURY', 'SNOW PLOUGH'],
+      },
+      {
+        name: 'Scourge of Aqshy Huskard on Thundertusk',
+        points: 260,
+        abilities: ['BATTLE DAMAGED', 'COOL TEMPERS', 'EVERWINTER’S IRE'],
+      },
+    ]
+    for (const { name, points, abilities } of cases) {
+      const warscroll = warscrollFor(ogor, name)
+      expect(warscroll).toBeDefined()
+      const profile = AOS4_CATALOG.entities.find(
+        (entity): entity is BattleProfile =>
+          entity.kind === 'battle-profile' && entity.warscrollId === warscroll!.id
+      )
+      expect(profile).toMatchObject({ unitSize: 1, points })
+      const selection = resolveSelection(AOS4_CATALOG, {
+        explicitIds: [ogor.id, warscroll!.id],
+        rulesContextId: seasonal.id,
+      })
+      expect(selection.diagnostics).toEqual([])
+      const reminders = projectReminders(AOS4_CATALOG, selection).filter(reminder =>
+        reminder.contributingEntityIds.includes(warscroll!.id)
+      )
+      expect(reminders.map(reminder => reminder.name).sort()).toEqual([...abilities].sort())
+      expect(hasProvisionalCommunityAttribution(warscroll!)).toBe(false)
+    }
+  })
+
   it('keeps every pre-supplement Ogor warscroll selectable with at least one reminder', () => {
     const ogorWarscrolls = AOS4_CATALOG.entities.filter(
       (entity): entity is Warscroll => entity.kind === 'warscroll' && entity.factionIds.includes(ogor.id)


### PR DESCRIPTION
## Summary

Follow-up to #1883, closing out the last documented #1850 gap: the two Scourge of Aqshy variants (Frostlord on Thundertusk, Huskard on Thundertusk) that #1874 noted as "staying index-era".

**Verification outcome: no data change is needed.** The July 2026 battletome did not rewrite the seasonal battlepack variants. Compared field-by-field against the commit-pinned BSData Ogor library (publication-pinned to the battletome, the same source the #1850/#1880 provisional facts come from):

- characteristics, keywords, and weapon lines identical
- all three ability texts per variant identical verbatim (Frostlord: Battle Damaged / Snow Plough / Cold Fury; Huskard: Battle Damaged / Everwinter's Ire / Cool Tempers)
- official points already applied (280 / 260)

Both variants correctly keep their preferred-secondary Wahapedia source with no provisional community facts — the same outcome as the ten #1850 units whose battletome ability sets matched the accepted text.

## Changes

One regression test in `src/tests/aos4/ogorSupplementProvisional.test.ts` locking the variants' ability sets, official points, and non-provisional attribution, so the verification is durable instead of tribal knowledge.

## Verification

- `yarn vitest run src/tests/aos4/ogorSupplementProvisional.test.ts` — 15/15 pass
- No corpus products touched; the beta gate (`aos4-corpus-2026-08-03-machine-r1`) is unaffected

Note: stacked on #1883 (contains its commit until that merges).
