### PR TITLE
chore(radar): advance the reviewed BSData baseline to f6363c26

### DIFF
--- a/data/aos4/radar/config.json
+++ b/data/aos4/radar/config.json
@@ -10,8 +10,8 @@
   "bsData": {
     "repository": "BSData/age-of-sigmar-4th",
     "branch": "main",
-    "baselineSha": "0d3eb56fe21d7893d6865143324509a4fede32c3",
-    "baselineReviewedAt": "2026-07-29T21:40:00.000Z"
+    "baselineSha": "f6363c260cdf032761864c02fd185c95bfe57f6a",
+    "baselineReviewedAt": "2026-08-04T14:08:33.749Z"
   },
   "github": {
     "repository": "daviseford/aos-reminders",

--- a/docs/data/aos4-maintenance.md
+++ b/docs/data/aos4-maintenance.md
@@ -372,6 +372,18 @@ it replaced as removed — a full lane of material events with nothing to intake
 `src/tests/aos4/rulesRadarCompare.test.ts` fails when either pointer is not the newest reviewed
 file of its kind.
 
+A BSData review starts by locating the corpus's own pins inside the signalled range, because the
+radar baseline and the accepted pins move independently: the accepted artifacts are pinned per file
+at their own commits, so most of a signalled range is usually content a prior intake already
+reviewed. Compare each pinned file's blob at its pin against the same path at the observed head —
+identical blobs mean no accepted byte moved and the review reduces to the remainder. The
+2026-08-04 review (`0d3eb56f` → `f6363c26`, issue #1757) is the worked example: all three pinned
+Ogor catalogues were byte-identical at head, the cross-faction points changes matched official
+facts the corpus already applied from the July 2026 Battle Profiles, and most remaining lines were
+apostrophe re-escaping. Community corrections to factions the corpus does not source from BSData
+are never adopted from the signal; they can only prompt a normal candidate against Wahapedia or an
+official document.
+
 Radar output is evidence, not acceptance. Automation may acquire source-scoped candidate bytes and
 compact manifests, but it never accepts a source, edits reviewed inputs, regenerates runtime data,
 or updates the beta certification pointer.

--- a/src/tests/aos4/rulesRadarCompare.test.ts
+++ b/src/tests/aos4/rulesRadarCompare.test.ts
@@ -329,7 +329,7 @@ describe('AoS 4 Rules Radar comparison', () => {
 
   it('loads the reviewed config and rejects stale repository paths', () => {
     expect(readRulesRadarConfig('data/aos4/radar/config.json', process.cwd()).bsData.baselineSha).toBe(
-      '0d3eb56fe21d7893d6865143324509a4fede32c3'
+      'f6363c260cdf032761864c02fd185c95bfe57f6a'
     )
 
     const config = JSON.parse(


### PR DESCRIPTION
Resolves the BSData lane of #1757 — the one material event that survived the #1928 pointer fix.

Reviewed `0d3eb56f…f6363c26` (17 commits, 30 files) against the accepted official sources, per the
BSData review obligation in `docs/data/aos4-maintenance.md`.

## Finding 1 — nothing the corpus pins moved

The radar baseline and the corpus's own pins move independently, so the signalled range is much
wider than the corpus's exposure. All three accepted BSData artifacts are **byte-identical at the
observed head**:

| Artifact | Pinned at | Blob at pin | Blob at `f6363c26` |
| --- | --- | --- | --- |
| `Ogor Mawtribes - Library.cat` | `c8e1b1c9` (ogors) | `3cab2329…` | `3cab2329…` |
| `Ogor Mawtribes.cat` | `a882188b` (main) | `b360079e…` | `b360079e…` |
| `Lores.cat` | `a882188b` (main) | `813d5131…` | `813d5131…` |

The `ogors` branch our library pin came from has since been merged into `main` (upstream PR #1290),
which is most of what makes the range look large. No provisional transcription this corpus ships is
affected, and no `communityWarscrollSources` checksum changes.

## Finding 2 — the signal is BSData catching up to publications we already accepted

Every cross-faction points change lands on a value the corpus already applies from the **July 2026
Battle Profiles**:

| Entry | BSData | Accepted official fact |
| --- | --- | --- |
| Killaboss on Great Gnashtoof (Scourge of Aqshy) | 230 → 150 | 150, `seasonal`, `applied-to-runtime`, p52 |
| Ogroid Thaumaturge (Scourge of Aqshy) | 210 → 140 | 140, `seasonal`, `applied-to-runtime`, p27 |
| Iridan the Witness (Scourge of Aqshy) | 360 → 320 | 320, `seasonal`, `applied-to-runtime`, p20 |
| Horn of Shattatusk (new) | 20 | 20, `seasonal`, `structured-reference` |
| Elongated Tibias / Perpetually Empowered Weapons / Utterly Unquestioning (new) | 10 each | 10 each, `seasonal`, `structured-reference` |

The same pattern holds for wording: the corpus already carries the corrected Sigvald replacement
text and the ability's current name (*The Prince in the Mirror*), which this diff is BSData renaming
*from* `Rising Fire`, and already carries the `Faction Terrain` exclusion on the battle tactic the
`.gst` just fixed. Where the two sources differ, ours was ahead.

## Finding 3 — the rest is mechanical or out of scope

Of the removed lines outside the Ogor files: **185** are apostrophe re-escaping (`'` → `&apos;`,
zero semantic change), **326** are a single relocated block in `Orruk Warclans - Library.cat` whose
only real edit is `on the target` → `on that unit`, and **21** are catalogue revision headers. The
residue is community transcription corrections in factions the corpus sources from Wahapedia, not
BSData — a passive/activated restructure of Nighthaunt's *Damned Vessel*, `friendly` added to a
Skaven declare clause, a Blades of Khorne manifestation rewording (which introduces a stray double
comma upstream), a removed Cities of Sigmar weapon option, and BattleScribe-only constraint and
Destiny Point sign fixes. **None of these may be adopted from the signal** — the fallback tier only
covers Ogor Mawtribes content, and corrections elsewhere can only ever prompt a normal candidate
against Wahapedia or an official document.

## What is not resolved by this PR

The battletome's three Ogor Armies of Renown arrive upstream as new catalogues — `Meatfist
Mawtribe`, `Beastclaw Alfrostun`, `Mawseeker Gollop`. None is named by any accepted official
document (absent from both `official-battle-profiles.json` and `catalog.json`; the `Mawseeker`
string in those files is the unit keyword, not the army), so fallback condition (a) is still unmet
and they stay out. Tracked in the #1757 triage comment along with the two Ogor Regiments of Renown,
which *are* officially established but carry a `structured-reference` disposition.

## Changes

- `data/aos4/radar/config.json` — `bsData.baselineSha` → `f6363c26…`, `baselineReviewedAt` → the
  review instant.
- `src/tests/aos4/rulesRadarCompare.test.ts` — the pinned baseline literal moves with it.
- `docs/data/aos4-maintenance.md` — records how to scope a BSData review (locate the corpus's pins
  inside the range first), using this review as the worked example.

No data, manifest, or runtime change.

## Testing

```powershell
yarn test --run src/tests/aos4/rulesRadarCompare.test.ts src/tests/aos4/rulesRadarObservation.test.ts src/tests/aos4/rulesRadarBsData.test.ts
yarn tsc --noEmit
yarn lint
```

24 tests pass; `tsc` and `eslint` clean. After merge, the next radar run should clear the BSData
lane and close #1757 automatically.

https://claude.ai/code/session_016NsJM79QExewCLLZQLtUDv
