### PR TITLE
chore: fix the pre-commit hook in worktrees and Prettier's global parser (#1930, #1929)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,16 +2,15 @@ name: Lint, Test, and Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CI: true
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -14,4 +14,4 @@ fi
 
 # Deliberately not `cd`-ing anywhere: git runs the hook from the top of the committing worktree, and
 # `--staged` reads whichever index that is. Only the binary comes from the owning checkout.
-"$pretty_quick" --staged --pattern "**/*.*(ts|tsx)"
+"$pretty_quick" --staged --pattern "**/*.*(js|jsx|ts|tsx|json|scss|css|yml|yaml|html)"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -14,4 +14,4 @@ fi
 
 # Deliberately not `cd`-ing anywhere: git runs the hook from the top of the committing worktree, and
 # `--staged` reads whichever index that is. Only the binary comes from the owning checkout.
-"$pretty_quick" --staged --pattern "**/*.*(js|jsx|ts|tsx|json|scss|css|yml|yaml|html)"
+"$pretty_quick" --staged --pattern "**/*.*(js|jsx|mjs|cjs|ts|tsx|mts|cts|json|scss|css|yml|yaml|html)"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,17 @@
-pretty-quick --staged --pattern "**/*.*(ts|tsx)"
+# Husky prepends a *relative* `node_modules/.bin` to PATH, which resolves against the current
+# working directory. A worktree created by `git worktree add` has no `node_modules` of its own, so
+# every commit from one was rejected with `pretty-quick: command not found` (#1930).
+# `--git-common-dir` points at the owning checkout's `.git` from a worktree and a plain clone alike,
+# so derive the repository that actually holds the dependencies from it.
+repo_root="$(cd "$(dirname "$(git rev-parse --git-common-dir)")" && pwd)"
+pretty_quick="$repo_root/node_modules/.bin/pretty-quick"
+
+if [ ! -f "$pretty_quick" ]; then
+  echo "pre-commit: $pretty_quick not found" >&2
+  echo "pre-commit: run 'yarn install --frozen-lockfile' in $repo_root" >&2
+  exit 1
+fi
+
+# Deliberately not `cd`-ing anywhere: git runs the hook from the top of the committing worktree, and
+# `--staged` reads whichever index that is. Only the binary comes from the owning checkout.
+"$pretty_quick" --staged --pattern "**/*.*(ts|tsx)"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,11 +1,34 @@
-package.json
-tsconfig.json
 node_modules/
 build/*
 dist/*
-src/tests/fixtures/**/*.json
 *.md
 *.sh
 *.log
 *.lock
 .vscode/
+
+# Local tooling scratch, not part of this repository's sources.
+.context/
+
+# A Google site-verification token that happens to carry an .html extension. It is not markup, and
+# the verifier reads it byte for byte.
+public/google*.html
+
+# Yarn and tsc rewrite these on their own schedule; leave the formatting to the tools that own them.
+package.json
+tsconfig.json
+
+# Byte-pinned inputs. The New Recruit corpus is captured from opted-in accounts and self-checking,
+# and the remaining fixtures are provider-shape contracts. Reformatting them rewrites the evidence.
+src/tests/fixtures/
+
+# Written by the deterministic serializer in src/aos4/generate/serialization.ts, which emits
+# `JSON.stringify(value, null, 2)`. Prettier collapses short arrays and objects that form always
+# expands, so formatting these would rewrite every generated product.
+src/aos4/generated/
+
+# The whole data pipeline tree is checksum-bound, products and reviewed inputs alike:
+# data/aos4/certifications/*/manifest.json records a SHA-256 for the accepted manifest, corpus
+# review, catalog, official battle profiles, and reconciliation report, and `yarn
+# data:aos4:verify:beta` fails closed when any of them moves. Formatting here breaks the beta gate.
+data/aos4/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,11 +1,10 @@
 {
-    "arrowParens": "avoid",
-    "endOfLine": "auto",
-    "parser": "typescript",
-    "printWidth": 110,
-    "semi": false,
-    "singleQuote": true,
-    "tabWidth": 2,
-    "trailingComma": "es5",
-    "useTabs": false
+  "arrowParens": "avoid",
+  "endOfLine": "auto",
+  "printWidth": 110,
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false
 }

--- a/index.html
+++ b/index.html
@@ -1,49 +1,51 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta property=og:site_name content="AoS Reminders">
-    <meta property="og:image" content="https://aosreminders.com/img/logo_border.png">
-    <meta property="article:tag" content="warhammer">
-    <meta name="author" content="Davis E. Ford">
-    <meta property="profile:first_name" content="Davis">
-    <meta property="profile:last_name" content="Ford">
-    <meta name="description"
-      content="Never forget your Warhammer: Age of Sigmar abilities again! Generate helpful in-game reminders tailored to your AoS army.">
-    <meta name="keywords" content="warhammer, sigmar, cheat, sheet, competitive">
-    <meta name="og:description"
-      content="Never forget your Warhammer: Age of Sigmar abilities again! Generate helpful in-game reminders tailored to your AoS army.">
-    <meta property="og:url" content="https://aosreminders.com/">
-    <meta property="og:locale" content="en_US">
+    <meta property="og:site_name" content="AoS Reminders" />
+    <meta property="og:image" content="https://aosreminders.com/img/logo_border.png" />
+    <meta property="article:tag" content="warhammer" />
+    <meta name="author" content="Davis E. Ford" />
+    <meta property="profile:first_name" content="Davis" />
+    <meta property="profile:last_name" content="Ford" />
+    <meta
+      name="description"
+      content="Never forget your Warhammer: Age of Sigmar abilities again! Generate helpful in-game reminders tailored to your AoS army."
+    />
+    <meta name="keywords" content="warhammer, sigmar, cheat, sheet, competitive" />
+    <meta
+      name="og:description"
+      content="Never forget your Warhammer: Age of Sigmar abilities again! Generate helpful in-game reminders tailored to your AoS army."
+    />
+    <meta property="og:url" content="https://aosreminders.com/" />
+    <meta property="og:locale" content="en_US" />
 
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=vMQB3wPOMa">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=vMQB3wPOMa">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=vMQB3wPOMa">
-    <link rel="manifest" href="/site.webmanifest?v=vMQB3wPOMa">
-    <link rel="mask-icon" href="/safari-pinned-tab.svg?v=vMQB3wPOMa" color="#1c7595">
-    <link rel="shortcut icon" href="/favicon.ico?v=vMQB3wPOMa">
-    <meta name="apple-mobile-web-app-title" content="AoS Reminders">
-    <meta name="application-name" content="AoS Reminders">
-    <meta name="msapplication-TileColor" content="#ffffff">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=vMQB3wPOMa" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=vMQB3wPOMa" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=vMQB3wPOMa" />
+    <link rel="manifest" href="/site.webmanifest?v=vMQB3wPOMa" />
+    <link rel="mask-icon" href="/safari-pinned-tab.svg?v=vMQB3wPOMa" color="#1c7595" />
+    <link rel="shortcut icon" href="/favicon.ico?v=vMQB3wPOMa" />
+    <meta name="apple-mobile-web-app-title" content="AoS Reminders" />
+    <meta name="application-name" content="AoS Reminders" />
+    <meta name="msapplication-TileColor" content="#ffffff" />
     <!-- Matches the masthead ($themeDarkBluePrimary / $themeDarkBlueSecondary) so the browser chrome
          does not sit white above a dark header. -->
