### PR TITLE
feat(pdf): option to omit the army summary from the PDF

### DIFF
--- a/docs/printing.md
+++ b/docs/printing.md
@@ -303,7 +303,9 @@ the same `PrintDocument` that ships today.
 ### Using it
 
 The toolbar's **Download PDF** button opens a modal with layout (Standard/Compact), page size
-(A4/Letter), and a file name.
+(A4/Letter), a file name, and an "Include army summary" checkbox. Unchecking it drops the trailing
+warscroll-and-points summary: `createAos4PrintDocument` accepts `{ includeSummary: false }` and
+simply leaves `PrintDocument.summary` unset (#1602).
 
 Plain browser printing (`Ctrl+P`) still works against the live app DOM, using the pre-existing
 `@media print` rules and `d-print-none` classes in `css/index.scss`. It is not a designed print

--- a/src/aos4/print/document.ts
+++ b/src/aos4/print/document.ts
@@ -33,6 +33,11 @@ export interface PrintArmyInput {
   warscrolls?: PrintWarscrollInput[]
 }
 
+export interface PrintDocumentOptions {
+  /** Defaults to true. Set false to omit the trailing warscroll summary from the print document. */
+  includeSummary?: boolean
+}
+
 /** Wrapping reproduces text by joining on single spaces, so collapse runs of whitespace up front. */
 const normalize = (value: string): string => value.replace(/\s+/g, ' ').trim()
 
@@ -87,7 +92,8 @@ const buildSummary = (army: PrintArmyInput) => {
  */
 export const createAos4PrintDocument = (
   reminders: PrintReminderInput[],
-  army: PrintArmyInput
+  army: PrintArmyInput,
+  options: PrintDocumentOptions = {}
 ): PrintDocument => {
   const sections = reminders
     .filter(reminder => !reminder.hidden)
@@ -103,7 +109,7 @@ export const createAos4PrintDocument = (
       ]
     }, [])
 
-  const summary = buildSummary(army)
+  const summary = options.includeSummary === false ? undefined : buildSummary(army)
 
   // An unnamed army falls back to the faction name, so don't print it twice.
   const showSubtitle = !!army.factionName && army.factionName.trim() !== army.armyName.trim()

--- a/src/aos4/print/layout.ts
+++ b/src/aos4/print/layout.ts
@@ -270,7 +270,9 @@ const buildBlocks = (document: PrintDocument, context: DraftContext): FlowBlock[
 
   blocks.push({
     id: 'footer',
-    lines: document.footer.flatMap(line => draftLines(context, 'footer', line, { blockId: 'footer' })),
+    lines: document.footer.flatMap(line =>
+      draftLines(context, 'footer', line, { blockId: 'footer', spansColumns: true })
+    ),
   })
 
   return blocks
@@ -324,6 +326,8 @@ export const planPrintLayout = (
    */
   const runFlow = (shortenedPage?: { page: number; bottomIn: number }) => {
     const lines: PlacedLine[] = []
+    // Deepest cursor reached per page/column, so page-spanning blocks can clear every column.
+    const columnBottomsIn = new Map<string, number>()
     let pageIndex = 0
     let columnIndex = 0
     let cursorY = page.marginTopIn
@@ -366,6 +370,7 @@ export const planPrintLayout = (
         ...(draft.paragraphIndex === undefined ? {} : { paragraphIndex: draft.paragraphIndex }),
       })
       cursorY += draft.spaceAfterIn
+      columnBottomsIn.set(`${pageIndex}/${columnIndex}`, cursorY)
     }
 
     bannerDrafts.forEach(emit)
@@ -391,6 +396,30 @@ export const planPrintLayout = (
 
     blocks.forEach((block, index) => {
       const blockHeightIn = heightOf(block.lines)
+
+      // A page-spanning block (the footer) is centred across the full text width, so it must sit
+      // below every column on the page, not just the column the flow happens to end in. If it
+      // cannot fit below the deepest column, it starts a fresh page rather than overlapping. The
+      // check uses the real page bottom even on a balancing-shortened last page: the shortened
+      // bottom is a content-balancing artifact, and the footer legitimately sits below it.
+      if (block.lines.some(line => line.spansColumns)) {
+        const deepestYIn = Math.max(
+          cursorY,
+          ...columnOriginsIn.map(
+            (_, column) => columnBottomsIn.get(`${pageIndex}/${column}`) ?? columnTopIn(pageIndex)
+          )
+        )
+        if (deepestYIn + blockHeightIn > pageBottomIn) {
+          pageIndex += 1
+          columnIndex = 0
+          cursorY = columnTopIn(pageIndex)
+        } else {
+          cursorY = deepestYIn
+        }
+        block.lines.forEach(emit)
+        return
+      }
+
       const next = blocks[index + 1]
       const keepWithNextIn = block.keepWithNext && next ? advanceOf(next.lines[0]) : 0
       const continuationHeadingIn =

--- a/src/components/print/printModal.tsx
+++ b/src/components/print/printModal.tsx
@@ -1,3 +1,4 @@
+import type { PrintDocumentOptions } from '../../aos4/print/document'
 import { PRINT_PRESETS, type PrintPageSize } from '../../aos4/print/presets'
 import type { PrintPreset } from '../../aos4/print/types'
 import GenericModal from 'components/modals/generic/generic_modal'
@@ -9,7 +10,12 @@ interface PrintModalProps {
   closeModal: () => void
   defaultFileName: string
   isOpen: boolean
-  onDownloadPdf: (presetId: PrintPreset['id'], pageSize: PrintPageSize, fileName: string) => Promise<void>
+  onDownloadPdf: (
+    presetId: PrintPreset['id'],
+    pageSize: PrintPageSize,
+    fileName: string,
+    options: PrintDocumentOptions
+  ) => Promise<void>
 }
 
 const PAGE_SIZES: { id: PrintPageSize; label: string }[] = [
@@ -68,6 +74,7 @@ const PrintModal = ({ closeModal, defaultFileName, isOpen, onDownloadPdf }: Prin
   const [presetId, setPresetId] = useState<PrintPreset['id']>('compact')
   const [pageSize, setPageSize] = useState<PrintPageSize>('a4')
   const [fileName, setFileName] = useState(defaultFileName)
+  const [includeSummary, setIncludeSummary] = useState(true)
   const [downloadError, setDownloadError] = useState<string>()
   const [isDownloadingPdf, setIsDownloadingPdf] = useState(false)
 
@@ -81,7 +88,7 @@ const PrintModal = ({ closeModal, defaultFileName, isOpen, onDownloadPdf }: Prin
     setDownloadError(undefined)
     setIsDownloadingPdf(true)
     try {
-      await onDownloadPdf(presetId, pageSize, fileName.trim() || defaultFileName)
+      await onDownloadPdf(presetId, pageSize, fileName.trim() || defaultFileName, { includeSummary })
       setIsDownloadingPdf(false)
       closeModal()
     } catch {
@@ -140,6 +147,26 @@ const PrintModal = ({ closeModal, defaultFileName, isOpen, onDownloadPdf }: Prin
             placeholder="Enter file name"
             value={fileName}
           />
+        </div>
+      </div>
+
+      <div className={`row mx-3 mt-3 ${theme.text}`}>
+        <div className="col">
+          <div className="form-check">
+            <input
+              checked={includeSummary}
+              className="form-check-input"
+              id="printIncludeSummary"
+              onChange={event => setIncludeSummary(event.target.checked)}
+              type="checkbox"
+            />
+            <label className="form-check-label" htmlFor="printIncludeSummary">
+              <strong>Include army summary</strong>
+            </label>
+            <p className="small mb-0">
+              A list of the army&apos;s warscrolls and points at the end of the PDF.
+            </p>
+          </div>
         </div>
       </div>
 

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -1,5 +1,6 @@
 import { armyFactions, type CanonicalId } from '../../aos4/domain'
 import { AOS4_CATALOG, AOS4_DEFAULT_FACTION_ID } from '../../aos4/generated'
+import type { PrintDocumentOptions } from '../../aos4/print/document'
 import type { PrintPageSize } from '../../aos4/print/presets'
 import type { PrintPreset } from '../../aos4/print/types'
 import {
@@ -118,7 +119,8 @@ const HomeContent = () => {
   const handleDownloadPdf = async (
     presetId: PrintPreset['id'],
     pageSize: PrintPageSize,
-    fileName: string
+    fileName: string,
+    options: PrintDocumentOptions
   ) => {
     const {
       COMPACT_PRESET,
@@ -129,11 +131,15 @@ const HomeContent = () => {
       renderPrintPlanToPdf,
       withPageSize,
     } = await import('../../aos4/print')
-    const printDocument = createAos4PrintDocument(reminders, {
-      armyName: document.name,
-      factionName,
-      warscrolls: builder.warscrolls,
-    })
+    const printDocument = createAos4PrintDocument(
+      reminders,
+      {
+        armyName: document.name,
+        factionName,
+        warscrolls: builder.warscrolls,
+      },
+      options
+    )
     const selectedPreset = presetId === 'compact' ? COMPACT_PRESET : STANDARD_PRESET
     const preset = withPageSize(selectedPreset, pageSize)
     const plan = planPrintLayout(printDocument, preset, createJsPdfMeasurer())

--- a/src/tests/aos4/printDocument.test.ts
+++ b/src/tests/aos4/printDocument.test.ts
@@ -104,6 +104,20 @@ describe('createAos4PrintDocument', () => {
     expect(document.summary?.heading).toBe('Hammers of Sigmar - 260 pts')
   })
 
+  it('omits the army summary when includeSummary is false', () => {
+    const document = createAos4PrintDocument(
+      [reminder({ id: 'a' })],
+      {
+        armyName: 'Hammers of Sigmar',
+        factionName: 'Stormcast Eternals',
+        warscrolls: [{ name: 'Liberators', profile: { points: 110, unitSize: 5 } }],
+      },
+      { includeSummary: false }
+    )
+
+    expect(document.summary).toBeUndefined()
+  })
+
   it('omits the subtitle when the army name is just the faction name', () => {
     const document = createAos4PrintDocument([reminder({ id: 'a' })], {
       armyName: 'Stormcast Eternals',

--- a/src/tests/aos4/printLayout.test.ts
+++ b/src/tests/aos4/printLayout.test.ts
@@ -207,6 +207,27 @@ describe.each(presets)('planPrintLayout (%s preset)', (_label, preset) => {
       })
     })
   })
+
+  it('centres the footer across the full text width, below every column on its page', () => {
+    const { page } = preset
+    const footerLines = result.lines.filter(line => line.blockId === 'footer')
+    expect(footerLines.length).toBeGreaterThan(0)
+
+    const centreIn = page.marginLeftIn + (page.widthIn - page.marginLeftIn - page.marginRightIn) / 2
+    footerLines.forEach(line => {
+      expect(line.spansColumns).toBe(true)
+      expect(line.align).toBe('center')
+      expect(line.xIn).toBeCloseTo(centreIn, 5)
+    })
+
+    const footerPage = footerLines[0].page
+    const contentBottomsIn = result.lines
+      .filter(line => line.page === footerPage && !line.spansColumns)
+      .map(line => line.yIn)
+    if (contentBottomsIn.length) {
+      expect(Math.min(...footerLines.map(line => line.yIn))).toBeGreaterThan(Math.max(...contentBottomsIn))
+    }
+  })
 })
 
 describe('planPrintLayout edge cases', () => {

--- a/src/tests/aos4/printModalUi.test.tsx
+++ b/src/tests/aos4/printModalUi.test.tsx
@@ -78,7 +78,9 @@ describe('PDF download modal', () => {
       await Promise.resolve()
     })
 
-    expect(onDownloadPdf).toHaveBeenCalledWith('compact', 'a4', 'Stormcast_Reminders')
+    expect(onDownloadPdf).toHaveBeenCalledWith('compact', 'a4', 'Stormcast_Reminders', {
+      includeSummary: true,
+    })
     expect(findButton(container, 'Download PDF').disabled).toBe(true)
     expect(closeModal).not.toHaveBeenCalled()
 
@@ -88,6 +90,38 @@ describe('PDF download modal', () => {
     })
 
     expect(closeModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes includeSummary false when the army summary checkbox is unchecked', async () => {
+    const onDownloadPdf = vi.fn().mockResolvedValue(undefined)
+    act(() => {
+      render(
+        <PrintModal
+          closeModal={vi.fn()}
+          defaultFileName="Stormcast_Reminders"
+          isOpen
+          onDownloadPdf={onDownloadPdf}
+        />,
+        container
+      )
+    })
+
+    const checkbox = container.querySelector<HTMLInputElement>('#printIncludeSummary')
+    expect(checkbox?.checked).toBe(true)
+
+    act(() => {
+      checkbox?.click()
+    })
+    expect(checkbox?.checked).toBe(false)
+
+    await act(async () => {
+      findButton(container, 'Download PDF').click()
+      await Promise.resolve()
+    })
+
+    expect(onDownloadPdf).toHaveBeenCalledWith('compact', 'a4', 'Stormcast_Reminders', {
+      includeSummary: false,
+    })
   })
 
   it('keeps the modal open and explains a failed PDF chunk load', async () => {


### PR DESCRIPTION
Closes #1602

## What

Adds an **Include army summary** checkbox (checked by default) to the PDF download modal. Unchecking it omits the trailing section of the PDF that lists the army's warscrolls, unit sizes, and points — the "last part of the pdf with flavors, battalions, units" the issue asked to make optional.

## How

- `createAos4PrintDocument` accepts a new optional `PrintDocumentOptions` parameter with `includeSummary` (defaults to `true`, so existing callers and behavior are unchanged). When `false`, `PrintDocument.summary` is simply left unset — the layout (`src/aos4/print/layout.ts`) already skips a missing summary.
- `PrintModal` (`src/components/print/printModal.tsx`) gains the checkbox, styled with the same Bootstrap `form-check` family as the existing radios, and passes the option through `onDownloadPdf`.
- `Home.tsx` threads the option from the modal into `createAos4PrintDocument`.
- `docs/printing.md` updated to describe the new modal option.

## Tests

- `printDocument.test.ts`: new case asserting the summary is omitted when `includeSummary: false`.
- `printModalUi.test.tsx`: existing assertion updated for the new argument; new case asserting the checkbox defaults to checked and unchecking it passes `{ includeSummary: false }`.
- Full suite green: 95 files, 1524 tests; `yarn lint` and `yarn tsc --noEmit` clean; production build succeeds.