### PR TITLE
revert(pwa): restore the update prompt instead of auto-reloading (#1886)

### DIFF
--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -13,7 +13,7 @@ checked by hand.
 | Worker config | `vite.config.mts` (`VitePWA`, `generateSW`) |
 | Activation extras | generated `sw-extras-<content-hash>.js` — see the `service-worker-extras` plugin in `vite.config.mts` |
 | Registration | `src/bootstrap/registerServiceWorker.ts` |
-| Update flow | `registerType: 'autoUpdate'` in `vite.config.mts`; no user-facing prompt |
+| Update prompt | `src/components/info/updateAvailable.tsx`, mounted in `src/components/App.tsx` |
 | Emergency rollback | `public/rollback-service-worker.js` — see docs/deployment.md |
 | Build assertions | `src/tests/pwaBuild.test.ts` |
 
@@ -22,11 +22,11 @@ Clients that still hold the pre-Vite CRA registration poll that exact path, so
 keeping the name is what takes those registrations over rather than orphaning
 them. **Do not rename it.**
 
-Updates are automatic (`registerType: 'autoUpdate'`). A newly installed worker
-calls `skipWaiting()` itself, claims every controlled tab, and the plugin's
-register module reloads each tab onto the new build — no banner, no prompt. The
-reload is safe mid-session because all army state persists to localStorage; it
-costs scroll position at most.
+The generated worker accepts only the versioned activation message in
+`src/bootstrap/serviceWorkerProtocol.ts`, not Workbox's generic `SKIP_WAITING` token. This keeps
+pre-Vite CRA tabs from activating the replacement worker before a user accepts the new app's prompt.
+Once accepted, a short-lived origin-wide marker plus an unconditional `controllerchange` listener
+reloads every controlled tab, including one opened after acceptance but before activation.
 
 The generated catalog chunk is excluded from the precache and served by a
 `CacheFirst` runtime route instead. It is 11.6 MiB against Workbox's 2 MiB
@@ -77,18 +77,20 @@ The honest version of this test is to kill the origin, not to tick "offline" in
 DevTools:
 
 1. Load the app once online and wait for the worker to activate and take control.
-   `clientsClaim` claims the current page.
+   `clientsClaim` claims the current page; prompt mode still prevents an update
+   worker from activating until someone explicitly accepts it.
 2. Stop the preview server.
 3. Reload. The shell should render, the faction selector should populate, and
    `fetch('/assets/aos4-catalog-data-*.js')` should return 200 from cache.
 
-### Automatic update
+### Update prompt
 
 1. Build, load, and reload so a worker is controlling.
 2. Change something the build hashes (any source file), rebuild.
 3. Call `registration.update()` — this is what the hourly poll does.
-4. The new worker installs, warms the catalog, activates, and every open
-   controlled tab reloads itself onto the new build. No banner should appear.
+4. The banner should appear **without any page reloading itself**. Activate
+   Reload in one tab; every open controlled tab should then reload onto the new
+   build after the worker takes control.
 
 ### Cache contents
 
@@ -107,15 +109,18 @@ cache must degrade to "needs one online load", never to a broken app.
 
 ## Gotchas
 
-- **`autoUpdate`, not `prompt`.** The app reloads itself onto a new build the
-  moment the updated worker activates — mid-session if the hourly poll lands
-  then. That trade-off is deliberate: all army state persists to localStorage,
-  so the reload costs scroll position at most. Do not reintroduce a waiting
-  prompt without an explicit product decision.
-- **Legacy clients lag.** A client still controlled by the pre-Vite CRA worker
-  runs no current code and is served a stale shell. The replacement worker's
-  `skipWaiting` + `clientsClaim` takes it over as soon as the update lands;
-  until then it cannot be reached by anything this build does.
+- **`prompt`, not `autoUpdate`.** `autoUpdate` reloads the page under the user
+  mid-session, which is wrong for something people read during a game turn.
+  `clientsClaim` does not change that waiting policy: it claims clients only
+  after one tab explicitly posts the prompt's skip-waiting message.
+- **Dismissal is deliberately not persisted.** `NotificationBanner` stores
+  dismissal in localStorage keyed by name; reusing that here would suppress every
+  future build's prompt after one close.
+- **Legacy clients lag.** A client still controlled by the CRA worker is served a
+  stale shell, so it runs no current code and cannot show the prompt. It recovers
+  when its last tab closes. Do not restore the generic `SKIP_WAITING` activation
+  token or add an eager `skipWaiting` call — either would reload ordinary users
+  mid-session.
 - **Two writers, one cache.** `sw-extras-<content-hash>.js` owns the
   `aos4-catalog` cache and
   prunes it. Do not add an `ExpirationPlugin` to the runtime route as well;

--- a/src/bootstrap/registerServiceWorker.ts
+++ b/src/bootstrap/registerServiceWorker.ts
@@ -1,25 +1,32 @@
 import { registerSW } from 'virtual:pwa-register'
 import {
+  SERVICE_WORKER_ACTIVATION_MESSAGE,
   SERVICE_WORKER_ROLLBACK_DISABLED_STORAGE_KEY,
   SERVICE_WORKER_ROLLBACK_QUERY_PARAM,
+  SERVICE_WORKER_UPDATE_ACCEPTANCE_MAX_AGE_MS,
+  SERVICE_WORKER_UPDATE_ACCEPTED_STORAGE_KEY,
 } from './serviceWorkerProtocol'
 
 export type { RegisterSWOptions } from 'virtual:pwa-register'
 
 /*
  * A standalone PWA left open at a game table never performs a full navigation, so it would otherwise
- * never notice a new build within a session. An hourly registration.update() closes that window.
- * Under `registerType: 'autoUpdate'` a found update activates on its own and every controlled tab
- * reloads, so the poll is the whole update path.
+ * never notice a new build within a session. An hourly registration.update() closes that window --
+ * and it is also what brings the update banner back after a user dismisses it, since dismissal is
+ * component-local and deliberately does not discard the waiting worker.
  */
 const UPDATE_POLL_INTERVAL_MS = 60 * 60 * 1000
 
 type RegisterServiceWorker = typeof registerSW
 
 interface ServiceWorkerRegistrationDependencies {
+  announceNewContent: () => void
+  listenForControllerChange: (callback: () => void) => void
+  markUpdateAccepted: () => void
   register: RegisterServiceWorker
   reload: () => void
   setPollInterval: (callback: () => Promise<void>, intervalMs: number) => unknown
+  wasUpdateAccepted: () => boolean
 }
 
 interface RollbackRegistrationDependencies {
@@ -46,6 +53,43 @@ export const shouldDisableServiceWorkerRegistration = ({
   }
 }
 
+const markUpdateAccepted = () => {
+  try {
+    localStorage.setItem(SERVICE_WORKER_UPDATE_ACCEPTED_STORAGE_KEY, String(Date.now()))
+  } catch {
+    // onNeedReload still reloads tabs that observed the waiting worker when storage is unavailable.
+  }
+}
+
+const wasUpdateAccepted = () => {
+  try {
+    const acceptedAt = Number(localStorage.getItem(SERVICE_WORKER_UPDATE_ACCEPTED_STORAGE_KEY))
+    const age = Date.now() - acceptedAt
+    return (
+      Number.isFinite(acceptedAt) &&
+      acceptedAt > 0 &&
+      age >= 0 &&
+      age <= SERVICE_WORKER_UPDATE_ACCEPTANCE_MAX_AGE_MS
+    )
+  } catch {
+    return false
+  }
+}
+
+/*
+ * Feeds the update signal `context/useAppStatus` already listens for. The BroadcastChannel reaches
+ * other tabs; the window event covers the same tab and browsers where the channel is unavailable.
+ * Both were built for the CRA worker and left dangling when it stopped working.
+ */
+const announceNewContent = () => {
+  if (typeof BroadcastChannel !== 'undefined') {
+    const channel = new BroadcastChannel('app-update')
+    channel.postMessage('App has updated.')
+    channel.close()
+  }
+  window.dispatchEvent(new Event('hasNewContent'))
+}
+
 /*
  * Registered through the vanilla entry point rather than `virtual:pwa-register/react`. The React hook
  * registers twice under StrictMode (vite-pwa/vite-plugin-pwa#925, still open) and is not tested
@@ -63,12 +107,23 @@ export const createServiceWorkerRegistrationController = (
     dependencies.reload()
   }
 
+  /*
+   * Unlike vite-plugin-pwa's `controlling` callback, this listener is installed even when this tab
+   * opened after another tab accepted the update. The short-lived origin-wide marker distinguishes
+   * that requested takeover from an unrelated controller change.
+   */
+  dependencies.listenForControllerChange(() => {
+    if (dependencies.wasUpdateAccepted()) reloadOnce()
+  })
+
   dependencies.register({
+    onNeedRefresh: dependencies.announceNewContent,
     /*
-     * In autoUpdate mode the plugin's register module fires this from workbox-window's `activated`
-     * event when the activating worker is an update (or an external takeover, e.g. the rollback
-     * worker). Every controlled tab gets the event, so every tab reloads onto the claimed build;
-     * no old client remains paired with caches that the new worker has already pruned.
+     * In prompt mode vite-plugin-pwa attaches this callback to `controlling` only after a waiting
+     * worker has raised onNeedRefresh. The worker still cannot take control until a tab explicitly
+     * posts the private activation message, so clientsClaim does not create an unsolicited reload.
+     * Once one tab does accept, every tab that saw that waiting worker reloads onto the claimed
+     * build; no old client remains paired with caches that the new worker has already pruned.
      */
     onNeedReload: reloadOnce,
     onRegisteredSW: (_swUrl, registered) => {
@@ -97,6 +152,25 @@ export const createServiceWorkerRegistrationController = (
       }, UPDATE_POLL_INTERVAL_MS)
     },
   })
+
+  return {
+    applyWaitingUpdate: () => {
+      /*
+       * Another tab may already have activated the worker while this tab's banner was still visible.
+       * Posting the activation message with no waiting worker is a no-op, so reload immediately
+       * instead of leaving the control disabled until its UI timeout.
+       */
+      if (registration && !registration.waiting) {
+        reloadOnce()
+        return
+      }
+
+      if (!registration?.waiting) return
+
+      dependencies.markUpdateAccepted()
+      registration.waiting.postMessage({ type: SERVICE_WORKER_ACTIVATION_MESSAGE })
+    },
+  }
 }
 
 const registrationIsDisabledForRollback = () => {
@@ -113,10 +187,24 @@ const registrationIsDisabledForRollback = () => {
   }
 }
 
