### PR TITLE
chore: clear the warnings vite prints on local start (#1927)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@types/react-modal": "3.16.3",
     "@typescript-eslint/eslint-plugin": "^8.66.0",
     "@typescript-eslint/parser": "^8.66.0",
-    "@vitejs/plugin-react-swc": "^4.3.3",
+    "@vitejs/plugin-react": "^6.0.5",
     "cross-env": "^10.1.0",
     "eslint": "^10.8.0",
     "eslint-config-prettier": "^10.1.8",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,11 +1,13 @@
-import react from '@vitejs/plugin-react-swc'
+import react from '@vitejs/plugin-react'
 import { createHash } from 'node:crypto'
 import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { defineConfig, type Plugin } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
 import { configDefaults } from 'vitest/config'
-import { SERVICE_WORKER_ACTIVATION_MESSAGE } from './src/bootstrap/serviceWorkerProtocol'
+// Extension included deliberately: `configLoader: 'native'` hands this file to Node, which does not
+// resolve extensionless specifiers. See the resolve aliases below for the other half of that move.
+import { SERVICE_WORKER_ACTIVATION_MESSAGE } from './src/bootstrap/serviceWorkerProtocol.ts'
 
 /*
  * The generated corpus is 11.6 MiB as a built chunk, against Workbox's 2 MiB precache ceiling — and
@@ -317,13 +319,13 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      components: path.resolve(__dirname, 'src/components'),
-      context: path.resolve(__dirname, 'src/context'),
-      css: path.resolve(__dirname, 'src/css'),
-      tests: path.resolve(__dirname, 'src/tests'),
-      theme: path.resolve(__dirname, 'src/theme'),
-      types: path.resolve(__dirname, 'src/types'),
-      utils: path.resolve(__dirname, 'src/utils'),
+      components: path.resolve(import.meta.dirname, 'src/components'),
+      context: path.resolve(import.meta.dirname, 'src/context'),
+      css: path.resolve(import.meta.dirname, 'src/css'),
+      tests: path.resolve(import.meta.dirname, 'src/tests'),
+      theme: path.resolve(import.meta.dirname, 'src/theme'),
+      types: path.resolve(import.meta.dirname, 'src/types'),
+      utils: path.resolve(import.meta.dirname, 'src/utils'),
       // Add more aliases as needed
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,105 +1801,12 @@
   resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-9.12.1.tgz#b6d13d48cfe8b49acf199233bd0626d180faeccb"
   integrity sha512-KLXPvjA0BfS4dQnW+ddHjwtIXMnIfKYxqmeNMmQCfKjvYog0cSG+Z7ZvK4RH1+bV90GC07nUztWDRWmJLi5HZQ==
 
-"@swc/core-darwin-arm64@1.15.47":
-  version "1.15.47"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.47.tgz#345ce6a1bf4033da189c2e3eff1244190195d15b"
-  integrity sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==
-
-"@swc/core-darwin-x64@1.15.47":
-  version "1.15.47"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.15.47.tgz#f3debf50b5c1602bf392acb412bd33fd6d7e4f98"
-  integrity sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==
-
-"@swc/core-linux-arm-gnueabihf@1.15.47":
-  version "1.15.47"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.47.tgz#14a247a12c6d3de1ee63fa4fdbf5a4302936b5d6"
-  integrity sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==
-
-"@swc/core-linux-arm64-gnu@1.15.47":
-  version "1.15.47"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.47.tgz#3b8d09c481ae51c7b72d98fb6ce98f7b90065a1a"
-  integrity sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==
-
-"@swc/core-linux-arm64-musl@1.15.47":
-  version "1.15.47"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.47.tgz#7ff2baa16e67b29017fdf7c6b69e40de7920ce1a"
-  integrity sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==
-
-"@swc/core-linux-ppc64-gnu@1.15.47":
-  version "1.15.47"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.47.tgz#a3841982fe2eb2d889648c8e212b6d821db316d6"
-  integrity sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==
-
-"@swc/core-linux-s390x-gnu@1.15.47":
-  version "1.15.47"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.47.tgz#edbfd705d6285f7dce48915871478bc9603904c3"
-  integrity sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==
-
-"@swc/core-linux-x64-gnu@1.15.47":
-  version "1.15.47"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.47.tgz#e7f61a7771d6a9b5b274521ba61809b3d7644325"
-  integrity sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==
-
-"@swc/core-linux-x64-musl@1.15.47":
-  version "1.15.47"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.47.tgz#7c1ef8305444bcc7894de177fe225f2d8f3be609"
-  integrity sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==
-
-"@swc/core-win32-arm64-msvc@1.15.47":
-  version "1.15.47"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.47.tgz#953856d26b28956d1a18ef10e5f221202b2cb8f1"
-  integrity sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==
-
-"@swc/core-win32-ia32-msvc@1.15.47":
-  version "1.15.47"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.47.tgz#2743a5bccc49f252c23bad3135193640cbdcef3a"
-  integrity sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==
-
-"@swc/core-win32-x64-msvc@1.15.47":
-  version "1.15.47"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.47.tgz#9674ad0c9187b7cbe5cc3080b31b960d3ee688b9"
-  integrity sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==
-
-"@swc/core@^1.15.46":
-  version "1.15.47"
-  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.15.47.tgz#6226e842160e247eb79a9aeac1095ebddb56639f"
-  integrity sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==
-  dependencies:
-    "@swc/counter" "^0.1.3"
-    "@swc/types" "^0.1.27"
-  optionalDependencies:
-    "@swc/core-darwin-arm64" "1.15.47"
-    "@swc/core-darwin-x64" "1.15.47"
-    "@swc/core-linux-arm-gnueabihf" "1.15.47"
-    "@swc/core-linux-arm64-gnu" "1.15.47"
-    "@swc/core-linux-arm64-musl" "1.15.47"
-    "@swc/core-linux-ppc64-gnu" "1.15.47"
-    "@swc/core-linux-s390x-gnu" "1.15.47"
-    "@swc/core-linux-x64-gnu" "1.15.47"
-    "@swc/core-linux-x64-musl" "1.15.47"
-    "@swc/core-win32-arm64-msvc" "1.15.47"
-    "@swc/core-win32-ia32-msvc" "1.15.47"
-    "@swc/core-win32-x64-msvc" "1.15.47"
-
-"@swc/counter@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.3.tgz#cc7463bd02949611c6329596fccd2b0ec782b0e9"
-  integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
-
 "@swc/helpers@^0.5.0":
   version "0.5.23"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.23.tgz#19287d0d86d962b111376039a50c792902c9a86a"
   integrity sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==
   dependencies:
     tslib "^2.8.0"
-
-"@swc/types@^0.1.27":
-  version "0.1.28"
-  resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.28.tgz#e3cd892383fba3b8904c40518bbe1265a50753f2"
-  integrity sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==
-  dependencies:
-    "@swc/counter" "^0.1.3"
 
 "@trickfilm400/rollup-plugin-off-main-thread@^3.0.0-pre1":
   version "3.0.0-pre1"
@@ -2150,13 +2057,12 @@
     "@typescript-eslint/types" "8.66.0"
     eslint-visitor-keys "^5.0.0"
 
-"@vitejs/plugin-react-swc@^4.3.3":
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react-swc/-/plugin-react-swc-4.3.3.tgz#babf99c9a3d49ae4fffbb2d64f4f2c8f54abc9d1"
-  integrity sha512-bti8ZAcvz4Lh6/e4Uk2k3aa1TiUXbbMsahuqOHvd3MveFTkKDZOA6wQVkpj7J/+tepX/wGfe+lsGh/t24HTXMQ==
+"@vitejs/plugin-react@^6.0.5":
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz#48ee7951093ff9054952cff9d64e874355cde372"
+  integrity sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==
   dependencies:
     "@rolldown/pluginutils" "^1.0.1"
-    "@swc/core" "^1.15.46"
 
 "@vitest/expect@4.1.10":
   version "4.1.10"


### PR DESCRIPTION
Closes #1927.

> **Stacked on #1932** (`fix/test-suite-failures`), which is where the green suite below comes from. This PR's own diff is the last commit only. Retarget to `master` once #1932 merges.

`yarn start` printed two warnings, both about how the config is loaded and transformed rather than about anything the app does.

## The `configLoader: 'native'` readiness warning

It named `__dirname`, so the seven alias resolutions move to `import.meta.dirname`. Fixing that revealed a second warning the first had masked: under the native loader Node resolves the config's own imports and will not accept an extensionless specifier, so the `./src/bootstrap/serviceWorkerProtocol` import gains its extension.

`vite.config.mts` sits outside the `tsconfig.json` `include`, so this needs no `allowImportingTsExtensions` or any other compiler-option change.

## The `vite:react-swc` recommendation

> We recommend switching to `@vitejs/plugin-react` for improved performance as no swc plugins are used.

On Vite 8 that plugin transforms through Rolldown's native oxc pass, so the SWC dependency buys nothing and costs a native binary. Swapped to `@vitejs/plugin-react@6`, whose only extra peers (`@rolldown/plugin-babel`, `babel-plugin-react-compiler`) are optional and unused here. This drops `@swc/core` and its platform binaries from the tree — 99 lines out of `yarn.lock`.

## Testing

Silence is not the bar — the point of the first warning is that the native loader will become the default, so I checked the config actually loads that way rather than that the message stopped printing:

```
$ vite --configLoader native --port 5180
  VITE v8.2.0  ready in 350 ms      # no warnings
```

- `yarn lint`, `yarn tsc --noEmit`, `yarn build` clean; the 850 kB initial-entry chunk budget still passes.
- `yarn test --run`: 95 files, 1,515 tests, no failures.
- Dev server loaded in a browser: masthead, `Subscribe` / `FAQ` / `Log in` navigation, edit/play control, faction selector, selection cards and reminder cards all render, with a clean console. The React plugin swap changes the dev JSX transform and Fast Refresh, which the test suite does not cover, so this was worth looking at directly.
- Single `@types/react` in the tree after the reinstall, per the AGENTS.md staleness check.

https://claude.ai/code/session_019PcwEbyb2mDMmiXmRusTz7
