### PR TITLE
fix(test): keep the offline review-cache assertion actually offline

### DIFF
--- a/src/aos4/review/packetCommand.ts
+++ b/src/aos4/review/packetCommand.ts
@@ -56,11 +56,18 @@ const PACKET_SHARD_SIZE = 250
 const MAX_EXCERPT_LENGTH = 1_200
 export const identityAliasesRequireAdversarialReview = (aliasCount: number): boolean => aliasCount > 1
 
+/**
+ * `environment` is threaded through to `createArtifactCache`, which reads `AOS4_ARTIFACT_STORE_*` and
+ * upgrades a plain local cache into one that restores misses from S3 over the AWS CLI. Production
+ * wants that. A caller that must stay offline — a test asserting the missing-artifact message — has
+ * no other way to say so, because the default is the ambient process environment.
+ */
 export const assertReviewCacheComplete = async (
   manifest: ArtifactManifest,
-  cacheDirectory: string
+  cacheDirectory: string,
+  environment: Record<string, string | undefined> = process.env
 ): Promise<void> => {
-  const cache = createArtifactCache(cacheDirectory)
+  const cache = createArtifactCache(cacheDirectory, environment)
   for (const artifact of manifest.artifacts) {
     const bytes = await cache.get(artifact.checksum)
     if (!bytes) {

--- a/src/tests/aos4/reviewPackets.test.ts
+++ b/src/tests/aos4/reviewPackets.test.ts
@@ -400,6 +400,9 @@ describe('AoS 4 review packet preparation', () => {
 
   it('reports missing accepted cache artifacts without attempting network access', async () => {
     const cacheDirectory = await mkdtemp(path.join(os.tmpdir(), 'aos4-review-cache-'))
+    // An empty environment is what makes the name true. Inheriting the ambient one picks up any
+    // AOS4_ARTIFACT_STORE_* a maintainer has exported, which turns the cache miss below into a real
+    // S3 restore over the AWS CLI — slow enough to trip the timeout, and network access besides.
     await expect(
       assertReviewCacheComplete(
         {
@@ -417,7 +420,8 @@ describe('AoS 4 review packet preparation', () => {
             },
           ],
         },
-        cacheDirectory
+        cacheDirectory,
+        {}
       )
     ).rejects.toThrow(
       `Accepted artifact ${ARTIFACT_CHECKSUM} is missing from ${cacheDirectory}; populate the local accepted-source cache before preparing review packets`


### PR DESCRIPTION
## Not flaky — wrong

`reviewPackets.test.ts:401` is named **"reports missing accepted cache artifacts without attempting network access"** and did exactly the opposite on any machine with these exported:

```
AOS4_ARTIFACT_STORE_BUCKET
AOS4_ARTIFACT_STORE_PREFIX
AOS4_ARTIFACT_STORE_EXPECTED_OWNER
```

`assertReviewCacheComplete` built its cache from the ambient `process.env`, and `createArtifactCache` (`artifactStore.ts:388`) upgrades a plain `FileArtifactCache` into a `RestoringArtifactCache` backed by `AwsS3ArtifactStore` the moment any of those is set. So the deliberate cache miss stopped being a filesystem check and became a real S3 restore shelled out through the AWS CLI.

That is the whole story of the intermittency. The round trip sat just under the 5s limit when the file ran alone and went over it under the parallel load of a full run — it failed three times in one evening and passed every time it was rerun in isolation, which is exactly the signature.

Worth calling out: **CI never saw this**, because CI does not set those variables. The failure only reproduced on a maintainer's machine, which is the worst possible place for it to live — it looks like local flakiness and gets rerun rather than fixed.

## The fix

`assertReviewCacheComplete` now accepts `environment`, defaulting to `process.env` so production keeps restoring from S3, and the test passes `{}`. This uses the injection seam `createArtifactCache` already had; it just wasn't reachable from this caller.

## Result

Measured with the store variables set, so under the conditions that used to fail:

| | before | after |
|---|---|---|
| test execution for the file | 1.42s | **64ms** |

Full suite: 96 files, 3323 tests, all passing. Lint clean.
