### PR TITLE
chore(deps): align @types/node with Node 22 (#1896)

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@types/jspdf": "1.3.3",
     "@types/lodash": "4.17.25",
     "@types/luxon": "^3",
-    "@types/node": "20.14.10",
+    "@types/node": "22.20.1",
     "@types/qs": "6.15.1",
     "@types/react": "19.2.18",
     "@types/react-copy-to-clipboard": "5.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1830,12 +1830,12 @@
   resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.7.3.tgz#8e5e6bc12f6c0b14ca665245b6f2542e883e5432"
   integrity sha512-pE7BSbKHiojpl4v7iEzdfFLXXJaH5RPJxI3Wr4x3HU59l83PJfhcUx4mGPWq245+DCAENAzRF/+ZoYr2tJCe/g==
 
-"@types/node@20.14.10":
-  version "20.14.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.10.tgz#a1a218290f1b6428682e3af044785e5874db469a"
-  integrity sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==
+"@types/node@22.20.1":
+  version "22.20.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.20.1.tgz#84e7cdf63cdaa20c134aa317ccc901aa21e16f0e"
+  integrity sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==
   dependencies:
-    undici-types "~5.26.4"
+    undici-types "~6.21.0"
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -7094,10 +7094,10 @@ uncontrollable@^8.0.4:
   resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-8.0.4.tgz#a0a8307f638795162fafd0550f4a1efa0f8c5eb6"
   integrity sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==
 
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## Summary

Upgrades `@types/node` from 20.14.10 to 22.20.1 (latest 22.x) so the type definitions match the pinned Node v22.23.2 runtime (`.nvmrc`, CI, companion APIs).

- `package.json`: `@types/node` 20.14.10 -> 22.20.1
- `yarn.lock`: regenerated; only `@types/node` and its `undici-types` dependency (~5.26.4 -> ~6.21.0) changed
- No source changes: `yarn tsc --noEmit` is clean under the Node 22 typings, so no fs/stream/Buffer call sites needed adjustment

## Verification

- `yarn lint` — pass
- `yarn tsc --noEmit` — pass (no new errors)
- `yarn build` — pass
- `yarn test --run` — 1440 passed; the 19 known pre-existing Windows Git Bash failures (`src/tests/deploymentContract.test.ts` x18, `src/tests/deploymentConfig.test.ts` x1, WSL path assumption, identical on clean master) plus one load-induced 5s timeout in `src/tests/aos4/certification.test.ts` that passes in isolation (22/22, re-run confirmed)

Closes #1896