### PR TITLE
fix(reminders): wrap overflowing timing tags beneath the name; refresh welcome banner

### DIFF
--- a/src/components/info/banners/app_banner.tsx
+++ b/src/components/info/banners/app_banner.tsx
@@ -2,10 +2,10 @@ import { NotificationBanner } from 'components/info/banners/notification_banner'
 import { UpdateAvailable } from 'components/info/updateAvailable'
 
 const WelcomeBanner = () => (
-  <NotificationBanner enableLog name="2026-aos4-welcome-back" variant="info">
+  <NotificationBanner enableLog name="2026-aos4-welcome-back-lists" variant="info">
     <span>
-      <strong>Welcome back!</strong> AoS Reminders is being updated to the latest and greatest. Please excuse
-      any bugs as we get the kinks sorted out.
+      <strong>Welcome back!</strong> AoS Reminders is being updated to the latest and greatest. We now support
+      importing Sigdex, Storm Forge, Listbot, and New Recruit lists!
     </span>
   </NotificationBanner>
 )

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -261,8 +261,11 @@ small {
  * Timing facet tags.
  *
  * Above the mobile breakpoint the heading is a single row with the name on the left and the tags
- * pushed to the right; at or below it the tags wrap onto their own line beneath the name. Tone
- * colours are set per theme below, never by the tone class alone, so light and dark can differ.
+ * pushed to the right; when a long name leaves no room for every tag, the overflow wraps
+ * tag-by-tag onto flush-left lines beneath the name rather than dropping the whole strip as one
+ * right-aligned block. At or below the breakpoint the tags sit on their own line beneath the name.
+ * Tone colours are set per theme below, never by the tone class alone, so light and dark can
+ * differ.
  */
 .ReminderHeadingRow {
   display: flex;
@@ -291,8 +294,17 @@ small {
   margin-inline-start: 0.85rem;
 }
 
+/*
+ * Inside the heading row the tag span holds no box of its own, so each chip is a flex item in its
+ * own right and wraps individually. The first chip keeps the auto margin that pushes the strip to
+ * the right edge; chips that wrap start flush left beneath the name.
+ */
 .ReminderHeadingRow > .ReminderTags {
-  margin-inline-start: auto;
+  display: contents;
+
+  > .ReminderTag:first-child {
+    margin-inline-start: auto;
+  }
 }
 
 .ReminderHeading > .ReminderTags {
@@ -317,8 +329,9 @@ small {
      * default army. Growing the chip itself would trade away the density the reminders surface is
      * built on, so this widens the hit box only — the same approach .ReminderMenuToggle takes.
      *
-     * 24px against a 20px chip overhangs 2px per side, and .ReminderTags sets a 0.25rem (4px) gap,
-     * so vertically stacked overlays meet exactly and never overlap.
+     * 24px against a 20px chip overhangs 2px per side. The gaps between stacked chip lines —
+     * 0.35rem on the heading row, 0.25rem inside the mobile tag block — are at least 4px, so
+     * vertically stacked overlays meet without overlapping.
      */
   position: relative;
 


### PR DESCRIPTION
## Summary

Two small changes:

**Reminder tag wrapping** (`src/css/index.scss`) — above the 576px mobile breakpoint, a long rule name (e.g. ACTIVATE PLACE OF POWER at ~640px) left no room for the tag strip, so the whole strip wrapped onto a second line and its auto margin right-aligned it beneath the left-aligned name: an awkward hanging indent. The tag span now uses `display: contents` inside the heading row, making each chip its own flex item. Chips that fit stay right-aligned beside the name exactly as before; overflow chips wrap individually onto flush-left lines beneath the name. The mobile block layout (≤576px) is untouched, and the jsPDF export is unaffected (it lays tags out in inches independently of the DOM).

**Welcome banner copy** (`src/components/info/banners/app_banner.tsx`) — announces Sigdex, Storm Forge, Listbot, and New Recruit importing. Resolved against #1935's `UpdateAvailable` wrapper: the wrapper stays, the new copy lands in its `WelcomeBanner` fallback, and the renamed banner key (`2026-aos4-welcome-back-lists`) resets prior dismissals so returning users see the announcement once more.

## Test plan

- [x] `yarn lint`, `yarn tsc --noEmit`, `yarn build`, `yarn test --run` pass
- [x] Browser-verified at 640px (light + dark themes): long names now wrap chips flush-left beneath the name; names that fit render identically to before
- [x] Mobile (375px) block layout unchanged
- [x] Print-media emulation (browser Ctrl+P): outline chips, no menu buttons, same clean wrap at 640px
- [x] Download PDF export regenerated and inspected for both Standard and Compact presets — no collisions, unchanged behavior