### PR TITLE
fix(pwa): give the update prompt the home banner slot and a reload that lands

### DIFF
--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -13,7 +13,7 @@ checked by hand.
 | Worker config | `vite.config.mts` (`VitePWA`, `generateSW`) |
 | Activation extras | generated `sw-extras-<content-hash>.js` — see the `service-worker-extras` plugin in `vite.config.mts` |
 | Registration | `src/bootstrap/registerServiceWorker.ts` |
-| Update prompt | `src/components/info/updateAvailable.tsx`, mounted in `src/components/App.tsx` |
+| Update prompt | `src/components/info/updateAvailable.tsx`, mounted in `src/components/info/banners/app_banner.tsx` on home and in `src/components/App.tsx` elsewhere |
 | Emergency rollback | `public/rollback-service-worker.js` — see docs/deployment.md |
 | Build assertions | `src/tests/pwaBuild.test.ts` |
 
@@ -88,9 +88,15 @@ DevTools:
 1. Build, load, and reload so a worker is controlling.
 2. Change something the build hashes (any source file), rebuild.
 3. Call `registration.update()` — this is what the hourly poll does.
-4. The banner should appear **without any page reloading itself**. Activate
-   Reload in one tab; every open controlled tab should then reload onto the new
-   build after the worker takes control.
+4. The banner should appear **without any page reloading itself**, and on home it
+   should take over the welcome banner's slot under the masthead rather than add
+   a second banner above it. Activate Reload in one tab; every open controlled
+   tab should then reload onto the new build after the worker takes control.
+
+Note that a source file whose only change is dead code will not produce a new
+worker: Rollup tree-shakes it back out, the precache manifest is unchanged, and
+the browser's byte-comparison finds nothing to install. Change something that
+reaches the output — `index.html`, or rendered copy.
 
 ### Cache contents
 
@@ -113,6 +119,22 @@ cache must degrade to "needs one online load", never to a broken app.
   mid-session, which is wrong for something people read during a game turn.
   `clientsClaim` does not change that waiting policy: it claims clients only
   after one tab explicitly posts the prompt's skip-waiting message.
+- **Accepting always ends in a reload.** Every path through `applyWaitingUpdate`
+  has to terminate, because the control tells the user it is reloading. A tab
+  with no registration of its own reloads immediately rather than posting into
+  the void. Otherwise it posts the activation message, watches both
+  `controllerchange` *and* the worker's own `statechange` — a claim does not
+  always reach the client that asked — and if neither has reloaded the tab
+  within `ACTIVATION_TIMEOUT_MS`, posts once more and then reloads regardless.
+  Do not collapse this back to a single post, and do not restore a branch that
+  returns without doing anything.
+
+  On 2026-08-04 a production tab posted the message to a worker that had been
+  waiting thirteen minutes and never saw a controller change; the button sat on
+  "Reloading..." indefinitely. A worker idle that long has been terminated, so
+  the retry exists on the theory that the first message was spent cold-starting
+  it. That cause is unconfirmed — the unconditional reload is the part that is
+  guaranteed to end the wait.
 - **Dismissal is deliberately not persisted.** `NotificationBanner` stores
   dismissal in localStorage keyed by name; reusing that here would suppress every
   future build's prompt after one close.

--- a/src/bootstrap/registerServiceWorker.ts
+++ b/src/bootstrap/registerServiceWorker.ts
@@ -17,14 +17,27 @@ export type { RegisterSWOptions } from 'virtual:pwa-register'
  */
 const UPDATE_POLL_INTERVAL_MS = 60 * 60 * 1000
 
