### PR TITLE
docs: how to test checkout locally against a deployed API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,4 @@ Topic-specific notes:
 - [docs/printing.md](./docs/printing.md) — how the print and PDF export path works
 - [docs/pwa.md](./docs/pwa.md) — how the service worker, install, and offline behaviour fit together
 - [docs/deployment.md](./docs/deployment.md) — the S3/CloudFront header contract, asset retention, and worker rollback
+- [docs/payments-local-testing.md](./docs/payments-local-testing.md) — running checkout locally against a deployed non-production subscription API

--- a/docs/payments-local-testing.md
+++ b/docs/payments-local-testing.md
@@ -1,0 +1,87 @@
+# Testing checkout locally
+
+How to exercise the Stripe and PayPal subscription flows from `yarn start` against a deployed
+non-production subscription API.
+
+This document covers only what this repository owns: which environment variables the client reads,
+which port it must serve on, and which build mode it must run in. Endpoint URLs, test accounts,
+provider dashboard wiring, and the account-matching rules the API enforces are billing detail and
+live in the private `aos-reminders-subscription-api` repository — see its
+`docs/local-ui-testing.md`. AGENTS.md keeps that material out of this repository.
+
+## Point the client at a deployed API
+
+`.env.local` (gitignored) overrides the endpoint the client calls:
+
+```
+VITE_SUBSCRIPTION_API_URL=<subscription API base URL>
+VITE_ARMY_API_URL=<army API base URL, or leave mocked>
+```
+
+Only the subscription URL matters for checkout. Subscription state is read exclusively through
+`SubscriptionApi` in `src/context/useSubscription.tsx`; the army API backs saved armies and sharing
+and can stay pointed at a mock.
+
+Vite reads `.env.local` once at server start, so restart after editing it.
+
+## Serve on port 5173, and enforce it
+
+```sh
+yarn start --port 5173 --strictPort
+```
+
+The API stage's allowed origin is a single fixed value, and it drives three things at once: the CORS
+allowance on every account route, the success and cancel URLs the server builds into a Stripe
+Checkout Session, and — because `Auth0Provider` passes `redirect_uri: window.location.origin`
+(`src/main.tsx`) — the Auth0 callback.
+
+Vite's default is 5173, but it silently walks to 5174 when the port is busy. That failure is worth
+naming because it does not look like a port problem: preflight fails on every account call, login
+returns to an unregistered callback, and checkout completes but returns the buyer to an origin
+nothing is running on. `--strictPort` turns it into an immediate, obvious startup error instead.
+
+## Use the dev server, never a production build
+
+`src/utils/env.ts` derives `isDev` from `process.env.NODE_ENV`, which Vite substitutes at build
+time. That one flag selects **both** the PayPal client ID and the PayPal plan IDs
+(`src/utils/plans.ts`, consumed in `src/components/payment/pricingPlans.tsx`).
+
+So `yarn build && yarn preview` renders the **live** PayPal button and charges a real card, no
+matter which API `VITE_SUBSCRIPTION_API_URL` points at. Only `yarn start` is safe for PayPal
+testing.
+
+Stripe does not share this hazard. Since #1942 the browser sends an intent — `{ kind, plan }` — and
+the server chooses the price from its own catalog, so the API's own stage decides whether the
+session is a test one. The client cannot select a price at all.
+
+## Stripe
+
+`/subscribe` → the Stripe button → `POST /account/checkout-session` → navigate to the returned URL.
+Test card `4242 4242 4242 4242`, any future expiry, any CVC, any postal code.
+
+You return to `/?subscribed=true&checkout_kind=subscription&plan=…&checkout_session_id=…`, which
+`src/utils/handleQueryParams` and the checkout outcome banner read.
+
+Activation does not arrive with that redirect. The provider posts `checkout.session.completed` to
+the deployed callback API, which the local app never sees, so the account row flips a moment after
+you land. Reload `/profile` to confirm rather than treating the immediate state as final.
+
+## PayPal
+
+The button is rendered imperatively by `src/components/payment/paypal/paypalButton.tsx` and needs a
+signed-in user with an e-mail before it will mount at all. On approval the client posts the
+subscription ID to `/account/paypal-grant`; the API treats it only as a locator and re-fetches the
+authoritative subscription before granting anything.
+
+The API requires the approving PayPal account's e-mail to match the signed-in account's. Set up a
+sandbox buyer that satisfies this before testing — the private repository's `docs/local-ui-testing.md`
+records how. A mismatch surfaces in the UI as a rejected grant, not as a login problem.
+
+The post-subscribe modal polls the grant while provider activation lands, so a brief spinner there
+is the normal path, not a failure.
+
+## Between runs
+
+Cancel from `/profile` after each test. An account that already holds an active subscription renders
+the already-subscribed path instead of the checkout controls, so the next run silently tests
+something else.


### PR DESCRIPTION
Adds `docs/payments-local-testing.md`, linked from `CLAUDE.md` beside the other topic notes.

Covers only what this repository owns:

- the `.env.local` overrides, and why only `VITE_SUBSCRIPTION_API_URL` matters for checkout
- `--port 5173 --strictPort`, and why Vite's silent walk to 5174 breaks CORS, the Auth0 callback, and the checkout return simultaneously — a failure that does not look like a port problem
- `isDev` deriving from `NODE_ENV` and selecting the PayPal client ID *and* plan IDs, so `yarn build && yarn preview` renders the live button and takes real money regardless of which API it points at
- why Stripe does not share that hazard: since #1942 the browser sends an intent and the server picks the price
- the test card, the return query string, and that activation arrives by webhook after the redirect rather than with it

Endpoints, test accounts, and provider dashboard wiring are deliberately absent. AGENTS.md keeps billing and payment-provider detail out of this public repository, so that material lives in the private subscription API repo and this document points at it.

## Testing

Documentation only — no source or build changes. Verified every file and symbol the document cites exists at the stated path (`src/utils/env.ts`, `src/utils/plans.ts`, `src/main.tsx`, `src/context/useSubscription.tsx`, `src/components/payment/paypal/paypalButton.tsx`, `src/utils/handleQueryParams.ts`, `src/components/info/banners/checkout_outcome_banner.tsx`).

The procedure itself was followed end to end against the dev stage before writing: the dev account API answers a `http://localhost:5173` preflight with a matching `access-control-allow-origin`, and the Stripe test-mode and PayPal sandbox webhooks are registered and enabled against the dev callback stage.
