### PR TITLE
fix(auth): replace access tokens left behind by the previous issuer

### DIFF
--- a/src/tests/aos4/authToken.test.tsx
+++ b/src/tests/aos4/authToken.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { AuthenticationRequiredError, useApiAccessToken } from 'utils/authToken'
+import { render, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import config from '../../auth_config.json'
+
+const auth = vi.hoisted(() => ({
+  getAccessTokenSilently: vi.fn(),
+  isAuthenticated: true,
+}))
+
+vi.mock('@auth0/auth0-react', () => ({
+  useAuth0: () => auth,
+}))
+
+const currentIssuer = `https://${config.domain}/`
+const previousIssuer = 'https://dev-4yesv5fz.auth0.com/'
+
+const tokenFrom = (issuer: string): string => {
+  const claims = btoa(JSON.stringify({ iss: issuer, sub: 'auth0|general' }))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+  return `header.${claims}.signature`
+}
+
+describe('API access tokens', () => {
+  let container: HTMLDivElement
+  let getToken: (() => Promise<string>) | undefined
+
+  const Probe = () => {
+    getToken = useApiAccessToken()
+    return null
+  }
+
+  beforeEach(async () => {
+    auth.isAuthenticated = true
+    auth.getAccessTokenSilently.mockReset()
+    getToken = undefined
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    await act(async () => {
+      render(<Probe />, container)
+      await Promise.resolve()
+    })
+  })
+
+  afterEach(() => {
+    act(() => {
+      unmountComponentAtNode(container)
+    })
+    container.remove()
+    vi.restoreAllMocks()
+  })
+
+  it('passes through a token minted by the configured issuer', async () => {
+    const token = tokenFrom(currentIssuer)
+    auth.getAccessTokenSilently.mockResolvedValue(token)
+
+    await expect(getToken?.()).resolves.toBe(token)
+    expect(auth.getAccessTokenSilently).toHaveBeenCalledTimes(1)
+  })
+
+  it('replaces a cached token left behind by a previous issuer', async () => {
+    // The cache key is client id, audience, and scope — never the tenant domain — so a token from
+    // before the custom-domain cutover survives in localStorage and every authorizer rejects it.
+    const reissued = tokenFrom(currentIssuer)
+    auth.getAccessTokenSilently
+      .mockResolvedValueOnce(tokenFrom(previousIssuer))
+      .mockResolvedValueOnce(reissued)
+
+    await expect(getToken?.()).resolves.toBe(reissued)
+    expect(auth.getAccessTokenSilently).toHaveBeenCalledTimes(2)
+    expect(auth.getAccessTokenSilently).toHaveBeenLastCalledWith(
+      expect.objectContaining({ cacheMode: 'off' })
+    )
+  })
+
+  it('leaves a token it cannot read alone rather than forcing a refresh it cannot pass', async () => {
+    auth.getAccessTokenSilently.mockResolvedValue('opaque-token')
+
+    await expect(getToken?.()).resolves.toBe('opaque-token')
+    expect(auth.getAccessTokenSilently).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports an empty reissue as needing a login rather than returning it', async () => {
+    auth.getAccessTokenSilently.mockResolvedValueOnce(tokenFrom(previousIssuer)).mockResolvedValueOnce('')
+
+    await expect(getToken?.()).rejects.toBeInstanceOf(AuthenticationRequiredError)
+  })
+
+  it('refuses to ask for a token while signed out', async () => {
+    auth.isAuthenticated = false
+    await act(async () => {
+      render(<Probe />, container)
+      await Promise.resolve()
+    })
+
+    await expect(getToken?.()).rejects.toBeInstanceOf(AuthenticationRequiredError)
+    expect(auth.getAccessTokenSilently).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/authToken.ts
+++ b/src/utils/authToken.ts
@@ -9,19 +9,53 @@ export class AuthenticationRequiredError extends Error {
   }
 }
 
+const expectedIssuer = `https://${config.domain}/`
+
+/**
+ * Returns the `iss` claim, or null when the token is not a readable JWT. Null means "do not judge" —
+ * an opaque or malformed token is left alone rather than forced through a refresh it cannot pass.
+ */
+const issuerOf = (token: string): string | null => {
+  try {
+    const payload = token.split('.')[1]
+    if (!payload) return null
+    const claims: unknown = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')))
+    if (typeof claims !== 'object' || claims === null || !('iss' in claims)) return null
+    return typeof claims.iss === 'string' ? claims.iss : null
+  } catch {
+    return null
+  }
+}
+
 export const useApiAccessToken = (): (() => Promise<string>) => {
   const { getAccessTokenSilently, isAuthenticated } = useAuth0()
 
   return useCallback(async () => {
     if (!isAuthenticated) throw new AuthenticationRequiredError()
+    const authorizationParams = {
+      audience: config.audience,
+      scope: 'openid profile email',
+    }
+
     try {
-      const token = await getAccessTokenSilently({
-        authorizationParams: {
-          audience: config.audience,
-          scope: 'openid profile email',
-        },
-      })
+      const token = await getAccessTokenSilently({ authorizationParams })
       if (!token) throw new AuthenticationRequiredError()
+
+      /*
+       * The SDK caches by client id, audience, and scope — the tenant domain is not part of the key.
+       * So the move to auth.aosreminders.com left tokens minted by the old issuer sitting in
+       * localStorage, handed back for their full 24h lifetime while both API Gateway authorizers
+       * rejected every one of them. The session looked signed in and nothing could refresh it,
+       * because a cached unexpired token is never re-fetched. Reading the claim is what notices;
+       * `cacheMode: 'off'` is what replaces it. Safe to delete once no pre-cutover token can survive.
+       */
+      const issuer = issuerOf(token)
+      if (issuer && issuer !== expectedIssuer) {
+        const reissued = await getAccessTokenSilently({ cacheMode: 'off', authorizationParams })
+        if (!reissued) throw new AuthenticationRequiredError()
+        return reissued
+      }
+
       return token
     } catch {
       throw new AuthenticationRequiredError()


### PR DESCRIPTION
## The bug

Fallout from the custom-domain cutover in #1945, and worse than I predicted there.

The Auth0 SDK caches tokens under this key:

```
@@auth0spajs@@::<clientId>::https://api.aosreminders.com::openid profile email offline_access
```

The tenant domain is **not** part of it. So moving to `auth.aosreminders.com` invalidated nothing — a token minted by `dev-4yesv5fz` stayed in localStorage and kept being handed back for its full 24 hour lifetime, while both API Gateway authorizers now pin the new issuer and rejected every one.

Nothing recovered on its own. I said in #1945 that affected users would recover on reload; that was wrong. The session still reports as signed in, and a cached unexpired token is never re-fetched, so a reload changes nothing. The only escapes were logging out or waiting out the 86400 second token lifetime. Signed-in users saw the subscription banner and lost cloud armies for that whole window.

## The fix

`useApiAccessToken` reads the `iss` claim and, when it is not the configured issuer, re-requests with `cacheMode: 'off'`.

Done here rather than in each API path because there are eight callers of this hook — the two contexts plus checkout, gifts, redeem, join, and theme. One check upstream fixes all of them, and it repairs the token *before* it is sent rather than after something 401s.

A token whose claims cannot be read returns `null` from the issuer check and is passed through untouched, so an opaque token is never pushed into a refresh it cannot pass.

The block comment marks this as removable once no pre-cutover token can still exist.

## Testing

New `src/tests/aos4/authToken.test.tsx`, 5 cases: pass-through on a matching issuer, reissue on a stale one (asserting `cacheMode: 'off'`), untouched opaque token, empty reissue treated as needing login, and no token request while signed out.

Full suite: 3327 pass. One unrelated flake, `reviewPackets.test.ts:401`, a 5s timeout under parallel load that has appeared three times tonight and passes in isolation — worth its own look.

## After deploy

Users currently stuck get repaired on their next page load with no action. No further tenant or infrastructure changes: the authorizers already pin `https://auth.aosreminders.com/`.
