### PR TITLE
chore(deps): upgrade Stripe packages (#1901)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "@auth0/auth0-react": "2.22.1",
     "@hello-pangea/dnd": "18.0.1",
-    "@stripe/react-stripe-js": "2.4.0",
-    "@stripe/stripe-js": "1.54.1",
+    "@stripe/react-stripe-js": "^6",
+    "@stripe/stripe-js": "^9",
     "bootstrap": "5.3.8",
     "core-js": "^3.49.0",
     "deepmerge": "4.3.1",

--- a/src/components/payment/giftSubscriptions.tsx
+++ b/src/components/payment/giftSubscriptions.tsx
@@ -2,6 +2,7 @@ import { useAuth0 } from '@auth0/auth0-react'
 import { Elements, useStripe } from '@stripe/react-stripe-js'
 import { loadStripe } from '@stripe/stripe-js'
 import GenericButton from 'components/input/generic_button'
+import { redirectToCheckout } from 'components/payment/legacyStripeCheckout'
 import { useSubscription } from 'context/useSubscription'
 import { useTheme } from 'context/useTheme'
 import { capitalize } from 'lodash'
@@ -221,7 +222,7 @@ const PlanComponent = ({ supportPlan }: { supportPlan: IGiftedSubscriptionPlans 
       quantity,
       plan: supportPlan.title,
     })
-    const result = await stripe.redirectToCheckout({
+    const result = await redirectToCheckout(stripe, {
       mode: 'payment',
       lineItems: [{ price, quantity }],
       customerEmail: user.email,

--- a/src/components/payment/legacyStripeCheckout.ts
+++ b/src/components/payment/legacyStripeCheckout.ts
@@ -1,0 +1,26 @@
+import type { Stripe, StripeError } from '@stripe/stripe-js'
+
+/*
+ * `stripe.redirectToCheckout` was dropped from the @stripe/stripe-js types in v9 (the legacy
+ * client-only hosted-Checkout surface), but the Stripe.js runtime at js.stripe.com/v3 still serves
+ * it for existing Checkout integrations. The subscribe and gift flows below predate Stripe's
+ * server-created Checkout Session model; replacing them needs backend work that is out of scope for
+ * the package upgrade, so the exact runtime call is preserved and the legacy surface is declared
+ * here.
+ */
+export interface ILegacyRedirectToCheckoutOptions {
+  mode?: 'payment' | 'subscription'
+  items?: Array<{ plan?: string; sku?: string; quantity: number }>
+  lineItems?: Array<{ price: string; quantity: number }>
+  customerEmail?: string
+  clientReferenceId?: string
+  successUrl: string
+  cancelUrl: string
+}
+
+interface ILegacyCheckoutStripe extends Stripe {
+  redirectToCheckout(options: ILegacyRedirectToCheckoutOptions): Promise<{ error?: StripeError }>
+}
+
+export const redirectToCheckout = (stripe: Stripe, options: ILegacyRedirectToCheckoutOptions) =>
+  (stripe as ILegacyCheckoutStripe).redirectToCheckout(options)

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -3,6 +3,7 @@ import { Elements, useStripe } from '@stripe/react-stripe-js'
 import { loadStripe } from '@stripe/stripe-js'
 import GenericButton from 'components/input/generic_button'
 import { PaypalPostSubscribeModal } from 'components/modals/paypal_post_subscribe_modal'
+import { redirectToCheckout } from 'components/payment/legacyStripeCheckout'
 import PayPalButton from 'components/payment/paypal/paypalButton'
 import { IApprovalResponse } from 'components/payment/paypal/paypalTypes'
 import { PaypalProvider } from 'context/usePaypal'
@@ -100,7 +101,7 @@ export const PlanComponent = (props: IPlanProps) => {
       plan: supportPlan.title,
     })
 
-    const result = await stripe.redirectToCheckout({
+    const result = await redirectToCheckout(stripe, {
       items: [{ plan, quantity: 1 }],
       customerEmail: user.email,
       clientReferenceId: user.email,

--- a/src/tests/aos4/legacyIsolation.test.ts
+++ b/src/tests/aos4/legacyIsolation.test.ts
@@ -142,6 +142,7 @@ describe('AoS 4 legacy isolation', () => {
       'components/modals/paypal_post_subscribe_modal.tsx',
       'components/modals/stripe_cancellation_modal.tsx',
       'components/payment/giftSubscriptions.tsx',
+      'components/payment/legacyStripeCheckout.ts',
       'components/payment/paypal/paypalButton.tsx',
       'components/payment/paypal/paypalTypes.ts',
       'components/payment/pricingPlans.tsx',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,17 +1840,17 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@stripe/react-stripe-js@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@stripe/react-stripe-js/-/react-stripe-js-2.4.0.tgz#b69d383a2b13e1104c5766695e7a865899cc84fb"
-  integrity sha512-1jVQEL3OuhuzNlf4OdfqovHt+MkWh8Uh8xpLxx/xUFUDdF+7/kDOrGKy+xJO3WLCfZUL7NAy+/ypwXbbYZi0tg==
+"@stripe/react-stripe-js@^6":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@stripe/react-stripe-js/-/react-stripe-js-6.8.0.tgz#388bb7b2fca7de99097ef31a1f08f6261a9d18e4"
+  integrity sha512-nRrPkos00CmUeqXHxtJkXmSbl9/6ybGI4jVebzsiA6QaE5A4iw9dn1C4hUx2tBmQQV2e6pm2aLkPYov4hdta2w==
   dependencies:
     prop-types "^15.7.2"
 
-"@stripe/stripe-js@1.54.1":
-  version "1.54.1"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.54.1.tgz#e298b80c2963d9e622ea355db6c35df48e08cd89"
-  integrity sha512-smEXPu1GKMcAj9g2luT16+oXfg2jAwyc68t2Dm5wdtYl3p8PqQaZEiI8tQmboaQAjgF8pIGma6byz1T1vgmpbA==
+"@stripe/stripe-js@^9":
+  version "9.12.1"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-9.12.1.tgz#b6d13d48cfe8b49acf199233bd0626d180faeccb"
+  integrity sha512-KLXPvjA0BfS4dQnW+ddHjwtIXMnIfKYxqmeNMmQCfKjvYog0cSG+Z7ZvK4RH1+bV90GC07nUztWDRWmJLi5HZQ==
 
 "@swc/core-darwin-arm64@1.6.13":
   version "1.6.13"


### PR DESCRIPTION
## Summary

- `@stripe/stripe-js` 1.54.1 -> `^9` (resolved 9.12.1)
- `@stripe/react-stripe-js` 2.4.0 -> `^6` (resolved 6.8.0)

## Port notes

- The only breaking change touching this app: `stripe.redirectToCheckout` was dropped from the `@stripe/stripe-js` v9 types (part of the v9 "Dahlia" legacy-API type removals; react-stripe-js v3–v6 breaking changes only affect the custom Checkout `CheckoutProvider`/`useCheckout` surface and React <18 support, neither of which applies here — the app is on React 19 and uses only `Elements`/`useStripe`).
- The method still exists in the live Stripe.js runtime at `js.stripe.com/v3` (verified: the served script still contains `redirectToCheckout`), so the subscribe and gift-checkout redirect flows are preserved exactly — same options (`items`/`lineItems`, `mode`, `customerEmail`, `clientReferenceId`, success/cancel URLs), same `result.error` handling.
- New module `src/components/payment/legacyStripeCheckout.ts` declares the legacy hosted-Checkout surface locally and exposes `redirectToCheckout(stripe, options)`; both call sites (`pricingPlans.tsx`, `giftSubscriptions.tsx`) route through it. Replacing client-only Checkout with server-created Checkout Sessions is backend work, explicitly out of scope here.
- Added the new module to the presentation-shell allowlist in `src/tests/aos4/legacyIsolation.test.ts` (the test enumerates every allowed file).
- No UI, flow, or error-handling changes; the existing `pricingPlans`/`giftSubscriptions` tests pass unmodified and pin the exact `redirectToCheckout` payloads.

## Verification

- `yarn lint` — clean
- `yarn tsc --noEmit` — clean
- `yarn build` — clean (PWA service worker generated)
- `yarn test --run` — 1441 passed; the only failures are the 19 known pre-existing Windows Git Bash failures (`deploymentContract.test.ts` x18, `deploymentConfig.test.ts` x1), identical on clean master
- Focused: `yarn vitest run src/tests/aos4/pricingPlans.test.tsx src/tests/aos4/giftSubscriptions.test.tsx` — 4/4 pass

Closes #1901
