### PR TITLE
fix(auth): persist Auth0 sessions with refresh tokens

### DIFF
--- a/src/api/subscriptionApi.ts
+++ b/src/api/subscriptionApi.ts
@@ -79,6 +79,16 @@ export const createSubscriptionApi = (endpoint: string, fetcher: Fetcher = fetch
 
   return {
     isConfigured: Boolean(baseUrl),
+    /*
+     * Server-created Stripe Checkout Sessions (#1942). The browser states an
+     * intent; the server chooses the price, the buyer identity, and the return
+     * URLs, and answers with the session URL to navigate to. Callers fall back
+     * to the legacy client-only redirect while stages without this route exist.
+     */
+    createCheckoutSession: (
+      data: { kind: 'subscription' | 'gift'; plan: string; quantity?: number },
+      token: string
+    ) => post<{ url?: string }>('/account/checkout-session', token, data),
     getSubscription: (token: string) => request('/account', token),
     cancelSubscription: (token: string) => post('/account/cancel', token),
     requestGrant: (data: { subscriptionId: string }, token: string) =>

--- a/src/components/payment/giftSubscriptions.tsx
+++ b/src/components/payment/giftSubscriptions.tsx
@@ -13,6 +13,7 @@ import { FaCheck, FaGift, FaRegSmileBeam } from 'react-icons/fa'
 import { centerContentClass } from 'theme/helperClasses'
 import { IGiftSubscription } from 'types/subscription'
 import { logBeginCheckout, logClick } from 'utils/analytics'
+import { useApiAccessToken } from 'utils/authToken'
 import { isDev, STRIPE_KEY } from 'utils/env'
 import useLogin from 'utils/hooks/useLogin'
 import useWindowSize from 'utils/hooks/useWindowSize'
@@ -22,6 +23,7 @@ import {
   MAX_GIFT_QUANTITY,
   toGiftSubscriptionAnalyticsItem,
 } from 'utils/plans'
+import { SubscriptionApi } from '../../api/subscriptionApi'
 
 const COL_SIZE = 'col-12 col-sm-12 col-md-10 col-xl-8 col-xxl-6'
 const GiftSubscriptionsComponent = () => {
@@ -189,10 +191,11 @@ const PlanComponent = ({ supportPlan }: { supportPlan: IGiftedSubscriptionPlans 
   const { login } = useLogin({ origin })
   const { theme } = useTheme()
   const stripe = useStripe()
+  const getAccessToken = useApiAccessToken()
   const { isMobile } = useWindowSize()
   const [quantity, setQuantity] = useState(1)
 
-  if (!stripe || !user) return null
+  if (!user) return null
 
   /*
    * parseInt('') is NaN, which priced the row "$NaN" and — because the checkout guard only compared
@@ -214,6 +217,27 @@ const PlanComponent = ({ supportPlan }: { supportPlan: IGiftedSubscriptionPlans 
       items: [toGiftSubscriptionAnalyticsItem(supportPlan, quantity)],
       provider: 'stripe',
     })
+
+    /*
+     * Server-created Checkout Session first (#1942); the legacy client-only redirect below is the
+     * fallback for stages the endpoint has not deployed to yet.
+     */
+    try {
+      const token = await getAccessToken()
+      const { body } = await SubscriptionApi.createCheckoutSession(
+        { kind: 'gift', plan: supportPlan.title, quantity },
+        token
+      )
+      if (body?.url) {
+        window.location.assign(body.url)
+        return
+      }
+      console.error('The checkout session endpoint answered without a URL.')
+    } catch (error) {
+      console.error(error)
+    }
+
+    if (!stripe) return console.error('Stripe.js has not loaded; the legacy fallback is unavailable.')
     const price = isDev ? supportPlan.stripe_dev : supportPlan.stripe_prod
     /*
      * window.location.origin, matching the subscription checkout. The old pair of hardcoded hosts

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -114,6 +114,7 @@ export const PlanComponent = (props: IPlanProps) => {
   const { login } = useLogin({ origin: supportPlan.title })
   const { theme } = useTheme()
   const stripe = useStripe()
+  const getAccessToken = useApiAccessToken()
   const [isRedirecting, setIsRedirecting] = useState(false)
   const [checkoutError, setCheckoutError] = useState('')
   const savingPct = monthlySavingPct(supportPlan)
@@ -126,13 +127,39 @@ export const PlanComponent = (props: IPlanProps) => {
 
   const handleStripeCheckout = async (event: React.MouseEvent) => {
     event.preventDefault()
-    if (!user || !stripe || isRedirecting) return
+    if (!user || isRedirecting) return
 
     logClick(supportPlan.title)
     logBeginCheckout({
       items: [toSubscriptionAnalyticsItem(supportPlan)],
       provider: 'stripe',
     })
+
+    setIsRedirecting(true)
+    setCheckoutError('')
+
+    /*
+     * Server-created Checkout Session first (#1942): the API chooses the price, the buyer identity,
+     * and the return URLs, and this navigation is the whole client-side job. `isRedirecting` is
+     * deliberately left on — the page is unloading, and re-enabling the button reads as failure.
+     */
+    try {
+      const token = await getAccessToken()
+      const { body } = await SubscriptionApi.createCheckoutSession(
+        { kind: 'subscription', plan: supportPlan.title },
+        token
+      )
+      if (body?.url) {
+        window.location.assign(body.url)
+        return
+      }
+      console.error('The checkout session endpoint answered without a URL.')
+    } catch (error) {
+      // A 404 is a stage the endpoint has not deployed to yet; anything else still falls back while
+      // the legacy surface exists at all. The fallback failing is what the visitor gets told about.
+      console.error(error)
+    }
+
     const plan = isDev ? supportPlan.stripe_dev : supportPlan.stripe_prod
     const origin = window.location.origin
     const successQuery = qs.stringify({
@@ -141,9 +168,8 @@ export const PlanComponent = (props: IPlanProps) => {
       plan: supportPlan.title,
     })
 
-    setIsRedirecting(true)
-    setCheckoutError('')
     try {
+      if (!stripe) throw new Error('Stripe.js has not loaded.')
       const result = await redirectToCheckout(stripe, {
         items: [{ plan, quantity: 1 }],
         customerEmail: user.email,
@@ -283,7 +309,11 @@ export const PlanComponent = (props: IPlanProps) => {
                     type="button"
                     aria-label={`Subscribe for ${supportPlan.title} with Stripe`}
                     className="btn d-block btn-primary TapTargetBlock py-2 PaymentChoiceOption--stripe"
-                    disabled={isRedirecting || !stripe}
+                    /*
+                      Not gated on Stripe.js any more: the session endpoint needs no client script,
+                      so a blocked or slow js.stripe.com only matters if the fallback runs.
+                    */
+                    disabled={isRedirecting}
                     onClick={handleStripeCheckout}
                   >
                     {isRedirecting ? (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,10 +25,20 @@ const onRedirectCallback = (appState?: { returnTo?: string }) => {
 const container = document.getElementById('root')
 if (!container) throw new Error('Root container #root is missing from index.html')
 
+/*
+ * `useRefreshTokens` and `cacheLocation` are both load-bearing. Without them the SDK defaults to an
+ * in-memory cache refilled by a hidden-iframe `prompt=none` call, which needs the Auth0 session
+ * cookie in a third-party context. Browsers no longer send that cookie, so every token renewal
+ * failed: signed-in users saw the subscription lookup error, and a reload dropped them to signed-out
+ * because nothing survived the page load. Refresh tokens do not depend on cookie policy, and
+ * localstorage is what carries the session across a reload.
+ */
 createRoot(container).render(
   <Auth0Provider
     domain={config.domain}
     clientId={config.clientId}
+    useRefreshTokens
+    cacheLocation="localstorage"
     authorizationParams={{
       audience: config.audience,
       redirect_uri: window.location.origin,

--- a/src/tests/aos4/pricingPlans.test.tsx
+++ b/src/tests/aos4/pricingPlans.test.tsx
@@ -103,7 +103,55 @@ describe('subscription pricing plans', () => {
     vi.restoreAllMocks()
   })
 
+  /*
+   * #1942: the click asks the API for a server-created Checkout Session first and simply navigates
+   * to its URL — no Stripe.js involved. The legacy client-only redirect survives only as the
+   * fallback for stages the endpoint has not deployed to yet.
+   */
+  it('navigates to the server-created checkout session without touching the legacy redirect', async () => {
+    const session = vi
+      .spyOn(SubscriptionApi, 'createCheckoutSession')
+      .mockResolvedValue({ body: { url: 'https://checkout.stripe.com/c/pay/cs_test_123' } })
+    const assign = vi.fn()
+    const originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, assign },
+    })
+
+    try {
+      await act(async () => {
+        render(
+          <PlanComponent
+            supportPlan={SUBSCRIPTION_PLANS[0]}
+            paypalModalIsOpen={false}
+            setPaypalModalIsOpen={vi.fn()}
+          />,
+          container
+        )
+      })
+
+      await act(async () => {
+        container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(session).toHaveBeenCalledWith({ kind: 'subscription', plan: '1 Month' }, 'audience-token')
+      expect(assign).toHaveBeenCalledWith('https://checkout.stripe.com/c/pay/cs_test_123')
+      expect(stripe.redirectToCheckout).not.toHaveBeenCalled()
+      // The page is unloading; a re-enabled button would read as failure.
+      expect(container.querySelector('button')?.disabled).toBe(true)
+    } finally {
+      Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
+    }
+  })
+
   it('keeps the established plan card stable while handing checkout to Stripe', async () => {
+    // The endpoint 404s on a stage it has not deployed to; the legacy redirect is the fallback.
+    vi.spyOn(SubscriptionApi, 'createCheckoutSession').mockRejectedValue(
+      Object.assign(new Error('Not found'), { status: 404 })
+    )
     stripe.redirectToCheckout.mockResolvedValue({})
 
     /*
@@ -250,6 +298,10 @@ describe('subscription pricing plans', () => {
    * button that takes money and watched the page do nothing at all.
    */
   it('surfaces a failed checkout redirect instead of only logging it', async () => {
+    // The session endpoint is down as well, so the click runs the whole gauntlet to the alert.
+    vi.spyOn(SubscriptionApi, 'createCheckoutSession').mockRejectedValue(
+      Object.assign(new Error('Not found'), { status: 404 })
+    )
     stripe.redirectToCheckout.mockResolvedValue({ error: { message: 'nope' } })
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
@@ -266,8 +318,9 @@ describe('subscription pricing plans', () => {
 
     await act(async () => {
       container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-      await Promise.resolve()
-      await Promise.resolve()
+      // A macrotask, not microtask ticks: the handler now awaits the session attempt before the
+      // legacy fallback, and counting awaits is exactly what made the old form brittle.
+      await new Promise(resolve => setTimeout(resolve, 0))
     })
 
     const alert = container.querySelector('[role="alert"]')

--- a/src/tests/aos4/subscriptionApi.test.ts
+++ b/src/tests/aos4/subscriptionApi.test.ts
@@ -19,4 +19,30 @@ describe('subscription API ownership boundary', () => {
       expect(serialized).not.toMatch(/authKey|userName|email|subscriptionId|"id"/)
     }
   })
+
+  /*
+   * #1942: the checkout-session request states an intent only. The server owns the price, the buyer
+   * identity (from the JWT), and the return URLs, so none of them may travel in the body.
+   */
+  it('requests a checkout session by intent, with the bearer token and no identity', async () => {
+    let captured: { url: string; options: RequestInit } | null = null
+    const fetcher = vi.fn(async (input: RequestInfo | URL, options?: RequestInit) => {
+      captured = { url: String(input), options: options || {} }
+      return new Response(JSON.stringify({ url: 'https://checkout.stripe.com/c/pay/cs_test_1' }), {
+        status: 200,
+      })
+    })
+    const api = createSubscriptionApi('https://subscriptions.example.test', fetcher)
+
+    const { body } = await api.createCheckoutSession({ kind: 'gift', plan: '3 Months', quantity: 2 }, 'token')
+
+    expect(body).toEqual({ url: 'https://checkout.stripe.com/c/pay/cs_test_1' })
+    expect(captured!.url).toBe('https://subscriptions.example.test/account/checkout-session')
+    expect(new Headers(captured!.options.headers).get('Authorization')).toBe('Bearer token')
+    expect(JSON.parse(String(captured!.options.body))).toEqual({
+      kind: 'gift',
+      plan: '3 Months',
+      quantity: 2,
+    })
+  })
 })


### PR DESCRIPTION
## The bug

Signed-in users on `/subscribe` saw **"Subscription status is temporarily unavailable"**, and reloading the page cleared the banner but left them signed out.

Both symptoms are the same root cause. `Auth0Provider` used the SDK defaults: an in-memory token cache, refilled by a hidden-iframe `prompt=none` call. That iframe needs the Auth0 session cookie in a third-party context, and browsers no longer send it.

So every silent token renewal failed:

- While the app still believed you were authenticated, `getAccessTokenSilently` threw, `useApiAccessToken` converted it to an `AuthenticationRequiredError` carrying no `status`, and `useSubscription` treats anything that isn't a 404 as an outage. Hence the banner. The subscription API was never actually called.
- On reload the in-memory cache was empty and the silent check failed outright, so `isAuthenticated` went false, `getSubscription` returned early without setting an error, and you got no banner but no session either.

`git log -S` confirms neither option has ever been set, so this was a latent gap rather than a regression.

## The fix

`useRefreshTokens` plus `cacheLocation="localstorage"`. Refresh tokens don't depend on cookie policy, and localstorage is what carries the session across a reload.

## Tenant changes (already applied)

- **Allow Offline Access** enabled on the AoS Reminders API (`https://api.aosreminders.com`)
- **Allow Refresh Token Rotation** enabled on the SPA client, which auto-enabled a 30-day maximum refresh token lifetime
- `refresh_token` was already among the client's grant types

## Ruled out

`PRODUCTION_SUBSCRIPTION_API_URL` is set and embedded in the artifact, CORS returns the correct `access-control-allow-origin`, and the API only ever returned a well-formed 401.

## Testing

- 3323 tests pass; `yarn lint` and `yarn build` clean
- After deploy: sign in, load `/subscribe`, confirm plans render with no warning banner, then reload and confirm the session persists

## Follow-ups (not in this PR)

- `useSubscription` collapses every non-404 failure into one message and offers a retry button that can never succeed for auth errors. Worth splitting, but it's a UX change and `subscriptionContext.test.tsx:160` pins the current copy.
- The `auth.aosreminders.com` custom domain is verified and serving, but switching `auth_config.json` to it changes the token `iss` to `https://auth.aosreminders.com/`. Both `aos-reminders-rest-api` and `aos-reminders-subscription-api` validate the issuer, so that switch needs their authorizers updated first. Signing keys are identical across both domains, so `iss` is the only thing that changes.
