### PR TITLE
chore(deps): upgrade react-icons 4 -> 5 (#1892)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-dom": "19.2.8",
     "react-dropzone": "11.5.1",
     "react-ga4": "2.1.0",
-    "react-icons": "4.8.0",
+    "react-icons": "^5.7.0",
     "react-modal": "3.16.3",
     "react-router": "8.3.0",
     "react-select": "5.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5891,10 +5891,10 @@ react-ga4@2.1.0:
   resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.1.0.tgz#56601f59d95c08466ebd6edfbf8dede55c4678f9"
   integrity sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==
 
-react-icons@4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.8.0.tgz#621e900caa23b912f737e41be57f27f6b2bff445"
-  integrity sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==
+react-icons@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.7.0.tgz#8969db00968ffdfc57fdc2ec9dd1ed88e35b3de9"
+  integrity sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==
 
 react-is@^16.13.1, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"


### PR DESCRIPTION
## Summary

Upgrades `react-icons` 4.8.0 -> ^5.7.0 (resolves 5.7.0). Closes #1892.

## Compatibility audit

react-icons v5 drops React 16/17 support (repo is on React 19) and removes a few deprecated icon packs — none of the packs we use. Audited every `react-icons` import in `src/` (18 import sites across `fa`, `md`, `fi`, plus `IconContext` and the `IconType` type):

- All 24 imported icon components (`FaGift`, `FaPaypal`, `FaSearchDollar`, `FaEllipsisH`, `FaRegFrown`, `FaRegSmileBeam`, `FaCcPaypal`, `FaDiscord`, `FaEnvelopeOpenText`, `FaGithub`, `FaCheck`, `FaTrash`, `MdCheckCircle`, `MdNotInterested`, `MdVisibilityOff`, `MdExpandMore`, `MdRemove`, `MdFileDownload`, `MdFileUpload`, `MdSave`, `MdShare`, `MdVisibility`, `FiWifiOff`) are still exported in 5.7.0 — verified programmatically against the installed package.
- `IconContext` and `IconType` are still exported from the package root.
- In v5 the `fa` pack still contains the Font Awesome 5 glyphs (Font Awesome 6 lives under the separate `fa6` pack), so every icon renders with the identical glyph — no visual changes, no renames needed.

**Code changes: none.** Only `package.json` and `yarn.lock` changed.

## Verification

- `yarn lint` — pass
- `yarn tsc --noEmit` — pass
- `yarn build` — pass
- `yarn test --run` — 1441 passed, 19 failed; all 19 are the known pre-existing local failures in `src/tests/deploymentContract.test.ts` (x18) and `src/tests/deploymentConfig.test.ts` (x1) caused by this machine's Windows Git Bash/WSL path assumption; they fail identically on clean master. (One full-suite run also showed a flaky 5s timeout in `src/tests/aos4/certification.test.ts` under load; it passes in isolation and in the re-run.)

Closes #1892