### PR TITLE
fix(auth): keep the installed PWA logged in across an app close

### DIFF
--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -49,6 +49,39 @@ there: activation holds fetch events until `waitUntil` settles, and the page
 reloads the moment the worker takes control, so a download on that path would
 leave the reload on a blank screen.
 
+## Staying logged in across an app close
+
+An installed app is closed and reopened constantly, and each reopen is a cold JS
+context. Two `Auth0Provider` options in `src/bootstrap/auth0Options.ts` are the
+only reason a session survives that, and both are deliberate departures from the
+SDK defaults:
+
+- **`cacheLocation: 'localstorage'`.** The default `memory` cache dies with the
+  JS context, so every reopen starts with no tokens at all.
+- **`useRefreshTokens: true`,** with `useRefreshTokensFallback: false`. Without a
+  refresh token the only recovery path is `checkSession()` — a hidden iframe to
+  `/authorize?prompt=none` that needs the Auth0 session cookie readable in a
+  third-party context. Safari ITP blocks that, and an iOS standalone PWA gets a
+  storage jar separate from Safari, so the cookie the login popup set may not be
+  reachable at all. The fallback is pinned off because it is that already-blocked
+  path; a failed refresh should surface as an error, not hang on an iframe.
+
+This is a genuine tradeoff, not a free win: tokens in localStorage are reachable
+by XSS. It is accepted because refresh token rotation is on, which revokes a
+stolen token the next time the legitimate one is used.
+
+**Half of this configuration lives outside the repository.** If either tenant
+setting is turned off, the SPA is issued no refresh token, `auth0Options.ts`
+quietly does nothing, and users are signed out on reopen again:
+
+- Application → Settings → **Refresh Token Rotation**, with its absolute and
+  inactivity expiries — those are the real "stay logged in" window
+- API `https://api.aosreminders.com` → Settings → **Allow Offline Access**,
+  or `offline_access` is stripped from the grant
+
+`src/tests/aos4/authSessionPersistence.test.ts` guards the repository half. The
+tenant half can only be checked by hand — see below.
+
 ## What CI checks
 
 `src/tests/pwaBuild.test.ts` asserts manifest fields, icon existence, worker
@@ -82,6 +115,23 @@ DevTools:
 2. Stop the preview server.
 3. Reload. The shell should render, the faction selector should populate, and
    `fetch('/assets/aos4-catalog-data-*.js')` should return 200 from cache.
+
+### Staying logged in
+
+The one that matters is a real installed app on a real phone, because the
+storage-partitioning behaviour this configuration works around does not
+reproduce in a desktop dev browser — there the blocked iframe path still
+happens to succeed, and a broken configuration looks fine.
+
+1. Install to the home screen, launch standalone, and log in.
+2. Fully close the app — swipe it out of the app switcher, not just background it.
+3. Reopen. You should still be signed in, with `Profile` and `Log out` in the nav.
+4. In DevTools (remote-inspect the installed app), Application → Local Storage
+   should hold an `@@auth0spajs@@::…` entry. If it is missing, `cacheLocation`
+   regressed; if it is present but you were signed out anyway, the tenant is not
+   issuing a refresh token — check the two settings above.
+
+Worth repeating after a few days, alongside the iOS eviction check below.
 
 ### Update prompt
 

--- a/src/bootstrap/auth0Options.ts
+++ b/src/bootstrap/auth0Options.ts
@@ -1,0 +1,40 @@
+import type { Auth0ProviderOptions } from '@auth0/auth0-react'
+import config from '../auth_config.json'
+
+/*
+ * Session persistence for the installed PWA.
+ *
+ * The SDK defaults — `cacheLocation: 'memory'` and `useRefreshTokens: false` — cannot keep a
+ * session across an app close. Memory cache dies with the JS context, and the only recovery path
+ * left is `checkSession()`, a hidden iframe to `/authorize?prompt=none` that needs the Auth0
+ * session cookie readable in a third-party context. Safari ITP blocks that, and an iOS standalone
+ * PWA gets a storage jar separate from Safari, so the cookie the login popup set may not be
+ * reachable at all. The result is a user who logs in, closes the app, reopens it, and is signed
+ * out.
+ *
+ * `localstorage` survives the close; the refresh token mints new access tokens without ever
+ * touching a third-party cookie. The tradeoff is that tokens become reachable by XSS — accepted
+ * here because refresh token rotation is enabled on the tenant, which revokes a stolen token the
+ * next time the legitimate one is used.
+ *
+ * This depends on tenant configuration that lives outside the repository. Both must stay on or
+ * the SPA is issued no refresh token and these options quietly do nothing:
+ *   - Application -> Settings -> Refresh Token Rotation
+ *   - API `https://api.aosreminders.com` -> Settings -> Allow Offline Access
+ */
+export const auth0ProviderOptions = {
+  domain: config.domain,
+  clientId: config.clientId,
+  cacheLocation: 'localstorage',
+  useRefreshTokens: true,
+  // The iframe fallback is the path already blocked on mobile. Pinned off so a failed refresh
+  // surfaces as an error the app can handle rather than a silent hang on a blocked iframe.
+  useRefreshTokensFallback: false,
+  authorizationParams: {
+    audience: config.audience,
+    redirect_uri: window.location.origin,
+    // The SDK appends `offline_access` whenever `useRefreshTokens` is set; naming it keeps the
+    // grant this configuration depends on visible at the call site.
+    scope: 'openid profile email offline_access',
+  },
+} satisfies Auth0ProviderOptions

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import 'css/index.scss' // organize-imports-ignore
 import './bootstrap/captureShareLink' // organize-imports-ignore
 import './bootstrap/registerServiceWorker' // organize-imports-ignore
 import { Auth0Provider } from '@auth0/auth0-react'
