### PR TITLE
docs: retire the two cleared 6.0.0 launch gates

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -126,21 +126,28 @@ Preserve it; do not change it as a side effect of other work.
   integration branch is explicitly established. Merging or pushing `master` requires explicit
   authorization.
 
-### Known launch gates
+### Launch gates (both cleared in the 2026-07-31 release window)
 
-**Production launch is blocked on subscription-API authorization.** The restored subscription API
-uses a public shared browser key and does not verify the user's Auth0 token or derive account
-ownership server-side. An Auth0-protected route is not API authorization. Launch requires
-server-side bearer-token verification, server-derived ownership, rejection of cross-account access,
-key rotation, and passing negative authorization tests. Do not describe the subscription API as
-secure. The separate army/share API (`src/api/armyApi.ts`) does send the user's Auth0 bearer token
-on every account operation.
+**Subscription-API authorization is resolved.** The subscription service verifies the caller's
+Auth0 bearer token, derives account ownership server-side, and verifies Stripe and PayPal callbacks
+against provider signatures; the shared browser key, caller-supplied account identifiers, and the
+legacy public routes were removed. `src/api/subscriptionApi.ts` sends `Authorization: Bearer` on
+every account call and fails closed without a token, as `src/api/armyApi.ts` already did. The work
+landed and was deployed to production on 2026-07-31 from the private
+`aos-reminders-subscription-api` repository; keep authorization and billing detail there rather than
+restating it here.
 
-**Cloud armies and sharing also require a coordinated production rollout.** The AoS 4-native
-army/share service was dev-validated, but the production frontend build must receive
-`VITE_ARMY_API_URL` and target a production deployment of that service. The current deployment
-workflow does not provide the variable. Until both sides are configured and smoke-tested, the
-capability is implemented but not production-ready; the coordinated work is tracked in #1804.
+**Cloud armies and sharing are configured and live.** `.github/workflows/deploy.yml` supplies
+`VITE_ARMY_API_URL` and `VITE_SUBSCRIPTION_API_URL` from the `PRODUCTION_ARMY_API_URL` and
+`PRODUCTION_SUBSCRIPTION_API_URL` repository variables, `scripts/deploymentConfig.ts` fails the
+build closed when either is missing or malformed, and the production smoke matrix recorded in #1805
+exercised create/list/update/load/delete plus opaque sharing against the live service. #1804 closed
+2026-08-02.
+
+Standing residue rather than launch gates: the operator-gated verification items (a second Auth0
+account for two-account negative matrices, a PayPal sandbox app for the valid-signature dev path,
+and live-money checkout observations) are follow-up coverage, not blockers on shipping or on paid
+messaging.
 
 ### Terminology
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -51,25 +51,28 @@ corrupt private bytes are a no-go for offline replay; do not fall back to an unr
 during a release. A UI-only release does not need to restore the source cache, but it still runs the
 checked-in beta gate.
 
-Before merging #1717, confirm all of the following:
+Before merging a release into `master`, confirm all of the following:
 
 - the PR title does not trip the WIP check and every required GitHub check is green;
 - the accepted beta pointer in `data/aos4/certifications/beta.json` resolves to the certification
   directory for the currently accepted corpus, and `yarn data:aos4:verify:beta` passes. Do not
   restate the directory name here — it changes with every accepted refresh;
 - the project owner explicitly authorizes the `master` merge and resulting frontend deployment;
-- the AoS 4-native army/share service through `aos-reminders-rest-api#11` is deployed to production
-  with the production entitlement URL, Auth0 issuer/audience, share base URL, and CORS origins;
-  [#1804](https://github.com/daviseford/aos-reminders/issues/1804) tracks the coordinated rollout;
 - repository variables `PRODUCTION_ARMY_API_URL` and `PRODUCTION_SUBSCRIPTION_API_URL` contain the
   compatible production HTTP API endpoints. The deployment workflow maps them to the two Vite
   variables, validates them, and confirms both are embedded in the artifact;
-- the subscription-account authorization work is resolved and its negative authorization matrix
-  passes. That work is tracked in the private `aos-reminders-subscription-api` repository; do not
-  restate its detail here.
+- any companion-service revision the release depends on is already deployed to production, so no
+  build advertises a capability the live services cannot serve.
 
-The last two bullets are production gates, not documentation warnings. Merging without them can
-publish paid-feature claims for capabilities that are unavailable or insufficiently authorized.
+Those are production gates, not documentation warnings. Merging without them can publish
+paid-feature claims for capabilities that are unavailable or insufficiently authorized.
+
+The two one-time 6.0.0 gates are closed and should not be restated as open work: the
+subscription-account authorization work shipped and deployed on 2026-07-31 (private
+`aos-reminders-subscription-api` repository; do not restate its detail here), and the coordinated
+army/share rollout tracked in
+[#1804](https://github.com/daviseford/aos-reminders/issues/1804) closed 2026-08-02 with both
+repository variables set and the production smoke matrix recorded in #1805.
 
 ## Cutover evidence record
 


### PR DESCRIPTION
## Summary

`PRODUCT.md` still described two conditions as blocking production launch. Both were resolved during the 2026-07-31 release window, so anything reading the docs — a person or an agent — concludes the paid funnel is gated when it is not.

**Subscription-API authorization.** The private `aos-reminders-subscription-api` work merged and deployed to production on 2026-07-31: bearer-token verification, server-derived account ownership, provider-signature-verified Stripe and PayPal callbacks, and removal of the shared browser key, caller-supplied account identifiers, and legacy public routes. `src/api/subscriptionApi.ts` already requires a token and sends `Authorization: Bearer` on every account call. `AGENTS.md` described this correctly; `PRODUCT.md` did not. Authorization and billing detail stays in the private repository.

**Cloud armies and sharing.** #1804 closed 2026-08-02. `.github/workflows/deploy.yml` supplies `VITE_ARMY_API_URL` and `VITE_SUBSCRIPTION_API_URL` from the `PRODUCTION_ARMY_API_URL` / `PRODUCTION_SUBSCRIPTION_API_URL` repository variables (both set, pointing at live API Gateway hosts), `scripts/deploymentConfig.ts` fails the build closed when either is missing or malformed, and the #1805 production smoke matrix exercised create/list/update/load/delete plus opaque sharing against the live service.

## Changes

- `PRODUCT.md`: the "Known launch gates" section becomes a cleared-gates section stating what actually shipped, plus a line separating the operator-gated verification leftovers (second Auth0 account for two-account negative matrices, PayPal sandbox app, live-money checkout observations) from blockers. Those are follow-up coverage and do not gate shipping or paid messaging.
- `docs/release.md`: the pre-merge checklist was still phrased around merging #1717, which merged 2026-07-31. Generalized it for future releases, replaced the two one-time gates with a general "companion services already deployed" gate, and moved the 6.0.0 gates into a closed-history note.

Documentation only. No runtime, data, or workflow changes.

## Verification

- `git diff` touches `PRODUCT.md` and `docs/release.md` only.
- Claims cross-checked against `deploy.yml:26-27`, `gh variable list`, `scripts/deploymentConfig.ts`, `src/api/subscriptionApi.ts:50-55`, the closed state of #1804/#1805, and the merged private-repo authorization PR.