+/*
+ * How long an accepted update has to take control before the accept escalates.
+ *
+ * Two of these elapse between the click and an unconditional reload: one before the activation
+ * message is retried, one before the tab reloads without it. Activation normally claims the tab in
+ * well under a second, so this is not a timing budget -- it is the deadline after which the accept
+ * is honoured some other way. Long enough that a cold worker start on a phone finishes first, short
+ * enough that the control does not sit on "Reloading..." waiting for something that is not coming.
+ */
+export const ACTIVATION_TIMEOUT_MS = 5 * 1000
+
 type RegisterServiceWorker = typeof registerSW
 
 interface ServiceWorkerRegistrationDependencies {
   announceNewContent: () => void
   listenForControllerChange: (callback: () => void) => void
+  listenForWorkerStateChange: (worker: ServiceWorker, callback: () => void) => void
   markUpdateAccepted: () => void
   register: RegisterServiceWorker
   reload: () => void
+  setActivationTimeout: (callback: () => void, delayMs: number) => unknown
   setPollInterval: (callback: () => Promise<void>, intervalMs: number) => unknown
   wasUpdateAccepted: () => boolean
 }
@@ -153,22 +166,57 @@ export const createServiceWorkerRegistrationController = (
     },
   })
 
+  /*
+   * Asks one waiting worker to take over.
+   *
+   * `controllerchange` is the signal this is expected to come back on, but it only fires if the
+   * worker's claim actually reaches this client. Watching the worker's own state as well means an
+   * activation that never claims this tab still reloads it.
+   */
+  const requestActivation = (waiting: ServiceWorker) => {
+    dependencies.markUpdateAccepted()
+    dependencies.listenForWorkerStateChange(waiting, () => {
+      if (waiting.state === 'activated') reloadOnce()
+    })
+    waiting.postMessage({ type: SERVICE_WORKER_ACTIVATION_MESSAGE })
+  }
+
   return {
     applyWaitingUpdate: () => {
       /*
-       * Another tab may already have activated the worker while this tab's banner was still visible.
-       * Posting the activation message with no waiting worker is a no-op, so reload immediately
-       * instead of leaving the control disabled until its UI timeout.
+       * Nothing of ours to activate. Either another tab already activated the worker while this
+       * tab's banner was still up, or this tab never got a registration at all -- `register()` waits
+       * for the window `load` event before it resolves, registration can fail outright, and
+       * `announceNewContent` broadcasts to every tab on the origin, so a tab can be showing the
+       * prompt on the strength of another tab's waiting worker.
+       *
+       * Reload either way. This used to `return` in the no-registration case, leaving the control
+       * reading "Reloading..." with nothing behind it and no path out.
        */
-      if (registration && !registration.waiting) {
+      if (!registration?.waiting) {
         reloadOnce()
         return
       }
 
-      if (!registration?.waiting) return
+      requestActivation(registration.waiting)
 
-      dependencies.markUpdateAccepted()
-      registration.waiting.postMessage({ type: SERVICE_WORKER_ACTIVATION_MESSAGE })
+      dependencies.setActivationTimeout(() => {
+        /*
+         * Nothing took control inside the window. A worker that has been waiting more than a few
+         * seconds has been terminated for idleness, so the first message had to cold-start it before
+         * it could be handled; ask again now that it is warm. This is a mitigation, not a diagnosis
+         * -- observed in production on 2026-08-04, where a tab posted the activation message to a
+         * worker that had been waiting thirteen minutes and never saw a controller change.
+         */
+        if (registration?.waiting) requestActivation(registration.waiting)
+
+        /*
+         * And reload regardless when the second window closes. The user asked for a reload, the army
+         * document is already persisted, and a page that comes back still on the old build is far
+         * better than a control that says "Reloading..." forever.
+         */
+        dependencies.setActivationTimeout(reloadOnce, ACTIVATION_TIMEOUT_MS)
+      }, ACTIVATION_TIMEOUT_MS)
     },
   }
 }
@@ -192,9 +240,11 @@ const serviceWorkerRegistrationController = !registrationIsDisabledForRollback()
       announceNewContent,
       listenForControllerChange: callback =>
         navigator.serviceWorker?.addEventListener('controllerchange', callback),