+import { auth0ProviderOptions } from './bootstrap/auth0Options'
 import { router } from './bootstrap/router'
 import App from 'components/App'
 import { AppStatusProvider } from 'context/useAppStatus'
@@ -10,7 +11,6 @@ import { SubscriptionProvider } from 'context/useSubscription'
 import { ThemeProvider } from 'context/useTheme'
 import React from 'react'
 import { createRoot } from 'react-dom/client'
-import config from './auth_config.json'
 
 const onRedirectCallback = (appState?: { returnTo?: string }) => {
   router.navigate(appState?.returnTo || window.location.pathname, { replace: true })
@@ -26,16 +26,7 @@ const container = document.getElementById('root')
 if (!container) throw new Error('Root container #root is missing from index.html')
 
 createRoot(container).render(
-  <Auth0Provider
-    domain={config.domain}
-    clientId={config.clientId}
-    authorizationParams={{
-      audience: config.audience,
-      redirect_uri: window.location.origin,
-      scope: 'openid profile email',
-    }}
-    onRedirectCallback={onRedirectCallback}
-  >
+  <Auth0Provider {...auth0ProviderOptions} onRedirectCallback={onRedirectCallback}>
     <AppStatusProvider>
       <SubscriptionProvider>
         <ThemeProvider>

--- a/src/tests/aos4/authSessionPersistence.test.ts
+++ b/src/tests/aos4/authSessionPersistence.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import config from '../../auth_config.json'
+import { auth0ProviderOptions } from '../../bootstrap/auth0Options'
+
+/*
+ * An installed PWA is closed and reopened constantly, and each reopen is a cold JS context. These
+ * options are the whole reason a session survives that; the SDK defaults do not. Regressing any
+ * one of them signs every mobile user out on reopen, which is invisible in a desktop dev browser
+ * where the blocked third-party cookie path still happens to work.
+ */
+describe('Auth0 session persistence', () => {
+  it('caches tokens somewhere that survives closing the installed app', () => {
+    expect(auth0ProviderOptions.cacheLocation).toBe('localstorage')
+  })
+
+  it('renews through refresh tokens rather than the blocked silent-auth iframe', () => {
+    expect(auth0ProviderOptions.useRefreshTokens).toBe(true)
+    expect(auth0ProviderOptions.useRefreshTokensFallback).toBe(false)
+    expect(auth0ProviderOptions.authorizationParams.scope.split(' ')).toContain('offline_access')
+  })
+
+  it('keeps the established identity, audience, and granted scopes', () => {
+    expect(auth0ProviderOptions.domain).toBe(config.domain)
+    expect(auth0ProviderOptions.clientId).toBe(config.clientId)
+    expect(auth0ProviderOptions.authorizationParams.audience).toBe(config.audience)
+    expect(auth0ProviderOptions.authorizationParams.redirect_uri).toBe(window.location.origin)
+    expect(auth0ProviderOptions.authorizationParams.scope.split(' ')).toEqual(
+      expect.arrayContaining(['openid', 'profile', 'email'])
+    )
+  })
+
+  it('is what the application bootstrap actually mounts the provider with', async () => {
+    const main = await readFile(path.resolve(process.cwd(), 'src/main.tsx'), 'utf8')
+
+    expect(main).toContain("import { auth0ProviderOptions } from './bootstrap/auth0Options'")
+    expect(main).toContain('<Auth0Provider {...auth0ProviderOptions}')
+    // A second literal prop list on the provider would silently override the spread.
+    expect(main).not.toMatch(/<Auth0Provider[^>]*\bcacheLocation=/)
+    expect(main).not.toMatch(/<Auth0Provider[^>]*\bauthorizationParams=/)
+  })
+})


### PR DESCRIPTION
## The bug

Log in on a phone with the installed PWA, close the app, immediately reopen it — you are signed out. No expiry is involved; it happens on every cold start.

`Auth0Provider` in `src/main.tsx` ran on the SDK defaults, and both are wrong for an installed app:

- **`cacheLocation` defaults to `'memory'`** — tokens live only in the JS heap. Closing the installed app tears down that context.
- **`useRefreshTokens` defaults to `false`** — so the only recovery path on reopen is `checkSession()`, a hidden iframe to `/authorize?prompt=none`. That needs the Auth0 session cookie readable in a *third-party* context. Safari ITP blocks it, and an iOS standalone PWA gets a storage jar separate from Safari, so the cookie the login popup set may not be reachable at all. Chrome/Android is on the same trajectory with third-party cookie phase-out.

Memory cache + blocked silent auth = signed out on every reopen.

## The change

Provider options move to `src/bootstrap/auth0Options.ts` so they can be asserted on, and switch to localstorage caching plus rotating refresh tokens:

```ts
cacheLocation: 'localstorage',
useRefreshTokens: true,
useRefreshTokensFallback: false,
authorizationParams: { ..., scope: 'openid profile email offline_access' },
```

`localstorage` survives the close; the refresh token mints new access tokens without ever touching a third-party cookie. The iframe fallback is pinned off because it is the already-blocked path — a failed refresh should surface as an error the app can handle, not hang.

Identity, audience, redirect URI, and the existing granted scopes are unchanged. No UI, navigation, or account-flow change.

## Tradeoff

Tokens in localStorage are reachable by XSS. This is the tradeoff Auth0 documents for exactly this situation, and it is accepted here because refresh token rotation is enabled, which revokes a stolen refresh token the next time the legitimate one is used.

## ⚠️ Requires tenant configuration — this PR is inert without it

Both must be on, or the SPA is issued no refresh token and `auth0Options.ts` quietly does nothing:

- Application → Settings → **Refresh Token Rotation**, with its absolute and inactivity expiries — those become the real "stay logged in" window
- API `https://api.aosreminders.com` → Settings → **Allow Offline Access**, or `offline_access` is stripped from the grant

## Testing instructions

### On device — the one that matters

This failure **does not reproduce in a desktop dev browser**: there the blocked-iframe path still succeeds, so a broken configuration looks fine. It has to be a real installed app on a real phone.

1. Install to the home screen from a deploy of this branch, launch standalone, log in.
2. Fully close the app — swipe it out of the app switcher, not just background it.
3. Reopen. **Expected:** still signed in, with `Profile` and `Log out` in the nav.
4. Remote-inspect the installed app → Application → Local Storage. Expect an `@@auth0spajs@@::…` entry.
   - Entry missing → `cacheLocation` regressed.
   - Entry present but signed out anyway → the tenant is not issuing a refresh token; check the two settings above.
5. Repeat after a few days, alongside the existing iOS eviction check in `docs/pwa.md`.

### Regression checks

- Log in, use a subscriber-only action (save an army / cloud collection) — the bearer token still reaches the army API.
- Log out. Confirm the `@@auth0spajs@@` localStorage entry is cleared and the nav returns to `Subscribe` / `FAQ` / `Log in`.
- Log in on desktop; confirm the popup flow and the post-login redirect are unchanged.
- DevTools → Application → Cache Storage should still hold exactly `workbox-precache-v2-<origin>/` and `aos4-catalog`. No Auth0 response belongs in a cache — see `docs/pwa.md`.

### Automated

`src/tests/aos4/authSessionPersistence.test.ts` (new, 4 tests) asserts each option, that identity/audience/scopes are unchanged, and that `main.tsx` actually spreads the object with no literal prop that could silently override it.

Full local verification, all green:

- `yarn lint`, `yarn tsc --noEmit`, `prettier --check`
- `yarn build`
- `yarn test --run` — 97 files, 3317 tests passed (build first, so `pwaBuild.test.ts` read the real `dist/`)

## Noted, not changed

`src/utils/authToken.ts:26` maps *every* `getAccessTokenSilently` failure to `AuthenticationRequiredError` ("Please log in again to continue."). With the fallback pinned off, an expired grant genuinely does need a re-login — but a plain network failure now also tells an offline user to log in again. Pre-existing behaviour, separate fix.

https://claude.ai/code/session_011YE24wv1qh6GXB1xvA8KSG
