### PR TITLE
fix(radar): compare against the current accepted snapshot

### DIFF
--- a/data/aos4/radar/config.json
+++ b/data/aos4/radar/config.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "acceptedManifestPath": "data/aos4/manifests/accepted-2026-07-27.json",
-  "sourceClassificationsPath": "data/aos4/reviews/source-observation-classifications-2026-07-28.json",
+  "acceptedManifestPath": "data/aos4/manifests/accepted-2026-08-02.json",
+  "sourceClassificationsPath": "data/aos4/reviews/source-observation-classifications-2026-07-29.json",
   "wahapedia": {
     "rootUrl": "https://wahapedia.ru/",
     "navigationUrl": "https://wahapedia.ru/aos4/the-rules/data-export/",

--- a/docs/data/aos4-maintenance.md
+++ b/docs/data/aos4-maintenance.md
@@ -365,6 +365,13 @@ reviewing its `.cat`/`.gst` diff against official sources. If the signal is unde
 normal PR. Likewise, accepted Games Workshop or Wahapedia baselines change only through the
 candidate-review-accept-generate-certify process below.
 
+Its `acceptedManifestPath` and `sourceClassificationsPath` are the Games Workshop lane's baseline
+and must move with every accepted snapshot. The config only proves those paths exist, so a
+superseded pointer reports each publication the intake accepted as a new one and each publication
+it replaced as removed — a full lane of material events with nothing to intake behind them.
+`src/tests/aos4/rulesRadarCompare.test.ts` fails when either pointer is not the newest reviewed
+file of its kind.
+
 Radar output is evidence, not acceptance. Automation may acquire source-scoped candidate bytes and
 compact manifests, but it never accepts a source, edits reviewed inputs, regenerates runtime data,
 or updates the beta certification pointer.

--- a/src/tests/aos4/rulesRadarCompare.test.ts
+++ b/src/tests/aos4/rulesRadarCompare.test.ts
@@ -1,3 +1,5 @@
+import { readdirSync } from 'node:fs'
+import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import type { ArtifactManifest } from '../../aos4/data'
 import {
@@ -336,7 +338,28 @@ describe('AoS 4 Rules Radar comparison', () => {
     config.acceptedManifestPath = 'data/aos4/manifests/missing.json'
     expect(() => validateRulesRadarConfig(config, { rootPath: process.cwd() })).toThrow(/stale or missing/)
   })
+
+  it('compares against the current accepted snapshot and reviewed classifications', () => {
+    // The config only proves its paths exist, so an intake that accepts a newer manifest without
+    // moving these pointers leaves the radar diffing a superseded baseline: every publication the
+    // intake accepted reports as a new one, and everything it replaced reports as removed.
+    const config = readRulesRadarConfig('data/aos4/radar/config.json', process.cwd())
+
+    expect(config.acceptedManifestPath).toBe(newestReviewedFile('data/aos4/manifests', 'accepted-'))
+    expect(config.sourceClassificationsPath).toBe(
+      newestReviewedFile('data/aos4/reviews', 'source-observation-classifications-')
+    )
+  })
 })
+
+const newestReviewedFile = (directory: string, prefix: string): string => {
+  const newest = readdirSync(path.resolve(process.cwd(), directory))
+    .filter(name => name.startsWith(prefix) && name.endsWith('.json'))
+    .sort()
+    .at(-1)
+  if (!newest) throw new Error(`No ${prefix}* file exists in ${directory}`)
+  return `${directory}/${newest}`
+}
 
 const lane = (
   source: RadarLane['source'],


### PR DESCRIPTION
Closes nothing on its own — this clears the Games Workshop lane of the Rules Radar issue (#1757).

## Why

The Rules Radar's Games Workshop lane builds `new-publication` / `removed-publication` events by
diffing the live downloads catalog against the manifest named in `data/aos4/radar/config.json`
(`src/aos4/radar/compare.ts:250-288`). That pointer still named `accepted-2026-07-27.json` and
`source-observation-classifications-2026-07-28.json` — it has not moved since the 6.0.0 squash,
while the corpus advanced through three accepted snapshots to `accepted-2026-08-02.json`.

So the 2026-08-04 report's fourteen Games Workshop events have nothing behind them:

- the **seven 29-07 publications** it reports as new (Battle Profiles, Rules Updates, Ogor Mawtribes
  supplement, Armies of Renown, Legends Warscrolls, Darkwater Hero Warscrolls, Scourge of Aqshy –
  Skaven) are already pinned by `accepted-2026-08-02.json`;
- the **six publications** it reports as removed are exactly the documents those replaced, present
  only in the 07-27 manifest;
- the **Tournament Organiser Pack 2026-27** is already dispositioned non-material in
  `source-observation-classifications-2026-07-29.json`, which the config does not name.

The #1820 intake obligation is therefore already satisfied for every document in that lane. The one
material event this report carries that is *not* explained by the stale pointer is the BSData
community-catalog change, which is out of scope here — it needs its `.cat`/`.gst` diff reviewed
against official sources before `bsData.baselineSha` moves, per `docs/data/aos4-maintenance.md`.

## What changed

- `data/aos4/radar/config.json` — `acceptedManifestPath` and `sourceClassificationsPath` now name
  the current reviewed files.
- `src/tests/aos4/rulesRadarCompare.test.ts` — a new check that both pointers are the newest
  reviewed file of their kind. `validateRulesRadarConfig` only proves a path *exists*, so nothing
  failed when the 08-01/08-02 intakes moved the snapshot and left the radar behind; this is the
  guard that would have caught it on 08-01.
- `docs/data/aos4-maintenance.md` — records the pointer obligation and the failure mode it causes.

No data, manifest, or runtime change: the accepted snapshot is untouched.

## Testing

```powershell
yarn test --run src/tests/aos4/rulesRadarCompare.test.ts src/tests/aos4/rulesRadarObservation.test.ts src/tests/aos4/rulesRadarBsData.test.ts
yarn tsc --noEmit
yarn lint
```

24 tests pass; `tsc` and `eslint` are clean. The new check was also verified negatively — pointing
`acceptedManifestPath` at the superseded `accepted-2026-08-01d.json` fails exactly that test and
nothing else.

After merge, run `AoS 4 Rules Radar` manually (`source: all`) and confirm the Games Workshop lane
comes back empty on #1757.

https://claude.ai/code/session_016NsJM79QExewCLLZQLtUDv
