### PR TITLE
chore(deps): upgrade react-ga4 2 -> 3 (#1894)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-copy-to-clipboard": "^5.1.1",
     "react-dom": "19.2.8",
     "react-dropzone": "11.5.1",
-    "react-ga4": "2.1.0",
+    "react-ga4": "^3.0.1",
     "react-icons": "^5.7.0",
     "react-modal": "3.16.3",
     "react-router": "8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5826,10 +5826,10 @@ react-dropzone@11.5.1:
     file-selector "^0.2.2"
     prop-types "^15.7.2"
 
-react-ga4@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.1.0.tgz#56601f59d95c08466ebd6edfbf8dede55c4678f9"
-  integrity sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==
+react-ga4@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-3.0.1.tgz#1512e0cdd1569e344a9d80b17b30288107a00e77"
+  integrity sha512-GyCc01bSheWXjzGDyHsXMOqk/SP5Cf/JrcJTg4hcpKx4eeSwaJKpJUc+ipF4ffLTZkmabmf3ZGBv4OKHTXNXyA==
 
 react-icons@^5.7.0:
   version "5.7.0"


### PR DESCRIPTION
## Summary

Upgrades `react-ga4` from 2.1.0 to ^3.0.1 (Phase 2 package track).

### v3 breaking changes vs. our usage

[v3.0.0's breaking change](https://github.com/codler/react-ga4/releases/tag/v.3.0.1) is a packaging/toolchain rewrite: TypeScript, tsdown, vitest, and ESM-only output (`type: module`, single `dist/index.mjs` export with bundled `dist/index.d.mts` types). The API surface is unchanged.

All `react-ga4` usage is confined to `src/utils/analytics.ts` (plus its mock in `src/tests/analytics.test.ts`):

- `ReactGA.initialize(id, { gaOptions, gtagOptions })` — signature preserved in v3 types
- `ReactGA.event(name, params)` — preserved
- `ReactGA.send({ hitType: 'pageview', ... })` — preserved (`send(fieldObject: any)`)

Vite and Vitest both handle the ESM-only package natively. No source changes were required; behavior (events, page-view tracking via the router singleton, location-key deduping) is identical.

## Verification

- `yarn lint` — clean
- `yarn tsc --noEmit` — clean
- `yarn build` — clean (PWA service worker generated)
- `yarn test --run` — 1441 passed; 19 failed, all pre-existing local Windows/WSL-path failures (`src/tests/deploymentContract.test.ts` x18, `src/tests/deploymentConfig.test.ts` x1), identical on clean master

Closes #1894