### PR TITLE
chore(deps): upgrade react-dropzone 11 -> 20 (#1902)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-bootstrap": "2.10.10",
     "react-copy-to-clipboard": "^5.1.1",
     "react-dom": "19.2.8",
-    "react-dropzone": "11.5.1",
+    "react-dropzone": "^20.0.0",
     "react-ga4": "^3.0.1",
     "react-icons": "^5.7.0",
     "react-modal": "3.16.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2521,10 +2521,10 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-attr-accept@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
-  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
+attr-accept@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.5.tgz#d7061d958e6d4f97bf8665c68b75851a0713ab5e"
+  integrity sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==
 
 autoprefixer@10.4.27:
   version "10.4.27"
@@ -3927,12 +3927,10 @@ file-saver@eligrey/FileSaver.js#1.3.8:
   version "1.3.8"
   resolved "https://codeload.github.com/eligrey/FileSaver.js/tar.gz/e865e37af9f9947ddcced76b549e27dc45c1cb2e"
 
-file-selector@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.2.2.tgz#76186ac94ea01a18262a1e9ee36a8815911bc0b4"
-  integrity sha512-tMZc0lkFzhOGlZUAkQ5iljPORvDX+nWEI+9C5nj9KT7Ax8bAUUtI/GYM8JFIjyKfKlQkJRC84D0UgxwDqRGvRQ==
-  dependencies:
-    tslib "^2.0.3"
+file-selector@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-4.1.0.tgz#8759e5b0ef030c5cee36ea6f4b66cd9b23a40d86"
+  integrity sha512-Io1mP8CI3zec5Bxy3P3TxdrKnt35Cm8vNIHnZsvyj43l4YFjD4NRInBp240S5bDJQ0EP1jnh7nCAwXsO818OCg==
 
 filelist@^1.0.4:
   version "1.0.4"
@@ -5853,14 +5851,13 @@ react-dom@19.2.8:
   dependencies:
     scheduler "^0.27.0"
 
-react-dropzone@11.5.1:
-  version "11.5.1"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.5.1.tgz#f4d664437bf8af6acfccbf5040a9890c6780a49f"
-  integrity sha512-eNhttdq4ZDe3eKbXAe54Opt+sbtqmNK5NWTHf/l5d+1TdZqShJ8gMjBrya00qx5zkI//TYxRhu1d9pemTgaWwg==
+react-dropzone@^20.0.0:
+  version "20.0.0"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-20.0.0.tgz#75eade48bede945796aac3a25cba5488d5d640a9"
+  integrity sha512-Xw8tvvVPJQzj8ir5wivUMzA+G6R+aGhdU5KQzUMvVBlJNb26AW/0137VoYVmb5UgZcbhM9OCpjE4KOqqSL9QuQ==
   dependencies:
-    attr-accept "^2.2.1"
-    file-selector "^0.2.2"
-    prop-types "^15.7.2"
+    attr-accept "^2.2.5"
+    file-selector "^4.1.0"
 
 react-ga4@^3.0.1:
   version "3.0.1"
@@ -6906,11 +6903,6 @@ tslib@^2.0.0, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
-tslib@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
-  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
## Summary

Closes #1902

Upgrades `react-dropzone` from 11.5.1 to ^20.0.0 (resolved: 20.0.0).

### Key finding: no call sites to adapt

`react-dropzone` has **zero imports** anywhere in `src/`. The roster import UI (`src/components/input/importArmy/importArmyModal.tsx`) was rebuilt AoS 4-native and uses a plain `<input type="file">` with native `onDragEnter`/`onDragOver`/`onDrop` handlers — the `accept` attribute there is a native HTML attribute, not the dropzone prop. The v12–v14+ breaking changes (new `Accept` object shape, ESM-only packaging, `FileWithPath`/event type changes, validator/`getDataTransferItems` changes) therefore touch no application code. This matches the checked-in Phase 2 modernization plan (`docs/plans/2026-07-28-003`), which already measured react-dropzone as a zero-import dead package slated for removal under R15 — this PR performs the upgrade tracked by the issue; a follow-up could remove the package outright if preferred.

### Behavior preservation

- No source files changed — only `package.json` and `yarn.lock`.
- Accepted file extensions (`.txt`, `.ros`, `.rosz`, `.json`), rejection handling, fail-closed behavior on malformed files, and all import UI are untouched and covered by the existing import tests (`src/tests/aos4/importUi.test.tsx`, New Recruit corpus tests), which pass.
- Lockfile changes: `react-dropzone` 11.5.1 -> 20.0.0, `attr-accept` ^2.2.1 -> ^2.2.5, `file-selector` ^0.2.2 -> ^4.1.0; `prop-types` and the old `tslib@^2.0.3` transitive entries dropped.

### Verification (worktree on Node 22, Yarn Classic)

- `yarn lint` — pass
- `yarn tsc --noEmit` — pass (zero errors)
- `yarn build` — pass (PWA service worker + manifest generated)
- `yarn test --run` — 1441 passed / 19 failed. The 19 failures are exactly the known pre-existing local failures on this Windows Git Bash machine (deploymentContract.test.ts x18 + deploymentConfig.test.ts x1, WSL `/mnt/c` path assumption; identical on clean master). All import tests pass.