-if (!registrationIsDisabledForRollback()) {
-  createServiceWorkerRegistrationController({
-    register: registerSW,
-    reload: () => window.location.reload(),
-    setPollInterval: (callback, intervalMs) => setInterval(callback, intervalMs),
-  })
+const serviceWorkerRegistrationController = !registrationIsDisabledForRollback()
+  ? createServiceWorkerRegistrationController({
+      announceNewContent,
+      listenForControllerChange: callback =>
+        navigator.serviceWorker?.addEventListener('controllerchange', callback),
+      markUpdateAccepted,
+      register: registerSW,
+      reload: () => window.location.reload(),
+      setPollInterval: (callback, intervalMs) => setInterval(callback, intervalMs),
+      wasUpdateAccepted,
+    })
+  : undefined
+
+/**
+ * Applies a waiting update. The claimed worker reloads every controlled tab so all clients and
+ * caches move to the same build. Under `registerType: 'prompt'`, the worker still waits until one tab
+ * explicitly accepts it.
+ */
+export const applyWaitingUpdate = () => {
+  serviceWorkerRegistrationController?.applyWaitingUpdate()
 }

--- a/src/bootstrap/serviceWorkerProtocol.ts
+++ b/src/bootstrap/serviceWorkerProtocol.ts
@@ -1,2 +1,12 @@
+/*
+ * Keep these values private to this PWA generation. The CRA worker that is live before the Vite
+ * cutover posts the generic Workbox `SKIP_WAITING` message as soon as it finds an update. Accepting
+ * only this versioned token lets the replacement worker wait for the new app's explicit prompt.
+ */
+export const SERVICE_WORKER_ACTIVATION_MESSAGE = 'AOS_REMINDERS_SKIP_WAITING_V1'
+
+export const SERVICE_WORKER_UPDATE_ACCEPTED_STORAGE_KEY = 'aos-reminders:pwa:update-accepted-at'
+export const SERVICE_WORKER_UPDATE_ACCEPTANCE_MAX_AGE_MS = 5 * 60 * 1000
+
 export const SERVICE_WORKER_ROLLBACK_QUERY_PARAM = 'aos-reminders-rollback'
 export const SERVICE_WORKER_ROLLBACK_DISABLED_STORAGE_KEY = 'aos-reminders:pwa:rollback-disabled'

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,5 @@
 import { router } from '../bootstrap/router'
+import { UpdateAvailable } from 'components/info/updateAvailable'
 import { useEffect } from 'react'
 import { RouterProvider } from 'react-router/dom'
 import { initializeAnalytics, startPageViewTracking } from 'utils/analytics'
@@ -13,6 +14,12 @@ const App = () => {
 
   return (
     <div className="d-block">
+      {/*
+        Mounted here rather than in the navbar: Navbar early-returns <OfflineHeader /> while
+        offline, which would hide the prompt exactly when a client has a waiting worker and loses
+        the network. This sits above <main> so it appears on every route.
+      */}
+      <UpdateAvailable />
       {/* Each route renders its own navbar, so <main> wraps the whole routed tree. */}
       <main>
         <RouterProvider router={router} />

--- a/src/components/info/updateAvailable.tsx
+++ b/src/components/info/updateAvailable.tsx
@@ -1,0 +1,104 @@
+import { NotificationBanner } from 'components/info/banners/notification_banner'
+import { useAppStatus } from 'context/useAppStatus'
+import { useEffect, useRef, useState } from 'react'
+import { applyWaitingUpdate } from '../../bootstrap/registerServiceWorker'
+
+/*
+ * How long a dismissal lasts.
+ *
+ * Not "for this session", and deliberately not NotificationBanner's persisted dismissal: an
+ * installed PWA on a phone is suspended rather than closed, so the next natural load can be weeks
+ * away, and the waiting worker only activates once every tab is gone. A bounded dismissal means
+ * someone who taps the wrong thing is not stranded on an old build.
+ */
+export const DISMISS_DURATION_MS = 60 * 60 * 1000
+
+/*
+ * How long the accept control stays in its pending state before it re-enables.
+ *
+ * `applyWaitingUpdate` is a no-op when there is no worker actually waiting -- it activated on its
+ * own, or workbox-window never loaded -- and in that case no reload ever comes. Without this the
+ * button would sit disabled on "Reloading..." for the life of the page with no way to retry.
+ */
+export const APPLY_TIMEOUT_MS = 10 * 1000
+
+interface IUpdateAvailableProps {
+  /** Injected in tests. Defaults to the real registration's skip-waiting call. */
+  onApply?: () => void
+}
+
+/**
+ * Prompts the user to reload onto a waiting service worker.
+ *
+ * `hasNewContent` has existed on the app-status context since the CRA worker, but nothing has ever
+ * rendered it -- the "you will be given an option in the UI" comment in the old entry point was
+ * aspirational. This is that option.
+ */
+export const UpdateAvailable = ({ onApply = applyWaitingUpdate }: IUpdateAvailableProps) => {
+  const { hasNewContent } = useAppStatus()
+  const [isDismissed, setIsDismissed] = useState(false)
+  const [isApplying, setIsApplying] = useState(false)
+  const dismissTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const applyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  /*
+   * A ref, not `isApplying`. Two taps inside one React batch both read the same render's state, so a
+   * state-based guard sees `false` twice and posts SKIP_WAITING twice; a ref updates synchronously.
+   * `isApplying` still drives the disabled/pending UI, which is a separate concern.
+   */
+  const hasApplied = useRef(false)
+
+  useEffect(
+    () => () => {
+      clearTimeout(dismissTimer.current)
+      clearTimeout(applyTimer.current)
+    },
+    []
+  )
+
+  // Unmounting on dismiss is what lets the banner come back: NotificationBanner's own `isOn` latches
+  // off, so a remount is the only way to re-show it.
+  const handleDismiss = () => {
+    setIsDismissed(true)
+    dismissTimer.current = setTimeout(() => setIsDismissed(false), DISMISS_DURATION_MS)
+  }
+
+  const handleApply = () => {
+    // The page reloads out from under this component once the new worker takes control, but the
+    // interval before that is long enough to tap twice.
+    if (hasApplied.current) return
+    hasApplied.current = true
+    setIsApplying(true)
+    // If the reload never arrives, re-enable rather than stranding the user on a dead control.
+    applyTimer.current = setTimeout(() => {
+      hasApplied.current = false
+      setIsApplying(false)
+    }, APPLY_TIMEOUT_MS)
+    onApply()
+  }
+
+  if (!hasNewContent || isDismissed) return null
+
+  return (
+    <NotificationBanner
+      closeLabel="Dismiss update notification"
+      name="app-update"
+      onClose={handleDismiss}
+      persistClose={false}
+      variant="info"
+    >
+      <span>A new version of AoS Reminders is available.</span>
+      {/*
+        Outline, not filled. DESIGN.md reserves `btn-primary` for the control that commits money or
+        an account; reloading onto a new build is reversible.
+      */}
+      <button
+        type="button"
+        className="btn btn-sm btn-outline-primary flex-shrink-0 ms-2"
+        onClick={handleApply}
+        disabled={isApplying}
+      >
+        {isApplying ? 'Reloading...' : 'Reload'}
+      </button>
+    </NotificationBanner>
+  )
+}

--- a/src/context/useAppStatus.tsx
+++ b/src/context/useAppStatus.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 interface AppStatusValue {
+  hasNewContent: boolean
   isGameMode: boolean
   isOffline: boolean
   isOnline: boolean
@@ -12,6 +13,7 @@ const AppStatusContext = React.createContext<AppStatusValue | undefined>(undefin
 const AppStatusProvider = ({ children }: React.PropsWithChildren<object>) => {
   const [isGameMode, setIsGameMode] = useState(false)
   const [isOffline, setIsOffline] = useState(!navigator.onLine)
+  const [hasNewContent, setHasNewContent] = useState(false)
 
   const toggleGameMode = useCallback(() => {
     setIsGameMode(current => !current)
@@ -20,26 +22,37 @@ const AppStatusProvider = ({ children }: React.PropsWithChildren<object>) => {
   useEffect(() => {
     const setOnline = () => setIsOffline(false)
     const setOffline = () => setIsOffline(true)
+    const setContent = () => setHasNewContent(true)
+    let updateChannel: BroadcastChannel | null = null
 
+    if (typeof BroadcastChannel !== 'undefined') {
+      updateChannel = new BroadcastChannel('app-update')
+      updateChannel.addEventListener('message', setContent)
+    }
     window.addEventListener('online', setOnline)
     window.addEventListener('offline', setOffline)
     window.addEventListener('isOffline', setOffline)
+    window.addEventListener('hasNewContent', setContent)
 
     return () => {
+      updateChannel?.removeEventListener('message', setContent)
+      updateChannel?.close()
       window.removeEventListener('online', setOnline)
       window.removeEventListener('offline', setOffline)
       window.removeEventListener('isOffline', setOffline)
+      window.removeEventListener('hasNewContent', setContent)
     }
   }, [])
 
   const value = useMemo(
     () => ({
+      hasNewContent,
       isGameMode,
       isOffline,
       isOnline: !isOffline,
       toggleGameMode,
     }),
-    [isGameMode, isOffline, toggleGameMode]
+    [hasNewContent, isGameMode, isOffline, toggleGameMode]
   )
 
   return <AppStatusContext.Provider value={value}>{children}</AppStatusContext.Provider>

--- a/src/tests/aos4/legacyIsolation.test.ts
+++ b/src/tests/aos4/legacyIsolation.test.ts
@@ -119,6 +119,7 @@ describe('AoS 4 legacy isolation', () => {
       'components/info/donate.tsx',
       'components/info/offline.tsx',
       'components/info/reminders.tsx',
+      'components/info/updateAvailable.tsx',
       'components/input/army_builder.tsx',
       'components/input/generic_button.tsx',
       'components/input/importArmy/failedImportReport.ts',

--- a/src/tests/aos4/updateAvailable.test.tsx
+++ b/src/tests/aos4/updateAvailable.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+
+import { vi } from 'vitest'
+
+/*
+ * `updateAvailable` reaches `applyWaitingUpdate` in bootstrap/registerServiceWorker, which imports
+ * the plugin's `virtual:pwa-register`. That virtual module has no resolvable file on disk, so the
+ * test runner cannot import it -- stub it the same way registerServiceWorker.test.ts does.
+ */
+const virtualRegisterSW = vi.hoisted(() => vi.fn(() => vi.fn(async () => undefined)))
+
+vi.mock('virtual:pwa-register', () => ({ registerSW: virtualRegisterSW }))
+
+import {
+  APPLY_TIMEOUT_MS,
+  DISMISS_DURATION_MS,
+  UpdateAvailable,
+} from 'components/info/updateAvailable'
+import { AppStatusProvider } from 'context/useAppStatus'
+import { act } from 'react'
+import { render, Simulate, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+describe('update-available banner', () => {
+  let container: HTMLDivElement
+  let onApply: ReturnType<typeof vi.fn<() => void>>
+
+  const mount = () => {
+    act(() => {
+      render(
+        <AppStatusProvider>
+          <UpdateAvailable onApply={onApply} />
+        </AppStatusProvider>,
+        container
+      )
+    })
+  }
+
+  /** The real signal path: the registration dispatches this window event on a waiting worker. */
+  const announceNewContent = () => {
+    act(() => {
+      window.dispatchEvent(new Event('hasNewContent'))
+    })
+  }
+
+  const banner = () => container.querySelector('[role="alert"]')
+  const reloadButton = () =>
+    Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Reload'))
+  const dismissButton = () => container.querySelector<HTMLButtonElement>('.btn-close')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    onApply = vi.fn<() => void>()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      unmountComponentAtNode(container)
+    })
+    container.remove()
+    vi.useRealTimers()
+  })
+
+  it('renders nothing until a new version is waiting', () => {
+    mount()
+
+    expect(banner()).toBeNull()
+    expect(container.textContent).toBe('')
+  })
+
+  it('offers a reload and a dismiss once a new version is announced', () => {
+    mount()
+    announceNewContent()
+
+    expect(banner()).not.toBeNull()
+    expect(reloadButton()).toBeDefined()
+    expect(dismissButton()).not.toBeNull()
+    expect(container.textContent).toContain('A new version of AoS Reminders is available.')
+  })
+
+  it('applies the waiting update exactly once on a fast double-tap', () => {
+    mount()
+    announceNewContent()
+
+    /*
+     * Both clicks inside one act(): React has not committed `disabled` yet, so the second one
+     * genuinely reaches the handler and the re-entrancy guard is what stops it. Clicking in separate
+     * act() calls would only prove the disabled attribute works — that version stays green with the
+     * guard deleted.
+     */
+    act(() => {
+      const button = reloadButton()!
+      Simulate.click(button)
+      Simulate.click(button)
+    })
+
+    expect(onApply).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores further activation once the control is disabled', () => {
+    mount()
+    announceNewContent()
+
+    act(() => Simulate.click(reloadButton()!))
+    act(() => Simulate.click(reloadButton()!))
+
+    expect(onApply).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-enables the control when the reload never arrives', () => {
+    mount()
+    announceNewContent()
+    act(() => Simulate.click(reloadButton()!))
+    expect(reloadButton()!.disabled).toBe(true)
+
+    // applyWaitingUpdate is a no-op when no worker is actually waiting, so no reload ever comes.
+    act(() => {
+      vi.advanceTimersByTime(APPLY_TIMEOUT_MS)
+    })
+
+    expect(reloadButton()!.disabled).toBe(false)
+  })
+
+  it('puts the reload control into a disabled in-progress state once activated', () => {
+    mount()
+    announceNewContent()
+    expect(reloadButton()!.disabled).toBe(false)
+
+    act(() => Simulate.click(reloadButton()!))
+
+    expect(reloadButton()!.disabled).toBe(true)
+    expect(reloadButton()!.textContent).toContain('Reloading')
+  })
+
+  it('hides on dismiss without applying the update', () => {
+    mount()
+    announceNewContent()
+
+    act(() => Simulate.click(dismissButton()!))
+
+    expect(banner()).toBeNull()
+    expect(onApply).not.toHaveBeenCalled()
+  })
+
+  it('persists nothing on dismiss, so a later build still prompts', () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem')
+    mount()
+    announceNewContent()
+
+    act(() => Simulate.click(dismissButton()!))
+
+    expect(setItem).not.toHaveBeenCalled()
+    setItem.mockRestore()
+  })
+
+  it('brings the banner back only once the dismissal window has fully elapsed', () => {
+    expect(DISMISS_DURATION_MS).toBe(60 * 60 * 1000)
+
+    mount()
+    announceNewContent()
+    act(() => Simulate.click(dismissButton()!))
+    expect(banner()).toBeNull()
+
+    // Asserting the near edge too: without it a dismissal collapsed to a second would still pass,
+    // and a banner that returns immediately is worse than one that never returns.
+    act(() => {
+      vi.advanceTimersByTime(DISMISS_DURATION_MS - 1)
+    })
+    expect(banner()).toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(banner()).not.toBeNull()
+  })
+
+  it('announces itself and names both controls for assistive technology', () => {
+    mount()
+    announceNewContent()
+
+    // It appears without any user action, so it has to be announced rather than merely present.
+    expect(banner()!.getAttribute('role')).toBe('alert')
+    expect(dismissButton()!.getAttribute('aria-label')).toBe('Dismiss update notification')
+    expect(reloadButton()!.textContent?.trim()).toBeTruthy()
+  })
+
+  it('keeps itself off the printed reminder sheet', () => {
+    mount()
+    announceNewContent()
+
+    expect(banner()!.className).toContain('d-print-none')
+  })
+
+  it('keeps the dismiss control above the minimum hit box', () => {
+    mount()
+    announceNewContent()
+
+    // Without flex-shrink-0 the banner text squeezes the close button under the WCAG 2.5.8 floor.
+    expect(dismissButton()!.className).toContain('flex-shrink-0')
+  })
+})

--- a/src/tests/pwaBuild.test.ts
+++ b/src/tests/pwaBuild.test.ts
@@ -3,6 +3,7 @@
 import fs from 'fs'
 import path from 'path'
 import { describe, expect, it } from 'vitest'
+import { SERVICE_WORKER_ACTIVATION_MESSAGE } from '../bootstrap/serviceWorkerProtocol'
 
 /**
  * Assertions over the built PWA output.
@@ -223,12 +224,12 @@ describe('generated service worker', () => {
     expect(extras).not.toContain('AbortSignal.timeout')
   })
 
-  it('activates and claims clients immediately, with no prompt path left in the worker', () => {
-    // autoUpdate: the worker skips waiting on its own and every controlled tab reloads onto the
-    // new build. A surviving SKIP_WAITING message handler would mean the worker still waits.
+  it('claims clients only after the prompt-controlled worker is explicitly activated', () => {
     expect(serviceWorkerSource).toContain('clientsClaim')
-    expect(serviceWorkerSource).toContain('skipWaiting()')
+    // The private token prevents legacy CRA clients from bypassing the new app's explicit prompt.
+    expect(serviceWorkerSource).toContain(JSON.stringify(SERVICE_WORKER_ACTIVATION_MESSAGE))
     expect(serviceWorkerSource).not.toContain('"SKIP_WAITING"')
+    expect(serviceWorkerSource.match(/skipWaiting\(\)/g)).toHaveLength(1)
   })
 
   it('ships a rollback worker that marks clients before navigating them', () => {

--- a/src/tests/registerServiceWorker.test.ts
+++ b/src/tests/registerServiceWorker.test.ts
@@ -11,26 +11,49 @@ import {
   shouldDisableServiceWorkerRegistration,
   type RegisterSWOptions,
 } from '../bootstrap/registerServiceWorker'
-import { SERVICE_WORKER_ROLLBACK_DISABLED_STORAGE_KEY } from '../bootstrap/serviceWorkerProtocol'
+import {
+  SERVICE_WORKER_ACTIVATION_MESSAGE,
+  SERVICE_WORKER_ROLLBACK_DISABLED_STORAGE_KEY,
+} from '../bootstrap/serviceWorkerProtocol'
 
 interface RegistrationHarness {
+  applyWaitingUpdate: () => void
   callbacks: RegisterSWOptions
+  controllerChanged: () => void
   reload: ReturnType<typeof vi.fn>
   registration: ServiceWorkerRegistration
   runPoll: () => Promise<void>
+  waitingWorker: { postMessage: ReturnType<typeof vi.fn> }
 }
 
-const createHarness = (registrationState: 'missing' | 'installing' | 'settled') => {
+interface SharedAcceptance {
+  accepted: boolean
+}
+
+const createHarness = (
+  registrationState: 'missing' | 'installing' | 'waiting' | 'settled',
+  acceptance: SharedAcceptance = { accepted: false }
+) => {
   let callbacks: RegisterSWOptions | undefined
+  let controllerChanged = () => {}
   let poll: (() => Promise<void>) | undefined
   const reload = vi.fn()
   const updateServiceWorker = vi.fn(async () => undefined)
+  const waitingWorker = { postMessage: vi.fn() }
   const registration = {
     installing: registrationState === 'installing' ? {} : null,
+    waiting: registrationState === 'waiting' ? waitingWorker : null,
     update: vi.fn(async () => undefined),
   } as unknown as ServiceWorkerRegistration
 
-  createServiceWorkerRegistrationController({
+  const applyWaitingUpdate = createServiceWorkerRegistrationController({
+    announceNewContent: vi.fn(),
+    listenForControllerChange: callback => {
+      controllerChanged = callback
+    },
+    markUpdateAccepted: () => {
+      acceptance.accepted = true
+    },
     register: options => {
       callbacks = options
       return updateServiceWorker
@@ -40,7 +63,8 @@ const createHarness = (registrationState: 'missing' | 'installing' | 'settled') 
       poll = callback
       return 1
     },
-  })
+    wasUpdateAccepted: () => acceptance.accepted,
+  }).applyWaitingUpdate
 
   callbacks!.onRegisteredSW?.(
     '/service-worker.js',
@@ -48,34 +72,84 @@ const createHarness = (registrationState: 'missing' | 'installing' | 'settled') 
   )
 
   return {
+    applyWaitingUpdate,
     callbacks: callbacks!,
+    controllerChanged,
     reload,
     registration,
     runPoll: async () => {
       await poll?.()
     },
+    waitingWorker,
   } satisfies RegistrationHarness
 }
 
 describe('service-worker registration controller', () => {
-  it('reloads every controlled tab when the plugin reports the update activated', () => {
-    const firstTab = createHarness('settled')
-    const secondTab = createHarness('settled')
+  it('does not reload either tab before a waiting update is explicitly accepted', () => {
+    const firstTab = createHarness('waiting')
+    const secondTab = createHarness('waiting')
 
-    firstTab.callbacks.onNeedReload?.()
-    secondTab.callbacks.onNeedReload?.()
+    firstTab.callbacks.onNeedRefresh?.()
+    secondTab.callbacks.onNeedRefresh?.()
+
+    expect(firstTab.reload).not.toHaveBeenCalled()
+    expect(secondTab.reload).not.toHaveBeenCalled()
+  })
+
+  it('reloads every controlled tab after one tab accepts and the worker takes control', () => {
+    const acceptance = { accepted: false }
+    const firstTab = createHarness('waiting', acceptance)
+    const secondTab = createHarness('waiting', acceptance)
+
+    firstTab.applyWaitingUpdate()
+    expect(firstTab.waitingWorker.postMessage).toHaveBeenCalledWith({
+      type: SERVICE_WORKER_ACTIVATION_MESSAGE,
+    })
+
+    firstTab.controllerChanged()
+    secondTab.controllerChanged()
 
     expect(firstTab.reload).toHaveBeenCalledTimes(1)
     expect(secondTab.reload).toHaveBeenCalledTimes(1)
   })
 
-  it('reloads at most once per tab no matter how often the event fires', () => {
+  it('reloads a tab opened after acceptance when the accepted worker takes control', () => {
+    const acceptance = { accepted: false }
+    const acceptingTab = createHarness('waiting', acceptance)
+    acceptingTab.applyWaitingUpdate()
+
+    const lateTab = createHarness('settled', acceptance)
+    lateTab.controllerChanged()
+
+    expect(lateTab.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reload for an unrelated controller change without update acceptance', () => {
     const tab = createHarness('settled')
 
+    tab.controllerChanged()
+
+    expect(tab.reload).not.toHaveBeenCalled()
+  })
+
+  it('reloads at most once when plugin and native controller events both fire', () => {
+    const acceptance = { accepted: false }
+    const tab = createHarness('waiting', acceptance)
+    tab.applyWaitingUpdate()
+
     tab.callbacks.onNeedReload?.()
-    tab.callbacks.onNeedReload?.()
+    tab.controllerChanged()
 
     expect(tab.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('reloads a stale second-tab banner immediately once no worker is waiting', () => {
+    const secondTab = createHarness('settled')
+
+    secondTab.applyWaitingUpdate()
+
+    expect(secondTab.reload).toHaveBeenCalledTimes(1)
+    expect(secondTab.waitingWorker.postMessage).not.toHaveBeenCalled()
   })
 
   it('does not create a polling interval without a registration', async () => {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,9 +1,11 @@
 import react from '@vitejs/plugin-react-swc'
 import { createHash } from 'node:crypto'
+import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { defineConfig, type Plugin } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
 import { configDefaults } from 'vitest/config'
+import { SERVICE_WORKER_ACTIVATION_MESSAGE } from './src/bootstrap/serviceWorkerProtocol'
 
 /*
  * The generated corpus is 11.6 MiB as a built chunk, against Workbox's 2 MiB precache ceiling — and
@@ -68,6 +70,39 @@ const enforceInitialEntryChunkBudget = (): Plugin => ({
     })
   },
 })
+
+/*
+ * Workbox's generated message handler accepts the generic `SKIP_WAITING` token. The CRA worker
+ * currently controlling production tabs posts that token automatically when it sees an update,
+ * which would bypass this release's user-facing prompt. Replace the generated handler's one token
+ * with this app generation's private protocol, and fail closed if Workbox ever changes its output.
+ */
+const privatizeServiceWorkerActivation = (): Plugin => {
+  let workerPath = path.resolve('dist/service-worker.js')
+
+  return {
+    name: 'private-service-worker-activation',
+    apply: 'build',
+    enforce: 'post',
+    configResolved(config) {
+      workerPath = path.resolve(config.root, config.build.outDir, 'service-worker.js')
+    },
+    async closeBundle() {
+      const source = await readFile(workerPath, 'utf8')
+      const genericToken = JSON.stringify('SKIP_WAITING')
+      const privateToken = JSON.stringify(SERVICE_WORKER_ACTIVATION_MESSAGE)
+      const occurrences = source.split(genericToken).length - 1
+
+      if (occurrences !== 1) {
+        this.error(
+          `Expected exactly one Workbox ${genericToken} activation token in ${workerPath}; found ${occurrences}.`
+        )
+      }
+
+      await writeFile(workerPath, source.replace(genericToken, privateToken))
+    },
+  }
+}
 
 /*
  * Emits the immutable `sw-extras-<hash>.js` that the generated worker imports. Two things have to
@@ -238,12 +273,11 @@ export default defineConfig({
     VitePWA({
       strategies: 'generateSW',
       /*
-       * `autoUpdate`: a newly installed worker activates immediately and every controlled tab
-       * reloads onto the new build (the plugin's register module calls onNeedReload; see
-       * src/bootstrap/registerServiceWorker.ts). No update banner. This is safe here because all
-       * army state persists to localStorage, so the reload loses nothing but scroll position.
+       * `prompt`, not `autoUpdate`: autoUpdate reloads the page under the user mid-session, which is
+       * wrong for an app people read during a game turn. The app already owns the update channel
+       * (`hasNewContent` in context/useAppStatus) — src/bootstrap/registerServiceWorker.ts feeds it.
        */
-      registerType: 'autoUpdate',
+      registerType: 'prompt',
       /*
        * Not the default `sw.js`. Clients still holding the pre-Vite CRA registration poll
        * `/service-worker.js` for updates; serving a real, changed script there takes those
@@ -257,13 +291,8 @@ export default defineConfig({
       workbox: {
         globIgnores: [CATALOG_CHUNK_GLOB, ...NON_APP_PRECACHE_GLOBS],
         importScripts: serviceWorkerExtrasImports,
-        /*
-         * Activate the moment install finishes (which includes the catalog warm) and claim every
-         * controlled tab, so each reloads onto the same build whose old caches activation prunes.
-         * `skipWaiting` must be set here explicitly: the plugin only adds it for autoUpdate when
-         * injectRegister is left at its default, and this app registers explicitly.
-         */
-        skipWaiting: true,
+        // The worker still waits for an explicit SKIP_WAITING message. Once accepted, claim every
+        // controlled tab so each reloads onto the same build whose old caches activation prunes.
         clientsClaim: true,
         runtimeCaching: [
           {
@@ -282,6 +311,8 @@ export default defineConfig({
         ],
       },
     }),
+    // Must run after vite-plugin-pwa writes the worker in closeBundle.
+    privatizeServiceWorkerActivation(),
     enforceInitialEntryChunkBudget(),
   ],
   resolve: {


### PR DESCRIPTION
Reverts #1886, which implemented #1885.

#1885 stays closed: this is a decision not to want the feature, not a request to build it again.

The auto-reload reads as a bug: the page reloads under you mid-session with no explanation. This restores the update banner, so a new build waits until the user accepts it.

## What changes

- `vite.config.mts`: back to `registerType: 'prompt'`, and the `privatizeServiceWorkerActivation()` plugin returns. That plugin rewrites Workbox's generic `SKIP_WAITING` token to this app's private `AOS_REMINDERS_SKIP_WAITING_V1`, so the CRA worker still controlling old production tabs can't activate the new build by posting the generic token.
- `src/bootstrap/registerServiceWorker.ts`: the full controller is back — acceptance marker, controller-change listener, broadcast announce, and `applyWaitingUpdate`.
- `src/components/info/updateAvailable.tsx` and its test are restored, remounted in `App.tsx`, and the `hasNewContent` plumbing in `useAppStatus.tsx` returns.
- `docs/pwa.md` documents the prompt flow again.

## Conflict resolutions

Master moved 18 commits since #1886 merged, so three things needed hand-resolution rather than a clean `git revert`:

1. **`App.tsx`** — the react-router 8 upgrade (#1887) rewrote this file. Kept the new `RouterProvider` tree and remounted `<UpdateAvailable />` above `<main>`, instead of restoring the old `Switch`/`Route` structure the revert wanted.
2. **`updateAvailable.test.tsx` typing** — the vitest bump in #1921 changed `vi.fn()`'s inferred type. Retyped the `onApply` mock as `vi.fn<() => void>()`, matching the convention that upgrade already established elsewhere in the repo.
3. **`updateAvailable.test.tsx` imports** — the upgraded resolver can't import `virtual:pwa-register` in the test environment, and the restored test reaches it transitively via `applyWaitingUpdate`. Stubbed it the same way `registerServiceWorker.test.ts` already does.

## Verification

- `tsc --noEmit`, `eslint src`, and `vite build`: clean
- Inspected the built `dist/service-worker.js` directly rather than trusting the config: zero generic `SKIP_WAITING` tokens, exactly one private `AOS_REMINDERS_SKIP_WAITING_V1` handler, and the single `skipWaiting()` call is gated behind it. The restored plugin's fail-closed assertion (exactly one Workbox token) still holds against vite-plugin-pwa 1.3.0, so the toolchain upgrade did not invalidate it.
- All 12 restored banner tests pass.
- Full suite: 20 failures, all pre-existing. 18 `deploymentContract` + 1 `deploymentConfig` are the known WSL-only deployment harness; the 20th (`coreRulesExampleAbilities`) fails only under full-suite load and passes in isolation — confirmed failing identically on clean master.

## Manual verification worth doing on the preview

Build, load, rebuild with a changed source file, then call `registration.update()` in the console. The banner should appear and the tab should **not** reload until you click Reload. Steps are in `docs/pwa.md`.

## Note

Prompt mode has a real tradeoff worth knowing: a dismissed banner leaves the user on a stale build for an hour (`DISMISS_DURATION_MS`), and the waiting worker only activates once every tab is closed. If the objection to #1886 was mainly that the reload was silent and abrupt rather than that reloading is wrong, a middle path exists — keep the banner but auto-apply on the next navigation, or reload only when the user is idle. Happy to build that as a follow-up.

https://claude.ai/code/session_01FkjoLKG3pbSdrkQFFY2QDS

