### PR TITLE
feat: overhaul the subscription funnel and restore Stripe checkout

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,7 +10,7 @@ colors:
   note-blue: "#1237c7"
   ink: "#212529"
   paper: "#ffffff"
-  action-blue: "#007bff"
+  action-blue: "#0070e8"
   success-green: "#28a745"
   danger-red: "#dc3545"
   warning-amber: "#ffc107"
@@ -245,10 +245,17 @@ Bootstrap's signal set, reached through utility classes in JSX rather than throu
 They do not appear on the reminders surface, which is the point: seeing one means something
 happened.
 
-- **Action Blue** (`#007bff`, `$primary`): `btn-primary` on every commitment control — the three
+- **Action Blue** (`#0070e8`, `$primary`): `btn-primary` on every commitment control — the three
   Subscribe CTAs, gift purchase, redemption. Also `badge bg-primary` on the `Official` marker beside a
   Games Workshop source link, which is the one place it appears on the reminders screen. It is the
   most saturated colour in the product and it means *this is the action* or *this is authoritative*.
+
+  It was `#007bff` — Bootstrap 4.6's `$blue`, pinned as a parity value — until that measured 3.98:1
+  against the white text it carries, under the 4.5:1 floor this product treats as correctness rather
+  than enhancement. `#0070e8` is the nearest hue clearing it, at 4.69:1. This is the one signal colour
+  that is *not* a 4.6 pin, and the ratio is the reason: a control that takes money is the last place
+  to inherit a framework's old default. Body links derive from the same token and were failing at the
+  same ratio; they clear it now too.
 - **Danger Red** (`#dc3545`): destructive confirmation buttons, `alert-danger` on failed saves,
   shares, and imports, and the `bg-danger` sale flash in the navbar and on plan cards.
 - **Success Green** (`#28a745`): confirmed saves and completed subscription state.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,10 +1,23 @@
 import { router } from '../bootstrap/router'
+import { CheckoutOutcomeBanner } from 'components/info/banners/checkout_outcome_banner'
 import { UpdateAvailable } from 'components/info/updateAvailable'
 import { useEffect, useSyncExternalStore } from 'react'
 import { RouterProvider } from 'react-router/dom'
 import { initializeAnalytics, startPageViewTracking } from 'utils/analytics'
+import { useCheckoutOutcome } from 'utils/checkoutOutcome'
 import { ROUTES } from 'utils/env'
 import { handleStripeCheckout } from 'utils/handleQueryParams'
+
+/*
+ * The banner slot for every route except Home, which owns its own under the masthead. A return from
+ * checkout takes the slot: a gift purchase returns to /profile, so this is the only place that
+ * confirmation can appear.
+ */
+const RouteBanner = () => {
+  const outcome = useCheckoutOutcome()
+  if (outcome) return <CheckoutOutcomeBanner />
+  return <UpdateAvailable />
+}
 
 /*
  * App sits outside <RouterProvider>, so the router hooks are unavailable here. The data router is a
@@ -30,7 +43,7 @@ const App = () => {
         in the navbar: Navbar early-returns <OfflineHeader /> while offline, which would hide the
         prompt exactly when a client has a waiting worker and loses the network.
       */}
-      {pathname !== ROUTES.HOME && <UpdateAvailable />}
+      {pathname !== ROUTES.HOME && <RouteBanner />}
       {/* Each route renders its own navbar, so <main> wraps the whole routed tree. */}
       <main>
         <RouterProvider router={router} />

--- a/src/components/info/banners/app_banner.tsx
+++ b/src/components/info/banners/app_banner.tsx
@@ -1,5 +1,7 @@
+import { CheckoutOutcomeBanner } from 'components/info/banners/checkout_outcome_banner'
 import { NotificationBanner } from 'components/info/banners/notification_banner'
 import { UpdateAvailable } from 'components/info/updateAvailable'
