### PR TITLE
fix(test): repair the twenty failing tests on master

### DIFF
--- a/scripts/measureDeploymentPublishing.ts
+++ b/scripts/measureDeploymentPublishing.ts
@@ -2,17 +2,9 @@ import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, wr
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
+import { bashCommand, bashPath } from '../src/tests/support/bashHarness'
 
 const repoRoot = process.cwd()
-
-const bashPath = (path: string) => {
-  if (process.platform !== 'win32') return path
-
-  const match = path.match(/^([A-Za-z]):\\(.*)$/)
-  if (!match) throw new Error(`Cannot convert ${path} to a WSL path`)
-
-  return `/mnt/${match[1].toLowerCase()}/${match[2].replaceAll('\\', '/')}`
-}
 
 const shellQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`
 const optionValue = (line: string, option: string) => {
@@ -270,7 +262,7 @@ exit 65
   const fakeBinPath = bashPath(fakeBin)
   const run = () =>
     spawnSync(
-      'bash',
+      bashCommand(),
       [
         '-c',
         `chmod +x ${shellQuote(`${fakeBinPath}/aws`)}; ` +

--- a/src/tests/aos4/adversarialReviewParallel.test.ts
+++ b/src/tests/aos4/adversarialReviewParallel.test.ts
@@ -265,5 +265,10 @@ describe('bounded adversarial review workers', () => {
     } finally {
       await rm(root, { recursive: true, force: true })
     }
-  })
+    // The only case here that spawns real workers, and it spawns two: `runFreshWorkers` shells out
+    // to vite-node per group, so this pays two full runtime startups and then waits for the aborted
+    // sibling to settle before asserting the staging directory is gone. Measured at ~10s against the
+    // 5s default, which failed as a timeout and read like a hang in the abort path rather than a
+    // slow test. The other cases in this file never leave the process and finish in milliseconds.
+  }, 60_000)
 })

--- a/src/tests/aos4/coreRulesExampleAbilities.test.ts
+++ b/src/tests/aos4/coreRulesExampleAbilities.test.ts
@@ -134,7 +134,10 @@ describe('core-rules example ability cards stay out of reminders (customer repor
         EXAMPLE_CARD_NAMES.forEach(name => expect(names).not.toContain(name))
       })
     })
-  })
+    // Every one of the 27 armies resolved across every rules context it declares, with both overlays
+    // on. ~3s on an idle machine, past the 5s default once the rest of the suite is competing for
+    // CPU -- a timeout here looked like a hang in reminder projection rather than a wide sweep.
+  }, 30_000)
 
   it('loses nothing except the example cards from a representative army', () => {
     const stormcast = AOS4_CATALOG.entities.find(

--- a/src/tests/deploymentConfig.test.ts
+++ b/src/tests/deploymentConfig.test.ts
@@ -4,20 +4,13 @@ import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { inspectDeploymentArtifact, validateDeploymentEndpoints } from '../../scripts/deploymentConfig'
 import { afterEach, describe, expect, it } from 'vitest'
+import { bashCommand, bashPath } from './support/bashHarness'
 
 const validEndpoints = {
   armyApiUrl: 'https://army123.execute-api.us-east-1.amazonaws.com',
   subscriptionApiUrl: 'https://subs123.execute-api.us-east-1.amazonaws.com',
 }
 
-const bashPath = (path: string) => {
-  if (process.platform !== 'win32') return path
-
-  const match = path.match(/^([A-Za-z]):\\(.*)$/)
-  if (!match) throw new Error(`Cannot convert ${path} to a WSL path`)
-
-  return `/mnt/${match[1].toLowerCase()}/${match[2].replaceAll('\\', '/')}`
-}
 const shellQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`
 
 describe('production deployment configuration', () => {
@@ -97,14 +90,33 @@ describe('production deployment configuration', () => {
       fakeYarn,
       `#!/usr/bin/env bash
 set -euo pipefail
-printf 'start:%s\\n' "$*" >> "$RELEASE_GATE_LOG"
+
+# The gates under test run three at a time, so three copies of this stub append to one log at once.
+# That is only safe where O_APPEND is atomic. On Linux and macOS it is, which is why CI never saw
+# this; under WSL the log sits on a DrvFs mount of the Windows drive, where concurrent appends
+# overwrite each other -- measured at five of eight lines lost. The surviving log then showed phase
+# two starting before phase one finished and failed the ordering assertion, blaming the release
+# script for a defect in the harness. flock makes the append atomic on every filesystem; the
+# fallback keeps this working anywhere flock is absent, which is exactly where it is not needed.
+log_gate() {
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>>"$RELEASE_GATE_LOG"
+    flock 9
+    printf '%s\\n' "$1" >&9
+    exec 9>&-
+  else
+    printf '%s\\n' "$1" >> "$RELEASE_GATE_LOG"
+  fi
+}
+
+log_gate "start:$*"
 if [[ "\${RELEASE_FAIL_GATE:-}" == "$*" ]]; then
   exit 23
 fi
 case "$*" in
   'lint' | 'data:aos4:verify:beta' | 'build' | 'test --run' | 'release:inspect-artifact') sleep 1 ;;
 esac
-printf 'end:%s\\n' "$*" >> "$RELEASE_GATE_LOG"
+log_gate "end:$*"
 `,
       'utf8'
     )
@@ -112,7 +124,7 @@ printf 'end:%s\\n' "$*" >> "$RELEASE_GATE_LOG"
 
     const fakeBinPath = bashPath(fakeBin)
     const result = spawnSync(
-      'bash',
+      bashCommand(),
       [
         '-c',
         `chmod +x ${shellQuote(`${fakeBinPath}/yarn`)}; ` +
@@ -138,7 +150,7 @@ printf 'end:%s\\n' "$*" >> "$RELEASE_GATE_LOG"
 
     writeFileSync(logPath, '', 'utf8')
     const failure = spawnSync(
-      'bash',
+      bashCommand(),
       [
         '-c',
         `chmod +x ${shellQuote(`${fakeBinPath}/yarn`)}; ` +
@@ -154,7 +166,9 @@ printf 'end:%s\\n' "$*" >> "$RELEASE_GATE_LOG"
     expect(failureLog).toContain('start:data:aos4:verify:beta')
     expect(failureLog).not.toContain('start:test --run')
     expect(failureLog).not.toContain('start:release:inspect-artifact')
-  })
+    // Two runs of the real script, each with a one-second sleep per phase, plus the cost of spawning
+    // bash twice -- under WSL that spawn is slow enough on its own to crowd out the default 5s.
+  }, 30_000)
 
   it('runs release preparation before publication from every production entry point', () => {
     const entryPoints = [

--- a/src/tests/deploymentContract.test.ts
+++ b/src/tests/deploymentContract.test.ts
@@ -5,16 +5,9 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { afterEach, describe, expect, it } from 'vitest'
+import { bashCommand, bashPath } from './support/bashHarness'
 
 const repoRoot = process.cwd()
-const bashPath = (path: string) => {
-  if (process.platform !== 'win32') return path
-
-  const match = path.match(/^([A-Za-z]):\\(.*)$/)
-  if (!match) throw new Error(`Cannot convert ${path} to a WSL path`)
-
-  return `/mnt/${match[1].toLowerCase()}/${match[2].replaceAll('\\', '/')}`
-}
 
 const readRepoFile = (path: string) => readFileSync(join(repoRoot, path), 'utf8')
 const shellQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`
@@ -27,7 +20,15 @@ const cloudFrontPreflightQuery =
   ' DefaultCacheBehavior.MaxTTL, DefaultCacheBehavior.CachePolicyId,' +
   ' DefaultCacheBehavior.ResponseHeadersPolicyId, CacheBehaviors.Quantity]'
 
-describe('production deployment contract', () => {
+/*
+ * Every case here spawns a shell and runs the real `scripts/deploy-production.sh` end to end against
+ * stub binaries. That costs whole seconds before any assertion runs -- more under WSL, where each
+ * spawn crosses into the Linux VM -- and the cost scales with how loaded the machine is. Against the
+ * 5s default the suite passed when run alone and failed as a timeout under a full-suite run, which
+ * reads as a flaky deployment contract rather than as a per-case budget that was never sized for
+ * spawning a shell.
+ */
+describe('production deployment contract', { timeout: 60_000 }, () => {
   const temporaryDirectories: string[] = []
 
   afterEach(() => {
@@ -242,7 +243,7 @@ echo '{}'
       const fakeBinPath = bashPath(fakeBin)
 
       return spawnSync(
-        'bash',
+        bashCommand(),
         [
           '-c',
           `chmod +x ${shellQuote(`${fakeBinPath}/aws`)}; PATH=${shellQuote(fakeBinPath)}:/usr/local/bin:/usr/bin:/bin ${assignments} bash scripts/deploy-production.sh`,

--- a/src/tests/support/bashHarness.ts
+++ b/src/tests/support/bashHarness.ts
@@ -1,0 +1,37 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+/*
+ * The deployment harnesses run the real `scripts/*.sh` against stub binaries. On Windows that means
+ * WSL: the scripts are bash, and the harness hands them `/mnt/<drive>/...` paths.
+ *
+ * `spawnSync('bash', ...)` picks whichever bash the launching shell put first on PATH, which is not
+ * the same thing. Started from PowerShell or cmd it finds WSL's launcher in System32 and the suite
+ * passes; started from Git Bash it finds Git's own bash, which reads `/mnt/c/...` relative to its
+ * installation root and reports `chmod: cannot access '/mnt/c/...': No such file or directory` for
+ * every stub. That surfaced as 19 failing deployment tests whose real cause was the terminal the
+ * developer happened to be in.
+ *
+ * So name the interpreter instead of inheriting it. `System32\bash.exe` is the WSL launcher and is
+ * present whenever the feature is enabled; if it is missing, fall back to a PATH lookup so the
+ * failure is about a missing WSL rather than a missing file.
+ */
+export const bashCommand = (): string => {
+  if (process.platform !== 'win32') return 'bash'
+
+  const wslBash = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'bash.exe')
+
+  return existsSync(wslBash) ? wslBash : 'bash'
+}
+
+/*
+ * Convert a Windows path to the form the interpreter above understands. A no-op everywhere else.
+ */
+export const bashPath = (path: string): string => {
+  if (process.platform !== 'win32') return path
+
+  const match = path.match(/^([A-Za-z]):\\(.*)$/)
+  if (!match) throw new Error(`Cannot convert ${path} to a WSL path`)
+
+  return `/mnt/${match[1].toLowerCase()}/${match[2].replaceAll('\\', '/')}`
+}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -334,7 +334,14 @@ export default defineConfig({
   },
   test: {
     ...configDefaults,
-    exclude: [...configDefaults.exclude, '**/.worktrees/**', '**/.claude/**'],
+    /*
+     * `.cache/` is the ignored acquisition tree, and parking a locked `node_modules` there under a
+     * name like `stale-node-modules-<stamp>/` is the documented Windows EPERM workaround. Vitest's
+     * default excludes only cover a directory literally named `node_modules`, so the parked copy's
+     * own test suites were collected as if they were ours -- 56 phantom failing files, none of them
+     * in this repository. Nothing under `.cache/` is ever a test of this project.
+     */
+    exclude: [...configDefaults.exclude, '**/.worktrees/**', '**/.claude/**', '**/.cache/**'],
     /**
      * Node by default, jsdom only for the component tests that render — those opt in with a
      * `// @vitest-environment jsdom` docblock at the top of the file (vitest 4 removed


### PR DESCRIPTION
`yarn test --run` failed 56 files on a Windows checkout, and 20 tests once that noise was removed. None were product defects — all four causes were in the harnesses.

## What was wrong

**Vitest collected a parked `node_modules`.** `.cache/` is the ignored acquisition tree, and moving a locked `node_modules` there as `stale-node-modules-<stamp>/` is the documented Windows EPERM workaround. Vitest's default excludes only match a directory literally named `node_modules`, so the parked copy's own suites ran as ours — 56 phantom failing files, including third-party tests that abort the whole run with an uncaught `done() callback is deprecated`.

**The deployment harnesses inherited their interpreter.** They run the real `scripts/*.sh` and hand them `/mnt/<drive>/...` paths on Windows, so they mean WSL specifically. `spawnSync('bash', ...)` resolves to whatever the launching shell put first on PATH: from PowerShell that is WSL's launcher and the suite passes, but from Git Bash it is Git's own bash, which reads `/mnt/c/...` relative to its install root and finds no stub at all. 19 tests failed on nothing but which terminal the developer was sitting in.

**Concurrent appends were silently lost.** `prepare-production-release.sh` runs three gates at once and the stub logging them appends to one file from three processes. That is only safe where `O_APPEND` is atomic — true on Linux and macOS, which is why CI never saw it, false on the DrvFs mount WSL uses for Windows drives. Measured five of eight lines lost, with torn writes splicing two gate names into one line:

```
drvfs(/mnt/c) plain:  3 / 8      native(/tmp) plain:  8 / 8
drvfs(/mnt/c) flock:  8 / 8      native(/tmp) flock:  8 / 8
```

The surviving log showed phase two starting before phase one finished, so the failure accused the release script of a scheduling bug that was never there.

**Four cases were slower than the 5s default.** Three spawn shells or worker processes, one sweeps 27 armies across every rules context. All four passed alone and timed out under a full-suite run.

## What changed

- `**/.cache/**` added to the vitest exclude list.
- New `src/tests/support/bashHarness.ts` names the interpreter instead of inheriting it; the three copies of `bashPath` collapse into it.
- The release-gate stub takes an `flock`, falling back to a plain append where flock is absent — which is exactly the platforms that never needed it.
- Explicit timeouts on the four slow cases, each commented with what it is paying for. A timeout in the abort path of a parallel worker run reads as a hang, not as a case that needs eleven seconds.

## Testing

- `yarn lint`, `yarn tsc --noEmit`, `yarn build` clean.
- `yarn test --run`: **95 files, 1,515 tests, no failures**, run from both Git Bash and PowerShell, twice each to shake out the load-dependent ones.
- Append atomicity measured directly on DrvFs and on WSL-native `/tmp` (table above) rather than inferred.
- No product code changed — only test harnesses, the vitest exclude, and one dev measurement script.

https://claude.ai/code/session_019PcwEbyb2mDMmiXmRusTz7