-    <meta name="theme-color" content="#063647">
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#182633">
+    <meta name="theme-color" content="#063647" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#182633" />
 
     <!-- https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect -->
-    <link rel="dns-prefetch" href="https://google.com">
+    <link rel="dns-prefetch" href="https://google.com" />
 
     <title>AoS Reminders</title>
-
   </head>
   <body>
     <div id="root"></div>
     <script>
       // To fix problems when using db-react-ui components (see https://github.com/vitejs/vite/discussions/5912#discussioncomment-5569850)
       if (global === undefined) {
-        var global = window;
+        var global = window
       }
     </script>
     <script type="module" src="/src/main.tsx"></script>

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "fixtures:official-app": "vite-node --script src/tests/support/officialAppFixturesCommand.ts",
     "fixtures:new-recruit": "vite-node --script src/tests/support/newRecruitManifestCommand.ts",
     "fixtures:new-recruit:ingest": "vite-node --script src/tests/support/newRecruitIngestCommand.ts --",
-    "format": "yarn prettier --write \"**/*.*(js|jsx|ts|tsx|json|scss|css|yml|yaml|html)\"",
+    "format": "yarn prettier --write \"**/*.*(js|jsx|mjs|cjs|ts|tsx|mts|cts|json|scss|css|yml|yaml|html)\"",
     "gitclean:win": "git branch | %{ $_.Trim() } | ?{ $_ -ne 'master' } | %{ git branch -D $_ }",
     "gitclean": "git branch | grep -v \"master\" | xargs git branch -D",
     "lint": "eslint src --max-warnings 0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "fixtures:official-app": "vite-node --script src/tests/support/officialAppFixturesCommand.ts",
     "fixtures:new-recruit": "vite-node --script src/tests/support/newRecruitManifestCommand.ts",
     "fixtures:new-recruit:ingest": "vite-node --script src/tests/support/newRecruitIngestCommand.ts --",
-    "format": "yarn prettier --write \"**/*.*(js|jsx|ts|tsx)\"",
+    "format": "yarn prettier --write \"**/*.*(js|jsx|ts|tsx|json|scss|css|yml|yaml|html)\"",
     "gitclean:win": "git branch | %{ $_.Trim() } | ?{ $_ -ne 'master' } | %{ git branch -D $_ }",
     "gitclean": "git branch | grep -v \"master\" | xargs git branch -D",
     "lint": "eslint src --max-warnings 0",