+import { useCheckoutOutcome } from 'utils/checkoutOutcome'
 
 const WelcomeBanner = () => (
   <NotificationBanner enableLog name="2026-aos4-welcome-back-lists" variant="info">
@@ -15,7 +17,15 @@ const WelcomeBanner = () => (
  *
  * A waiting update takes the slot over rather than adding a second banner above the masthead: of the
  * two only the update is actionable, and stacking them put two alerts on screen at once.
+ *
+ * A return from checkout outranks both. It reports something that just happened to the visitor's
+ * money, it cannot be recovered once dismissed, and it is the reason this screen was loaded at all —
+ * where the other two will still be true on the next visit.
  */
-const AppBanner = () => <UpdateAvailable fallback={<WelcomeBanner />} />
+const AppBanner = () => {
+  const outcome = useCheckoutOutcome()
+  if (outcome) return <CheckoutOutcomeBanner />
+  return <UpdateAvailable fallback={<WelcomeBanner />} />
+}
 
 export default AppBanner

--- a/src/components/info/banners/checkout_outcome_banner.tsx
+++ b/src/components/info/banners/checkout_outcome_banner.tsx
@@ -37,7 +37,15 @@ export const CheckoutOutcomeBanner = () => {
           <>
             <strong>Payment received.</strong> Thanks for subscribing. Activation can take a few moments —
             your{' '}
-            <Link to={ROUTES.PROFILE} onClick={() => logClick('CheckoutBanner-Profile')}>
+            {/*
+              alert-link, Bootstrap's own treatment for links inside alerts: plain Action Blue on the
+              tinted alert-success background measures ~3.8:1, under the 4.5:1 floor.
+            */}
+            <Link
+              className="alert-link"
+              to={ROUTES.PROFILE}
+              onClick={() => logClick('CheckoutBanner-Profile')}
+            >
               Profile
             </Link>{' '}
             shows the current status.

--- a/src/components/info/banners/checkout_outcome_banner.tsx
+++ b/src/components/info/banners/checkout_outcome_banner.tsx
@@ -1,0 +1,62 @@
+import { NotificationBanner } from 'components/info/banners/notification_banner'
+import { Link } from 'react-router'
+import { logClick } from 'utils/analytics'
+import { clearCheckoutOutcome, useCheckoutOutcome } from 'utils/checkoutOutcome'
+import { ROUTES } from 'utils/env'
+
+/**
+ * What the buyer sees on returning from a hosted checkout.
+ *
+ * Stripe returns to `/` for a subscription and to `/profile` for a gift, and both the success and the
+ * cancel return used to render a page identical to the one an abandoned checkout produces — so the
+ * money moment ended in silence, at exactly the point the buyer most needs evidence.
+ *
+ * The copy claims only what the return itself proves. Reaching the success URL means Stripe took the
+ * payment; it does not mean the subscription webhook has landed yet, so this points at the Profile
+ * screen that reports the real status rather than asserting the features are already on.
+ *
+ * Not persisted: this is a one-time report of something that just happened, and a dismissal
+ * remembered in localStorage would suppress the confirmation of the *next* purchase.
+ */
+export const CheckoutOutcomeBanner = () => {
+  const outcome = useCheckoutOutcome()
+  if (!outcome) return null
+
+  const variant = outcome.kind === 'canceled' ? 'info' : 'success'
+
+  return (
+    <NotificationBanner
+      closeLabel="Close checkout message"
+      name="checkout-outcome"
+      onClose={clearCheckoutOutcome}
+      persistClose={false}
+      variant={variant}
+    >
+      <span>
+        {outcome.kind === 'subscribed' && (
+          <>
+            <strong>Payment received.</strong> Thanks for subscribing. Activation can take a few moments —
+            your{' '}
+            <Link to={ROUTES.PROFILE} onClick={() => logClick('CheckoutBanner-Profile')}>
+              Profile
+            </Link>{' '}
+            shows the current status.
+          </>
+        )}
+        {outcome.kind === 'gifted' && (
+          <>
+            <strong>Payment received.</strong>{' '}
+            {outcome.quantity > 1
+              ? `Your ${outcome.quantity} gift subscriptions are ready to send — copy a link below.`
+              : 'Your gift subscription is ready to send — copy its link below.'}
+          </>
+        )}
+        {outcome.kind === 'canceled' && (
+          <>
+            <strong>Checkout canceled.</strong> You have not been charged.
+          </>
+        )}
+      </span>
+    </NotificationBanner>
+  )
+}

--- a/src/components/info/banners/checkout_outcome_banner.tsx
+++ b/src/components/info/banners/checkout_outcome_banner.tsx
@@ -35,8 +35,7 @@ export const CheckoutOutcomeBanner = () => {
       <span>
         {outcome.kind === 'subscribed' && (
           <>
-            <strong>Payment received.</strong> Thanks for subscribing. Activation can take a few moments —
-            your{' '}
+            <strong>Payment received.</strong> Thanks for subscribing. Activation can take a few moments. Your{' '}
             {/*
               alert-link, Bootstrap's own treatment for links inside alerts: plain Action Blue on the
               tinted alert-success background measures ~3.8:1, under the 4.5:1 floor.
@@ -55,8 +54,8 @@ export const CheckoutOutcomeBanner = () => {
           <>
             <strong>Payment received.</strong>{' '}
             {outcome.quantity > 1
-              ? `Your ${outcome.quantity} gift subscriptions are ready to send — copy a link below.`
-              : 'Your gift subscription is ready to send — copy its link below.'}
+              ? `Your ${outcome.quantity} gift subscriptions are ready to send. Copy a link below.`
+              : 'Your gift subscription is ready to send. Copy its link below.'}
           </>
         )}
         {outcome.kind === 'canceled' && (

--- a/src/components/input/importArmy/subscriberAction.tsx
+++ b/src/components/input/importArmy/subscriberAction.tsx
@@ -1,35 +1,70 @@
 import { useAuth0 } from '@auth0/auth0-react'
 import { useSubscription } from 'context/useSubscription'
-import { useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { ROUTES } from 'utils/env'
 import useLogin from 'utils/hooks/useLogin'
 
 interface UseSubscriberActionOptions {
+  /** Display name of the gated feature, shown on /subscribe so the visitor knows why they are there. */
+  featureName: string
   onAuthorized: () => void
   origin: string
 }
 
+/**
+ * Runs a subscriber-only action, sending the visitor wherever they need to go first.
+ *
+ * Two things this used to get wrong, both at the highest-intent moment in the funnel:
+ *
+ * 1. An unauthenticated visitor was sent to log in and then simply left on Home. The action they
+ *    asked for was dropped silently, so the only feedback for a successful login was that nothing
+ *    happened. The intent is now held and completed once auth and the subscription lookup settle.
+ * 2. A non-subscriber was navigated to /subscribe with no message at all — a page that opens by
+ *    asking for support, arrived at for reasons it never stated. The feature's name travels with the
+ *    navigation so that page can say which control sent them.
+ */
 export const useSubscriberAction = ({
+  featureName,
   onAuthorized,
   origin,
 }: UseSubscriberActionOptions): { disabled: boolean; run: () => void } => {
   const { isAuthenticated, isLoading } = useAuth0()
   const { isActive, subscriptionLoading } = useSubscription()
-  const { isLoggingIn, login } = useLogin({ origin })
+  const [isPending, setIsPending] = useState(false)
+  // Closing the popup abandons the intent; without this it would fire on some later, unrelated login.
+  const { isLoggingIn, login, popupIsClosed } = useLogin({ onPopupClose: () => setIsPending(false), origin })
   const navigate = useNavigate()
 
-  const run = useCallback(() => {
-    if (!isAuthenticated) {
-      void login()
-      return
-    }
+  const proceed = useCallback(() => {
     if (!isActive) {
-      navigate(ROUTES.SUBSCRIBE)
+      navigate(ROUTES.SUBSCRIBE, { state: { featureName } })
       return
     }
     onAuthorized()
-  }, [isActive, isAuthenticated, login, navigate, onAuthorized])
+  }, [featureName, isActive, navigate, onAuthorized])
+
+  const run = useCallback(() => {
+    if (!isAuthenticated) {
+      setIsPending(true)
+      void login()
+      return
+    }
+    proceed()
+  }, [isAuthenticated, login, proceed])
+
+  useEffect(() => {
+    if (!isPending) return
+    if (popupIsClosed) {
+      setIsPending(false)
+      return
+    }
+    // Wait for the subscription answer too: acting on a stale `isActive` would route a fresh
+    // subscriber to /subscribe rather than opening what they asked for.
+    if (!isAuthenticated || isLoading || subscriptionLoading) return
+    setIsPending(false)
+    proceed()
+  }, [isAuthenticated, isLoading, isPending, popupIsClosed, proceed, subscriptionLoading])
 
   return {
     disabled: isLoading || isLoggingIn || subscriptionLoading,

--- a/src/components/input/toolbar/toolbar.tsx
+++ b/src/components/input/toolbar/toolbar.tsx
@@ -22,7 +22,18 @@ const ToolbarButton = ({
 }: React.PropsWithChildren<{ disabled?: boolean; onClick: () => void }>) => {
   const { theme } = useTheme()
   return (
-    <button type="button" className={theme.genericButtonBlock} disabled={disabled} onClick={onClick}>
+    /*
+     * TapTargetBlock: Bootstrap's default button padding left these at 38px tall, under the 44px
+     * DESIGN.md sets. This is the most-tapped row in the product and it is used mid-turn with one
+     * hand, so the six of them are sized by the finger. Applied here rather than on
+     * theme.genericButtonBlock, which is also the default for every GenericButton in the app.
+     */
+    <button
+      type="button"
+      className={`${theme.genericButtonBlock} TapTargetBlock`}
+      disabled={disabled}
+      onClick={onClick}
+    >
       <div className="d-flex align-items-center justify-content-center text-nowrap">{children}</div>
     </button>
   )

--- a/src/components/modals/paypal_post_subscribe_modal.tsx
+++ b/src/components/modals/paypal_post_subscribe_modal.tsx
@@ -1,9 +1,12 @@
 import { LargeSpinner } from 'components/helpers/suspenseFallbacks'
 import GenericButton from 'components/input/generic_button'
 import GenericModal from 'components/modals/generic/generic_modal'
+import Contact from 'components/page/contact'
 import { useSubscription } from 'context/useSubscription'
 import { useTheme } from 'context/useTheme'
 import React, { useState } from 'react'
+import { Link } from 'react-router'
+import { ROUTES } from 'utils/env'
 import { useSetInterval } from 'utils/hooks/useInterval'
 
 interface IModalComponentProps {
@@ -12,10 +15,25 @@ interface IModalComponentProps {
   retryGrant?: () => Promise<unknown>
 }
 
+const POLL_INTERVAL_MS = 1000
+
+/**
+ * How long to keep asking PayPal's webhook to land before saying so.
+ *
+ * The modal used to poll forever under the words "this could take up to one minute", so a grant that
+ * never arrived left the buyer watching a spinner with no account of what had happened to their
+ * money. Ninety seconds is well past the median 12s webhook delay the grant retry is written around.
+ */
+const POLL_TIMEOUT_MS = 90 * 1000
+const MAX_ATTEMPTS = POLL_TIMEOUT_MS / POLL_INTERVAL_MS
+
 export const PaypalPostSubscribeModal = ({ closeModal, modalIsOpen, retryGrant }: IModalComponentProps) => {
   const { isActive, subscriptionLoading, getSubscription } = useSubscription()
   const { theme } = useTheme()
-  const [interval, setInterval] = useState<number | null>(1000)
+  const [interval, setInterval] = useState<number | null>(POLL_INTERVAL_MS)
+  const [attempts, setAttempts] = useState(0)
+
+  const hasTimedOut = interval === null && !isActive
 
   useSetInterval(() => {
     if (subscriptionLoading) return
@@ -24,6 +42,11 @@ export const PaypalPostSubscribeModal = ({ closeModal, modalIsOpen, retryGrant }
       closeModal()
       return
     }
+    if (attempts >= MAX_ATTEMPTS) {
+      setInterval(null)
+      return
+    }
+    setAttempts(current => current + 1)
     // Re-send the grant each tick: the first attempt races PayPal's CREATED
     // webhook (median 12s behind the approval) and may have found no row yet
     void retryGrant?.().catch(() => undefined)
@@ -34,14 +57,40 @@ export const PaypalPostSubscribeModal = ({ closeModal, modalIsOpen, retryGrant }
     <GenericModal isOpen={modalIsOpen} closeModal={closeModal} label="Post Paypal Subscription Modal">
       <div className="row">
         <div className={`col ${theme.text}`}>
-          <h4 className="mb-3">Thanks! :)</h4>
-          <p className="text-center mb-1">One sec, we&apos;re verifying your PayPal transaction...</p>
-          <LargeSpinner className="text-dark" />
-          <p className="text-center mt-1">
-            This application will automatically reload when your subscription is available.
-            <br />
-            This could take up to one minute. Feel free to close this window and browse around.
-          </p>
+          {hasTimedOut ? (
+            /*
+             * Names what is and is not known. The payment is PayPal's record, not ours — the only
+             * thing that failed is our confirmation of it — so this must not imply anything was lost.
+             */
+            <div role="alert">
+              <h4 className="mb-3">Still waiting on PayPal</h4>
+              <p className="mb-1">
+                PayPal has your subscription, but we have not had confirmation of it yet. Nothing has gone
+                wrong with your payment.
+              </p>
+              <p className="mb-3">
+                It usually lands within a few minutes. Your <Link to={ROUTES.PROFILE}>Profile</Link> shows the
+                status, and it is worth checking there before paying again. If it has not appeared shortly,
+                please get in touch.
+              </p>
+              <Contact size="small" />
+            </div>
+          ) : (
+            <div role="status">
+              <h4 className="mb-3">Thanks! :)</h4>
+              <p className="text-center mb-1">One sec, we&apos;re verifying your PayPal transaction...</p>
+              <LargeSpinner className="text-dark" />
+              {/*
+                It closes itself; it does not reload the application, which is what this used to
+                promise. Saying the wrong thing here reads as a failure when the modal simply
+                disappears.
+              */}
+              <p className="text-center mt-1">
+                This closes itself as soon as your subscription is available. Feel free to close it and browse
+                around in the meantime.
+              </p>
+            </div>
+          )}
         </div>
       </div>
       <div className="row text-center">

--- a/src/components/modals/paypal_post_subscribe_modal.tsx
+++ b/src/components/modals/paypal_post_subscribe_modal.tsx
@@ -69,9 +69,13 @@ export const PaypalPostSubscribeModal = ({ closeModal, modalIsOpen, retryGrant }
                 wrong with your payment.
               </p>
               <p className="mb-3">
-                It usually lands within a few minutes. Your <Link to={ROUTES.PROFILE}>Profile</Link> shows the
-                status, and it is worth checking there before paying again. If it has not appeared shortly,
-                please get in touch.
+                {/* FaqLink: Action Blue measures 3.29:1 on the dark modal surface. */}
+                It usually lands within a few minutes. Your{' '}
+                <Link className="FaqLink" to={ROUTES.PROFILE}>
+                  Profile
+                </Link>{' '}
+                shows the status, and it is worth checking there before paying again. If it has not appeared
+                shortly, please get in touch.
               </p>
               <Contact size="small" />
             </div>

--- a/src/components/page/contact.tsx
+++ b/src/components/page/contact.tsx
@@ -8,7 +8,13 @@ const Contact = ({ size = 'normal' }: { size?: 'normal' | 'small' | 'large' }) =
   const { isOffline } = useAppStatus()
   const { isDark } = useTheme()
   const btnSize = size === 'small' ? 'btn-sm' : size === 'large' ? 'btn-lg' : ''
-  const btnClass = `btn ${btnSize} btn-outline-${isDark ? 'light' : 'dark'} mx-1`
+  /*
+   * TapTarget: `btn-sm` renders these at 31px tall, and `small` is the size the account routes
+   * and the footer use — so the product's contact links were below the 44px target everywhere they
+   * actually appear. The class sets a floor rather than a height, so the `large` variant is
+   * unaffected and nothing gets narrower.
+   */
+  const btnClass = `btn ${btnSize} btn-outline-${isDark ? 'light' : 'dark'} mx-1 TapTarget`
 
   if (isOffline) return null
 

--- a/src/components/page/footer.tsx
+++ b/src/components/page/footer.tsx
@@ -24,7 +24,11 @@ const Footer = () => (
   </footer>
 )
 
-const Disclaimer = () => {
+/*
+ * Exported because PRODUCT.md requires this on every page, and the account routes render their own
+ * layout rather than <Footer /> — /subscribe and /profile were shipping without it.
+ */
+export const Disclaimer = () => {
   const { theme } = useTheme()
 
   return (

--- a/src/components/payment/giftSubscriptions.tsx
+++ b/src/components/payment/giftSubscriptions.tsx
@@ -264,7 +264,7 @@ const PlanComponent = ({ supportPlan }: { supportPlan: IGiftedSubscriptionPlans 
       <td>${(parseFloat(supportPlan.cost) * quantity).toFixed(2)}</td>
       <td>
         <GenericButton
-          className={`btn ${isMobile ? 'btn-sm' : ''} d-block w-100 btn-primary CommitButton`}
+          className={`btn ${isMobile ? 'btn-sm' : ''} d-block w-100 btn-primary TapTargetBlock`}
           disabled={isAuthenticated && quantity < 1}
           onClick={isAuthenticated ? handleCheckout : login}
         >

--- a/src/components/payment/giftSubscriptions.tsx
+++ b/src/components/payment/giftSubscriptions.tsx
@@ -215,7 +215,12 @@ const PlanComponent = ({ supportPlan }: { supportPlan: IGiftedSubscriptionPlans 
       provider: 'stripe',
     })
     const price = isDev ? supportPlan.stripe_dev : supportPlan.stripe_prod
-    const url = isDev ? 'localhost:3000' : 'aosreminders.com'
+    /*
+     * window.location.origin, matching the subscription checkout. The old pair of hardcoded hosts
+     * pinned dev to `localhost:3000` — the CRA port, which no longer exists now the dev server is
+     * Vite — so every gift checkout in development returned to a dead address.
+     */
+    const baseUrl = window.location.origin
     const successQuery = qs.stringify({
       gifted: true,
       checkout_kind: 'gift_subscription',
@@ -227,8 +232,8 @@ const PlanComponent = ({ supportPlan }: { supportPlan: IGiftedSubscriptionPlans 
       lineItems: [{ price, quantity }],
       customerEmail: user.email,
       clientReferenceId: user.email,
-      successUrl: `${window.location.protocol}//${url}/profile?${successQuery}&checkout_session_id={CHECKOUT_SESSION_ID}`,
-      cancelUrl: `${window.location.protocol}//${url}?${qs.stringify({
+      successUrl: `${baseUrl}/profile?${successQuery}&checkout_session_id={CHECKOUT_SESSION_ID}`,
+      cancelUrl: `${baseUrl}?${qs.stringify({
         canceled: true,
         checkout_kind: 'gift_subscription',
         plan: supportPlan.title,
@@ -259,7 +264,7 @@ const PlanComponent = ({ supportPlan }: { supportPlan: IGiftedSubscriptionPlans 
       <td>${(parseFloat(supportPlan.cost) * quantity).toFixed(2)}</td>
       <td>
         <GenericButton
-          className={`btn ${isMobile ? 'btn-sm' : ''} d-block w-100 btn-primary`}
+          className={`btn ${isMobile ? 'btn-sm' : ''} d-block w-100 btn-primary CommitButton`}
           disabled={isAuthenticated && quantity < 1}
           onClick={isAuthenticated ? handleCheckout : login}
         >

--- a/src/components/payment/giftSubscriptions.tsx
+++ b/src/components/payment/giftSubscriptions.tsx
@@ -1,8 +1,8 @@
 import { useAuth0 } from '@auth0/auth0-react'
 import { Elements, useStripe } from '@stripe/react-stripe-js'
-import { loadStripe } from '@stripe/stripe-js'
+
 import GenericButton from 'components/input/generic_button'
-import { redirectToCheckout } from 'components/payment/legacyStripeCheckout'
+import { loadLegacyStripe, redirectToCheckout } from 'components/payment/legacyStripeCheckout'
 import { useSubscription } from 'context/useSubscription'
 import { useTheme } from 'context/useTheme'
 import { capitalize } from 'lodash'
@@ -275,7 +275,8 @@ const PlanComponent = ({ supportPlan }: { supportPlan: IGiftedSubscriptionPlans 
   )
 }
 
-const stripePromise = loadStripe(STRIPE_KEY)
+// The versioned loader is deliberately absent here: its runtime refuses redirectToCheckout.
+const stripePromise = loadLegacyStripe(STRIPE_KEY)
 
 export const GiftSubscriptions = () => (
   <Elements stripe={stripePromise}>

--- a/src/components/payment/legacyStripeCheckout.ts
+++ b/src/components/payment/legacyStripeCheckout.ts
@@ -1,12 +1,19 @@
-import type { Stripe, StripeError } from '@stripe/stripe-js'
+import type { Stripe, StripeConstructor, StripeError } from '@stripe/stripe-js'
 
 /*
- * `stripe.redirectToCheckout` was dropped from the @stripe/stripe-js types in v9 (the legacy
- * client-only hosted-Checkout surface), but the Stripe.js runtime at js.stripe.com/v3 still serves
- * it for existing Checkout integrations. The subscribe and gift flows below predate Stripe's
- * server-created Checkout Session model; replacing them needs backend work that is out of scope for
- * the package upgrade, so the exact runtime call is preserved and the legacy surface is declared
- * here.
+ * The client-only hosted-Checkout call this product's subscribe and gift flows are built on.
+ *
+ * `stripe.redirectToCheckout` was removed outright in Stripe's Clover release (changelog
+ * 2025-09-30), and the versioned runtime that @stripe/stripe-js v9 pins refuses it with an
+ * IntegrationError — which silently broke every card checkout on the site. The evergreen build at
+ * js.stripe.com/v3 still honours the call for this grandfathered integration: verified 2026-08-07
+ * with a live test-mode call that redirected to checkout.stripe.com.
+ *
+ * So this module loads /v3 itself, the same way context/usePaypal.tsx loads PayPal's SDK, and the
+ * checkout surfaces use `loadLegacyStripe` instead of the package's `loadStripe`. The two loaders
+ * must not mix: whichever build defines `window.Stripe` first wins, and the versioned build answers
+ * redirectToCheckout by throwing. Replacing this properly means server-created Checkout Sessions,
+ * which is subscription-API work, not frontend work.
  */
 export interface ILegacyRedirectToCheckoutOptions {
   mode?: 'payment' | 'subscription'
@@ -20,6 +27,43 @@ export interface ILegacyRedirectToCheckoutOptions {
 
 interface ILegacyCheckoutStripe extends Stripe {
   redirectToCheckout(options: ILegacyRedirectToCheckoutOptions): Promise<{ error?: StripeError }>
+}
+
+// window.Stripe is already declared by @stripe/stripe-js as StripeConstructor | undefined.
+const LEGACY_SCRIPT_URL = 'https://js.stripe.com/v3'
+
+let scriptPromise: Promise<StripeConstructor | null> | null = null
+
+/*
+ * One script tag per page, shared by the subscribe and gift surfaces. Resolves null rather than
+ * rejecting on a load failure, matching what loadStripe callers already handle: the buttons stay
+ * disabled and the card explains that card checkout is unavailable.
+ */
+const loadScript = (): Promise<StripeConstructor | null> => {
+  if (scriptPromise) return scriptPromise
+
+  scriptPromise = new Promise(resolve => {
+    if (typeof window === 'undefined') return resolve(null)
+    if (window.Stripe) return resolve(window.Stripe)
+
+    const script = document.createElement('script')
+    script.src = LEGACY_SCRIPT_URL
+    script.async = true
+    script.onload = () => resolve(window.Stripe ?? null)
+    script.onerror = () => {
+      console.error('The Stripe checkout script could not be loaded.')
+      resolve(null)
+    }
+    document.body.appendChild(script)
+  })
+
+  return scriptPromise
+}
+
+/** Drop-in for `loadStripe`, returning an instance whose redirectToCheckout actually works. */
+export const loadLegacyStripe = async (key: string): Promise<Stripe | null> => {
+  const factory = await loadScript()
+  return factory ? factory(key) : null
 }
 
 export const redirectToCheckout = (stripe: Stripe, options: ILegacyRedirectToCheckoutOptions) =>

--- a/src/components/payment/paypal/paypalButton.tsx
+++ b/src/components/payment/paypal/paypalButton.tsx
@@ -8,6 +8,8 @@ interface IStyle {
   layout?: 'vertical' | 'horizontal'
   color?: 'gold' | 'blue' | 'silver' | 'white' | 'black'
   shape?: 'pill' | 'rect'
+  /** PayPal accepts 25-55. Anything outside that range is rejected and the button fails to render. */
+  height?: number
   label?: 'paypal'
   tagline?: boolean
 }
@@ -43,10 +45,16 @@ interface IPayPalButtonProps {
   style?: IStyle
 }
 
+/*
+ * height: 44 is load-bearing. Left unset, PayPal sizes the button itself — it came out at 35px, so
+ * beside the 44px Stripe button the pair sat at two different heights with a 9px gap under PayPal.
+ * 44 is also the touch target DESIGN.md sets, and it is inside PayPal's own 25-55 range.
+ */
 const DEFAULT_STYLE: IStyle = {
   layout: 'vertical',
   color: 'gold',
   shape: 'rect',
+  height: 44,
   label: 'paypal',
   tagline: false,
 }

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -208,7 +208,7 @@ export const PlanComponent = (props: IPlanProps) => {
             */}
             {savingPct > 0 ? (
               <>
-                <strong>Save {savingPct}%</strong> against the monthly rate
+                <strong>Save {savingPct}%</strong>
               </>
             ) : (
               // The baseline plan discounts nothing, so the row would otherwise be empty.

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -1,9 +1,9 @@
 import { useAuth0 } from '@auth0/auth0-react'
 import { Elements, useStripe } from '@stripe/react-stripe-js'
-import { loadStripe } from '@stripe/stripe-js'
+
 import GenericButton from 'components/input/generic_button'
 import { PaypalPostSubscribeModal } from 'components/modals/paypal_post_subscribe_modal'
-import { redirectToCheckout } from 'components/payment/legacyStripeCheckout'
+import { loadLegacyStripe, redirectToCheckout } from 'components/payment/legacyStripeCheckout'
 import PayPalButton from 'components/payment/paypal/paypalButton'
 import { IApprovalResponse } from 'components/payment/paypal/paypalTypes'
 import { PaypalProvider } from 'context/usePaypal'
@@ -185,11 +185,18 @@ export const PlanComponent = (props: IPlanProps) => {
      * gone in print and for colour-blind players.
      */
     <div className={`${theme.card} mb-4 shadow-sm px-0${isBestValue ? ' border-primary' : ''}`}>
-      <div className="card-header bg-themeDarkBluePrimary text-light">
-        <h3 className="my-0 fw-normal">
-          {supportPlan.title}
-          {isBestValue && <span className="ms-2 badge rounded-pill bg-light text-dark">Best value</span>}
-        </h3>
+      {/*
+        The badge sits absolutely at the header's right edge rather than inline in the heading, so
+        "1 Year" stays centred on the same axis as the other two titles instead of being pushed left
+        by the badge's width.
+      */}
+      <div className="card-header bg-themeDarkBluePrimary text-light position-relative">
+        <h3 className="my-0 fw-normal">{supportPlan.title}</h3>
+        {isBestValue && (
+          <span className="badge rounded-pill bg-light text-dark position-absolute top-50 end-0 translate-middle-y me-3">
+            Best value
+          </span>
+        )}
       </div>
       {/*
         A flex column so the CTA can be pushed to the bottom. Without it the buttons sat at different
@@ -206,28 +213,25 @@ export const PlanComponent = (props: IPlanProps) => {
           */}
           <small className={theme.textMuted}>/ month</small>
         </p>
-        <ul className="list-unstyled mt-3 mb-4">
-          {!!supportPlan.discount_pct && (
-            <li>
-              <span className="badge rounded-pill bg-danger mb-2">{supportPlan.discount_pct}% off!</span>
-            </li>
-          )}
-          {/*
-            Derived from plans.ts, never written down: the figure and the prices above it cannot
-            drift apart. This is the page's strongest true claim and it went unsaid for years.
-          */}
-          {savingPct > 0 && (
-            <li>
-              <strong>Save {savingPct}%</strong>
-            </li>
-          )}
-          {/* The real charge, in the buyer's own units, before any checkout opens. */}
-          <li>
-            <small className={theme.textMuted}>
-              ${supportPlan.cost}, {billingCadence[supportPlan.title] ?? 'billed up front'}
-            </small>
-          </li>
-        </ul>
+        {/* Rendered only when it has content; the baseline plan carries neither badge nor saving. */}
+        {(savingPct > 0 || !!supportPlan.discount_pct) && (
+          <ul className="list-unstyled mt-3 mb-4">
+            {!!supportPlan.discount_pct && (
+              <li>
+                <span className="badge rounded-pill bg-danger mb-2">{supportPlan.discount_pct}% off!</span>
+              </li>
+            )}
+            {/*
+              Derived from plans.ts, never written down: the figure and the prices above it cannot
+              drift apart. This is the page's strongest true claim and it went unsaid for years.
+            */}
+            {savingPct > 0 && (
+              <li>
+                <strong>Save {savingPct}%</strong>
+              </li>
+            )}
+          </ul>
+        )}
         {/*
           No `mx-3`. That inset was sized for a single full-width button; with two rails beside each
           other it cost 32px, which was exactly what pushed them past PayPal's 150px floor and wrapped
@@ -309,6 +313,15 @@ export const PlanComponent = (props: IPlanProps) => {
               </div>
             </>
           )}
+          {/*
+            The real charge, in the buyer's own units, directly under the controls that open a
+            checkout. Derived from plans.ts, so it cannot drift from the price above.
+          */}
+          <p className="mt-2 mb-0">
+            <small className={theme.textMuted}>
+              ${supportPlan.cost}, {billingCadence[supportPlan.title] ?? 'billed up front'}
+            </small>
+          </p>
           {checkoutError && (
             <div className="alert alert-danger mt-2 mb-0 py-2" role="alert">
               <small>{checkoutError}</small>
@@ -395,7 +408,8 @@ const PayPalComponent = (props: IPlanProps) => {
   )
 }
 
-const stripePromise = loadStripe(STRIPE_KEY)
+// The versioned loader is deliberately absent here: its runtime refuses redirectToCheckout.
+const stripePromise = loadLegacyStripe(STRIPE_KEY)
 
 export const PricingPlans = () => (
   <Elements stripe={stripePromise}>

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -150,11 +150,11 @@ export const PlanComponent = (props: IPlanProps) => {
        */
       if (result.error) {
         console.error(result.error)
-        setCheckoutError('We could not open the checkout page. Please try again, or use PayPal below.')
+        setCheckoutError('We could not open the checkout page. Please try again, or use PayPal instead.')
       }
     } catch (error) {
       console.error(error)
-      setCheckoutError('We could not open the checkout page. Please try again, or use PayPal below.')
+      setCheckoutError('We could not open the checkout page. Please try again, or use PayPal instead.')
     } finally {
       // Reached only when the redirect did not happen; a successful one has already left the page.
       setIsRedirecting(false)
@@ -223,54 +223,80 @@ export const PlanComponent = (props: IPlanProps) => {
           padding is the margin now.
         */}
         <div className="mt-auto">
-          {/*
-            The two rails sit side by side as equal choices rather than stacked with Stripe on top,
-            where PayPal read as an afterthought.
-
-            flex-wrap with a 150px flex-basis rather than a breakpoint: PayPal's SDK will not render
-            its button below 150px, and the card's own width varies with the 1/2/3-up plan grid, so
-            the pair drops to stacked exactly when there is no longer room for both — on a phone, and
-            in the narrowest desktop column — without guessing which viewport that happens at.
-          */}
-          <div className="d-flex flex-wrap align-items-start gap-2 PaymentChoice">
-            <IconContext.Provider value={{ size: '1.2em' }}>
+          {!isAuthenticated ? (
+            /*
+             * Signed out, the payment rails are withheld entirely. PayPal cannot render without an
+             * account e-mail, so the brand pair collapsed to one lopsided wordmark button — and
+             * clicking it opened the login popup while its accessible name promised Stripe. One
+             * plain, truthfully-labelled button carries the intent; the rails appear after login,
+             * when each really is one click from its checkout.
+             */
+            <GenericButton
+              type="button"
+              className="btn d-block w-100 btn-primary TapTargetBlock py-2"
+              onClick={login}
+            >
+              Subscribe for {supportPlan.title}
+            </GenericButton>
+          ) : (
+            <>
               {/*
-                The visible label is now just the wordmark, because half a card cannot hold "Subscribe
-                for 3 Months" as well. The accessible name carries the whole sentence, and the plan it
-                belongs to, since three cards of identical buttons would otherwise be indistinguishable.
+                Names the action the brand marks below only imply. Both buttons' visible labels are
+                logos, so without this line the card ends in two wordmarks and no verb.
               */}
-              <GenericButton
-                type="button"
-                aria-label={`Subscribe for ${supportPlan.title} with Stripe`}
-                className="btn d-block btn-primary TapTargetBlock py-2 PaymentChoiceOption--stripe"
-                disabled={isAuthenticated && (isRedirecting || !stripe)}
-                onClick={isAuthenticated ? handleStripeCheckout : login}
-              >
-                {isRedirecting ? (
-                  <span className={centerContentClass}>
-                    <span
-                      aria-hidden="true"
-                      className="spinner-border spinner-border-sm me-2"
-                      role="status"
-                    />
-                    Opening&hellip;
-                  </span>
-                ) : (
-                  <span className={centerContentClass}>
-                    {/*
-                      The Stripe wordmark, from the react-icons Font Awesome brand set DESIGN.md
-                      already names as the product's icon source. aria-hidden because the accessible
-                      name above already says "Stripe" — announcing it twice is noise.
-                    */}
-                    <span className="StripeMark">
-                      <FaStripe size="3.4em" aria-hidden="true" />
-                    </span>
-                  </span>
-                )}
-              </GenericButton>
-            </IconContext.Provider>
-            <PayPalComponent {...props} />
-          </div>
+              <p className="mb-1">
+                <small className={theme.textMuted}>Subscribe with:</small>
+              </p>
+              {/*
+                The two rails sit side by side as equal choices rather than stacked with Stripe on
+                top, where PayPal read as an afterthought.
+
+                flex-wrap rather than a breakpoint: the card's own width varies with the 1/2/3-up
+                plan grid, so the pair drops to stacked exactly when there is no longer room for
+                both, without guessing which viewport that happens at.
+              */}
+              <div className="d-flex flex-wrap align-items-start gap-2 PaymentChoice">
+                <IconContext.Provider value={{ size: '1.2em' }}>
+                  {/*
+                    The visible label is just the wordmark, because half a card cannot hold
+                    "Subscribe for 3 Months" as well. The accessible name carries the whole sentence,
+                    and the plan it belongs to, since three cards of identical buttons would
+                    otherwise be indistinguishable.
+                  */}
+                  <GenericButton
+                    type="button"
+                    aria-label={`Subscribe for ${supportPlan.title} with Stripe`}
+                    className="btn d-block btn-primary TapTargetBlock py-2 PaymentChoiceOption--stripe"
+                    disabled={isRedirecting || !stripe}
+                    onClick={handleStripeCheckout}
+                  >
+                    {isRedirecting ? (
+                      <span className={centerContentClass}>
+                        <span
+                          aria-hidden="true"
+                          className="spinner-border spinner-border-sm me-2"
+                          role="status"
+                        />
+                        Opening&hellip;
+                      </span>
+                    ) : (
+                      <span className={centerContentClass}>
+                        {/*
+                          The Stripe wordmark, from the react-icons Font Awesome brand set DESIGN.md
+                          already names as the product's icon source. aria-hidden because the
+                          accessible name above already says "Stripe" — announcing it twice is noise.
+                        */}
+                        <span className="StripeMark">
+                          <FaStripe size="3.4em" aria-hidden="true" />
+                        </span>
+                      </span>
+                    )}
+                  </GenericButton>
+                </IconContext.Provider>
+                <PayPalComponent {...props} />
+              </div>
+            </>
+          )}
           {checkoutError && (
             <div className="alert alert-danger mt-2 mb-0 py-2" role="alert">
               <small>{checkoutError}</small>

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -11,6 +11,8 @@ import { useTheme } from 'context/useTheme'
 import qs from 'qs'
 import React, { useState } from 'react'
 import { IconContext } from 'react-icons'
+import { FaStripe } from 'react-icons/fa'
+import { centerContentClass } from 'theme/helperClasses'
 import { logBeginCheckout, logCheckoutCancelled, logClick, logPurchase } from 'utils/analytics'
 import { useApiAccessToken } from 'utils/authToken'
 import { isDev, STRIPE_KEY } from 'utils/env'
@@ -200,37 +202,75 @@ export const PlanComponent = (props: IPlanProps) => {
                 <br />
               </>
             )}
-            Total: ${supportPlan.cost}
             {/*
               Derived from plans.ts, never written down: the figure and the prices above it cannot
               drift apart. This is the page's strongest true claim and it went unsaid for years.
             */}
-            {savingPct > 0 && (
+            {savingPct > 0 ? (
               <>
-                <br />
                 <strong>Save {savingPct}%</strong> against the monthly rate
               </>
+            ) : (
+              // The baseline plan discounts nothing, so the row would otherwise be empty.
+              <>Billed monthly</>
             )}
           </li>
         </ul>
-        <div className="mx-3 mt-auto">
-          <IconContext.Provider value={{ size: '1.2em' }}>
-            <GenericButton
-              type="button"
-              className="btn d-block w-100 btn-primary TapTargetBlock py-2"
-              disabled={isAuthenticated && (isRedirecting || !stripe)}
-              onClick={isAuthenticated ? handleStripeCheckout : login}
-            >
-              {isRedirecting ? (
-                <>
-                  <span aria-hidden="true" className="spinner-border spinner-border-sm me-2" role="status" />
-                  Opening checkout&hellip;
-                </>
-              ) : (
-                `Subscribe for ${supportPlan.title}`
-              )}
-            </GenericButton>
-          </IconContext.Provider>
+        {/*
+          No `mx-3`. That inset was sized for a single full-width button; with two rails beside each
+          other it cost 32px, which was exactly what pushed them past PayPal's 150px floor and wrapped
+          them at 1280 and 1440 — the two most common laptop widths. The card body's own 1.25rem
+          padding is the margin now.
+        */}
+        <div className="mt-auto">
+          {/*
+            The two rails sit side by side as equal choices rather than stacked with Stripe on top,
+            where PayPal read as an afterthought.
+
+            flex-wrap with a 150px flex-basis rather than a breakpoint: PayPal's SDK will not render
+            its button below 150px, and the card's own width varies with the 1/2/3-up plan grid, so
+            the pair drops to stacked exactly when there is no longer room for both — on a phone, and
+            in the narrowest desktop column — without guessing which viewport that happens at.
+          */}
+          <div className="d-flex flex-wrap align-items-start gap-2 PaymentChoice">
+            <IconContext.Provider value={{ size: '1.2em' }}>
+              {/*
+                The visible label is now just the wordmark, because half a card cannot hold "Subscribe
+                for 3 Months" as well. The accessible name carries the whole sentence, and the plan it
+                belongs to, since three cards of identical buttons would otherwise be indistinguishable.
+              */}
+              <GenericButton
+                type="button"
+                aria-label={`Subscribe for ${supportPlan.title} with Stripe`}
+                className="btn d-block btn-primary TapTargetBlock py-2 PaymentChoiceOption--stripe"
+                disabled={isAuthenticated && (isRedirecting || !stripe)}
+                onClick={isAuthenticated ? handleStripeCheckout : login}
+              >
+                {isRedirecting ? (
+                  <span className={centerContentClass}>
+                    <span
+                      aria-hidden="true"
+                      className="spinner-border spinner-border-sm me-2"
+                      role="status"
+                    />
+                    Opening&hellip;
+                  </span>
+                ) : (
+                  <span className={centerContentClass}>
+                    {/*
+                      The Stripe wordmark, from the react-icons Font Awesome brand set DESIGN.md
+                      already names as the product's icon source. aria-hidden because the accessible
+                      name above already says "Stripe" — announcing it twice is noise.
+                    */}
+                    <span className="StripeMark">
+                      <FaStripe size="3.4em" aria-hidden="true" />
+                    </span>
+                  </span>
+                )}
+              </GenericButton>
+            </IconContext.Provider>
+            <PayPalComponent {...props} />
+          </div>
           {checkoutError && (
             <div className="alert alert-danger mt-2 mb-0 py-2" role="alert">
               <small>{checkoutError}</small>
@@ -238,13 +278,10 @@ export const PlanComponent = (props: IPlanProps) => {
           )}
           {isAuthenticated && !stripe && !checkoutError && (
             <p className="mt-2 mb-0">
-              <small className={theme.textMuted}>
-                Card checkout is still loading. PayPal is ready below.
-              </small>
+              <small className={theme.textMuted}>Card checkout is still loading. PayPal is ready.</small>
             </p>
           )}
         </div>
-        <PayPalComponent {...props} />
       </div>
     </div>
   )
@@ -291,11 +328,15 @@ const PayPalComponent = (props: IPlanProps) => {
 
   return (
     /*
-     * `mt-2`, not `col mt-2`. This is a card body, not a row, so the `.col` was one of the
-     * outside-a-row columns theme.scss keeps a shim for — and inside the flex column it resolved to
+     * A flex item beside the Stripe button now, so it carries PaymentChoiceOption rather than any
+     * spacing of its own — the row's `gap-2` owns the space between the two rails.
+     *
+     * Historical note on what this used to be: `col mt-2`. This is a card body, not a row, so the
+     * `.col` was one of the outside-a-row columns theme.scss keeps a shim for — and inside the flex
+     * column it resolved to
      * `flex: 1 0 0%`, absorbing the slack the CTA's `mt-auto` needs to sit at the card's bottom edge.
      */
-    <div className="mt-2">
+    <div className="PaymentChoiceOption--paypal">
       {!props.paypalModalIsOpen && (
         <PayPalButton
           onClick={() => logBeginCheckout({ items: [analyticsItem], provider: 'paypal' })}

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -15,44 +15,62 @@ import { logBeginCheckout, logCheckoutCancelled, logClick, logPurchase } from 'u
 import { useApiAccessToken } from 'utils/authToken'
 import { isDev, STRIPE_KEY } from 'utils/env'
 import useLogin from 'utils/hooks/useLogin'
-import { ISubscriptionPlan, SubscriptionPlans, toSubscriptionAnalyticsItem } from 'utils/plans'
+import {
+  bestValuePlan,
+  ISubscriptionPlan,
+  monthlySavingPct,
+  SubscriptionPlans,
+  toSubscriptionAnalyticsItem,
+} from 'utils/plans'
 import { SubscriptionApi } from '../../api/subscriptionApi'
 
 const PricingPlansComponent = () => {
   const [paypalModalIsOpen, setPaypalModalIsOpen] = useState(false)
+  const bestValue = bestValuePlan()
 
   return (
     <PaypalProvider>
       <div className="container">
         <PlansHeader />
+        {/*
+          Above the cards, not below them. These three sentences are the answer to what stops someone
+          committing — no card details here, cancel whenever, keep access to the end of the period —
+          and they used to sit in 12px italic underneath all three plans, arriving after the decision
+          they exist to unblock.
+        */}
+        <TrustNote />
         <div className="row row-cols-1 row-cols-md-2 row-cols-lg-3 justify-content-center text-center">
           {SubscriptionPlans.map(plan => (
             <PlanComponent
               supportPlan={plan}
+              isBestValue={plan.title === bestValue?.title}
               paypalModalIsOpen={paypalModalIsOpen}
               setPaypalModalIsOpen={setPaypalModalIsOpen}
               key={plan.title}
             />
           ))}
         </div>
-        <div className="row text-center justify-content-center">
-          <div className="col-12 col-sm-10 col-md-10 col-xl-8 col-xxl-6">
-            <small>
-              <em>
-                AoS Reminders does not store your credit card information.
-                <br />
-                Subscriptions are managed by Stripe and PayPal. They can be canceled at any time.
-                <br />
-                You will have access to all subscription features until the end of your subscription, even if
-                you cancel the recurring payments.
-              </em>
-            </small>
-          </div>
-        </div>
       </div>
     </PaypalProvider>
   )
 }
+
+const TrustNote = () => (
+  <div className="row text-center justify-content-center mb-4">
+    <div className="col-12 col-sm-10 col-md-10 col-xl-8 col-xxl-6">
+      <small>
+        <em>
+          AoS Reminders does not store your credit card information.
+          <br />
+          Subscriptions are managed by Stripe and PayPal. They can be canceled at any time.
+          <br />
+          You will have access to all subscription features until the end of your subscription, even if you
+          cancel the recurring payments.
+        </em>
+      </small>
+    </div>
+  </div>
+)
 
 const PlansHeader = () => {
   const hasSale = SubscriptionPlans.some(plan => plan.sale)
@@ -71,22 +89,30 @@ const PlansHeader = () => {
 
 interface IPlanProps {
   supportPlan: ISubscriptionPlan
+  isBestValue?: boolean
   paypalModalIsOpen: boolean
   setPaypalModalIsOpen: (isOpen: boolean) => void
 }
 
 export const PlanComponent = (props: IPlanProps) => {
-  const { supportPlan } = props
+  const { supportPlan, isBestValue } = props
   const { user, isAuthenticated } = useAuth0()
   const { login } = useLogin({ origin: supportPlan.title })
   const { theme } = useTheme()
   const stripe = useStripe()
+  const [isRedirecting, setIsRedirecting] = useState(false)
+  const [checkoutError, setCheckoutError] = useState('')
+  const savingPct = monthlySavingPct(supportPlan)
 
-  if (!stripe) return null
+  /*
+   * No `if (!stripe) return null`. Stripe.js failing to load used to delete the entire card — taking
+   * the PayPal button rendered inside it with it — so a visitor who could have paid by PayPal was
+   * shown an empty pricing band and no explanation. The card stays; only the card button goes quiet.
+   */
 
   const handleStripeCheckout = async (event: React.MouseEvent) => {
     event.preventDefault()
-    if (!user) return
+    if (!user || !stripe || isRedirecting) return
 
     logClick(supportPlan.title)
     logBeginCheckout({
@@ -101,19 +127,36 @@ export const PlanComponent = (props: IPlanProps) => {
       plan: supportPlan.title,
     })
 
-    const result = await redirectToCheckout(stripe, {
-      items: [{ plan, quantity: 1 }],
-      customerEmail: user.email,
-      clientReferenceId: user.email,
-      successUrl: `${origin}/?${successQuery}&checkout_session_id={CHECKOUT_SESSION_ID}`,
-      cancelUrl: `${origin}/?${qs.stringify({
-        canceled: true,
-        checkout_kind: 'subscription',
-        plan: supportPlan.title,
-      })}`,
-    })
+    setIsRedirecting(true)
+    setCheckoutError('')
+    try {
+      const result = await redirectToCheckout(stripe, {
+        items: [{ plan, quantity: 1 }],
+        customerEmail: user.email,
+        clientReferenceId: user.email,
+        successUrl: `${origin}/?${successQuery}&checkout_session_id={CHECKOUT_SESSION_ID}`,
+        cancelUrl: `${origin}/?${qs.stringify({
+          canceled: true,
+          checkout_kind: 'subscription',
+          plan: supportPlan.title,
+        })}`,
+      })
 
-    if (result.error) console.error(result.error)
+      /*
+       * A rejected redirect used to reach console.error and nothing else, so the visitor pressed the
+       * one button that takes money and watched the page do nothing at all.
+       */
+      if (result.error) {
+        console.error(result.error)
+        setCheckoutError('We could not open the checkout page. Please try again, or use PayPal below.')
+      }
+    } catch (error) {
+      console.error(error)
+      setCheckoutError('We could not open the checkout page. Please try again, or use PayPal below.')
+    } finally {
+      // Reached only when the redirect did not happen; a successful one has already left the page.
+      setIsRedirecting(false)
+    }
   }
 
   /*
@@ -122,13 +165,25 @@ export const PlanComponent = (props: IPlanProps) => {
    * `.row-cols-*`, so unlike the other opt-outs (see navbar_wrapper) this one must not touch it.
    */
   return (
-    <div className={`${theme.card} mb-4 shadow-sm px-0`}>
+    /*
+     * The best-value card is marked by a border and by the words "Best value" in its header, never by
+     * colour alone — DESIGN.md's rule that a tone always pairs with a text label, because the tone is
+     * gone in print and for colour-blind players.
+     */
+    <div className={`${theme.card} mb-4 shadow-sm px-0${isBestValue ? ' border-primary' : ''}`}>
       <div className="card-header bg-themeDarkBluePrimary text-light">
-        <h3 className="my-0 fw-normal">{supportPlan.title}</h3>
+        <h3 className="my-0 fw-normal">
+          {supportPlan.title}
+          {isBestValue && <span className="ms-2 badge rounded-pill bg-light text-dark">Best value</span>}
+        </h3>
       </div>
-      <div className={theme.cardBody}>
+      {/*
+        A flex column so the CTA can be pushed to the bottom. Without it the buttons sat at different
+        heights across the three cards, because only two of them carry a saving line above.
+      */}
+      <div className={`${theme.cardBody} d-flex flex-column`}>
         {/* A price is not a heading. The .h1 class keeps the type scale unchanged. */}
-        <p className="card-title pricing-card-title h1">
+        <p className="card-title h1">
           ${supportPlan.monthly_cost}
           {/*
             theme.textMuted, not text-muted: Bootstrap's #6c757d lands at 3.28:1 on the dark card
@@ -146,18 +201,48 @@ export const PlanComponent = (props: IPlanProps) => {
               </>
             )}
             Total: ${supportPlan.cost}
+            {/*
+              Derived from plans.ts, never written down: the figure and the prices above it cannot
+              drift apart. This is the page's strongest true claim and it went unsaid for years.
+            */}
+            {savingPct > 0 && (
+              <>
+                <br />
+                <strong>Save {savingPct}%</strong> against the monthly rate
+              </>
+            )}
           </li>
         </ul>
-        <div className="mx-3">
+        <div className="mx-3 mt-auto">
           <IconContext.Provider value={{ size: '1.2em' }}>
             <GenericButton
               type="button"
-              className="btn btn d-block w-100 btn-primary btn-pill py-2"
+              className="btn d-block w-100 btn-primary CommitButton py-2"
+              disabled={isAuthenticated && (isRedirecting || !stripe)}
               onClick={isAuthenticated ? handleStripeCheckout : login}
             >
-              Subscribe for {supportPlan.title}
+              {isRedirecting ? (
+                <>
+                  <span aria-hidden="true" className="spinner-border spinner-border-sm me-2" role="status" />
+                  Opening checkout&hellip;
+                </>
+              ) : (
+                `Subscribe for ${supportPlan.title}`
+              )}
             </GenericButton>
           </IconContext.Provider>
+          {checkoutError && (
+            <div className="alert alert-danger mt-2 mb-0 py-2" role="alert">
+              <small>{checkoutError}</small>
+            </div>
+          )}
+          {isAuthenticated && !stripe && !checkoutError && (
+            <p className="mt-2 mb-0">
+              <small className={theme.textMuted}>
+                Card checkout is still loading. PayPal is ready below.
+              </small>
+            </p>
+          )}
         </div>
         <PayPalComponent {...props} />
       </div>
@@ -205,7 +290,12 @@ const PayPalComponent = (props: IPlanProps) => {
   }
 
   return (
-    <div className="col mt-2">
+    /*
+     * `mt-2`, not `col mt-2`. This is a card body, not a row, so the `.col` was one of the
+     * outside-a-row columns theme.scss keeps a shim for — and inside the flex column it resolved to
+     * `flex: 1 0 0%`, absorbing the slack the CTA's `mt-auto` needs to sit at the card's bottom edge.
+     */
+    <div className="mt-2">
       {!props.paypalModalIsOpen && (
         <PayPalButton
           onClick={() => logBeginCheckout({ items: [analyticsItem], provider: 'paypal' })}

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -56,7 +56,7 @@ const PricingPlansComponent = () => {
 }
 
 const TrustNote = () => (
-  <div className="row text-center justify-content-center mb-4">
+  <div className="row text-center justify-content-center mb-3 mb-sm-4">
     <div className="col-12 col-sm-10 col-md-10 col-xl-8 col-xxl-6">
       <small>
         <em>
@@ -217,7 +217,7 @@ export const PlanComponent = (props: IPlanProps) => {
           <IconContext.Provider value={{ size: '1.2em' }}>
             <GenericButton
               type="button"
-              className="btn d-block w-100 btn-primary CommitButton py-2"
+              className="btn d-block w-100 btn-primary TapTargetBlock py-2"
               disabled={isAuthenticated && (isRedirecting || !stripe)}
               onClick={isAuthenticated ? handleStripeCheckout : login}
             >

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -96,6 +96,18 @@ interface IPlanProps {
   setPaypalModalIsOpen: (isOpen: boolean) => void
 }
 
+/*
+ * How each plan actually charges, in words. The cards lead with a per-month figure, but two of the
+ * three plans do not bill monthly — and a page that shows only the per-month framing of an annually
+ * billed plan is the exact pattern the FTC's dark-patterns work names as drip pricing. One quiet
+ * line per card states the real charge before any checkout is opened.
+ */
+const billingCadence: Record<string, string> = {
+  '1 Month': 'billed monthly',
+  '3 Months': 'billed every 3 months',
+  '1 Year': 'billed once a year',
+}
+
 export const PlanComponent = (props: IPlanProps) => {
   const { supportPlan, isBestValue } = props
   const { user, isAuthenticated } = useAuth0()
@@ -195,25 +207,25 @@ export const PlanComponent = (props: IPlanProps) => {
           <small className={theme.textMuted}>/ month</small>
         </p>
         <ul className="list-unstyled mt-3 mb-4">
+          {!!supportPlan.discount_pct && (
+            <li>
+              <span className="badge rounded-pill bg-danger mb-2">{supportPlan.discount_pct}% off!</span>
+            </li>
+          )}
+          {/*
+            Derived from plans.ts, never written down: the figure and the prices above it cannot
+            drift apart. This is the page's strongest true claim and it went unsaid for years.
+          */}
+          {savingPct > 0 && (
+            <li>
+              <strong>Save {savingPct}%</strong>
+            </li>
+          )}
+          {/* The real charge, in the buyer's own units, before any checkout opens. */}
           <li>
-            {!!supportPlan.discount_pct && (
-              <>
-                <span className="badge rounded-pill bg-danger mb-2">{supportPlan.discount_pct}% off!</span>
-                <br />
-              </>
-            )}
-            {/*
-              Derived from plans.ts, never written down: the figure and the prices above it cannot
-              drift apart. This is the page's strongest true claim and it went unsaid for years.
-            */}
-            {savingPct > 0 ? (
-              <>
-                <strong>Save {savingPct}%</strong>
-              </>
-            ) : (
-              // The baseline plan discounts nothing, so the row would otherwise be empty.
-              <>Billed monthly</>
-            )}
+            <small className={theme.textMuted}>
+              ${supportPlan.cost}, {billingCadence[supportPlan.title] ?? 'billed up front'}
+            </small>
           </li>
         </ul>
         {/*

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -92,10 +92,12 @@ const HomeContent = () => {
   const [pendingShareId, setPendingShareId] = useState(() => consumePendingShareId())
   const [printModalIsOpen, setPrintModalIsOpen] = useState(false)
   const savedArmiesAction = useSubscriberAction({
+    featureName: 'My Armies',
     onAuthorized: () => setSavedArmiesModalIsOpen(true),
     origin: 'SavedArmies',
   })
   const shareAction = useSubscriberAction({
+    featureName: 'Share Army',
     onAuthorized: () => setShareModalIsOpen(true),
     origin: 'ShareArmy',
   })

--- a/src/components/routes/Profile.tsx
+++ b/src/components/routes/Profile.tsx
@@ -91,7 +91,7 @@ const CancelBtn = () => {
   return (
     <>
       <GenericButton
-        className={`btn btn-sm btn${isLight ? '-outline-' : '-'}danger`}
+        className={`btn btn-sm btn${isLight ? '-outline-' : '-'}danger TapTarget`}
         onClick={() => setModalIsOpen(true)}
       >
         Cancel Subscription

--- a/src/components/routes/Profile.tsx
+++ b/src/components/routes/Profile.tsx
@@ -4,6 +4,7 @@ import GenericButton from 'components/input/generic_button'
 import { CancelPaypalSubscriptionModal } from 'components/modals/paypal_cancellation_modal'
 import { CancelStripeSubscriptionModal } from 'components/modals/stripe_cancellation_modal'
 import Contact from 'components/page/contact'
+import { Disclaimer } from 'components/page/footer'
 import { GiftSubscriptions } from 'components/payment/giftSubscriptions'
 import { useSubscription } from 'context/useSubscription'
 import { useTheme } from 'context/useTheme'
@@ -38,7 +39,15 @@ const Profile = () => {
           <Navbar />
         </Suspense>
       </div>
-      <div className={`container ${theme.bgColor} px-0`}>
+      {/*
+        No `px-0`. The container's gutter padding is what absorbs the .row's -15px margins; stripping
+        it ran the row 15px wider than the viewport and scrolled this page sideways at 390, 375, 335
+        and 320 — the exact failure DESIGN.md names under Layout, on the account screen, in the
+        one-handed phone scene. /redeem, /join and AlreadySubscribed all use the plain container; this
+        is that pattern. Visible delta: the card column gains the standard 15px side gutter it should
+        always have had, rather than touching the screen edge.
+      */}
+      <div className={`container ${theme.bgColor}`}>
         <div className="row d-flex justify-content-center">
           <div className="col-12 col-md-8 col-lg-6 col-xl-6">
             <UserCard />
@@ -46,6 +55,10 @@ const Profile = () => {
         </div>
       </div>
       <GiftSubscriptions />
+      {/* PRODUCT.md requires the Games Workshop disclaimer on every page; this route had none. */}
+      <div className={`container ${theme.bgColor} ${theme.text} pb-4`}>
+        <Disclaimer />
+      </div>
     </div>
   )
 }
@@ -233,7 +246,19 @@ const SubscriptionInfoBody = () => {
 
   if (isPending) return <p className="lead mb-0">Your subscription is pending activation.</p>
 
-  return <p className="lead mb-0">You do not have an active subscription.</p>
+  /* A dead end in the incumbent: it named the state and offered nothing to do about it. */
+  return (
+    <>
+      <p className="lead mb-2">You do not have an active subscription.</p>
+      <Link
+        to={ROUTES.SUBSCRIBE}
+        className={theme.genericButton}
+        onClick={() => logClick('Profile-Subscribe')}
+      >
+        See what a subscription includes
+      </Link>
+    </>
+  )
 }
 
 const SubscriptionInfo = () => {

--- a/src/components/routes/Profile.tsx
+++ b/src/components/routes/Profile.tsx
@@ -427,7 +427,8 @@ const ToggleTheme = () => {
         {/* Standing guidance, present at first render — not an outcome worth announcing on load. */}
         {!isActive && (
           <div className="alert alert-info text-center mt-3">
-            <Link to={ROUTES.SUBSCRIBE} onClick={() => logClick('SubscribeDarkTheme')}>
+            {/* alert-link: plain Action Blue on the tinted alert background sits under 4.5:1. */}
+            <Link className="alert-link" to={ROUTES.SUBSCRIBE} onClick={() => logClick('SubscribeDarkTheme')}>
               Subscribe now
             </Link>{' '}
             to use dark theme!

--- a/src/components/routes/Subscribe.tsx
+++ b/src/components/routes/Subscribe.tsx
@@ -75,7 +75,14 @@ const Subscribe = () => {
           <PricingPlans />
         )}
       </div>
-      <ExamplesRow />
+      {/*
+        Directly under the plans. These three answer the questions the prices raise, so they belong
+        where the prices end.
+
+        The dark-mode demo video used to sit between them, which pushed all of this past 2,100px —
+        beyond the point anyone who had just read the prices was still reading. It is removed for now
+        and will come back later; `public/img/dark_mode1.mp4` is deliberately kept for that.
+      */}
       <MoreQuestions />
       <div className={`container ${theme.bgColor} ${theme.text} text-center py-4`}>
         <Contact size="small" />
@@ -246,67 +253,6 @@ const MoreQuestions = () => {
         </small>
       </p>
     </div>
-  )
-}
-
-/*
- * The only visual proof of a paid feature anywhere in the funnel. It used to render below 576px only,
- * so desktop got an empty section band and saw nothing at all — this now shows at every width.
- *
- * It stays *below* the plans rather than above them. Tried above, and a 550px-tall portrait video
- * became the centre of the page and pushed all three prices under the fold: proof that costs the
- * offer its position is a bad trade. Here it backs up the dark-theme line for anyone still deciding.
- */
-const ExamplesRow = () => {
-  const { theme } = useTheme()
-
-  return (
-    <div className={`py-5 px-3 ${theme.sectionBand} ${theme.text} text-center`}>
-      <DemoVideo videoUrl="/img/dark_mode1.mp4" description="Dark Mode" label="Demo-DarkMode" />
-    </div>
-  )
-}
-
-interface DemoVideoProps {
-  videoUrl: string
-  description: string
-  label: string
-}
-
-/**
- * The demo loops, so it needs a way to stop it (WCAG 2.2.2). The native controls provide that, and
- * their fullscreen button covers what the old wrapping link to the raw file was standing in for — a
- * link around the video would have swallowed every click the controls need.
- *
- * There is no .webm asset in public/img; the old `video/webm` source pointed at this same .mp4, and
- * the poster was a 1.8MB gif fronting an 862KB video. Both are gone.
- */
-const DemoVideo = ({ videoUrl, description, label }: DemoVideoProps) => {
-  const prefersReducedMotion =
-    typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
-
-  return (
-    <figure className="figure">
-      {/* muted + playsInline are required for autoplay on iOS Safari and Android Chrome. */}
-      <video
-        aria-label={`${description} demo`}
-        autoPlay={!prefersReducedMotion}
-        className="figure-img img-fluid rounded img-thumbnail"
-        controls
-        height="550"
-        loop
-        muted
-        onClick={() => logClick(label)}
-        playsInline
-        preload="metadata"
-        width="320"
-      >
-        <source src={videoUrl} type="video/mp4" />
-      </video>
-      <figcaption className="figure-caption text-center">
-        <strong>{description}</strong>
-      </figcaption>
-    </figure>
   )
 }
 

--- a/src/components/routes/Subscribe.tsx
+++ b/src/components/routes/Subscribe.tsx
@@ -246,15 +246,6 @@ const MoreQuestions = () => {
         Slate, under the 4.5:1 floor. FaqLink is the incumbent answer for links on themed surfaces —
         inherit the theme's text colour and let the underline mark the link.
       */}
-      <p className="mb-1">
-        <Link
-          className="FaqLink TapTarget"
-          to={`${ROUTES.FAQ}#what-subscription-includes`}
-          onClick={() => logClick('Subscribe-Faq')}
-        >
-          More about subscriptions in the FAQ
-        </Link>
-      </p>
       <p className="mb-0">
         <small>
           Already subscribed? You can buy gift subscriptions for friends from your{' '}

--- a/src/components/routes/Subscribe.tsx
+++ b/src/components/routes/Subscribe.tsx
@@ -19,7 +19,12 @@ const Navbar = lazy(() => import('components/page/navbar'))
  * two prose blocks starting 236px apart on a 1440px screen.
  */
 const contentClass = 'col-12 col-lg-8 col-xl-8 mx-auto'
-const headerClass = `${contentClass} pt-5`
+/*
+ * pt-4 below 576px, pt-5 above. On a phone the whole first screen was preamble — logo, heading,
+ * lead, bullets — and the first price did not appear until roughly 1,135px down. Every fixed unit
+ * above the plans is paid for by the visitor who has to scroll past it to find out what this costs.
+ */
+const headerClass = `${contentClass} pt-4 pt-sm-5`
 
 const Subscribe = () => {
   const { isLoading } = useAuth0()
@@ -54,7 +59,8 @@ const Subscribe = () => {
         A full-bleed band, not a .row: a bare row's -15px margins overflowed the viewport by 15px and
         scrolled the whole page sideways. PricingPlans supplies its own .container.
       */}
-      <div className={`py-5 ${theme.sectionBand} ${theme.text}`}>
+      {/* py-4 below 576px: band padding above the prices is pure scroll cost on a phone. */}
+      <div className={`py-4 py-sm-5 ${theme.sectionBand} ${theme.text}`}>
         {/*
           Nothing here used to read subscriptionLoading or subscriptionError, so an account whose
           lookup was still in flight — or had failed — was shown three live buy buttons. A subscriber
@@ -111,11 +117,17 @@ const Intro = () => {
 
   return (
     <div className={`${headerClass} ${theme.text}`}>
-      {/* height reserves the box before the image loads; the intrinsic ratio is 919x843. */}
+      {/*
+        height reserves the box before the image loads; the intrinsic ratio is 919x843.
+
+        Hidden below 576px. It is purely decorative — the masthead already identifies the product,
+        which is why it carries an empty alt — and on a phone it was ~150px of the one screen that
+        has to make the case, pushing the prices further down for no information gained.
+      */}
       <img
         alt=""
         aria-hidden="true"
-        className="d-block mx-auto mb-4 img-fluid rounded-circle bg-white"
+        className="d-none d-sm-block mx-auto mb-4 img-fluid rounded-circle bg-white"
         height="110"
         src="/img/logo_medium_padding.png"
         width="120"
@@ -130,7 +142,7 @@ const Intro = () => {
       */}
       <p className="lead">
         Your army is saved in this browser, and only this browser. A subscription keeps it on your account
-        instead, so it follows you to the phone in your hand at the table — and survives losing that phone.
+        instead — so it follows you to the table, and survives a lost phone.
       </p>
     </div>
   )
@@ -155,10 +167,6 @@ const CurrentFeatures = () => (
         <strong>Dark theme</strong> — stored against your account, so it follows you too.
       </li>
     </ul>
-    <p>
-      Everything else — the builder, importing, reminders, notes, hiding, reordering, and the PDF — is free,
-      and stays free. Subscribing is what keeps it that way.
-    </p>
   </div>
 )
 
@@ -210,6 +218,15 @@ const MoreQuestions = () => {
 
   return (
     <div className={`container ${theme.bgColor} ${theme.text} text-center pt-4`}>
+      {/*
+        The free-and-stays-free note lives here rather than above the plans. It is the closing
+        argument, not the offer, and every line above the prices is one the visitor has to scroll
+        past before learning what this costs.
+      */}
+      <p>
+        Everything else — the builder, importing, reminders, notes, hiding, reordering, and the PDF — is free,
+        and stays free. Subscribing is what keeps it that way.
+      </p>
       <p className="mb-1">
         <Link
           className="TapTarget"

--- a/src/components/routes/Subscribe.tsx
+++ b/src/components/routes/Subscribe.tsx
@@ -134,14 +134,17 @@ const Intro = () => {
       {/* Rendered at h2 size so the page gains a top-level heading without a visual change. */}
       <h1 className="h2">Subscribe to AoS Reminders</h1>
       {/*
-        Leads with what the subscription does rather than with an appeal for support. The old opening
-        — "those who wish to support AoS Reminders" — framed a hard paywall as a tip jar, and left the
-        three features it actually unlocks unsold. The support line survives, at the end, where it
-        reads as context rather than as the offer.
+        The one-person fact leads the page. It is the product's strongest trust signal in a niche
+        trained on hobbyist-made tools, and it colours how everything after it reads — the ask, the
+        prices, and the plain look of the page itself. The old opening buried it below the fold.
       */}
       <p className="lead">
+        <strong>AoS Reminders is built and run by one person</strong>, and subscriptions are what keep it
+        running.
+      </p>
+      <p className="lead">
         Your army is saved in this browser, and only this browser. A subscription keeps it on your account
-        instead — so it follows you to the table, and survives a lost phone.
+        instead, so it follows you to the table and survives a lost phone.
       </p>
     </div>
   )
@@ -156,14 +159,14 @@ const CurrentFeatures = () => (
   <div className={`${contentClass} mt-3`}>
     <ul className="lead">
       <li>
-        <strong>My Armies</strong> — save, load, rename, update, and delete your AoS 4 armies, on every device
+        <strong>My Armies</strong>: save, load, rename, update, and delete your AoS 4 armies, on every device
         you sign in on.
       </li>
       <li>
-        <strong>Share Army</strong> — send a link a friend can open to take their own copy of your list.
+        <strong>Share Army</strong>: send a link a friend can open to take their own copy of your list.
       </li>
       <li>
-        <strong>Dark theme</strong> — stored against your account, so it follows you too.
+        <strong>Dark theme</strong>: stored against your account, so it follows you too.
       </li>
     </ul>
   </div>
@@ -223,20 +226,20 @@ const MoreQuestions = () => {
         past before learning what this costs.
 
         The second paragraph follows the strongest finding in Wikimedia's published banner testing:
-        concrete facts about the thing being supported outperform sentiment roughly threefold, and a
-        personal voice carries them best. Both facts here are anchored: the price ceiling is derived
-        from plans.ts at render time, and the army count is pinned to the corpus by a test
-        (accountRoutes.test.tsx), so neither can drift from the truth silently. Stating the *maximum*
-        price is deliberate — "from $0.99" is the sales voice this product doesn't use.
+        concrete facts about the thing being supported outperform sentiment roughly threefold. Both
+        facts here are anchored: the price ceiling is derived from plans.ts at render time, and the
+        army count is pinned to the corpus by a test (accountRoutes.test.tsx), so neither can drift
+        from the truth silently. Stating the *maximum* price is deliberate — "from $0.99" is the
+        sales voice this product doesn't use. The one-person sentence itself lives in the intro now,
+        above the fold.
       */}
       <p>
-        Everything else — the builder, importing, reminders, notes, hiding, reordering, and the PDF — is free,
-        and stays free.
+        Everything else is free, and stays free: the builder, importing, reminders, notes, hiding, reordering,
+        and the PDF.
       </p>
       <p>
-        AoS Reminders is built and run by one person. Subscriptions — none more than $
-        {baselineMonthlyCost().toFixed(2)} a month — are what keep all 27 armies&apos; reminders free for
-        everyone.
+        No plan costs more than ${baselineMonthlyCost().toFixed(2)} a month, and subscriptions are what keep
+        all 27 armies&apos; reminders free for everyone.
       </p>
       {/*
         FaqLink on both: Action Blue was tuned for white backgrounds and measures 3.29:1 on Midnight

--- a/src/components/routes/Subscribe.tsx
+++ b/src/components/routes/Subscribe.tsx
@@ -125,20 +125,11 @@ const Intro = () => {
   return (
     <div className={`${headerClass} ${theme.text}`}>
       {/*
-        height reserves the box before the image loads; the intrinsic ratio is 919x843.
-
-        Hidden below 576px. It is purely decorative — the masthead already identifies the product,
-        which is why it carries an empty alt — and on a phone it was ~150px of the one screen that
-        has to make the case, pushing the prices further down for no information gained.
+        No logo. It was decorative — the masthead already identifies the product — and it had already
+        been hidden on mobile for exactly that reason; on desktop it was ~150px of the screen that has
+        to make the case, and in dark theme its white circle read as a rendering artifact. Removing it
+        finishes the decision the mobile hiding started.
       */}
-      <img
-        alt=""
-        aria-hidden="true"
-        className="d-none d-sm-block mx-auto mb-4 img-fluid rounded-circle bg-white"
-        height="110"
-        src="/img/logo_medium_padding.png"
-        width="120"
-      />
       {/* Rendered at h2 size so the page gains a top-level heading without a visual change. */}
       <h1 className="h2">Subscribe to AoS Reminders</h1>
       {/*
@@ -234,9 +225,14 @@ const MoreQuestions = () => {
         Everything else — the builder, importing, reminders, notes, hiding, reordering, and the PDF — is free,
         and stays free. Subscribing is what keeps it that way.
       </p>
+      {/*
+        FaqLink on both: Action Blue was tuned for white backgrounds and measures 3.29:1 on Midnight
+        Slate, under the 4.5:1 floor. FaqLink is the incumbent answer for links on themed surfaces —
+        inherit the theme's text colour and let the underline mark the link.
+      */}
       <p className="mb-1">
         <Link
-          className="TapTarget"
+          className="FaqLink TapTarget"
           to={`${ROUTES.FAQ}#what-subscription-includes`}
           onClick={() => logClick('Subscribe-Faq')}
         >
@@ -246,7 +242,7 @@ const MoreQuestions = () => {
       <p className="mb-0">
         <small>
           Already subscribed? You can buy gift subscriptions for friends from your{' '}
-          <Link to={ROUTES.PROFILE} onClick={() => logClick('Subscribe-GiftPointer')}>
+          <Link className="FaqLink" to={ROUTES.PROFILE} onClick={() => logClick('Subscribe-GiftPointer')}>
             Profile
           </Link>
           .

--- a/src/components/routes/Subscribe.tsx
+++ b/src/components/routes/Subscribe.tsx
@@ -2,12 +2,14 @@ import { useAuth0 } from '@auth0/auth0-react'
 import AlreadySubscribed from 'components/helpers/alreadySubscribed'
 import { LoadingBody, LoadingHeader } from 'components/helpers/suspenseFallbacks'
 import Contact from 'components/page/contact'
+import { Disclaimer } from 'components/page/footer'
 import { PricingPlans } from 'components/payment/pricingPlans'
 import { useSubscription } from 'context/useSubscription'
 import { useTheme } from 'context/useTheme'
-import React, { lazy, Suspense, useEffect } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
+import { Link, useLocation } from 'react-router'
 import { logClick } from 'utils/analytics'
-import useWindowSize from 'utils/hooks/useWindowSize'
+import { ROUTES } from 'utils/env'
 
 const Navbar = lazy(() => import('components/page/navbar'))
 
@@ -21,7 +23,8 @@ const headerClass = `${contentClass} pt-5`
 
 const Subscribe = () => {
   const { isLoading } = useAuth0()
-  const { isSubscribed, isActive, getSubscription } = useSubscription()
+  const { isSubscribed, isActive, getSubscription, subscriptionError, subscriptionLoading } =
+    useSubscription()
   const { theme } = useTheme()
 
   useEffect(() => {
@@ -42,6 +45,7 @@ const Subscribe = () => {
           <Navbar />
         </Suspense>
       </div>
+      <PaywallNotice />
       <Intro />
       <div className={`${theme.bgColor} ${theme.text}`}>
         <CurrentFeatures />
@@ -51,24 +55,53 @@ const Subscribe = () => {
         scrolled the whole page sideways. PricingPlans supplies its own .container.
       */}
       <div className={`py-5 ${theme.sectionBand} ${theme.text}`}>
-        <PricingPlans />
+        {/*
+          Nothing here used to read subscriptionLoading or subscriptionError, so an account whose
+          lookup was still in flight — or had failed — was shown three live buy buttons. A subscriber
+          on a bad venue connection could be charged a second time for what they already have. The
+          plans appear only once the answer is known to be "not subscribed".
+        */}
+        {subscriptionLoading ? (
+          <CheckingSubscription />
+        ) : subscriptionError ? (
+          <SubscriptionUnavailable error={subscriptionError} onRetry={getSubscription} />
+        ) : (
+          <PricingPlans />
+        )}
       </div>
       <ExamplesRow />
+      <MoreQuestions />
       <div className={`container ${theme.bgColor} ${theme.text} text-center py-4`}>
         <Contact size="small" />
+        <Disclaimer />
       </div>
     </div>
   )
 }
 
-const ExamplesRow = () => {
-  const { isMobile } = useWindowSize()
-  const { theme } = useTheme()
-  if (!isMobile) return null
+/**
+ * Names the control that sent the visitor here.
+ *
+ * `useSubscriberAction` used to navigate to this page silently, so the highest-intent moment in the
+ * funnel — pressing a gated button — arrived at a page headed "Support AoS Reminders" for reasons it
+ * never stated. The feature name travels in the navigation state; arriving any other way renders
+ * nothing, so this never speculates about why someone is here.
+ */
+const PaywallNotice = () => {
+  const { state } = useLocation()
+  const featureName = (state as { featureName?: string } | null)?.featureName
+  if (!featureName) return null
 
   return (
-    <div className={`py-5 px-3 ${theme.sectionBand} ${theme.text}`}>
-      <DemoVideo videoUrl="/img/dark_mode1.mp4" description="Dark Mode" label="Demo-DarkMode" />
+    <div className="container pt-4">
+      <div className="row justify-content-center">
+        <div className={contentClass}>
+          {/* Announced: it is the reason the route changed, and it is absent on a direct visit. */}
+          <div className="alert alert-info mb-0" role="alert">
+            <strong>{featureName}</strong> needs a subscription. Here is what one includes.
+          </div>
+        </div>
+      </div>
     </div>
   )
 }
@@ -80,38 +113,138 @@ const Intro = () => {
     <div className={`${headerClass} ${theme.text}`}>
       {/* height reserves the box before the image loads; the intrinsic ratio is 919x843. */}
       <img
-        alt="Subscribe to support AoS Reminders"
+        alt=""
+        aria-hidden="true"
         className="d-block mx-auto mb-4 img-fluid rounded-circle bg-white"
         height="110"
         src="/img/logo_medium_padding.png"
         width="120"
       />
       {/* Rendered at h2 size so the page gains a top-level heading without a visual change. */}
-      <h1 className="h2">Support AoS Reminders</h1>
+      <h1 className="h2">Subscribe to AoS Reminders</h1>
+      {/*
+        Leads with what the subscription does rather than with an appeal for support. The old opening
+        — "those who wish to support AoS Reminders" — framed a hard paywall as a tip jar, and left the
+        three features it actually unlocks unsold. The support line survives, at the end, where it
+        reads as context rather than as the offer.
+      */}
       <p className="lead">
-        <strong>
-          It takes a lot of time, effort, and money to keep this project going. While the core product will{' '}
-          <i>always</i> be free, I do offer this subscription service to those who wish to support AoS
-          Reminders.
-        </strong>
+        Your army is saved in this browser, and only this browser. A subscription keeps it on your account
+        instead, so it follows you to the phone in your hand at the table — and survives losing that phone.
       </p>
     </div>
   )
 }
 
+/*
+ * Written to match the FAQ's answers, which were consistently more concrete than this page's. "Create
+ * read-only army links" became the sharing sentence the FAQ already used, because what the recipient
+ * can actually do — take their own copy — is the part worth paying for.
+ */
 const CurrentFeatures = () => (
   <div className={`${contentClass} mt-3`}>
-    <p className="lead">
-      <strong>What do you get when you subscribe?</strong>
-    </p>
     <ul className="lead">
-      <li>Save, load, rename, update, and delete AoS 4 armies across your devices.</li>
-      <li>Create read-only army links to share with your friends.</li>
-      <li>Spare your eyes! Turn on dark mode!</li>
-      <li>Help keep AoS Reminders free for everyone.</li>
+      <li>
+        <strong>My Armies</strong> — save, load, rename, update, and delete your AoS 4 armies, on every device
+        you sign in on.
+      </li>
+      <li>
+        <strong>Share Army</strong> — send a link a friend can open to take their own copy of your list.
+      </li>
+      <li>
+        <strong>Dark theme</strong> — stored against your account, so it follows you too.
+      </li>
     </ul>
+    <p>
+      Everything else — the builder, importing, reminders, notes, hiding, reordering, and the PDF — is free,
+      and stays free. Subscribing is what keeps it that way.
+    </p>
   </div>
 )
+
+/**
+ * Stands in for the plans while the account's subscription is still being looked up. Mirrors the
+ * wording and the role="status" announcement /profile already uses for the same wait.
+ */
+const CheckingSubscription = () => (
+  <div className="container text-center" role="status">
+    <span className="spinner-border spinner-border-sm me-2" aria-hidden="true" />
+    Checking your subscription&hellip;
+  </div>
+)
+
+/**
+ * Stands in for the plans when the lookup failed. Buying is withheld rather than offered on a guess:
+ * the one thing this page must not do is sell a second subscription to someone who already has one.
+ */
+const SubscriptionUnavailable = ({ error, onRetry }: { error: string; onRetry: () => void }) => {
+  const { theme } = useTheme()
+
+  return (
+    <div className="container">
+      <div className="row justify-content-center">
+        <div className="col-12 col-md-10 col-xl-8">
+          <div className="alert alert-warning text-center mb-0" role="alert">
+            {error}
+            <br />
+            We have not shown the plans, in case you are already subscribed.
+            <br />
+            <button type="button" className={`${theme.secondaryButton} mt-2`} onClick={() => void onRetry()}>
+              Check again
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The FAQ answers every objection this page raises — what a subscription includes, how to cancel,
+ * whether card details are stored — and this page linked to none of it. Gift subscriptions get a
+ * pointer for the same reason: they are real, they are cheaper per period, and nothing outside
+ * /profile has ever mentioned them.
+ */
+const MoreQuestions = () => {
+  const { theme } = useTheme()
+
+  return (
+    <div className={`container ${theme.bgColor} ${theme.text} text-center pt-4`}>
+      <p className="mb-1">
+        <Link to={`${ROUTES.FAQ}#what-subscription-includes`} onClick={() => logClick('Subscribe-Faq')}>
+          More about subscriptions in the FAQ
+        </Link>
+      </p>
+      <p className="mb-0">
+        <small>
+          Already subscribed? You can buy gift subscriptions for friends from your{' '}
+          <Link to={ROUTES.PROFILE} onClick={() => logClick('Subscribe-GiftPointer')}>
+            Profile
+          </Link>
+          .
+        </small>
+      </p>
+    </div>
+  )
+}
+
+/*
+ * The only visual proof of a paid feature anywhere in the funnel. It used to render below 576px only,
+ * so desktop got an empty section band and saw nothing at all — this now shows at every width.
+ *
+ * It stays *below* the plans rather than above them. Tried above, and a 550px-tall portrait video
+ * became the centre of the page and pushed all three prices under the fold: proof that costs the
+ * offer its position is a bad trade. Here it backs up the dark-theme line for anyone still deciding.
+ */
+const ExamplesRow = () => {
+  const { theme } = useTheme()
+
+  return (
+    <div className={`py-5 px-3 ${theme.sectionBand} ${theme.text} text-center`}>
+      <DemoVideo videoUrl="/img/dark_mode1.mp4" description="Dark Mode" label="Demo-DarkMode" />
+    </div>
+  )
+}
 
 interface DemoVideoProps {
   videoUrl: string

--- a/src/components/routes/Subscribe.tsx
+++ b/src/components/routes/Subscribe.tsx
@@ -10,6 +10,7 @@ import { lazy, Suspense, useEffect } from 'react'
 import { Link, useLocation } from 'react-router'
 import { logClick } from 'utils/analytics'
 import { ROUTES } from 'utils/env'
+import { baselineMonthlyCost } from 'utils/plans'
 
 const Navbar = lazy(() => import('components/page/navbar'))
 
@@ -220,10 +221,22 @@ const MoreQuestions = () => {
         The free-and-stays-free note lives here rather than above the plans. It is the closing
         argument, not the offer, and every line above the prices is one the visitor has to scroll
         past before learning what this costs.
+
+        The second paragraph follows the strongest finding in Wikimedia's published banner testing:
+        concrete facts about the thing being supported outperform sentiment roughly threefold, and a
+        personal voice carries them best. Both facts here are anchored: the price ceiling is derived
+        from plans.ts at render time, and the army count is pinned to the corpus by a test
+        (accountRoutes.test.tsx), so neither can drift from the truth silently. Stating the *maximum*
+        price is deliberate — "from $0.99" is the sales voice this product doesn't use.
       */}
       <p>
         Everything else — the builder, importing, reminders, notes, hiding, reordering, and the PDF — is free,
-        and stays free. Subscribing is what keeps it that way.
+        and stays free.
+      </p>
+      <p>
+        AoS Reminders is built and run by one person. Subscriptions — none more than $
+        {baselineMonthlyCost().toFixed(2)} a month — are what keep all 27 armies&apos; reminders free for
+        everyone.
       </p>
       {/*
         FaqLink on both: Action Blue was tuned for white backgrounds and measures 3.29:1 on Midnight

--- a/src/components/routes/Subscribe.tsx
+++ b/src/components/routes/Subscribe.tsx
@@ -211,7 +211,11 @@ const MoreQuestions = () => {
   return (
     <div className={`container ${theme.bgColor} ${theme.text} text-center pt-4`}>
       <p className="mb-1">
-        <Link to={`${ROUTES.FAQ}#what-subscription-includes`} onClick={() => logClick('Subscribe-Faq')}>
+        <Link
+          className="TapTarget"
+          to={`${ROUTES.FAQ}#what-subscription-includes`}
+          onClick={() => logClick('Subscribe-Faq')}
+        >
           More about subscriptions in the FAQ
         </Link>
       </p>

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -78,29 +78,39 @@ small {
 }
 
 /*
- * The controls that take money, sized by the finger rather than by the label.
+ * Touch targets, sized by the finger rather than by the label.
  *
- * Bootstrap's button padding plus `py-2` lands these at 42px tall, under the 44px touch target
- * DESIGN.md sets for the phone-in-one-hand scene. Only the height needs correcting — every one of
- * them is already full-width or wider than 44px — so a min-height fixes it without moving anything
- * else on the card.
+ * DESIGN.md sets 44x44 for the phone-in-one-hand scene, with WCAG 2.5.8's 24x24 as the absolute
+ * floor. Bootstrap's own metrics land short of 44 almost everywhere: a `btn` with `py-2` is 42px,
+ * `btn-sm` is 31px, and a bare text link is whatever its line-height happens to be. These two rules
+ * correct the height only — every element carrying them is already wider than 44px — so nothing
+ * reflows horizontally.
+ *
+ * Two variants because the elements differ: `.TapTargetBlock` leaves an existing block or
+ * full-width button alone, while `.TapTarget` has to establish a box at all, since an inline
+ * element cannot take a height.
  */
-.CommitButton {
+/*
+ * Height only, deliberately. Every element carrying this is a Bootstrap `.btn` with `d-block`, whose
+ * `display: block !important` would beat any display declared here — so setting one would be a style
+ * that silently never applies. The button's own symmetric padding centres the label.
+ */
+.TapTargetBlock {
+  min-height: 44px;
+}
+
+.TapTarget {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   min-height: 44px;
 }
 
 /*
- * A standalone text link that is its own tap target rather than a word inside a sentence.
- *
- * WCAG 2.5.8 exempts links set inline in a block of text — the sentence around them is the target —
- * but a link sitting alone on its own line gets no such help, and line-height alone leaves it around
- * 21px tall. This raises the box without changing the type.
+ * WCAG 2.5.8 exempts a link set inline in a block of text, because the sentence around it is the
+ * target. `.TapTarget` is for the other kind: a link alone on its own line, or one acting as a
+ * control, which gets no such help.
  */
-.TapTarget {
-  display: inline-flex;
-  align-items: center;
-  min-height: 44px;
-}
 
 /*
  * Bootstrap's default `code` pink measures 3.82:1 on white — under AA — and it carries the one line

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -78,6 +78,18 @@ small {
 }
 
 /*
+ * The controls that take money, sized by the finger rather than by the label.
+ *
+ * Bootstrap's button padding plus `py-2` lands these at 42px tall, under the 44px touch target
+ * DESIGN.md sets for the phone-in-one-hand scene. Only the height needs correcting — every one of
+ * them is already full-width or wider than 44px — so a min-height fixes it without moving anything
+ * else on the card.
+ */
+.CommitButton {
+  min-height: 44px;
+}
+
+/*
  * Bootstrap's default `code` pink measures 3.82:1 on white — under AA — and it carries the one line
  * of a failed redemption the player has to read back to us. The monospace face already marks the
  * string as the server's own words, so the colour was only decorating. Inherit rather than pick a

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -107,6 +107,54 @@ small {
 }
 
 /*
+ * The Stripe wordmark on the checkout button.
+ *
+ * Font Awesome's brand glyph sits in a 640x512 box with the mark occupying only the middle band, so
+ * sizing it large enough to read as a logo rather than as bold text inflated the button from 44px to
+ * 72px. This crops the empty vertical padding instead of shrinking the mark: the glyph keeps its
+ * size, the box claims only the height the mark actually needs, and the button stays at 44px.
+ */
+.StripeMark {
+  display: inline-flex;
+  align-items: center;
+  overflow: hidden;
+  height: 1.5em;
+
+  > svg {
+    flex-shrink: 0;
+  }
+}
+
+/*
+ * The two payment rails, side by side as equal choices.
+ *
+ * PayPal's SDK renders its button into a zoid iframe with a hard 200px floor — measured, not
+ * documented; below that it overflows its column rather than shrinking. Two 200px buttons plus the
+ * gap need 408px inside a plan card, and the 3-up grid gives roughly 300-340px at every ordinary
+ * laptop width, so a symmetric pair could only ever sit side by side above ~1500px.
+ *
+ * So the shortfall is given to Stripe, whose label is just the wordmark and reads fine narrow:
+ * PayPal holds its floor, Stripe takes whatever is left on the line. They still wrap to stacked if a
+ * card is ever narrower than the two of them together.
+ */
+/*
+ * The bases have to add up to less than the card, because flex wraps before it shrinks: two 200px
+ * bases would wrap to stacked at every ordinary width rather than squeezing onto one line. Stripe
+ * asks for 100 and grows into whatever is left; PayPal asks for its floor and neither grows nor
+ * shrinks past it. Below roughly 308px of card — a 320px phone — the pair still wraps, which is the
+ * right answer there.
+ */
+.PaymentChoiceOption--stripe {
+  flex: 1 1 100px;
+  min-width: 0;
+}
+
+.PaymentChoiceOption--paypal {
+  flex: 0 1 200px;
+  min-width: 200px;
+}
+
+/*
  * WCAG 2.5.8 exempts a link set inline in a block of text, because the sentence around it is the
  * target. `.TapTarget` is for the other kind: a link alone on its own line, or one acting as a
  * control, which gets no such help.

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -107,6 +107,27 @@ small {
 }
 
 /*
+ * The 44px hit area without the 44px visual box, for controls whose look must stay small — the
+ * navbar's Log in/Log out button drew its border at the full tap-target height and looked inflated
+ * beside the borderless links. A centred pseudo-element extends the clickable area to 44px while the
+ * border keeps the button's own size; the same approach .ReminderMenuToggle uses.
+ */
+.TapTargetOverlay {
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 100%;
+    min-width: 44px;
+    height: 44px;
+    transform: translate(-50%, -50%);
+  }
+}
+
+/*
  * The Stripe wordmark on the checkout button.
  *
  * Font Awesome's brand glyph sits in a 640x512 box with the mark occupying only the middle band, so

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -90,6 +90,19 @@ small {
 }
 
 /*
+ * A standalone text link that is its own tap target rather than a word inside a sentence.
+ *
+ * WCAG 2.5.8 exempts links set inline in a block of text — the sentence around them is the target —
+ * but a link sitting alone on its own line gets no such help, and line-height alone leaves it around
+ * 21px tall. This raises the box without changing the type.
+ */
+.TapTarget {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+}
+
+/*
  * Bootstrap's default `code` pink measures 3.82:1 on white — under AA — and it carries the one line
  * of a failed redemption the player has to read back to us. The monospace face already marks the
  * string as the server's own words, so the colour was only decorating. Inherit rather than pick a

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -149,8 +149,14 @@ small {
   min-width: 0;
 }
 
+/*
+ * grow 1: on the shared line both rails split the spare space, and when the pair wraps on a narrow
+ * phone PayPal fills its own line instead of sitting at a fixed 200px under a full-width Stripe —
+ * two different widths, stacked, read as a rendering accident. The 200px basis (PayPal's measured
+ * render floor) still decides where the wrap happens.
+ */
 .PaymentChoiceOption--paypal {
-  flex: 0 1 200px;
+  flex: 1 1 200px;
   min-width: 200px;
 }
 

--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -77,7 +77,17 @@ $enable-rfs: false;
  * 4.6 values as part of the product's palette (Action Blue, Success Green, Info Cyan), and $dark is
  * the toolbar's btn-outline-dark, the most repeated control on the game screen.
  */
-$blue: #007bff; // 5.3 default: #0d6efd
+/*
+ * Action Blue. Not a 4.6 pin any more: #007bff carries white text at 3.98:1, under the 4.5:1 floor
+ * this product treats as a correctness requirement, and it is the colour of every control that takes
+ * money — the Subscribe CTAs, gift purchase, and redemption. #0070e8 clears it at 4.69:1 and is the
+ * nearest hue that does, so the identity is unchanged at a glance.
+ *
+ * $primary derives from this, so the same fix reaches the `Official` badge (white on primary, and the
+ * only saturated colour on the reminders surface) and body links, which sat at the same failing ratio
+ * against white.
+ */
+$blue: #0070e8; // 4.6/live: #007bff (3.98:1) · 5.3 default: #0d6efd
 $green: #28a745; // 5.3 default: #198754
 $cyan: #17a2b8; // 5.3 default: #0dcaf0
 $dark: #343a40; // 5.3 default: $gray-900 (#212529)
@@ -90,9 +100,11 @@ $dark: #343a40; // 5.3 default: $gray-900 (#212529)
  * reproduces every one of 4.6's eight decisions exactly: white on primary/secondary/success/
  * danger/info/dark, black on warning/light.
  *
- * This lowers a contrast floor, so it is worth being explicit: it does not make anything less
- * legible than it is on the live site today — it keeps the existing rendering rather than changing
- * it. Raising the real contrast of these buttons is a design change, and a separate decision.
+ * This lowers a contrast floor, so it is worth being explicit: it decides which *text* colour sits on
+ * a filled button, not how legible the pair actually is. It is still 2.5 because raising it would
+ * flip warning and light to a different text colour than the live site renders. The real contrast of
+ * the commitment button was the separate decision this comment used to defer, and it has been taken:
+ * $blue above is now #0070e8, so white on primary measures 4.69:1 rather than 3.98:1.
  */
 $min-contrast-ratio: 2.5; // 5.3 default: 4.5
 

--- a/src/tests/aos4/accountRoutes.test.tsx
+++ b/src/tests/aos4/accountRoutes.test.tsx
@@ -189,12 +189,12 @@ describe('established account routes', () => {
     expect(container.querySelector('video')).toBeNull()
     expect(container.querySelector('[src="/img/dark_mode1.mp4"]')).toBeNull()
 
+    // Davis removed the FAQ link from the closing block by hand; the close is now the two facts
+    // and the gift pointer, and the ordering guard covers what remains.
     const plans = container.textContent?.indexOf('Subscription Plans') ?? -1
     const closing = container.textContent?.indexOf('is free, and stays free') ?? -1
-    const faq = container.textContent?.indexOf('More about subscriptions in the FAQ') ?? -1
     expect(plans).toBeGreaterThan(-1)
     expect(closing).toBeGreaterThan(plans)
-    expect(faq).toBeGreaterThan(closing)
 
     /*
      * The closing paragraph makes two factual claims, and PRODUCT.md treats stale copy on a paid

--- a/src/tests/aos4/accountRoutes.test.tsx
+++ b/src/tests/aos4/accountRoutes.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 
+import { armyFactions } from '../../aos4/domain'
+import { AOS4_CATALOG } from '../../aos4/generated'
 import { protectedRoute } from 'components/page/privateRoute'
 import Profile from 'components/routes/Profile'
 import Subscribe from 'components/routes/Subscribe'
@@ -7,6 +9,7 @@ import { AppStatusProvider } from 'context/useAppStatus'
 import { render, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
 import { act } from 'react'
 import { MemoryRouter, Route, Routes } from 'react-router'
+import { baselineMonthlyCost } from 'utils/plans'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const auth = vi.hoisted(() => ({
@@ -130,7 +133,7 @@ describe('established account routes', () => {
     expect(container.textContent).toContain('Subscribe to AoS Reminders')
     // Leads with what the subscription does; the support appeal is a closing note, not the offer.
     expect(container.textContent).toContain('Your army is saved in this browser, and only this browser.')
-    expect(container.textContent).toContain('Subscribing is what keeps it that way.')
+    expect(container.textContent).toContain('AoS Reminders is built and run by one person.')
     expect(container.textContent).not.toContain(
       'Import current army lists from the AoS app, Listbot 4.0, and New Recruit.'
     )
@@ -189,6 +192,17 @@ describe('established account routes', () => {
     expect(plans).toBeGreaterThan(-1)
     expect(closing).toBeGreaterThan(plans)
     expect(faq).toBeGreaterThan(closing)
+
+    /*
+     * The closing paragraph makes two factual claims, and PRODUCT.md treats stale copy on a paid
+     * surface as a blocking defect — so both are pinned to their sources of truth here. The price
+     * ceiling is derived from plans.ts at render time; the army count is hardcoded in the copy
+     * (deriving it would pull the catalog chunk into the route), so this test is what fails when
+     * the corpus next changes shape.
+     */
+    expect(container.textContent).toContain(`none more than $${baselineMonthlyCost().toFixed(2)} a month`)
+    expect(container.textContent).toContain("all 27 armies' reminders free for everyone")
+    expect(armyFactions(AOS4_CATALOG)).toHaveLength(27)
   })
 
   it('shows the already-subscribed screen instead of the plans for an active subscriber', async () => {

--- a/src/tests/aos4/accountRoutes.test.tsx
+++ b/src/tests/aos4/accountRoutes.test.tsx
@@ -127,16 +127,20 @@ describe('established account routes', () => {
       await Promise.resolve()
     })
 
-    expect(container.textContent).toContain('Support AoS Reminders')
-    expect(container.textContent).toContain('What do you get when you subscribe?')
-    expect(container.textContent).toContain('Spare your eyes! Turn on dark mode!')
+    expect(container.textContent).toContain('Subscribe to AoS Reminders')
+    // Leads with what the subscription does; the support appeal is a closing note, not the offer.
+    expect(container.textContent).toContain('Your army is saved in this browser, and only this browser.')
+    expect(container.textContent).toContain('Subscribing is what keeps it that way.')
     expect(container.textContent).not.toContain(
       'Import current army lists from the AoS app, Listbot 4.0, and New Recruit.'
     )
     expect(container.textContent).toContain(
-      'Save, load, rename, update, and delete AoS 4 armies across your devices.'
+      'save, load, rename, update, and delete your AoS 4 armies, on every device you sign in on.'
     )
-    expect(container.textContent).toContain('Create read-only army links to share with your friends.')
+    expect(container.textContent).toContain(
+      'send a link a friend can open to take their own copy of your list.'
+    )
+    // PricingPlans is stubbed here; the plan cards themselves are covered by pricingPlans.test.tsx.
     expect(container.textContent).toContain('Subscription Plans')
     expect(container.textContent).toContain('Dark Mode')
     expect(container.querySelector('[src="/img/dark_mode1.mp4"]')).not.toBeNull()
@@ -160,7 +164,16 @@ describe('established account routes', () => {
     expect(container.querySelector('[src="/img/save_load_demo.mp4"]')).toBeNull()
   })
 
-  it('does not leave an empty examples section on desktop', async () => {
+  /*
+   * The demo used to render below 576px only, which left desktop with an empty section band. It is
+   * the sole visual proof of a paid feature anywhere in the funnel, so the band is filled rather than
+   * removed: the video renders at every width now.
+   *
+   * It stays below the plans. Tried above, and a 550px-tall portrait video became the centre of the
+   * page and pushed all three prices under the fold — proof that costs the offer its position is a
+   * bad trade.
+   */
+  it('shows the dark mode demo on desktop, below the plans', async () => {
     await act(async () => {
       render(
         <AppStatusProvider>
@@ -173,8 +186,14 @@ describe('established account routes', () => {
       await Promise.resolve()
     })
 
-    expect(container.textContent).toContain('Spare your eyes! Turn on dark mode!')
-    expect(container.querySelector('[src="/img/dark_mode1.mp4"]')).toBeNull()
+    const video = container.querySelector('[src="/img/dark_mode1.mp4"]')
+    expect(video).not.toBeNull()
+    expect(container.textContent).toContain('Dark Mode')
+
+    const plans = container.textContent?.indexOf('Subscription Plans') ?? -1
+    const demo = container.textContent?.indexOf('Dark Mode') ?? -1
+    expect(plans).toBeGreaterThan(-1)
+    expect(demo).toBeGreaterThan(plans)
   })
 
   it('shows the already-subscribed screen instead of the plans for an active subscriber', async () => {

--- a/src/tests/aos4/accountRoutes.test.tsx
+++ b/src/tests/aos4/accountRoutes.test.tsx
@@ -132,8 +132,11 @@ describe('established account routes', () => {
 
     expect(container.textContent).toContain('Subscribe to AoS Reminders')
     // Leads with what the subscription does; the support appeal is a closing note, not the offer.
-    expect(container.textContent).toContain('Your army is saved in this browser, and only this browser.')
-    expect(container.textContent).toContain('AoS Reminders is built and run by one person.')
+    // The one-person fact leads the page, above the fold, ahead of the value proposition.
+    const onePerson = container.textContent?.indexOf('AoS Reminders is built and run by one person') ?? -1
+    const valueProp = container.textContent?.indexOf('Your army is saved in this browser') ?? -1
+    expect(onePerson).toBeGreaterThan(-1)
+    expect(valueProp).toBeGreaterThan(onePerson)
     expect(container.textContent).not.toContain(
       'Import current army lists from the AoS app, Listbot 4.0, and New Recruit.'
     )
@@ -200,7 +203,9 @@ describe('established account routes', () => {
      * (deriving it would pull the catalog chunk into the route), so this test is what fails when
      * the corpus next changes shape.
      */
-    expect(container.textContent).toContain(`none more than $${baselineMonthlyCost().toFixed(2)} a month`)
+    expect(container.textContent).toContain(
+      `No plan costs more than $${baselineMonthlyCost().toFixed(2)} a month`
+    )
     expect(container.textContent).toContain("all 27 armies' reminders free for everyone")
     expect(armyFactions(AOS4_CATALOG)).toHaveLength(27)
   })

--- a/src/tests/aos4/accountRoutes.test.tsx
+++ b/src/tests/aos4/accountRoutes.test.tsx
@@ -142,8 +142,6 @@ describe('established account routes', () => {
     )
     // PricingPlans is stubbed here; the plan cards themselves are covered by pricingPlans.test.tsx.
     expect(container.textContent).toContain('Subscription Plans')
-    expect(container.textContent).toContain('Dark Mode')
-    expect(container.querySelector('[src="/img/dark_mode1.mp4"]')).not.toBeNull()
 
     const staleClaims = [
       'Import lists from the new Warhammer App!',
@@ -165,15 +163,11 @@ describe('established account routes', () => {
   })
 
   /*
-   * The demo used to render below 576px only, which left desktop with an empty section band. It is
-   * the sole visual proof of a paid feature anywhere in the funnel, so the band is filled rather than
-   * removed: the video renders at every width now.
-   *
-   * It stays below the plans. Tried above, and a 550px-tall portrait video became the centre of the
-   * page and pushed all three prices under the fold — proof that costs the offer its position is a
-   * bad trade.
+   * The dark-mode demo is out for now and will return later, so this guards what its absence has to
+   * leave behind: no empty section band where it used to sit, and the closing block landing directly
+   * under the plans rather than 550px of video further down.
    */
-  it('shows the dark mode demo on desktop, below the plans', async () => {
+  it('renders no demo video, and closes straight after the plans', async () => {
     await act(async () => {
       render(
         <AppStatusProvider>
@@ -186,14 +180,15 @@ describe('established account routes', () => {
       await Promise.resolve()
     })
 
-    const video = container.querySelector('[src="/img/dark_mode1.mp4"]')
-    expect(video).not.toBeNull()
-    expect(container.textContent).toContain('Dark Mode')
+    expect(container.querySelector('video')).toBeNull()
+    expect(container.querySelector('[src="/img/dark_mode1.mp4"]')).toBeNull()
 
     const plans = container.textContent?.indexOf('Subscription Plans') ?? -1
-    const demo = container.textContent?.indexOf('Dark Mode') ?? -1
+    const closing = container.textContent?.indexOf('is free, and stays free') ?? -1
+    const faq = container.textContent?.indexOf('More about subscriptions in the FAQ') ?? -1
     expect(plans).toBeGreaterThan(-1)
-    expect(demo).toBeGreaterThan(plans)
+    expect(closing).toBeGreaterThan(plans)
+    expect(faq).toBeGreaterThan(closing)
   })
 
   it('shows the already-subscribed screen instead of the plans for an active subscriber', async () => {

--- a/src/tests/aos4/giftSubscriptions.test.tsx
+++ b/src/tests/aos4/giftSubscriptions.test.tsx
@@ -118,15 +118,19 @@ describe('gift subscription checkout', () => {
       ],
       provider: 'stripe',
     })
+    /*
+     * Built from window.location.origin, matching the subscription checkout. The pair of hardcoded
+     * hosts this replaced pinned development to `localhost:3000` — the retired CRA port — so every
+     * gift checkout in dev returned to an address nothing was serving.
+     */
+    const baseUrl = window.location.origin
     expect(stripe.redirectToCheckout).toHaveBeenCalledWith({
-      cancelUrl:
-        'https://aosreminders.com?canceled=true&checkout_kind=gift_subscription&plan=1%20Month&quantity=3',
+      cancelUrl: `${baseUrl}?canceled=true&checkout_kind=gift_subscription&plan=1%20Month&quantity=3`,
       clientReferenceId: 'gifter@example.com',
       customerEmail: 'gifter@example.com',
       lineItems: [{ price: GiftedSubscriptionPlans[0].stripe_prod, quantity: 3 }],
       mode: 'payment',
-      successUrl:
-        'https://aosreminders.com/profile?gifted=true&checkout_kind=gift_subscription&quantity=3&plan=1%20Month&checkout_session_id={CHECKOUT_SESSION_ID}',
+      successUrl: `${baseUrl}/profile?gifted=true&checkout_kind=gift_subscription&quantity=3&plan=1%20Month&checkout_session_id={CHECKOUT_SESSION_ID}`,
     })
   })
 

--- a/src/tests/aos4/homePresentation.test.tsx
+++ b/src/tests/aos4/homePresentation.test.tsx
@@ -196,8 +196,12 @@ describe('AoS 4 home presentation', () => {
       Simulate.click(findButton('Share Army')!)
     })
 
-    expect(navigate).toHaveBeenNthCalledWith(1, '/subscribe')
-    expect(navigate).toHaveBeenNthCalledWith(2, '/subscribe')
+    /*
+     * The feature's display name travels with the navigation so /subscribe can name the control that
+     * sent them. It used to arrive with no context at all, at the highest-intent moment in the funnel.
+     */
+    expect(navigate).toHaveBeenNthCalledWith(1, '/subscribe', { state: { featureName: 'My Armies' } })
+    expect(navigate).toHaveBeenNthCalledWith(2, '/subscribe', { state: { featureName: 'Share Army' } })
 
     await act(async () => {
       Simulate.click(findButton('Import Army')!)

--- a/src/tests/aos4/importUi.test.tsx
+++ b/src/tests/aos4/importUi.test.tsx
@@ -135,7 +135,11 @@ const deferred = <T,>() => {
 }
 
 const SubscriberActionHarness = ({ onAuthorized }: { onAuthorized: () => void }) => {
-  const action = useSubscriberAction({ onAuthorized, origin: 'SubscriberActionTest' })
+  const action = useSubscriberAction({
+    featureName: 'My Armies',
+    onAuthorized,
+    origin: 'SubscriberActionTest',
+  })
   return (
     <button disabled={action.disabled} onClick={action.run} type="button">
       Subscriber action

--- a/src/tests/aos4/pricingPlans.test.tsx
+++ b/src/tests/aos4/pricingPlans.test.tsx
@@ -236,7 +236,12 @@ describe('subscription pricing plans', () => {
     expect(container.textContent).toContain('Save 50%')
     // Never colour alone: the marker is a word, so it survives print and colour blindness.
     expect(container.textContent).toContain('Best value')
-    // The per-period total was removed from the card; Stripe's own checkout states the amount.
+    /*
+     * The card leads with a per-month figure, but this plan bills $11.88 once a year — and per-month
+     * framing with the real charge nowhere on the page is the pattern the FTC's dark-patterns work
+     * names as drip pricing. The fine print states the actual charge before any checkout opens.
+     */
+    expect(container.textContent).toContain('$11.88, billed once a year')
     expect(container.textContent).not.toContain('Total:')
   })
 

--- a/src/tests/aos4/pricingPlans.test.tsx
+++ b/src/tests/aos4/pricingPlans.test.tsx
@@ -147,7 +147,18 @@ describe('subscription pricing plans', () => {
       ],
       provider: 'stripe',
     })
-    expect(container.querySelector('button')?.textContent).toBe('Subscribe for 1 Month')
+    /*
+     * The visible label is the wordmark alone, because the two payment rails sit side by side and
+     * half a card cannot hold "Subscribe for 3 Months" as well. That makes the accessible name the
+     * only thing carrying the plan: three cards of identically-marked buttons would otherwise be
+     * indistinguishable to a screen reader, since the plan name lives in a separate heading.
+     */
+    expect(container.querySelector('button')?.textContent).toBe('')
+    expect(container.querySelector('button')?.getAttribute('aria-label')).toBe(
+      'Subscribe for 1 Month with Stripe'
+    )
+    expect(container.querySelector('.StripeMark svg')).not.toBeNull()
+    expect(container.querySelector('.StripeMark svg')?.getAttribute('aria-hidden')).toBe('true')
     expect(container.querySelector('[role="alert"]')).toBeNull()
   })
 
@@ -178,6 +189,8 @@ describe('subscription pricing plans', () => {
     expect(container.textContent).toContain('Save 50%')
     // Never colour alone: the marker is a word, so it survives print and colour blindness.
     expect(container.textContent).toContain('Best value')
+    // The per-period total was removed from the card; Stripe's own checkout states the amount.
+    expect(container.textContent).not.toContain('Total:')
   })
 
   /*

--- a/src/tests/aos4/pricingPlans.test.tsx
+++ b/src/tests/aos4/pricingPlans.test.tsx
@@ -38,11 +38,14 @@ vi.mock('utils/authToken', () => ({
   useApiAccessToken: () => token.get,
 }))
 
+// Mutable so individual tests can exercise the signed-out card, which renders a different control.
+const auth = vi.hoisted(() => ({
+  isAuthenticated: true,
+  user: { email: 'general@example.com' } as { email: string } | undefined,
+}))
+
 vi.mock('@auth0/auth0-react', () => ({
-  useAuth0: () => ({
-    isAuthenticated: true,
-    user: { email: 'general@example.com' },
-  }),
+  useAuth0: () => auth,
 }))
 
 vi.mock('@stripe/react-stripe-js', () => ({
@@ -71,8 +74,10 @@ vi.mock('context/useTheme', () => ({
   }),
 }))
 
+const loginHook = vi.hoisted(() => ({ login: vi.fn() }))
+
 vi.mock('utils/hooks/useLogin', () => ({
-  default: () => ({ login: vi.fn() }),
+  default: () => loginHook,
 }))
 
 describe('subscription pricing plans', () => {
@@ -83,6 +88,8 @@ describe('subscription pricing plans', () => {
     paypal.callbacks = null
     token.get.mockReset()
     token.get.mockResolvedValue('audience-token')
+    auth.isAuthenticated = true
+    auth.user = { email: 'general@example.com' }
     vi.clearAllMocks()
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -159,7 +166,47 @@ describe('subscription pricing plans', () => {
     )
     expect(container.querySelector('.StripeMark svg')).not.toBeNull()
     expect(container.querySelector('.StripeMark svg')?.getAttribute('aria-hidden')).toBe('true')
+    // Both rails' visible labels are logos, so this line is the card's only visible verb.
+    expect(container.textContent).toContain('Subscribe with:')
     expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  /*
+   * Signed out, PayPal cannot render (it needs the account e-mail), so the brand pair used to
+   * collapse to one lopsided wordmark button whose accessible name promised Stripe while its click
+   * opened the login popup. The signed-out card instead shows a single plainly-labelled button that
+   * carries the intent to login.
+   */
+  it('shows a truthfully-labelled login button when signed out, with no payment branding', async () => {
+    auth.isAuthenticated = false
+    auth.user = undefined
+
+    await act(async () => {
+      render(
+        <PlanComponent
+          supportPlan={SUBSCRIPTION_PLANS[0]}
+          paypalModalIsOpen={false}
+          setPaypalModalIsOpen={vi.fn()}
+        />,
+        container
+      )
+    })
+
+    const buttons = container.querySelectorAll('button')
+    expect(buttons).toHaveLength(1)
+    expect(buttons[0].textContent).toBe('Subscribe for 1 Month')
+    // No brand promise it cannot keep: the click opens login, not a Stripe checkout.
+    expect(buttons[0].getAttribute('aria-label')).toBeNull()
+    expect(container.querySelector('.StripeMark')).toBeNull()
+    expect(container.textContent).not.toContain('PayPal')
+    expect(container.textContent).not.toContain('Subscribe with:')
+
+    await act(async () => {
+      buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(loginHook.login).toHaveBeenCalledTimes(1)
+    expect(stripe.redirectToCheckout).not.toHaveBeenCalled()
   })
 
   /*

--- a/src/tests/aos4/pricingPlans.test.tsx
+++ b/src/tests/aos4/pricingPlans.test.tsx
@@ -5,7 +5,7 @@ import { PlanComponent } from 'components/payment/pricingPlans'
 import type { IApprovalResponse } from 'components/payment/paypal/paypalTypes'
 import { render, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
 import { act } from 'react'
-import { SUBSCRIPTION_PLANS } from 'utils/plans'
+import { bestValuePlan, monthlySavingPct, SUBSCRIPTION_PLANS } from 'utils/plans'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SubscriptionApi } from '../../api/subscriptionApi'
 
@@ -149,6 +149,67 @@ describe('subscription pricing plans', () => {
     })
     expect(container.querySelector('button')?.textContent).toBe('Subscribe for 1 Month')
     expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  /*
+   * The annual plan really is half the monthly rate, and the page never said so. The figure is
+   * derived from plans.ts rather than written into the markup, so it cannot drift from the prices
+   * printed beside it.
+   */
+  it('states the saving against the monthly rate and marks the best-value plan', async () => {
+    const yearly = SUBSCRIPTION_PLANS.find(plan => plan.title === '1 Year')!
+    expect(monthlySavingPct(yearly)).toBe(50)
+    expect(bestValuePlan()?.title).toBe('1 Year')
+    // The baseline plan discounts nothing, so it must not claim a saving.
+    expect(monthlySavingPct(SUBSCRIPTION_PLANS[0])).toBe(0)
+
+    await act(async () => {
+      render(
+        <PlanComponent
+          supportPlan={yearly}
+          isBestValue
+          paypalModalIsOpen={false}
+          setPaypalModalIsOpen={vi.fn()}
+        />,
+        container
+      )
+    })
+
+    expect(container.textContent).toContain('Save 50%')
+    // Never colour alone: the marker is a word, so it survives print and colour blindness.
+    expect(container.textContent).toContain('Best value')
+  })
+
+  /*
+   * A rejected redirect used to reach console.error and nothing else, so the visitor pressed the one
+   * button that takes money and watched the page do nothing at all.
+   */
+  it('surfaces a failed checkout redirect instead of only logging it', async () => {
+    stripe.redirectToCheckout.mockResolvedValue({ error: { message: 'nope' } })
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await act(async () => {
+      render(
+        <PlanComponent
+          supportPlan={SUBSCRIPTION_PLANS[0]}
+          paypalModalIsOpen={false}
+          setPaypalModalIsOpen={vi.fn()}
+        />,
+        container
+      )
+    })
+
+    await act(async () => {
+      container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const alert = container.querySelector('[role="alert"]')
+    expect(alert).not.toBeNull()
+    expect(alert!.textContent).toContain('We could not open the checkout page')
+    // The control comes back rather than stranding the visitor on a dead button.
+    expect(container.querySelector('button')?.disabled).toBe(false)
   })
 
   it('reports the PayPal checkout lifecycle with the same stable commerce item', async () => {

--- a/src/tests/handleQueryParams.test.ts
+++ b/src/tests/handleQueryParams.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearCheckoutOutcome, readCheckoutOutcome } from 'utils/checkoutOutcome'
 import { handleStripeCheckout } from 'utils/handleQueryParams'
 
 const analytics = vi.hoisted(() => ({
@@ -12,6 +13,7 @@ vi.mock('utils/analytics', () => analytics)
 
 beforeEach(() => {
   vi.clearAllMocks()
+  clearCheckoutOutcome()
   window.history.replaceState({}, '', '/')
 })
 
@@ -106,5 +108,81 @@ describe('Stripe checkout return handling', () => {
       provider: 'stripe',
     })
     expect(window.location.pathname + window.location.search).toBe('/')
+  })
+})
+
+/*
+ * The params are stripped from the URL the moment they are read, so without this store the buyer
+ * landed on a page identical to the one an abandoned checkout produces — no evidence the charge went
+ * through, at exactly the moment they most need it.
+ */
+describe('checkout outcome reported to the returning buyer', () => {
+  it('records a completed subscription', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/?subscribed=true&checkout_kind=subscription&plan=1%20Month&checkout_session_id=cs_live_123'
+    )
+
+    handleStripeCheckout()
+
+    expect(readCheckoutOutcome()).toEqual({ kind: 'subscribed' })
+  })
+
+  it('records a completed gift purchase with its quantity', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/profile?gifted=true&checkout_kind=gift_subscription&plan=3%20Months&quantity=3&checkout_session_id=cs_live_gift'
+    )
+
+    handleStripeCheckout()
+
+    expect(readCheckoutOutcome()).toEqual({ kind: 'gifted', quantity: 3 })
+  })
+
+  it('records an abandoned checkout, so the two returns stop being indistinguishable', () => {
+    window.history.replaceState({}, '', '/?canceled=true&checkout_kind=subscription&plan=1%20Year')
+
+    handleStripeCheckout()
+
+    expect(readCheckoutOutcome()).toEqual({ kind: 'canceled' })
+  })
+
+  /*
+   * Deliberately looser than the analytics gates: a purchase whose session id or plan lookup failed
+   * is still a purchase, and the one thing the buyer must not be told is nothing at all.
+   */
+  it('still confirms a purchase whose plan could not be resolved for analytics', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/?subscribed=true&checkout_kind=subscription&plan=Unknown&checkout_session_id=cs_live_bad'
+    )
+
+    handleStripeCheckout()
+
+    expect(analytics.logPurchase).not.toHaveBeenCalled()
+    expect(readCheckoutOutcome()).toEqual({ kind: 'subscribed' })
+  })
+
+  it('reports nothing for contradictory state that names both outcomes at once', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/?subscribed=true&canceled=true&checkout_kind=subscription&plan=1%20Month'
+    )
+
+    handleStripeCheckout()
+
+    expect(readCheckoutOutcome()).toBeNull()
+  })
+
+  it('reports nothing on an ordinary visit', () => {
+    window.history.replaceState({}, '', '/')
+
+    handleStripeCheckout()
+
+    expect(readCheckoutOutcome()).toBeNull()
   })
 })

--- a/src/theme/helperClasses.ts
+++ b/src/theme/helperClasses.ts
@@ -6,12 +6,13 @@ export const centerContentClass = 'd-flex align-items-center justify-content-cen
  * phone held in one hand, dice in the other — every one of them was a miss waiting to happen, and
  * one of them is the Subscribe link.
  *
- * `.TapTarget` on both the links and the button takes all of them to 44px. The
- * navbar row grows by roughly 12px as a result, on every page. That is the visible cost of the fix
- * and it is deliberate: the alternative is a control the thumb cannot reliably hit.
+ * The links take `.TapTarget` and grow to 44px visually — they are borderless, so the extra height
+ * is invisible. The Log in/Log out button cannot: it draws a border, and at 44px the border box
+ * looked inflated beside the links. `.TapTargetOverlay` keeps its btn-sm look and extends only the
+ * clickable area to 44px with a pseudo-element, the same approach .ReminderMenuToggle uses.
  */
 export const navbarStyles = {
-  btn: 'btn btn-outline-light btn-sm mx-2 TapTarget',
+  btn: 'btn btn-outline-light btn-sm mx-2 TapTargetOverlay',
   headerClass: 'pt-2 d-print-none d-flex justify-content-center align-items-center',
   link: 'fw-bold text-light mx-2 TapTarget',
 }

--- a/src/theme/helperClasses.ts
+++ b/src/theme/helperClasses.ts
@@ -1,12 +1,17 @@
 export const centerContentClass = 'd-flex align-items-center justify-content-center'
 
+/*
+ * The navbar sat at the 24px WCAG 2.5.8 floor rather than at the 44px target DESIGN.md actually
+ * sets: links were 31-32px tall and the Log in/Log out button 31px. On the primary usage scene — a
+ * phone held in one hand, dice in the other — every one of them was a miss waiting to happen, and
+ * one of them is the Subscribe link.
+ *
+ * `.TapTarget` on both the links and the button takes all of them to 44px. The
+ * navbar row grows by roughly 12px as a result, on every page. That is the visible cost of the fix
+ * and it is deliberate: the alternative is a control the thumb cannot reliably hit.
+ */
 export const navbarStyles = {
-  btn: 'btn btn-outline-light btn-sm mx-2',
+  btn: 'btn btn-outline-light btn-sm mx-2 TapTarget',
   headerClass: 'pt-2 d-print-none d-flex justify-content-center align-items-center',
-  /*
-   * d-inline-block + py-1 takes the links from 21px to 29px, clearing the 24px WCAG 2.5.8 floor.
-   * The navbar's own height is set by the taller Log in/Log out button beside them, so nothing
-   * moves; an inline element could not carry the vertical padding at all.
-   */
-  link: 'fw-bold text-light mx-2 d-inline-block py-1',
+  link: 'fw-bold text-light mx-2 TapTarget',
 }

--- a/src/utils/checkoutOutcome.ts
+++ b/src/utils/checkoutOutcome.ts
@@ -1,0 +1,41 @@
+import { useSyncExternalStore } from 'react'
+
+/**
+ * What a return from a hosted checkout meant.
+ *
+ * `handleStripeCheckout` reads the outcome out of the query string and immediately scrubs those
+ * params from the URL, so the only record of a completed purchase is gone by the time any route
+ * renders. That is why the buyer used to land on a page identical to the one they would have seen by
+ * abandoning checkout. This store keeps the answer alive for the one render that has to report it.
+ *
+ * It is a store rather than a prop because the parse happens once in App's mount effect, while the
+ * screen that shows the result is a lazily-loaded route that may not have mounted yet.
+ */
+export type CheckoutOutcome =
+  { kind: 'subscribed' } | { kind: 'gifted'; quantity: number } | { kind: 'canceled' }
+
+let outcome: CheckoutOutcome | null = null
+const listeners = new Set<() => void>()
+
+const emit = () => listeners.forEach(listener => listener())
+
+export const setCheckoutOutcome = (next: CheckoutOutcome | null) => {
+  outcome = next
+  emit()
+}
+
+/** Called when the banner is dismissed, so a later navigation cannot resurrect a stale confirmation. */
+export const clearCheckoutOutcome = () => setCheckoutOutcome(null)
+
+const subscribe = (onStoreChange: () => void) => {
+  listeners.add(onStoreChange)
+  return () => void listeners.delete(onStoreChange)
+}
+
+const getSnapshot = () => outcome
+
+/** Reads the current outcome outside React. Exists for tests and for non-component callers. */
+export const readCheckoutOutcome = (): CheckoutOutcome | null => outcome
+
+export const useCheckoutOutcome = (): CheckoutOutcome | null =>
+  useSyncExternalStore(subscribe, getSnapshot, getSnapshot)

--- a/src/utils/handleQueryParams.ts
+++ b/src/utils/handleQueryParams.ts
@@ -1,4 +1,5 @@
 import { logCheckoutCancelled, logPurchase } from 'utils/analytics'
+import { setCheckoutOutcome } from 'utils/checkoutOutcome'
 import {
   findGiftedSubscriptionPlan,
   findSubscriptionPlan,
@@ -40,6 +41,13 @@ export const handleStripeCheckout = () => {
   const transactionId = searchParams.get('checkout_session_id')?.trim() ?? ''
   const checkoutKind = searchParams.get('checkout_kind')
 
+  /*
+   * The outcome is recorded on the flags alone, deliberately looser than the analytics gates below.
+   * A purchase whose session id or plan lookup failed is still a purchase the buyer made, and the
+   * one thing they must not be told is nothing at all.
+   */
+  if (subscribed && checkoutKind === 'subscription') setCheckoutOutcome({ kind: 'subscribed' })
+
   if (subscribed && checkoutKind === 'subscription' && transactionId) {
     const plan = findSubscriptionPlan(planTitle)
     if (plan) {
@@ -53,6 +61,11 @@ export const handleStripeCheckout = () => {
 
   const quantity = Number(searchParams.get('quantity'))
   const validGiftQuantity = Number.isInteger(quantity) && quantity >= 1 && quantity <= MAX_GIFT_QUANTITY
+
+  if (gifted && checkoutKind === 'gift_subscription') {
+    setCheckoutOutcome({ kind: 'gifted', quantity: validGiftQuantity ? quantity : 1 })
+  }
+
   if (gifted && checkoutKind === 'gift_subscription' && transactionId && validGiftQuantity) {
     const plan = findGiftedSubscriptionPlan(planTitle)
     if (plan) {
@@ -65,6 +78,8 @@ export const handleStripeCheckout = () => {
   }
 
   if (canceled) {
+    setCheckoutOutcome({ kind: 'canceled' })
+
     if (checkoutKind === 'gift_subscription') {
       const plan = findGiftedSubscriptionPlan(planTitle)
       if (plan) {

--- a/src/utils/plans.ts
+++ b/src/utils/plans.ts
@@ -78,6 +78,32 @@ export type SubscriptionPlan = ISubscriptionPlan
 
 export const MAX_GIFT_QUANTITY = 99
 
+/**
+ * The rate every other plan is discounted against — the highest monthly cost on offer, which is the
+ * shortest period billed at full price.
+ *
+ * Derived rather than written down: the annual plan really is half the monthly rate ($11.88 against
+ * $23.88 a year), and that was true and unstated on /subscribe for as long as the page existed.
+ * Computing it means the claim cannot drift away from the prices beside it.
+ */
+export const baselineMonthlyCost = (): number =>
+  Math.max(...SubscriptionPlans.map(plan => parseFloat(plan.monthly_cost)))
+
+/** Whole-percent saving against the baseline monthly rate. 0 for the baseline plan itself. */
+export const monthlySavingPct = (plan: ISubscriptionPlan): number => {
+  const baseline = baselineMonthlyCost()
+  const monthly = parseFloat(plan.monthly_cost)
+  if (!Number.isFinite(baseline) || !Number.isFinite(monthly) || monthly >= baseline) return 0
+  return Math.round((1 - monthly / baseline) * 100)
+}
+
+/** The plan that saves the most per month. Ties resolve to the first declared. */
+export const bestValuePlan = (): ISubscriptionPlan | undefined =>
+  SubscriptionPlans.reduce<ISubscriptionPlan | undefined>(
+    (best, plan) => (!best || monthlySavingPct(plan) > monthlySavingPct(best) ? plan : best),
+    undefined
+  )
+
 export const findSubscriptionPlan = (title: string): ISubscriptionPlan | undefined =>
   SubscriptionPlans.find(plan => plan.title === title)
 


### PR DESCRIPTION
## Restores card checkout (broken in production)

Stripe's Clover release (changelog 2025-09-30) removed `stripe.redirectToCheckout`, and the runtime pinned by `@stripe/stripe-js` v9 refuses the call with an IntegrationError. Every Subscribe and gift Purchase click has failed silently since that runtime shipped; reproduced in dev and confirmed against production.

The evergreen build at `js.stripe.com/v3` still honours the call for this grandfathered client-only integration, verified live in test mode with a real redirect to checkout.stripe.com. `legacyStripeCheckout.ts` now loads `/v3` itself (the same pattern as the PayPal SDK loader) and both checkout surfaces use `loadLegacyStripe` instead of the package's `loadStripe`. The long-term replacement is server-created Checkout Sessions, which is subscription-API work.

## The funnel overhaul

A dual-agent critique of the whole funnel (paywall triggers, `/subscribe`, plan selection, both checkout handoffs, the return from checkout, `/profile`, `/redeem`, `/join`) scored it 19/40 on Nielsen's heuristics. The plumbing was sound; the money moments were silent.

**Blocking defects fixed:**
- The Stripe success and cancel returns rendered pixel-identical Home pages. A new checkout-outcome store survives the URL scrub and the banner slot reports "Payment received" / "Checkout canceled. You have not been charged."
- `/subscribe` never read `subscriptionError`, so a paying subscriber whose lookup failed was shown three live buy buttons. The plans render only once the answer is known.

**Accessibility and mobile:**
- Action Blue moves `#007bff` to `#0070e8`: white on the old value measured 3.98:1 on every control that takes money. Links on dark and tinted surfaces move to the incumbent `FaqLink` / `alert-link` patterns.
- Every funnel control reaches the 44px touch target; the navbar button keeps its compact border via a pseudo-element overlay.
- `/profile` no longer scrolls sideways on phones; zero horizontal overflow at 320 through 1440.

**The paywall and the sell:**
- Pressing a gated button now names the feature on `/subscribe` and resumes the action after login instead of dropping it.
- Signed out, each card shows one truthfully-labelled "Subscribe for X" button that leads to login; signed in, Stripe and PayPal sit side by side as equal 44px rails under a "Subscribe with:" label.
- The 1 Year card is marked Best value with the saving derived from `plans.ts` (Save 50%), and every card states its real charge ("$11.88, billed once a year") below the buttons.
- The commitment button gained busy and error states; the PayPal post-subscribe modal bounds its polling and says what is and is not known.

**Copy, per research and Davis's direction:**
- "AoS Reminders is built and run by one person" leads the page, above the fold.
- Value-first framing in the FAQ's own concrete wording; the support line closes with two anchored facts (the $1.99/month ceiling derived at render time, the 27-army count pinned by a corpus test).
- No em-dashes anywhere in customer-facing prose; hobbyist-plain over slick throughout.
- The dark-mode demo video is removed for now (`public/img/dark_mode1.mp4` kept for its return); the page closes directly after the plans.

**Also:** gift checkout no longer returns to the retired `localhost:3000` in dev, `/subscribe` and `/profile` regained the Games Workshop disclaimer, `/profile`'s "not subscribed" dead end gained a path to `/subscribe`, and the dead `pricing-card-title` / `btn-pill` classes are gone.

## Testing

96 test files / 3321 tests passing; `tsc` and `eslint --max-warnings 0` clean; production build within the entry-chunk budget. Verified in-browser across signed-out/signed-in, light/dark, and 320-1440 widths, including a live test-mode Stripe redirect. Factual copy claims are pinned by tests so they fail loudly if plans or the corpus change.
