### PR TITLE
feat(auth): move Auth0 onto the auth.aosreminders.com custom domain

### DIFF
--- a/src/auth_config.json
+++ b/src/auth_config.json
@@ -1,5 +1,5 @@
 {
-  "domain": "dev-4yesv5fz.auth0.com",
+  "domain": "auth.aosreminders.com",
   "clientId": "QHLRyZn1I3HltmvLNQtfwTf6WvpMUoNZ",
   "audience": "https://api.aosreminders.com"
 }

--- a/src/tests/aos4/accountShell.test.tsx
+++ b/src/tests/aos4/accountShell.test.tsx
@@ -142,8 +142,11 @@ describe('established account shell', () => {
     })
   })
 
-  it('uses the same Auth0 tenant configured for the established live account flow', () => {
-    expect(config.domain).toBe('dev-4yesv5fz.auth0.com')
+  it('reaches the tenant through the first-party custom domain', () => {
+    // A subdomain of the site, not the canonical dev-*.auth0.com host: same tenant either way, but
+    // only this one is same-site, so the Auth0 session cookie is first-party. Tokens minted here
+    // carry iss https://auth.aosreminders.com/, which both API Gateway JWT authorizers pin exactly.
+    expect(config.domain).toBe('auth.aosreminders.com')
     expect(config.clientId).toBeTruthy()
     expect(config.audience).toBe('https://api.aosreminders.com')
   })


### PR DESCRIPTION
## Why

`dev-4yesv5fz.auth0.com` has no relationship to `aosreminders.com`, so the Auth0 session cookie was third-party and browsers withheld it. That is the root cause behind #1944 — refresh tokens routed around the problem, they did not remove it.

`auth.aosreminders.com` is same-site with the app, so the cookie is first-party. Same tenant, same signing keys (verified: both domains publish identical `kid` values), so the only change on the wire is `iss`, which becomes `https://auth.aosreminders.com/`.

Once this is stable, `cacheLocation="localstorage"` can revert to `memory`, which removes the XSS exposure noted on #1944.

## Coordinated cutover

Both APIs use API Gateway JWT authorizers, and those pin exactly **one** `issuerUrl` — `audience` is a list, the issuer is not. There is no way to accept both issuers at once, so this cannot be phased.

The authorizers on both APIs are updated to `https://auth.aosreminders.com/` at the moment this deploy completes:

| API | id | authorizer |
|---|---|---|
| subscription | `n4rooaysk6` | `xalex5` |
| army / share | `yoq91n586l` | `io8wzx` |

Sequenced this way because the frontend deploy takes ~5 minutes during which the old bundle and old issuer still agree. Flipping the authorizers first would mean a multi-minute outage; flipping them as the deploy lands reduces the window to seconds.

## Expected disruption

- Users holding a cached bundle from the service worker keep sending old-issuer tokens and will get 401s until they reload. Self-healing, no data loss.
- One-time re-authentication, since the Auth0 session cookie lives on the old host.

## Important: the authorizer change is not in infrastructure-as-code

`AUTH0_ISSUER_URL` is supplied from the shell at `sls deploy` time in both API repos — it is not committed. The authorizers are being updated directly via `apigatewayv2 update-authorizer`, so **the next `deploy.sh` run will silently revert this cutover unless `AUTH0_ISSUER_URL` is changed to `https://auth.aosreminders.com/` in whatever supplies it.** That is the one manual follow-up this PR cannot cover.

## Rollback

Set both authorizers back to `https://dev-4yesv5fz.auth0.com/` (pre-change snapshots captured) and revert this commit. Auto-deploy is enabled on both `$default` stages, so authorizer changes apply immediately in both directions.

## Testing

3323 tests pass, lint clean. After deploy: sign in, confirm the Auth0 page is served from `auth.aosreminders.com`, confirm `/subscribe` renders plans, and confirm My Armies loads (that exercises the army API authorizer).