--- a/src/aos4/data/gamesWorkshop/pageDiscovery.ts
+++ b/src/aos4/data/gamesWorkshop/pageDiscovery.ts
@@ -6,8 +6,7 @@ import type { GamesWorkshopDiagnostic, GamesWorkshopDiscoveryResult, GamesWorksh
 type Node = DefaultTreeAdapterMap['node']
 type Element = DefaultTreeAdapterMap['element']
 
-const isElement = (node: Node): node is Element =>
-  'tagName' in node && Array.isArray(node.attrs)
+const isElement = (node: Node): node is Element => 'tagName' in node && Array.isArray(node.attrs)
 
 const attribute = (element: Element, name: string): string | undefined =>
   element.attrs.find(item => item.name.toLowerCase() === name)?.value

--- a/src/aos4/data/gamesWorkshop/pdfText.ts
+++ b/src/aos4/data/gamesWorkshop/pdfText.ts
@@ -62,10 +62,9 @@ export const createPdfJsDocumentLoader = (): PdfDocumentLoader => ({
     // and `destroy()` moved from the document to the loading task. It also rejects Node Buffers
     // outright, and the artifact cache hands out `readFile` Buffers, so copy into a plain
     // Uint8Array here — the copy also keeps pdf.js from ever touching cached bytes.
-    const loadingTask = (getDocument as unknown as (options: {
-      data: Uint8Array
-      isEvalSupported: boolean
-    }) => PdfJsLoadingTask)({
+    const loadingTask = (
+      getDocument as unknown as (options: { data: Uint8Array; isEvalSupported: boolean }) => PdfJsLoadingTask
+    )({
       data: new Uint8Array(bytes),
       isEvalSupported: false,
     })

--- a/src/aos4/normalize/text.ts
+++ b/src/aos4/normalize/text.ts
@@ -47,8 +47,7 @@ export interface SourceTextNormalizationResult {
 type Node = DefaultTreeAdapterMap['node']
 type Element = DefaultTreeAdapterMap['element']
 
-const isElement = (node: Node): node is Element =>
-  'tagName' in node && Array.isArray(node.attrs)
+const isElement = (node: Node): node is Element => 'tagName' in node && Array.isArray(node.attrs)
 
 const isUnsafeUrl = (value: string): boolean => {
   const normalized = value.trim().toLowerCase()

--- a/src/aos4/reminders/projectReminders.ts
+++ b/src/aos4/reminders/projectReminders.ts
@@ -1,11 +1,4 @@
-import type {
-  Ability,
-  AbilityCost,
-  AbilityText,
-  Aos4Catalog,
-  CanonicalId,
-  SourceReference,
-} from '../domain'
+import type { Ability, AbilityCost, AbilityText, Aos4Catalog, CanonicalId, SourceReference } from '../domain'
 import type { ResolvedSelection, SelectionCause } from '../select'
 import { reminderOccurrenceId, semanticTimingKey } from './reminderIdentity'
 import { orderReminders } from './orderReminders'

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -1,10 +1,10 @@
-@import "./theme.scss";
+@import './theme.scss';
 
 /* Make sure our document fills the page - important for dark theme! */
 html,
 body {
-    margin: 0;
-    height: 100%;
+  margin: 0;
+  height: 100%;
 }
 
 /*
@@ -15,31 +15,32 @@ body {
  * and lets the box grow with the content on long ones.
  */
 #root {
-    margin: 0;
-    min-height: 100%;
+  margin: 0;
+  min-height: 100%;
 }
 
 /* Elements */
 body {
-    margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
-        "Droid Sans", "Helvetica Neue", sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+  margin: 0;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
+    'Droid Sans', 'Helvetica Neue', sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-    font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
 small {
-    font-size: 12px;
+  font-size: 12px;
 }
 
 /* Custom Classes */
 
 .LoadingContainer {
-    padding-top: 35vh;
+  padding-top: 35vh;
 }
 
 /*
@@ -51,10 +52,10 @@ small {
  * lets it grow from the top on a short one.
  */
 .RedemptionContainer {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    min-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 70vh;
 }
 
 /*
@@ -63,17 +64,17 @@ small {
  * ragged orphan is the most visible thing on the page. Browsers without it wrap as they do today.
  */
 .RedemptionColumn {
-    max-width: 38rem;
+  max-width: 38rem;
 
-    h1,
-    p {
-        text-wrap: balance;
-    }
+  h1,
+  p {
+    text-wrap: balance;
+  }
 }
 
 /* A coupon code is seven-ish characters. A full-width field promises a paragraph. */
 .RedemptionCodeField {
-    max-width: 18rem;
+  max-width: 18rem;
 }
 
 /*
@@ -83,7 +84,7 @@ small {
  * literal, so the surrounding theme slot stays the single source of the text colour.
  */
 .RedemptionErrorDetail {
-    color: inherit;
+  color: inherit;
 }
 
 /*
@@ -92,8 +93,8 @@ small {
  * the h4 these replaced; the breakpoint overrides further down are unchanged.
  */
 .CardHeaderTitle {
-    margin-bottom: 0;
-    font-size: 1.5rem;
+  margin-bottom: 0;
+  font-size: 1.5rem;
 }
 
 /*
@@ -101,22 +102,22 @@ small {
  * padding the .card-header used to own, so the whole header stays clickable and looks identical.
  */
 .CardHeaderToggle {
-    display: block;
-    width: 100%;
-    margin: 0;
-    padding: 0.5rem 1.25rem;
-    border: 0;
-    background-color: transparent;
-    color: inherit;
-    font: inherit;
-    text-align: inherit;
-    -webkit-appearance: none;
-    appearance: none;
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0.5rem 1.25rem;
+  border: 0;
+  background-color: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: inherit;
+  -webkit-appearance: none;
+  appearance: none;
 }
 
 .CardHeaderToggle-Mobile {
-    @extend .CardHeaderToggle;
-    padding: 1rem;
+  @extend .CardHeaderToggle;
+  padding: 1rem;
 }
 
 /*
@@ -128,17 +129,17 @@ small {
  * unconstrained by neighbours, so it takes the full 44px.
  */
 .ReminderMenuToggle {
-    position: relative;
+  position: relative;
 
-    &::after {
-        content: "";
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        width: 40px;
-        height: 44px;
-        transform: translate(-50%, -50%);
-    }
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 40px;
+    height: 44px;
+    transform: translate(-50%, -50%);
+  }
 }
 
 /*
@@ -149,21 +150,21 @@ small {
  * value, so the chip matches every other control on the page.
  */
 .SkipLink:focus {
-    position: absolute;
-    z-index: 1030;
-    top: 0;
-    left: 0;
-    margin: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid currentcolor;
-    border-radius: $border-radius;
-    text-decoration: none;
+  position: absolute;
+  z-index: 1030;
+  top: 0;
+  left: 0;
+  margin: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid currentcolor;
+  border-radius: $border-radius;
+  text-decoration: none;
 }
 
 /* Reboot sizes <legend> at 1.5rem; these group labels replaced 1rem <label>s. */
 .FieldsetLegend {
-    margin-bottom: 0.25rem;
-    font-size: 1rem;
+  margin-bottom: 0.25rem;
+  font-size: 1rem;
 }
 
 /*
@@ -172,7 +173,7 @@ small {
  * the floor; position and colour already make it subordinate.
  */
 .DisclaimerText {
-    font-size: 12px;
+  font-size: 12px;
 }
 
 /*
@@ -181,13 +182,13 @@ small {
  * draws around a card; on Midnight Slate that hairline is invisible, so dark supplies its own.
  */
 .FaqEntry + .FaqEntry {
-    margin-block-start: 1.25rem;
-    padding-block-start: 1.25rem;
-    border-block-start: 1px solid rgba(0, 0, 0, 0.125);
+  margin-block-start: 1.25rem;
+  padding-block-start: 1.25rem;
+  border-block-start: 1px solid rgba(0, 0, 0, 0.125);
 }
 
 .FaqEntry-Dark + .FaqEntry-Dark {
-    border-block-start-color: rgba(255, 255, 255, 0.2);
+  border-block-start-color: rgba(255, 255, 255, 0.2);
 }
 
 /*
@@ -196,64 +197,64 @@ small {
  * for the controls that commit. The underline carries "this is a link" in both themes.
  */
 .FaqLink {
+  color: inherit;
+  text-decoration: underline;
+
+  &:hover,
+  &:focus {
     color: inherit;
     text-decoration: underline;
-
-    &:hover,
-    &:focus {
-        color: inherit;
-        text-decoration: underline;
-    }
+  }
 }
 
 .text-white-75 {
-    color: rgba(255, 255, 255, 0.75) !important;
+  color: rgba(255, 255, 255, 0.75) !important;
 }
 
 .border-light-gray {
-    border: 1px solid $themeLightGray;
+  border: 1px solid $themeLightGray;
 }
 
 .bg-themeDarkBluePrimary {
-    background-color: $themeDarkBluePrimary;
+  background-color: $themeDarkBluePrimary;
 }
 .bg-themeDarkBlueSecondary {
-    background-color: $themeDarkBlueSecondary;
+  background-color: $themeDarkBlueSecondary;
 }
 .bg-themeLightBlue {
-    background-color: $themeLightBlue;
+  background-color: $themeLightBlue;
 }
 .bg-profileHeader {
-    background-color: rgba(28, 117, 149, 0.15);
+  background-color: rgba(28, 117, 149, 0.15);
 }
 /*
  * Dark's equivalent of the wash above — quieter than the full-strength Signal Teal on the reminder
  * card headers, which is the same distinction the light wash draws.
  */
 .bg-profileHeader-dark {
-    background-color: $themeProfileHeaderDark;
+  background-color: $themeProfileHeaderDark;
 }
 .bg-themeLightGray {
-    background-color: $themeLightGray;
+  background-color: $themeLightGray;
 }
 
 .text-light-gray {
-    color: $themeLightGray !important;
+  color: $themeLightGray !important;
 }
 
 .ReminderEntry {
-    font-size: 1rem;
-    padding-top: 0.5rem;
-    padding-bottom: 0;
-    margin-block-end: 0;
+  font-size: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0;
+  margin-block-end: 0;
 }
 
 .ReminderHr {
-    background-color: rgba(255, 255, 255, 0.15);
-    &-Dark {
-        @extend .ReminderHr;
-        background-color: rgba(255, 255, 255, 0.2);
-    }
+  background-color: rgba(255, 255, 255, 0.15);
+  &-Dark {
+    @extend .ReminderHr;
+    background-color: rgba(255, 255, 255, 0.2);
+  }
 }
 
 /**
@@ -264,17 +265,17 @@ small {
  * colours are set per theme below, never by the tone class alone, so light and dark can differ.
  */
 .ReminderHeadingRow {
-    display: flex;
-    align-items: baseline;
-    gap: 0.35rem;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  flex-wrap: wrap;
 }
 
 .ReminderTags {
-    display: inline-flex;
-    flex-wrap: wrap;
-    gap: 0.25rem;
-    align-items: baseline;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  align-items: baseline;
 }
 
 /**
@@ -283,35 +284,35 @@ small {
  * name's line box; without it the button chases the tallest element on the row.
  */
 .ReminderOptions {
-    display: flex;
-    align-items: center;
-    align-self: flex-start;
-    min-height: 1.5rem;
-    margin-inline-start: 0.85rem;
+  display: flex;
+  align-items: center;
+  align-self: flex-start;
+  min-height: 1.5rem;
+  margin-inline-start: 0.85rem;
 }
 
 .ReminderHeadingRow > .ReminderTags {
-    margin-inline-start: auto;
+  margin-inline-start: auto;
 }
 
 .ReminderHeading > .ReminderTags {
-    margin-block-start: 0.25rem;
+  margin-block-start: 0.25rem;
 }
 
 .ReminderTag {
-    appearance: none;
-    font-family: inherit;
-    font-size: 0.7rem;
-    font-weight: 700;
-    line-height: 1.35;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-    white-space: nowrap;
-    padding: 0.1rem 0.4rem;
-    border-radius: 3px;
-    border: 1px solid transparent;
-    cursor: help;
-    /*
+  appearance: none;
+  font-family: inherit;
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1.35;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  border: 1px solid transparent;
+  cursor: help;
+  /*
      * The chip renders 20px tall, under the 24px WCAG 2.5.8 floor, and there are 85 of them on the
      * default army. Growing the chip itself would trade away the density the reminders surface is
      * built on, so this widens the hit box only — the same approach .ReminderMenuToggle takes.
@@ -319,22 +320,22 @@ small {
      * 24px against a 20px chip overhangs 2px per side, and .ReminderTags sets a 0.25rem (4px) gap,
      * so vertically stacked overlays meet exactly and never overlap.
      */
-    position: relative;
+  position: relative;
 
-    &::after {
-        content: "";
-        position: absolute;
-        top: 50%;
-        left: 0;
-        width: 100%;
-        height: 24px;
-        transform: translateY(-50%);
-    }
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 100%;
+    height: 24px;
+    transform: translateY(-50%);
+  }
 
-    &:focus-visible {
-        outline: 2px solid $themeLightBlue;
-        outline-offset: 1px;
-    }
+  &:focus-visible {
+    outline: 2px solid $themeLightBlue;
+    outline-offset: 1px;
+  }
 }
 
 /**
@@ -342,383 +343,395 @@ small {
  * flex sibling of the tag row it wraps below without disturbing the row's right alignment.
  */
 .ReminderTagExplainer {
-    display: block;
-    flex-basis: 100%;
-    width: 100%;
-    margin-block-start: 0.2rem;
-    font-size: 0.78rem;
-    font-style: italic;
-    line-height: 1.35;
-    text-align: start;
+  display: block;
+  flex-basis: 100%;
+  width: 100%;
+  margin-block-start: 0.2rem;
+  font-size: 0.78rem;
+  font-style: italic;
+  line-height: 1.35;
+  text-align: start;
 
-    &.ReminderTags-Light {
-        color: $themeMutedInk;
-    }
+  &.ReminderTags-Light {
+    color: $themeMutedInk;
+  }
 
-    &.ReminderTags-Dark {
-        color: rgba(255, 255, 255, 0.78);
-    }
+  &.ReminderTags-Dark {
+    color: rgba(255, 255, 255, 0.78);
+  }
 }
 
-@mixin tag-tones($cost, $active, $reaction, $passive, $your, $enemy, $neutral, $usage, $source, $provenance, $keyword) {
-    .ReminderTag {
-        &--cost {
-            @include tag-tone($cost...);
-        }
-        &--kind-active {
-            @include tag-tone($active...);
-        }
-        &--kind-reaction {
-            @include tag-tone($reaction...);
-        }
-        &--kind-passive {
-            @include tag-tone($passive...);
-        }
-        &--turn-your {
-            @include tag-tone($your...);
-        }
-        &--turn-enemy {
-            @include tag-tone($enemy...);
-        }
-        &--turn-neutral {
-            @include tag-tone($neutral...);
-        }
-        &--priority {
-            @include tag-tone($reaction...);
-        }
-        &--usage {
-            @include tag-tone($usage...);
-            border-style: dashed;
-        }
-        &--source {
-            @include tag-tone($source...);
-        }
-        /*
+@mixin tag-tones(
+  $cost,
+  $active,
+  $reaction,
+  $passive,
+  $your,
+  $enemy,
+  $neutral,
+  $usage,
+  $source,
+  $provenance,
+  $keyword
+) {
+  .ReminderTag {
+    &--cost {
+      @include tag-tone($cost...);
+    }
+    &--kind-active {
+      @include tag-tone($active...);
+    }
+    &--kind-reaction {
+      @include tag-tone($reaction...);
+    }
+    &--kind-passive {
+      @include tag-tone($passive...);
+    }
+    &--turn-your {
+      @include tag-tone($your...);
+    }
+    &--turn-enemy {
+      @include tag-tone($enemy...);
+    }
+    &--turn-neutral {
+      @include tag-tone($neutral...);
+    }
+    &--priority {
+      @include tag-tone($reaction...);
+    }
+    &--usage {
+      @include tag-tone($usage...);
+      border-style: dashed;
+    }
+    &--source {
+      @include tag-tone($source...);
+    }
+    /*
          * The quiet cousin of --source: names a game-wide origin (core rules, the season, battle
          * traits) rather than something the player picked, so it keeps the source family's hue as
          * an outline instead of a fill (issue #1857).
          */
-        &--provenance {
-            @include tag-tone($provenance...);
-        }
-        &--keyword {
-            @include tag-tone($keyword...);
-        }
+    &--provenance {
+      @include tag-tone($provenance...);
     }
+    &--keyword {
+      @include tag-tone($keyword...);
+    }
+  }
 }
 
 @mixin tag-tone($bg, $fg, $border) {
-    background-color: $bg;
-    color: $fg;
-    border-color: $border;
+  background-color: $bg;
+  color: $fg;
+  border-color: $border;
 }
 
 .ReminderTags-Light {
-    @include tag-tones(
-        (transparent, #355c64, #9db8be),
-        (#e0eff5, #0c4a60, #b4d7e4),
-        (#f8ecd9, #79490d, #e6cda4),
-        (#e9eef1, #46585f, #d0dade),
-        (#e6f2ea, #1f5334, #bcdcc7),
-        (#f9e8e8, #7c3535, #ecc9c9),
-        (#eef0f2, #4d5a63, #d8dee2),
-        (transparent, #5b6b74, #b9c5cc),
-        (#efeaf7, #543e7a, #d3c6e8),
-        (transparent, #6b6085, #cfc4e2),
-        (#f7e9f1, #7a2e5b, #e6c3d8)
-    );
+  @include tag-tones(
+    (transparent, #355c64, #9db8be),
+    (#e0eff5, #0c4a60, #b4d7e4),
+    (#f8ecd9, #79490d, #e6cda4),
+    (#e9eef1, #46585f, #d0dade),
+    (#e6f2ea, #1f5334, #bcdcc7),
+    (#f9e8e8, #7c3535, #ecc9c9),
+    (#eef0f2, #4d5a63, #d8dee2),
+    (transparent, #5b6b74, #b9c5cc),
+    (#efeaf7, #543e7a, #d3c6e8),
+    (transparent, #6b6085, #cfc4e2),
+    (#f7e9f1, #7a2e5b, #e6c3d8)
+  );
 }
 
 .ReminderTags-Dark {
-    @include tag-tones(
-        (transparent, #a4cbd2, rgba(164, 203, 210, 0.48)),
-        (rgba(28, 117, 149, 0.34), #86d3ea, rgba(28, 117, 149, 0.62)),
-        (rgba(198, 144, 58, 0.26), #f2c982, rgba(198, 144, 58, 0.5)),
-        (rgba(255, 255, 255, 0.1), #bccad2, rgba(255, 255, 255, 0.2)),
-        (rgba(72, 160, 105, 0.24), #92d8ac, rgba(72, 160, 105, 0.45)),
-        (rgba(190, 90, 90, 0.24), #f0a6a6, rgba(190, 90, 90, 0.45)),
-        (rgba(255, 255, 255, 0.08), #b3c1ca, rgba(255, 255, 255, 0.18)),
-        (transparent, #a9bac3, rgba(255, 255, 255, 0.3)),
-        (rgba(132, 100, 190, 0.24), #cbb8ee, rgba(132, 100, 190, 0.45)),
-        (transparent, #b3a4cf, rgba(132, 100, 190, 0.45)),
-        (rgba(190, 90, 145, 0.24), #f0b1d4, rgba(190, 90, 145, 0.45))
-    );
+  @include tag-tones(
+    (transparent, #a4cbd2, rgba(164, 203, 210, 0.48)),
+    (rgba(28, 117, 149, 0.34), #86d3ea, rgba(28, 117, 149, 0.62)),
+    (rgba(198, 144, 58, 0.26), #f2c982, rgba(198, 144, 58, 0.5)),
+    (rgba(255, 255, 255, 0.1), #bccad2, rgba(255, 255, 255, 0.2)),
+    (rgba(72, 160, 105, 0.24), #92d8ac, rgba(72, 160, 105, 0.45)),
+    (rgba(190, 90, 90, 0.24), #f0a6a6, rgba(190, 90, 90, 0.45)),
+    (rgba(255, 255, 255, 0.08), #b3c1ca, rgba(255, 255, 255, 0.18)),
+    (transparent, #a9bac3, rgba(255, 255, 255, 0.3)),
+    (rgba(132, 100, 190, 0.24), #cbb8ee, rgba(132, 100, 190, 0.45)),
+    (transparent, #b3a4cf, rgba(132, 100, 190, 0.45)),
+    (rgba(190, 90, 145, 0.24), #f0b1d4, rgba(190, 90, 145, 0.45))
+  );
 }
 
 /** Browser print drops the fills; the border and weight carry the distinction on paper. */
 @media print {
-    .ReminderTag {
-        background-color: transparent !important;
-        color: black !important;
-        border-color: rgba(0, 0, 0, 0.45) !important;
-    }
+  .ReminderTag {
+    background-color: transparent !important;
+    color: black !important;
+    border-color: rgba(0, 0, 0, 0.45) !important;
+  }
 }
 
 .SelectArmy {
-    margin-block-start: 2rem;
-    margin-inline-end: 5%;
-    margin-inline-start: 5%;
-    text-align: center;
+  margin-block-start: 2rem;
+  margin-inline-end: 5%;
+  margin-inline-start: 5%;
+  text-align: center;
 }
 
 .SelectArmy-Row {
-    margin-block-end: 2px;
-    margin-block-start: 2px;
+  margin-block-end: 2px;
+  margin-block-start: 2px;
 }
 
 .ImportTextarea {
-    min-width: 45%;
-    width: 100%;
-    height: 7.6em !important;
-    resize: none;
-    overflow: hidden;
-    padding: 8px;
-    box-sizing: border-box;
+  min-width: 45%;
+  width: 100%;
+  height: 7.6em !important;
+  resize: none;
+  overflow: hidden;
+  padding: 8px;
+  box-sizing: border-box;
 
-    &-Dark {
-        @extend .ImportTextarea;
-        background-color: black !important;
-        color: white !important;
-        border-width: 2px;
-        border-color: $themeLightGray;
-    }
+  &-Dark {
+    @extend .ImportTextarea;
+    background-color: black !important;
+    color: white !important;
+    border-width: 2px;
+    border-color: $themeLightGray;
+  }
 }
 
 .NoteInput {
-    min-width: 45%;
-    width: 95%;
-    max-width: 100%;
-    height: 7em;
-    /* `both` let the textarea be dragged wider than the card, scrolling the whole page sideways. */
-    resize: vertical;
-    padding: 8px;
-    box-sizing: border-box;
+  min-width: 45%;
+  width: 95%;
+  max-width: 100%;
+  height: 7em;
+  /* `both` let the textarea be dragged wider than the card, scrolling the whole page sideways. */
+  resize: vertical;
+  padding: 8px;
+  box-sizing: border-box;
 }
 
 .NoteText {
-    font-style: italic;
+  font-style: italic;
 }
 
 .NoteBorder {
-    max-width: 95%;
-    width: max-content;
-    border: 1px dashed $themeDarkBlueSecondary;
-    border-width: 1px;
-    border-style: dashed;
-    border-color: $themeDarkBlueSecondary;
+  max-width: 95%;
+  width: max-content;
+  border: 1px dashed $themeDarkBlueSecondary;
+  border-width: 1px;
+  border-style: dashed;
+  border-color: $themeDarkBlueSecondary;
 
-    &-Dark {
-        @extend .NoteBorder;
-        border-width: 2px;
-        border-color: $themeLightGray;
-    }
+  &-Dark {
+    @extend .NoteBorder;
+    border-width: 2px;
+    border-color: $themeLightGray;
+  }
 }
 
 .dropdown-toggle.btn-link::after {
-    display: none;
+  display: none;
 }
 
 /* Modal */
 .Modal-Light {
-    padding: 1.5%;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    right: auto;
-    bottom: auto;
-    margin-right: -50%;
-    transform: translate(-50%, -50%);
-    border: 1px solid #000000;
-    background-color: rgba(255, 255, 255, 1);
-    /*
+  padding: 1.5%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  right: auto;
+  bottom: auto;
+  margin-right: -50%;
+  transform: translate(-50%, -50%);
+  border: 1px solid #000000;
+  background-color: rgba(255, 255, 255, 1);
+  /*
      * The overlay is fixed and does not scroll, and the modal is centred with a translate. Without
      * these bounds any modal taller than the viewport pushes its own top above y=0 where it cannot
      * be reached — the print modal already exceeds a phone held in landscape.
      */
-    max-height: 90vh;
-    max-width: calc(100vw - 2rem);
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
+  max-height: 90vh;
+  max-width: calc(100vw - 2rem);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .Modal-Dark {
-    @extend .Modal-Light;
-    border: 1px solid $themeLightGray;
-    background-color: $themeDarkBlueSecondary;
+  @extend .Modal-Light;
+  border: 1px solid $themeLightGray;
+  background-color: $themeDarkBlueSecondary;
 }
 
 .Modal-Transparent {
-    @extend .Modal-Light;
-    background-color: rgba(0, 0, 0, 0);
+  @extend .Modal-Light;
+  background-color: rgba(0, 0, 0, 0);
 }
 
 .Modal-Overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(0, 0, 0, 0.9);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.9);
 }
 
 .aos4-import-modal {
-    width: min(42rem, calc(100vw - 4rem));
+  width: min(42rem, calc(100vw - 4rem));
 }
 
 .aos4-account-modal {
-    width: min(46rem, calc(100vw - 4rem));
+  width: min(46rem, calc(100vw - 4rem));
 }
 
 /* Dropzone */
 .dropzone {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 20px;
-    border-width: 2px;
-    border-radius: 2px;
-    border-color: #eeeeee;
-    border-style: dashed;
-    background-color: #fafafa;
-    /*
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  border-width: 2px;
+  border-radius: 2px;
+  border-color: #eeeeee;
+  border-style: dashed;
+  background-color: #fafafa;
+  /*
      * Was #bdbdbd, which put the dropzone's own instructions at 1.80:1 against this background —
      * both the "Drag and drop your roster here" label and the accepted-formats line. This is the
      * same muted ink the timing-tag explainer uses, and measures 6.80:1 here.
      */
-    color: $themeMutedInk;
-    outline: none;
-    transition: border 0.24s ease-in-out;
+  color: $themeMutedInk;
+  outline: none;
+  transition: border 0.24s ease-in-out;
 }
 
 .dropzone:focus {
-    border-color: $themeDropzoneAccent;
+  border-color: $themeDropzoneAccent;
 }
 
 .dropzone.is-dragging {
-    border-color: $themeDropzoneAccent;
-    background-color: rgba($themeDropzoneAccent, 0.08);
+  border-color: $themeDropzoneAccent;
+  background-color: rgba($themeDropzoneAccent, 0.08);
 }
 
 .dropzone.disabled {
-    opacity: 0.6;
+  opacity: 0.6;
 }
 
 /* Dropzone Dark Mode */
 .dropzone-dark {
-    @extend .dropzone;
-    background-color: black;
-    color: whitesmoke;
+  @extend .dropzone;
+  background-color: black;
+  color: whitesmoke;
 }
 
 .dropzone-dark:focus {
-    border-color: $themeDropzoneAccent;
+  border-color: $themeDropzoneAccent;
 }
 
 .dropzone-dark.disabled {
-    opacity: 0.6;
+  opacity: 0.6;
 }
 
 /* IFrame sizes for stats */
 .StatsIFrame {
-    height: 900px;
+  height: 900px;
 }
 
 @media (max-width: 768px) {
-    .StatsIFrame {
-        height: 920px;
-    }
-    .Modal-Light {
-        padding-top: 4%;
-        padding-bottom: 4%;
-    }
+  .StatsIFrame {
+    height: 920px;
+  }
+  .Modal-Light {
+    padding-top: 4%;
+    padding-bottom: 4%;
+  }
 }
 
 @media (max-width: 575.98px) {
-    .CardHeaderTitle {
-        font-size: 1.1rem;
-    }
-    .ReminderCardBody {
-        padding-top: 0.75rem;
-        padding-bottom: 0.75rem;
-    }
-    .StatsIFrame {
-        height: 600px;
-    }
-    .Modal-Light {
-        padding-top: 6%;
-        padding-bottom: 6%;
-    }
+  .CardHeaderTitle {
+    font-size: 1.1rem;
+  }
+  .ReminderCardBody {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+  .StatsIFrame {
+    height: 600px;
+  }
+  .Modal-Light {
+    padding-top: 6%;
+    padding-bottom: 6%;
+  }
 }
 
 @media (max-width: 395px) {
-    .CardHeaderTitle {
-        font-size: 1rem;
-    }
-    .StatsIFrame {
-        height: 540px;
-    }
-    .Modal-Light {
-        padding-top: 5%;
-        padding-bottom: 5%;
-    }
+  .CardHeaderTitle {
+    font-size: 1rem;
+  }
+  .StatsIFrame {
+    height: 540px;
+  }
+  .Modal-Light {
+    padding-top: 5%;
+    padding-bottom: 5%;
+  }
 }
 
 @media (max-width: 374px) {
-    .CardHeaderTitle {
-        font-size: 0.8rem;
-    }
-    .StatsIFrame {
-        height: 480px;
-    }
+  .CardHeaderTitle {
+    font-size: 0.8rem;
+  }
+  .StatsIFrame {
+    height: 480px;
+  }
 }
 
 /* Print styles/helpers below */
 .PageBreak {
-    page-break-inside: avoid !important;
+  page-break-inside: avoid !important;
 }
 
 @media print {
-    .text-white,
-    .text-light,
-    .text-white-50,
-    .text-white-75 {
-        color: black !important;
-    }
+  .text-white,
+  .text-light,
+  .text-white-50,
+  .text-white-75 {
+    color: black !important;
+  }
 
-    header > h1 {
-        font-size: 1.5rem;
-    }
+  header > h1 {
+    font-size: 1.5rem;
+  }
 
-    p {
-        margin-bottom: 0.5rem;
-    }
+  p {
+    margin-bottom: 0.5rem;
+  }
 
-    .CardHeaderTitle {
-        font-size: 1.1rem;
-    }
+  .CardHeaderTitle {
+    font-size: 1.1rem;
+  }
 
-    .card-header {
-        background: white;
-        padding: 0.5rem 1.25rem;
-    }
+  .card-header {
+    background: white;
+    padding: 0.5rem 1.25rem;
+  }
 
-    .card-body {
-        padding-top: 0.5rem;
-        padding-bottom: 0.5rem;
-    }
+  .card-body {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
 
-    .ReminderCardBody {
-        padding-top: 0;
-        padding-bottom: 0;
-    }
+  .ReminderCardBody {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 
-    .ReminderContainer {
-        flex: 0 0 90% !important;
-        max-width: 90% !important;
-    }
+  .ReminderContainer {
+    flex: 0 0 90% !important;
+    max-width: 90% !important;
+  }
 
-    .ReminderEntry {
-        font-size: 0.9rem;
-    }
+  .ReminderEntry {
+    font-size: 0.9rem;
+  }
 }

--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -29,20 +29,20 @@ $themeDropzoneAccent: #2196f3;
 
 /* Override default Bootstrap variables */
 $grid-breakpoints: (
-    xs: 0,
-    sm: 576px,
-    md: 768px,
-    lg: 1025px,
-    xl: 1200px,
-    xxl: 1900px,
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 1025px,
+  xl: 1200px,
+  xxl: 1900px,
 );
 
 $container-max-widths: (
-    sm: 540px,
-    md: 720px,
-    lg: 992px,
-    xl: 1140px,
-    xxl: 1610px,
+  sm: 540px,
+  md: 720px,
+  lg: 992px,
+  xl: 1140px,
+  xxl: 1610px,
 );
 
 /*
@@ -62,7 +62,7 @@ $container-max-widths: (
  * than hardcoding the resulting hexes. This defines no rules and emits no CSS; the full framework
  * is imported further down, and re-importing functions there is a no-op.
  */
-@import "bootstrap/scss/functions";
+@import 'bootstrap/scss/functions';
 
 /*
  * Responsive font sizes. 4.6 shipped RFS switched off ($enable-responsive-font-sizes: false); 5.x
@@ -109,8 +109,9 @@ $text-muted: #6c757d; // 5.3 default: var(--bs-secondary-color)
  * src/css/index.scss already paints on <body> keeps Bootstrap and the app in agreement, and keeps
  * every input rendering the font it renders today.
  */
-$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
-    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+$font-family-sans-serif:
+  -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
+  'Droid Sans', 'Helvetica Neue', sans-serif;
 $small-font-size: 80%; // 5.3 default: .875em
 $code-font-size: 87.5%; // 5.3 default: $small-font-size
 $figure-caption-font-size: 90%; // 5.3 default: $small-font-size — the /subscribe demo-video caption
@@ -220,7 +221,7 @@ $hr-border-color: rgba(0, 0, 0, 0.1);
 $hr-opacity: 1;
 
 /* Import Bootstrap source */
-@import "bootstrap/scss/bootstrap";
+@import 'bootstrap/scss/bootstrap';
 
 /*
  * Reboot parity.
@@ -231,8 +232,8 @@ $hr-opacity: 1;
  * is a compatibility shim, not a new style — it reproduces 4.6's Reboot exactly.
  */
 label {
-    display: inline-block;
-    margin-bottom: 0.5rem;
+  display: inline-block;
+  margin-bottom: 0.5rem;
 }
 
 /*
@@ -242,7 +243,7 @@ label {
  * Without this the shim above pushes the print modal's radio rows 8px apart.
  */
 .form-check-label {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 /*
@@ -251,8 +252,8 @@ label {
  * so the Official marker and the sale flash keep their current shape.
  */
 .badge.rounded-pill {
-    padding-right: 0.6em;
-    padding-left: 0.6em;
+  padding-right: 0.6em;
+  padding-left: 0.6em;
 }
 
 /*
@@ -262,7 +263,7 @@ label {
  */
 small,
 .small {
-    font-weight: 400;
+  font-weight: 400;
 }
 
 /*
@@ -283,7 +284,7 @@ small,
  *    inside dark-theme cards. `inherit` restores the 4.6 contract that ITheme relies on.
  */
 .card {
-    color: inherit;
+  color: inherit;
 }
 
 /*
@@ -294,11 +295,11 @@ small,
  * win instead and pad those rows 1.25rem all round.
  */
 .card-body:not(.list-group-item) {
-    padding: $card-spacer-x;
+  padding: $card-spacer-x;
 }
 
 .card-body {
-    color: inherit;
+  color: inherit;
 }
 
 /*
@@ -316,13 +317,13 @@ small,
  * padding is pinned above; this restores where the lines land.
  */
 .table > :not(caption) > * > * {
-    border-top: var(--bs-border-width) solid var(--bs-table-border-color);
-    border-bottom-width: 0;
+  border-top: var(--bs-border-width) solid var(--bs-table-border-color);
+  border-bottom-width: 0;
 }
 
 .table > thead > tr > th {
-    vertical-align: bottom;
-    border-bottom: calc(var(--bs-border-width) * 2) solid var(--bs-table-border-color);
+  vertical-align: bottom;
+  border-bottom: calc(var(--bs-border-width) * 2) solid var(--bs-table-border-color);
 }
 
 /*
@@ -331,22 +332,22 @@ small,
  * page's Midnight Slate in dark mode, with the Pale Gray divider used by other dark surfaces.
  */
 .GiftPurchaseTable-Light {
-    --bs-table-color: #{$body-color};
-    --bs-table-bg: #{$white};
-    --bs-table-border-color: #{$table-border-color};
+  --bs-table-color: #{$body-color};
+  --bs-table-bg: #{$white};
+  --bs-table-border-color: #{$table-border-color};
 }
 
 .GiftPurchaseTable-Dark {
-    --bs-table-color: #{$white};
-    --bs-table-bg: #{$themeDarkBlueSecondary};
-    --bs-table-border-color: #{$themeLightGray};
+  --bs-table-color: #{$white};
+  --bs-table-bg: #{$themeDarkBlueSecondary};
+  --bs-table-border-color: #{$themeLightGray};
 }
 
 select.form-control {
-    appearance: auto;
-    /* 4.6 gave .form-control an explicit height; 5.x lets content size it, and a native select
+  appearance: auto;
+  /* 4.6 gave .form-control an explicit height; 5.x lets content size it, and a native select
        lands a pixel short of the text inputs beside it. */
-    height: calc(1.5em + 0.75rem + 2px);
+  height: calc(1.5em + 0.75rem + 2px);
 }
 
 /*
@@ -360,11 +361,11 @@ select.form-control {
  * from `.row > *` and are untouched.
  */
 :not(.row) > .col,
-:not(.row) > [class^="col-"],
-:not(.row) > [class*=" col-"] {
-    position: relative;
-    padding-right: $grid-gutter-width * 0.5;
-    padding-left: $grid-gutter-width * 0.5;
+:not(.row) > [class^='col-'],
+:not(.row) > [class*=' col-'] {
+  position: relative;
+  padding-right: $grid-gutter-width * 0.5;
+  padding-left: $grid-gutter-width * 0.5;
 }
 
 /*
@@ -376,7 +377,7 @@ select.form-control {
  * the height, leaving the width to shrink to fit.
  */
 :not(.row) > .col {
-    width: 100%;
+  width: 100%;
 }
 
 /*
@@ -386,5 +387,5 @@ select.form-control {
  * still reaches .form-text). This restores 4.6's colour.
  */
 .text-muted {
-    color: $text-muted !important;
+  color: $text-muted !important;
 }

--- a/src/tests/aos4/updateAvailable.test.tsx
+++ b/src/tests/aos4/updateAvailable.test.tsx
@@ -11,11 +11,7 @@ const virtualRegisterSW = vi.hoisted(() => vi.fn(() => vi.fn(async () => undefin
 
 vi.mock('virtual:pwa-register', () => ({ registerSW: virtualRegisterSW }))
 
-import {
-  APPLY_TIMEOUT_MS,
-  DISMISS_DURATION_MS,
-  UpdateAvailable,
-} from 'components/info/updateAvailable'
+import { APPLY_TIMEOUT_MS, DISMISS_DURATION_MS, UpdateAvailable } from 'components/info/updateAvailable'
 import { AppStatusProvider } from 'context/useAppStatus'
 import { act } from 'react'
 import { render, Simulate, unmountComponentAtNode } from 'tests/support/reactTestHelpers'

--- a/src/tests/pwaBuild.test.ts
+++ b/src/tests/pwaBuild.test.ts
@@ -97,7 +97,11 @@ describe('web app manifest', () => {
 
   it('agrees with the masthead colour index.html sets', () => {
     // In standalone mode the manifest wins, so a mismatch puts the wrong chrome above a dark header.
-    const lightThemeColor = read('index.html').match(/<meta name="theme-color" content="([^"]+)">/)
+    // The optional slash keeps this off Prettier's void-tag style: index.html is formatted now, and
+    // an anchor on `">` silently stopped matching the moment the tag became self-closing, which read
+    // as "the manifest has no theme_color" rather than as a broken pattern.
+    const lightThemeColor = read('index.html').match(/<meta name="theme-color" content="([^"]+)"\s*\/?>/)
+    expect(lightThemeColor?.[1], 'index.html no longer declares a light theme-color').toBeDefined()
     expect(manifest.theme_color).toBe(lightThemeColor?.[1])
   })
 })


### PR DESCRIPTION
Closes #1930. Closes #1929.

Two formatting-tooling defects that share a file, so they share a branch. Four commits, each reviewable on its own.

## #1930 — the pre-commit hook failed in every worktree

Husky prepends a *relative* `node_modules/.bin` to PATH, which resolves against the current working directory. A worktree created by `git worktree add` has no `node_modules`, so every commit from one was rejected with `pretty-quick: command not found` — including commits touching nothing a formatter would rewrite. The obvious escape hatch, `--no-verify`, silently drops the formatting the hook exists to apply.

The hook now derives the repository that actually holds the dependencies from `git rev-parse --git-common-dir`, which points at the owning checkout from a worktree and a plain clone alike. It deliberately does not change directory, so `--staged` still reads the *committing* worktree's index.

Worth knowing for review: `core.hooksPath` is an absolute path into the main checkout, so a worktree commit runs the main checkout's copy of this hook. Testing the worktree's own copy proves nothing — I hit that first.

Verified by real commits, not by reading:

| case | before | after |
|---|---|---|
| commit from a worktree | `command not found (127)` | formats the worktree's staged file, exit 0 |
| commit from the main checkout | ok | ok |
| `node_modules` genuinely absent | ok — hook skipped | fails with the install command to run |

## #1929 — a global `parser` broke every non-TS file

`.prettierrc.json` set a top-level `"parser": "typescript"`. That is not a default — it overrides per-extension inference for *every* file, so any non-TS file not in `.prettierignore` was handed to the TypeScript parser and threw. Nothing caught it because both entry points already worked around it by restricting themselves to TS/JS.

Dropped it; inference resolves `.ts`/`.tsx` on its own, so no `overrides` entry is needed. The `format` script and pre-commit pattern widen to JSON, SCSS, CSS, YAML and HTML — plus `.mts`/`.cts`/`.mjs`/`.cjs`, which the old glob also silently skipped (`vite.config.mts` was never formatted; it already conforms, so that commit changes nothing on disk).

**What deliberately stays out**, each with its reason recorded in `.prettierignore`:

- **`data/aos4/` in full.** `data/aos4/certifications/*/manifest.json` records a SHA-256 for the accepted manifest, corpus review, catalog, official battle profiles and reconciliation report, and `yarn data:aos4:verify:beta` fails closed when any of them moves. Products and reviewed inputs are equally checksum-bound, so the whole tree belongs to the pipeline.
- **`src/aos4/generated/`**, written by the deterministic serializer, which emits `JSON.stringify(value, null, 2)`. That always expands; Prettier collapses short arrays and objects that fit inside `printWidth`, so formatting would rewrite every generated product.
- **`src/tests/fixtures/` in full** rather than just its JSON — byte-pinned capture corpora and provider-shape contracts.
- **`public/google*.html`**, a Google site-verification token that only happens to carry an `.html` extension.

## The reformat

Its own commit. Whitespace and quoting only, but two files earned a direct check rather than an assumption:

- **`src/css/index.scss` and `src/css/theme.scss`** reindent 4→2 spaces and move to single quotes. `theme.scss` pins the Bootstrap 4.6 defaults the interface was built against (DESIGN.md, "The Parity Pin Rule"), so I compared the compiled output: `dist/assets/*.css` is **byte-identical** across the reformat, down to the content hash.
- **`index.html`** gains self-closing void tags, a lowercase doctype, and a quote around the previously bare `property=og:site_name`. Parsed with parse5 before and after, the tag and attribute trees are identical apart from one dropped semicolon inside the inline `global` shim.

The remaining files reflow to the configured 110 columns. They were committed at 80 — which is what the hook stopped enforcing for anyone committing from a worktree, i.e. #1930's own fallout.

One test needed fixing: `pwaBuild.test.ts` matched the theme-colour meta with an anchor on `">`, which stopped matching the moment the tag became self-closing. The regex now tolerates either void-tag style, and the test asserts it matched at all — as written, a pattern that missed read as "the manifest declares no theme_color" rather than failing as a broken pattern.

## Testing

- `yarn lint`, `yarn tsc --noEmit`, `yarn build` clean.
- `yarn data:aos4:verify:beta` passes unchanged — **81,956 checks, 0 findings** — confirming the pipeline tree stayed out of the formatter's reach.
- Compiled CSS byte-compared; `index.html` structurally compared with parse5.
- Test suite passes apart from failures that are pre-existing on `master` and unrelated to this branch — those are #1932, which can merge in either order.

https://claude.ai/code/session_019PcwEbyb2mDMmiXmRusTz7