+      listenForWorkerStateChange: (worker, callback) => worker.addEventListener('statechange', callback),
       markUpdateAccepted,
       register: registerSW,
       reload: () => window.location.reload(),
+      setActivationTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
       setPollInterval: (callback, intervalMs) => setInterval(callback, intervalMs),
       wasUpdateAccepted,
     })

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,11 +1,21 @@
 import { router } from '../bootstrap/router'
 import { UpdateAvailable } from 'components/info/updateAvailable'
-import { useEffect } from 'react'
+import { useEffect, useSyncExternalStore } from 'react'
 import { RouterProvider } from 'react-router/dom'
 import { initializeAnalytics, startPageViewTracking } from 'utils/analytics'
+import { ROUTES } from 'utils/env'
 import { handleStripeCheckout } from 'utils/handleQueryParams'
 
+/*
+ * App sits outside <RouterProvider>, so the router hooks are unavailable here. The data router is a
+ * module singleton and exposes the same subscription analytics page-view tracking already uses.
+ */
+const subscribeToRouter = (onStoreChange: () => void) => router.subscribe(onStoreChange)
+const getPathname = () => router.state.location.pathname
+
 const App = () => {
+  const pathname = useSyncExternalStore(subscribeToRouter, getPathname)
+
   useEffect(() => {
     initializeAnalytics()
     handleStripeCheckout()
@@ -15,11 +25,12 @@ const App = () => {
   return (
     <div className="d-block">
       {/*
-        Mounted here rather than in the navbar: Navbar early-returns <OfflineHeader /> while
-        offline, which would hide the prompt exactly when a client has a waiting worker and loses
-        the network. This sits above <main> so it appears on every route.
+        Home owns a banner slot under its masthead and renders the prompt there itself, so this
+        instance covers only the routes that have nowhere better to put it. Mounted here rather than
+        in the navbar: Navbar early-returns <OfflineHeader /> while offline, which would hide the
+        prompt exactly when a client has a waiting worker and loses the network.
       */}
-      <UpdateAvailable />
+      {pathname !== ROUTES.HOME && <UpdateAvailable />}
       {/* Each route renders its own navbar, so <main> wraps the whole routed tree. */}
       <main>
         <RouterProvider router={router} />

--- a/src/components/info/banners/app_banner.tsx
+++ b/src/components/info/banners/app_banner.tsx
@@ -1,14 +1,21 @@
 import { NotificationBanner } from 'components/info/banners/notification_banner'
+import { UpdateAvailable } from 'components/info/updateAvailable'
 
-const AppBanner = () => {
-  return (
-    <NotificationBanner enableLog name="2026-aos4-welcome-back" variant="info">
-      <span>
-        <strong>Welcome back!</strong> AoS Reminders is being updated to the latest and greatest. Please
-        excuse any bugs as we get the kinks sorted out.
-      </span>
-    </NotificationBanner>
-  )
-}
+const WelcomeBanner = () => (
+  <NotificationBanner enableLog name="2026-aos4-welcome-back" variant="info">
+    <span>
+      <strong>Welcome back!</strong> AoS Reminders is being updated to the latest and greatest. Please excuse
+      any bugs as we get the kinks sorted out.
+    </span>
+  </NotificationBanner>
+)
+
+/**
+ * The home screen's single banner slot, directly under the masthead.
+ *
+ * A waiting update takes the slot over rather than adding a second banner above the masthead: of the
+ * two only the update is actionable, and stacking them put two alerts on screen at once.
+ */
+const AppBanner = () => <UpdateAvailable fallback={<WelcomeBanner />} />
 
 export default AppBanner

--- a/src/components/info/updateAvailable.tsx
+++ b/src/components/info/updateAvailable.tsx
@@ -1,6 +1,6 @@
 import { NotificationBanner } from 'components/info/banners/notification_banner'
 import { useAppStatus } from 'context/useAppStatus'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { applyWaitingUpdate } from '../../bootstrap/registerServiceWorker'
 
 /*
@@ -16,13 +16,20 @@ export const DISMISS_DURATION_MS = 60 * 60 * 1000
 /*
  * How long the accept control stays in its pending state before it re-enables.
  *
- * `applyWaitingUpdate` is a no-op when there is no worker actually waiting -- it activated on its
- * own, or workbox-window never loaded -- and in that case no reload ever comes. Without this the
- * button would sit disabled on "Reloading..." for the life of the page with no way to retry.
+ * `applyWaitingUpdate` now always ends in a reload, and it reaches that unconditionally after two
+ * ACTIVATION_TIMEOUT_MS windows, so this has to outlast both -- otherwise the control flips back to
+ * "Reload" in the moment before the page goes. It still matters where there is no controller to
+ * reach at all -- registration disabled for a rollback, or workbox-window never loaded -- because
+ * without it the button would sit disabled for the life of the page with no way to retry.
  */
-export const APPLY_TIMEOUT_MS = 10 * 1000
+export const APPLY_TIMEOUT_MS = 15 * 1000
 
 interface IUpdateAvailableProps {
+  /**
+   * Rendered in this component's place whenever no update is being offered. Lets one banner slot
+   * carry both this prompt and whatever the host would otherwise show there.
+   */
+  fallback?: ReactNode
   /** Injected in tests. Defaults to the real registration's skip-waiting call. */
   onApply?: () => void
 }
@@ -34,7 +41,7 @@ interface IUpdateAvailableProps {
  * rendered it -- the "you will be given an option in the UI" comment in the old entry point was
  * aspirational. This is that option.
  */
-export const UpdateAvailable = ({ onApply = applyWaitingUpdate }: IUpdateAvailableProps) => {
+export const UpdateAvailable = ({ fallback = null, onApply = applyWaitingUpdate }: IUpdateAvailableProps) => {
   const { hasNewContent } = useAppStatus()
   const [isDismissed, setIsDismissed] = useState(false)
   const [isApplying, setIsApplying] = useState(false)
@@ -76,7 +83,7 @@ export const UpdateAvailable = ({ onApply = applyWaitingUpdate }: IUpdateAvailab
     onApply()
   }
 
-  if (!hasNewContent || isDismissed) return null
+  if (!hasNewContent || isDismissed) return <>{fallback}</>
 
   return (
     <NotificationBanner

--- a/src/tests/aos4/homePresentation.test.tsx
+++ b/src/tests/aos4/homePresentation.test.tsx
@@ -26,6 +26,14 @@ vi.mock('@auth0/auth0-react', () => ({
   useAuth0: () => auth,
 }))
 
+/*
+ * Home's banner slot renders the update prompt, which reaches `applyWaitingUpdate` in
+ * bootstrap/registerServiceWorker and through it the plugin's `virtual:pwa-register`. That virtual
+ * module has no resolvable file on disk, so the test runner cannot import it -- stub it the same way
+ * registerServiceWorker.test.ts does.
+ */
+vi.mock('virtual:pwa-register', () => ({ registerSW: vi.fn(() => vi.fn(async () => undefined)) }))
+
 vi.mock('../../api/subscriptionApi', () => ({
   SubscriptionApi: {
     cancelSubscription: vi.fn(),

--- a/src/tests/aos4/updateAvailable.test.tsx
+++ b/src/tests/aos4/updateAvailable.test.tsx
@@ -13,7 +13,7 @@ vi.mock('virtual:pwa-register', () => ({ registerSW: virtualRegisterSW }))
 
 import { APPLY_TIMEOUT_MS, DISMISS_DURATION_MS, UpdateAvailable } from 'components/info/updateAvailable'
 import { AppStatusProvider } from 'context/useAppStatus'
-import { act } from 'react'
+import { act, type ReactNode } from 'react'
 import { render, Simulate, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
@@ -21,11 +21,11 @@ describe('update-available banner', () => {
   let container: HTMLDivElement
   let onApply: ReturnType<typeof vi.fn<() => void>>
 
-  const mount = () => {
+  const mount = (fallback?: ReactNode) => {
     act(() => {
       render(
         <AppStatusProvider>
-          <UpdateAvailable onApply={onApply} />
+          <UpdateAvailable fallback={fallback} onApply={onApply} />
         </AppStatusProvider>,
         container
       )
@@ -187,6 +187,30 @@ describe('update-available banner', () => {
     announceNewContent()
 
     expect(banner()!.className).toContain('d-print-none')
+  })
+
+  /*
+   * The home screen has one banner slot under its masthead. Handing the slot's usual occupant in as
+   * a fallback is what lets the prompt take that slot over instead of stacking a second alert above
+   * the masthead.
+   */
+  it('takes over the host slot only while an update is being offered', () => {
+    mount(<p>slot occupant</p>)
+    expect(container.textContent).toBe('slot occupant')
+
+    announceNewContent()
+
+    expect(container.textContent).toContain('A new version of AoS Reminders is available.')
+    expect(container.textContent).not.toContain('slot occupant')
+  })
+
+  it('hands the host slot back when the prompt is dismissed', () => {
+    mount(<p>slot occupant</p>)
+    announceNewContent()
+
+    act(() => Simulate.click(dismissButton()!))
+
+    expect(container.textContent).toBe('slot occupant')
   })
 
   it('keeps the dismiss control above the minimum hit box', () => {

--- a/src/tests/registerServiceWorker.test.ts
+++ b/src/tests/registerServiceWorker.test.ts
@@ -7,6 +7,7 @@ const virtualRegisterSW = vi.hoisted(() => vi.fn(() => vi.fn(async () => undefin
 vi.mock('virtual:pwa-register', () => ({ registerSW: virtualRegisterSW }))
 
 import {
+  ACTIVATION_TIMEOUT_MS,
   createServiceWorkerRegistrationController,
   shouldDisableServiceWorkerRegistration,
   type RegisterSWOptions,
@@ -16,14 +17,21 @@ import {
   SERVICE_WORKER_ROLLBACK_DISABLED_STORAGE_KEY,
 } from '../bootstrap/serviceWorkerProtocol'
 
+interface WaitingWorkerStub {
+  activate: () => void
+  postMessage: ReturnType<typeof vi.fn>
+  state: ServiceWorkerState
+}
+
 interface RegistrationHarness {
   applyWaitingUpdate: () => void
   callbacks: RegisterSWOptions
   controllerChanged: () => void
   reload: ReturnType<typeof vi.fn>
   registration: ServiceWorkerRegistration
+  runActivationTimeout: () => void
   runPoll: () => Promise<void>
-  waitingWorker: { postMessage: ReturnType<typeof vi.fn> }
+  waitingWorker: WaitingWorkerStub
 }
 
 interface SharedAcceptance {
@@ -36,10 +44,20 @@ const createHarness = (
 ) => {
   let callbacks: RegisterSWOptions | undefined
   let controllerChanged = () => {}
+  const activationTimeouts: Array<{ callback: () => void; delayMs: number }> = []
   let poll: (() => Promise<void>) | undefined
   const reload = vi.fn()
   const updateServiceWorker = vi.fn(async () => undefined)
-  const waitingWorker = { postMessage: vi.fn() }
+  const workerStateChanged: Array<() => void> = []
+  const waitingWorker: WaitingWorkerStub = {
+    /** Drives the worker's own lifecycle, which is a reload signal independent of any claim. */
+    activate: () => {
+      waitingWorker.state = 'activated'
+      workerStateChanged.forEach(callback => callback())
+    },
+    postMessage: vi.fn(),
+    state: 'installed',
+  }
   const registration = {
     installing: registrationState === 'installing' ? {} : null,
     waiting: registrationState === 'waiting' ? waitingWorker : null,
@@ -51,6 +69,9 @@ const createHarness = (
     listenForControllerChange: callback => {
       controllerChanged = callback
     },
+    listenForWorkerStateChange: (_worker, callback) => {
+      workerStateChanged.push(callback)
+    },
     markUpdateAccepted: () => {
       acceptance.accepted = true
     },
@@ -59,6 +80,10 @@ const createHarness = (
       return updateServiceWorker
     },
     reload,
+    setActivationTimeout: (callback, delayMs) => {
+      activationTimeouts.push({ callback, delayMs })
+      return 2
+    },
     setPollInterval: callback => {
       poll = callback
       return 1
@@ -77,6 +102,12 @@ const createHarness = (
     controllerChanged,
     reload,
     registration,
+    /** Runs the next pending deadline, asserting the controller scheduled it at the stated window. */
+    runActivationTimeout: () => {
+      const next = activationTimeouts.shift()
+      expect(next?.delayMs).toBe(ACTIVATION_TIMEOUT_MS)
+      next?.callback()
+    },
     runPoll: async () => {
       await poll?.()
     },
@@ -150,6 +181,76 @@ describe('service-worker registration controller', () => {
 
     expect(secondTab.reload).toHaveBeenCalledTimes(1)
     expect(secondTab.waitingWorker.postMessage).not.toHaveBeenCalled()
+  })
+
+  /*
+   * `announceNewContent` broadcasts to every tab on the origin, and `register()` does not resolve
+   * until the window `load` event, so a tab can be showing the prompt with no registration of its
+   * own. Doing nothing here left the control reading "Reloading..." with no path out.
+   */
+  it('reloads rather than stalling when the accepting tab has no registration', () => {
+    const tab = createHarness('missing')
+
+    tab.applyWaitingUpdate()
+
+    expect(tab.reload).toHaveBeenCalledTimes(1)
+    expect(tab.waitingWorker.postMessage).not.toHaveBeenCalled()
+  })
+
+  /*
+   * The production failure of 2026-08-04: the message went to a worker that had been waiting for
+   * thirteen minutes, and no controller change ever came back. A waiting worker that idle has been
+   * terminated, so the first message had to cold-start it; the retry reaches a warm one.
+   */
+  it('asks a second time when the first activation message goes unanswered', () => {
+    const tab = createHarness('waiting')
+
+    tab.applyWaitingUpdate()
+    expect(tab.waitingWorker.postMessage).toHaveBeenCalledTimes(1)
+
+    tab.runActivationTimeout()
+
+    expect(tab.waitingWorker.postMessage).toHaveBeenCalledTimes(2)
+    expect(tab.waitingWorker.postMessage).toHaveBeenLastCalledWith({
+      type: SERVICE_WORKER_ACTIVATION_MESSAGE,
+    })
+    expect(tab.reload).not.toHaveBeenCalled()
+  })
+
+  it('reloads without the update once both activation windows have closed', () => {
+    const tab = createHarness('waiting')
+
+    tab.applyWaitingUpdate()
+    tab.runActivationTimeout()
+    expect(tab.reload).not.toHaveBeenCalled()
+
+    tab.runActivationTimeout()
+
+    expect(tab.reload).toHaveBeenCalledTimes(1)
+  })
+
+  /*
+   * `controllerchange` only fires if the claim reaches this client. The worker reporting its own
+   * activation is a second, independent signal that the accepted build is live.
+   */
+  it('reloads when the accepted worker activates without claiming this tab', () => {
+    const tab = createHarness('waiting')
+
+    tab.applyWaitingUpdate()
+    tab.waitingWorker.activate()
+
+    expect(tab.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reload a second time when a deadline passes after the worker took control', () => {
+    const tab = createHarness('waiting')
+
+    tab.applyWaitingUpdate()
+    tab.controllerChanged()
+    tab.runActivationTimeout()
+    tab.runActivationTimeout()
+
+    expect(tab.reload).toHaveBeenCalledTimes(1)
   })
 
   it('does not create a polling interval without a registration', async () => {


### PR DESCRIPTION
Two defects in the service-worker update prompt, both reported from production.

## 1. Two banners at once

The prompt sat above the masthead while the welcome notice sat below it, so any
client with a waiting worker showed two alerts stacked around the header.

Home now has a single banner slot. `AppBanner` renders
`<UpdateAvailable fallback={<WelcomeBanner />} />` — the prompt takes the slot
over while an update is offered and hands it straight back when there is none or
the user dismisses it. `App` keeps its own top-of-page instance for the routes
that have no slot (FAQ, Subscribe, Join, Redeem, Profile), gated on the route via
`useSyncExternalStore` over the router singleton, so home never shows both.

## 2. "Reloading..." forever

A production tab hit this on 2026-08-04: the acceptance marker was written at
14:50:59Z, thirteen minutes after that day's 14:37:37Z deploy, so
`registration.waiting` was set and the activation message *was* posted — and no
controller change ever came back. The control sat disabled on "Reloading..."
with no path out, because the only fallback re-enabled the button so the next
click could fail the same way.

Every path through `applyWaitingUpdate` now terminates:

- **No registration of its own → reload immediately** instead of returning
  silently. `register()` does not resolve until the window `load` event,
  registration can fail outright, and `announceNewContent` broadcasts to every
  tab on the origin — so a tab can be showing the prompt with no waiting worker
  of its own. This branch previously did nothing at all.
- **Watch the worker's own `statechange` alongside `controllerchange`**, so an
  activation whose claim never reaches this client still reloads it.
- **Retry the message after `ACTIVATION_TIMEOUT_MS`** (5s). A worker idle for
  thirteen minutes has been terminated, so the first message had to cold-start
  it; the retry reaches a warm one.
- **Reload regardless 5s after that.** The army document is already persisted,
  and a page that comes back still on the old build is far better than a control
  that lies about what it is doing.

The retry is a mitigation for an unconfirmed cause. The unconditional reload is
what guarantees the wait ends. `APPLY_TIMEOUT_MS` moves 10s → 15s so the button
cannot flip back to "Reload" in the moment before the page goes.

Follows #1886 and its revert in #1926, which established that this prompt must
never reload the page on its own — that constraint is unchanged here. Nothing
reloads without an explicit accept.

## Testing

Verified in Chrome against real built workers on `vite preview`, two build
generations apart.

**Banner placement**
1. Load, let the worker take control, rebuild, call `registration.update()`.
2. Banner appears **under the masthead**, in the welcome notice's slot, with
   nothing above the header.
3. Dismiss it — the welcome banner returns to the same slot.
4. Navigate to `/faq` — the prompt is still there, at the top of the page.

**Accept, healthy worker**
5. Click Reload — page reloads essentially instantly, `registration.waiting` is
   null, banner gone.

**Accept, worker that never activates** (fault injection: patch the built
`dist/service-worker.js` activation token so the worker ignores the message)
6. Install it as the waiting worker, click Reload.
7. `PerformanceNavigationTiming.type === "reload"` **11.2s after the click**,
   worker still stuck in `installed`, banner honestly back offering the update.
   On `master` this hangs indefinitely.

`yarn lint`, `yarn tsc --noEmit`, `yarn build`, `yarn test --run` all clean —
1522 passed, 95 files, zero failures.

Note: `src/tests/aos4/homePresentation.test.tsx` needed the `virtual:pwa-register`
stub added, since home now pulls the PWA module in through its banner slot.

https://claude.ai/code/session_016NsJM79QExewCLLZQLtUDv
