### PR TITLE
feat: bring Save Army out of My Armies as its own toolbar button

### DIFF
--- a/src/components/input/cloudArmies/saveArmyModal.tsx
+++ b/src/components/input/cloudArmies/saveArmyModal.tsx
@@ -1,0 +1,84 @@
+import type { Aos4ArmyDocument } from '../../../aos4/state'
+import { withName } from './withName'
+import GenericModal from 'components/modals/generic/generic_modal'
+import { useArmyCollection } from 'context/useArmyCollection'
+import { useTheme } from 'context/useTheme'
+import { useState } from 'react'
+
+interface SaveArmyModalProps {
+  closeModal: () => void
+  currentDocument: Aos4ArmyDocument
+  isOpen: boolean
+  onSaved: (document: Aos4ArmyDocument, cloudArmyId: string) => void
+}
+
+const SaveArmyModal = ({ closeModal, currentDocument, isOpen, onSaved }: SaveArmyModalProps) => {
+  const { collectionError, configured, createArmy } = useArmyCollection()
+  const { theme } = useTheme()
+  const [saveName, setSaveName] = useState(currentDocument.name)
+  const [isSaving, setIsSaving] = useState(false)
+
+  const saveNew = async () => {
+    setIsSaving(true)
+    try {
+      const savedDocument = withName(currentDocument, saveName)
+      const created = await createArmy(savedDocument)
+      onSaved(savedDocument, created.id)
+      closeModal()
+    } catch {
+      // The collection context exposes the service error beside the controls.
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <GenericModal closeModal={closeModal} isOpen={isOpen} isProcessing={isSaving} label="Save Army">
+      <div className={`aos4-account-modal ${theme.text}`}>
+        <div className="d-flex align-items-start justify-content-between mb-3">
+          <div>
+            <h2 className="h4 mb-1">Save Army</h2>
+            <p className="small mb-0">Save this army to your cloud armies.</p>
+          </div>
+          <button aria-label="Close save army" className={theme.modalDangerClass} onClick={closeModal}>
+            ×
+          </button>
+        </div>
+
+        {!configured && (
+          <div className="alert alert-warning" role="alert">
+            Cloud armies are not configured for this build.
+          </div>
+        )}
+        {collectionError && (
+          <div className="alert alert-danger" role="alert">
+            {collectionError}
+          </div>
+        )}
+
+        <label className="fw-bold" htmlFor="save-army-name">
+          Army name
+        </label>
+        <div className="input-group">
+          <input
+            className={`form-control ${theme.bgColor} ${theme.text}`}
+            id="save-army-name"
+            maxLength={200}
+            onChange={event => setSaveName(event.target.value)}
+            value={saveName}
+          />
+          <button
+            className={theme.modalSuccessClass}
+            disabled={!configured || !saveName.trim() || isSaving}
+            onClick={() => void saveNew()}
+            type="button"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </GenericModal>
+  )
+}
+
+export default SaveArmyModal

--- a/src/components/input/cloudArmies/savedArmiesModal.tsx
+++ b/src/components/input/cloudArmies/savedArmiesModal.tsx
@@ -1,5 +1,6 @@
 import type { RemoteArmy } from '../../../api/armyApi'
-import { createAos4ArmyDocument, type Aos4ArmyDocument } from '../../../aos4/state'
+import type { Aos4ArmyDocument } from '../../../aos4/state'
+import { withName } from './withName'
 import GenericModal from 'components/modals/generic/generic_modal'
 import { useArmyCollection } from 'context/useArmyCollection'
 import { useTheme } from 'context/useTheme'
@@ -10,12 +11,19 @@ interface SavedArmiesModalProps {
   currentDocument: Aos4ArmyDocument
   isOpen: boolean
   onApply: (document: Aos4ArmyDocument) => void
+  /** The current document became a copy of this cloud army (saved, updated from current, or loaded). */
+  onLinked?: (cloudArmyId: string) => void
+  onDeleted?: (cloudArmyId: string) => void
 }
 
-const withName = (document: Aos4ArmyDocument, name: string): Aos4ArmyDocument =>
-  createAos4ArmyDocument({ ...document, name: name.trim() || document.name })
-
-const SavedArmiesModal = ({ closeModal, currentDocument, isOpen, onApply }: SavedArmiesModalProps) => {
+const SavedArmiesModal = ({
+  closeModal,
+  currentDocument,
+  isOpen,
+  onApply,
+  onDeleted,
+  onLinked,
+}: SavedArmiesModalProps) => {
   const {
     armies,
     collectionError,
@@ -62,8 +70,9 @@ const SavedArmiesModal = ({ closeModal, currentDocument, isOpen, onApply }: Save
   const saveNew = () =>
     mutate(async () => {
       const savedDocument = withName(currentDocument, saveName)
-      await createArmy(savedDocument)
+      const created = await createArmy(savedDocument)
       onApply(savedDocument)
+      onLinked?.(created.id)
     }, 'Army saved.')
 
   const rename = (army: RemoteArmy) =>
@@ -76,6 +85,7 @@ const SavedArmiesModal = ({ closeModal, currentDocument, isOpen, onApply }: Save
       const savedDocument = withName(currentDocument, draftNames[army.id] ?? currentDocument.name)
       await updateArmy(army.id, savedDocument)
       onApply(savedDocument)
+      onLinked?.(army.id)
     }, 'Saved army updated from the current army.')
 
   const confirmDelete = (army: RemoteArmy) =>
@@ -83,6 +93,7 @@ const SavedArmiesModal = ({ closeModal, currentDocument, isOpen, onApply }: Save
       await deleteArmy(army.id)
       setPendingDeleteId(undefined)
       if (pendingLoad?.id === army.id) setPendingLoad(undefined)
+      onDeleted?.(army.id)
     }, 'Saved army deleted.')
 
   return (
@@ -232,6 +243,7 @@ const SavedArmiesModal = ({ closeModal, currentDocument, isOpen, onApply }: Save
               className={`${theme.modalConfirmClass} btn-sm me-2`}
               onClick={() => {
                 onApply(pendingLoad.document)
+                onLinked?.(pendingLoad.id)
                 closeModal()
               }}
               type="button"

--- a/src/components/input/cloudArmies/withName.ts
+++ b/src/components/input/cloudArmies/withName.ts
@@ -1,0 +1,4 @@
+import { createAos4ArmyDocument, type Aos4ArmyDocument } from '../../../aos4/state'
+
+export const withName = (document: Aos4ArmyDocument, name: string): Aos4ArmyDocument =>
+  createAos4ArmyDocument({ ...document, name: name.trim() || document.name })

--- a/src/components/input/toolbar/toolbar.tsx
+++ b/src/components/input/toolbar/toolbar.tsx
@@ -1,16 +1,30 @@
 import { useTheme } from 'context/useTheme'
 import { FaTrash } from 'react-icons/fa'
-import { MdFileDownload, MdFileUpload, MdSave, MdShare, MdVisibility } from 'react-icons/md'
+import {
+  MdCloud,
+  MdCloudUpload,
+  MdFileDownload,
+  MdFileUpload,
+  MdSave,
+  MdSaveAs,
+  MdShare,
+  MdVisibility,
+} from 'react-icons/md'
 
 interface ToolbarProps {
+  /** The current army mirrors a cloud army, so saving splits into Update Army and Save As. */
+  cloudArmyLinked: boolean
   hiddenCount: number
   onClearArmy: () => void
   onDownloadPdf: () => void
   onImportArmy: () => void
   onOpenSavedArmies: () => void
+  onSaveArmy: () => void
   onShareArmy: () => void
   onShowAll: () => void
+  onUpdateArmy: () => void
   subscriberActionDisabled?: boolean
+  updateArmyStatus: 'idle' | 'updating' | 'updated'
 }
 
 const buttonWrapperClass = 'col-6 col-sm-4 col-lg px-2 pb-2'
@@ -39,15 +53,25 @@ const ToolbarButton = ({
   )
 }
 
+const updateArmyLabel = (status: ToolbarProps['updateArmyStatus']): string => {
+  if (status === 'updating') return 'Updating…'
+  if (status === 'updated') return 'Updated'
+  return 'Update Army'
+}
+
 const Toolbar = ({
+  cloudArmyLinked,
   hiddenCount,
   onClearArmy,
   onDownloadPdf,
   onImportArmy,
   onOpenSavedArmies,
+  onSaveArmy,
   onShareArmy,
   onShowAll,
+  onUpdateArmy,
   subscriberActionDisabled,
+  updateArmyStatus,
 }: ToolbarProps) => (
   <div className="container d-print-none">
     <div className="row justify-content-center pt-3">
@@ -69,9 +93,35 @@ const Toolbar = ({
           Import Army
         </ToolbarButton>
       </div>
+      {cloudArmyLinked ? (
+        <>
+          <div className={buttonWrapperClass}>
+            <ToolbarButton
+              disabled={subscriberActionDisabled || updateArmyStatus === 'updating'}
+              onClick={onUpdateArmy}
+            >
+              <MdCloudUpload className="me-2" />
+              {updateArmyLabel(updateArmyStatus)}
+            </ToolbarButton>
+          </div>
+          <div className={buttonWrapperClass}>
+            <ToolbarButton disabled={subscriberActionDisabled} onClick={onSaveArmy}>
+              <MdSaveAs className="me-2" />
+              Save As
+            </ToolbarButton>
+          </div>
+        </>
+      ) : (
+        <div className={buttonWrapperClass}>
+          <ToolbarButton disabled={subscriberActionDisabled} onClick={onSaveArmy}>
+            <MdSave className="me-2" />
+            Save Army
+          </ToolbarButton>
+        </div>
+      )}
       <div className={buttonWrapperClass}>
         <ToolbarButton disabled={subscriberActionDisabled} onClick={onOpenSavedArmies}>
-          <MdSave className="me-2" />
+          <MdCloud className="me-2" />
           My Armies
         </ToolbarButton>
       </div>

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -24,13 +24,14 @@ import { useSubscriberAction } from 'components/input/importArmy/subscriberActio
 import Toolbar from 'components/input/toolbar/toolbar'
 import Footer from 'components/page/footer'
 import { Header } from 'components/page/homeHeader'
-import { ArmyCollectionProvider } from 'context/useArmyCollection'
+import { ArmyCollectionProvider, messageForError, useArmyCollection } from 'context/useArmyCollection'
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
 import { logFactionSelection, logGameModeChange, logPdfDownload } from 'utils/analytics'
 import { consumePendingShareId } from 'utils/shareLink'
 
 const ImportArmyModal = lazy(() => import('components/input/importArmy/importArmyModal'))
 const PrintModal = lazy(() => import('components/print/printModal'))
+const SaveArmyModal = lazy(() => import('components/input/cloudArmies/saveArmyModal'))
 const SavedArmiesModal = lazy(() => import('components/input/cloudArmies/savedArmiesModal'))
 const ShareArmyModal = lazy(() => import('components/input/armySharing/shareArmyModal'))
 const SharedArmyModal = lazy(() => import('components/input/armySharing/sharedArmyModal'))
@@ -63,7 +64,7 @@ const selectableFactions = armyFactions(AOS4_CATALOG)
 const toFileName = (name: string) => `${name.trim().split(/\s+/).join('_') || 'AoS'}_Reminders`
 
 /*
- * The masthead, mode switch, faction select, builder cards, and the seven toolbar buttons all sit
+ * The masthead, mode switch, faction select, builder cards, and the toolbar buttons all sit
  * between the top of the document and the reminders, so reaching the content by keyboard means
  * tabbing past roughly a dozen controls. The link targets the reminders rather than <main>, because
  * <main> wraps the routed tree from the navbar down and skipping to it would move nothing.
@@ -84,13 +85,24 @@ const SkipToReminders = () => (
 )
 
 const HomeContent = () => {
+  const { updateArmy } = useArmyCollection()
   const [document, setDocument] = useState(loadDocument)
   const [isGameMode, setIsGameMode] = useState(false)
   const [importModalIsOpen, setImportModalIsOpen] = useState(false)
   const [savedArmiesModalIsOpen, setSavedArmiesModalIsOpen] = useState(false)
+  const [saveArmyModalIsOpen, setSaveArmyModalIsOpen] = useState(false)
   const [shareModalIsOpen, setShareModalIsOpen] = useState(false)
   const [pendingShareId, setPendingShareId] = useState(() => consumePendingShareId())
   const [printModalIsOpen, setPrintModalIsOpen] = useState(false)
+  /*
+   * Which cloud army the current document is a copy of, if any. Held in memory only: it starts a
+   * session unlinked, links through the save/load flows, and unlinks when the document stops being
+   * that army (clear, faction switch, import, incoming share, remote delete). It decides whether
+   * the toolbar offers one-click Update Army alongside Save As, or a single Save Army.
+   */
+  const [cloudArmyId, setCloudArmyId] = useState<string>()
+  const [updateArmyStatus, setUpdateArmyStatus] = useState<'idle' | 'updating' | 'updated'>('idle')
+  const [updateArmyError, setUpdateArmyError] = useState<string>()
   const savedArmiesAction = useSubscriberAction({
     featureName: 'My Armies',
     onAuthorized: () => setSavedArmiesModalIsOpen(true),
@@ -101,6 +113,38 @@ const HomeContent = () => {
     onAuthorized: () => setShareModalIsOpen(true),
     origin: 'ShareArmy',
   })
+  const saveArmyAction = useSubscriberAction({
+    featureName: 'Save Army',
+    onAuthorized: () => setSaveArmyModalIsOpen(true),
+    origin: 'SaveArmy',
+  })
+  const updateCloudArmy = async () => {
+    if (!cloudArmyId) return
+    setUpdateArmyStatus('updating')
+    setUpdateArmyError(undefined)
+    try {
+      await updateArmy(cloudArmyId, document)
+      setUpdateArmyStatus('updated')
+    } catch (error) {
+      setUpdateArmyStatus('idle')
+      setUpdateArmyError(messageForError(error))
+    }
+  }
+  const updateArmyAction = useSubscriberAction({
+    featureName: 'Update Army',
+    onAuthorized: () => void updateCloudArmy(),
+    origin: 'UpdateArmy',
+  })
+  const unlinkCloudArmy = () => {
+    setCloudArmyId(undefined)
+    setUpdateArmyError(undefined)
+  }
+
+  useEffect(() => {
+    if (updateArmyStatus !== 'updated') return
+    const timer = window.setTimeout(() => setUpdateArmyStatus('idle'), 2500)
+    return () => window.clearTimeout(timer)
+  }, [updateArmyStatus])
   const factions = useMemo(
     () =>
       selectableFactions
@@ -174,6 +218,7 @@ const HomeContent = () => {
   }
 
   const clearArmy = () => {
+    unlinkCloudArmy()
     setDocument(current =>
       createAos4ArmyDocument({
         ...current,
@@ -186,6 +231,7 @@ const HomeContent = () => {
   const selectFaction = (nextFactionId: CanonicalId<'faction'>) => {
     const faction = factionById.get(nextFactionId)
     logFactionSelection(nextFactionId, faction?.name ?? 'Unknown faction')
+    unlinkCloudArmy()
     setDocument(current =>
       createAos4ArmyDocument({
         ...current,
@@ -315,15 +361,27 @@ const HomeContent = () => {
 
       {!isGameMode && (
         <Toolbar
+          cloudArmyLinked={Boolean(cloudArmyId)}
           hiddenCount={hiddenCount}
           onClearArmy={clearArmy}
           onDownloadPdf={() => setPrintModalIsOpen(true)}
           onImportArmy={() => setImportModalIsOpen(true)}
           onOpenSavedArmies={savedArmiesAction.run}
+          onSaveArmy={saveArmyAction.run}
           onShareArmy={shareAction.run}
           onShowAll={showAll}
+          onUpdateArmy={updateArmyAction.run}
           subscriberActionDisabled={savedArmiesAction.disabled || shareAction.disabled}
+          updateArmyStatus={updateArmyStatus}
         />
+      )}
+
+      {!isGameMode && updateArmyError && (
+        <div className="container d-print-none">
+          <div className="alert alert-danger" role="alert">
+            {updateArmyError}
+          </div>
+        </div>
       )}
 
       <Reminders
@@ -354,6 +412,7 @@ const HomeContent = () => {
             closeModal={() => setImportModalIsOpen(false)}
             isOpen={importModalIsOpen}
             onApply={nextDocument => {
+              unlinkCloudArmy()
               setDocument(nextDocument)
               setImportModalIsOpen(false)
             }}
@@ -368,6 +427,24 @@ const HomeContent = () => {
             currentDocument={document}
             isOpen={savedArmiesModalIsOpen}
             onApply={setDocument}
+            onDeleted={deletedId =>
+              setCloudArmyId(current => (current === deletedId ? undefined : current))
+            }
+            onLinked={setCloudArmyId}
+          />
+        </Suspense>
+      )}
+
+      {saveArmyModalIsOpen && (
+        <Suspense fallback={null}>
+          <SaveArmyModal
+            closeModal={() => setSaveArmyModalIsOpen(false)}
+            currentDocument={document}
+            isOpen={saveArmyModalIsOpen}
+            onSaved={(savedDocument, savedCloudArmyId) => {
+              setDocument(savedDocument)
+              setCloudArmyId(savedCloudArmyId)
+            }}
           />
         </Suspense>
       )}
@@ -387,7 +464,10 @@ const HomeContent = () => {
           <SharedArmyModal
             closeModal={() => setPendingShareId(undefined)}
             isOpen
-            onApply={setDocument}
+            onApply={nextDocument => {
+              unlinkCloudArmy()
+              setDocument(nextDocument)
+            }}
             shareId={pendingShareId}
           />
         </Suspense>

--- a/src/context/useArmyCollection.tsx
+++ b/src/context/useArmyCollection.tsx
@@ -18,7 +18,7 @@ interface ArmyCollectionContextValue {
 
 const ArmyCollectionContext = React.createContext<ArmyCollectionContextValue | undefined>(undefined)
 
-const messageForError = (error: unknown): string => {
+export const messageForError = (error: unknown): string => {
   if (error instanceof ArmyApiError && error.status === 401) return 'Please log in again to continue.'
   if (error instanceof Error) return error.message
   return 'Cloud armies are temporarily unavailable.'

--- a/src/tests/aos4/accountCapabilitiesUi.test.tsx
+++ b/src/tests/aos4/accountCapabilitiesUi.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import SaveArmyModal from 'components/input/cloudArmies/saveArmyModal'
 import SavedArmiesModal from 'components/input/cloudArmies/savedArmiesModal'
 import ShareArmyModal from 'components/input/armySharing/shareArmyModal'
 import { createDefaultAos4ArmyDocument } from '../../aos4/runtime'
@@ -101,6 +102,8 @@ describe('saved-army and sharing controls', () => {
   it('saves explicitly, previews before load, and confirms delete', async () => {
     const closeModal = vi.fn()
     const onApply = vi.fn()
+    const onDeleted = vi.fn()
+    const onLinked = vi.fn()
     act(() => {
       render(
         <SavedArmiesModal
@@ -108,6 +111,8 @@ describe('saved-army and sharing controls', () => {
           currentDocument={currentDocument}
           isOpen
           onApply={onApply}
+          onDeleted={onDeleted}
+          onLinked={onLinked}
         />,
         container
       )
@@ -121,11 +126,13 @@ describe('saved-army and sharing controls', () => {
       await Promise.resolve()
     })
     expect(collection.createArmy).toHaveBeenCalledWith(expect.objectContaining({ name: 'Tournament Army' }))
+    expect(onLinked).toHaveBeenLastCalledWith('cloud-1')
 
     act(() => findButton(container, 'Load').click())
     expect(container.textContent).toContain('Replace the current army with Saved Stormhost?')
     act(() => findButton(container, 'Replace current army').click())
     expect(onApply).toHaveBeenLastCalledWith(savedDocument)
+    expect(onLinked).toHaveBeenLastCalledWith('cloud-1')
 
     act(() => findButton(container, 'Delete').click())
     await act(async () => {
@@ -133,6 +140,51 @@ describe('saved-army and sharing controls', () => {
       await Promise.resolve()
     })
     expect(collection.deleteArmy).toHaveBeenCalledWith('cloud-1')
+    expect(onDeleted).toHaveBeenCalledWith('cloud-1')
+  })
+
+  it('saves the current army from the dedicated Save Army dialog and links the result', async () => {
+    const closeModal = vi.fn()
+    const onSaved = vi.fn()
+    collection.createArmy.mockResolvedValue({ ...remoteArmy, id: 'cloud-9' })
+    act(() => {
+      render(
+        <SaveArmyModal closeModal={closeModal} currentDocument={currentDocument} isOpen onSaved={onSaved} />,
+        container
+      )
+    })
+
+    const nameInput = container.querySelector<HTMLInputElement>('#save-army-name')!
+    nameInput.value = 'Tournament Army'
+    act(() => Simulate.change(nameInput))
+    await act(async () => {
+      findButton(container, 'Save').click()
+      await Promise.resolve()
+    })
+
+    expect(collection.createArmy).toHaveBeenCalledWith(expect.objectContaining({ name: 'Tournament Army' }))
+    expect(onSaved).toHaveBeenCalledWith(expect.objectContaining({ name: 'Tournament Army' }), 'cloud-9')
+    expect(closeModal).toHaveBeenCalled()
+  })
+
+  it('keeps the Save Army dialog open and shows the service error when saving fails', async () => {
+    const closeModal = vi.fn()
+    const onSaved = vi.fn()
+    collection.createArmy.mockRejectedValue(new Error('Cloud armies are temporarily unavailable.'))
+    act(() => {
+      render(
+        <SaveArmyModal closeModal={closeModal} currentDocument={currentDocument} isOpen onSaved={onSaved} />,
+        container
+      )
+    })
+
+    await act(async () => {
+      findButton(container, 'Save').click()
+      await Promise.resolve()
+    })
+
+    expect(onSaved).not.toHaveBeenCalled()
+    expect(closeModal).not.toHaveBeenCalled()
   })
 
   it('creates an opaque share link only after confirmation and copies it', async () => {

--- a/src/tests/aos4/bundleBoundaries.test.ts
+++ b/src/tests/aos4/bundleBoundaries.test.ts
@@ -16,8 +16,8 @@ describe('initial bundle boundaries', () => {
     // The lazy route table lives in the router singleton so the Auth0 callback and analytics can
     // share one data router; the catalog must stay behind those lazy boundaries.
     expect(router).toMatch(/const Home = lazy\(\(\) => import\('components\/routes\/Home'\)\)/)
-    expect(main).not.toContain("import { ArmyCollectionProvider } from 'context/useArmyCollection'")
-    expect(home).toContain("import { ArmyCollectionProvider } from 'context/useArmyCollection'")
+    expect(main).not.toContain("from 'context/useArmyCollection'")
+    expect(home).toMatch(/import \{ ArmyCollectionProvider[^}]*\} from 'context\/useArmyCollection'/)
     expect(main.indexOf("import './bootstrap/captureShareLink'")).toBeLessThan(
       main.indexOf("import App from 'components/App'")
     )

--- a/src/tests/aos4/homePresentation.test.tsx
+++ b/src/tests/aos4/homePresentation.test.tsx
@@ -149,6 +149,7 @@ describe('AoS 4 home presentation', () => {
     // `master` shipped a Download PDF toolbar button, not a browser-print one.
     expect(container.textContent).toContain('Download PDF')
     expect(container.textContent).toContain('Import Army')
+    expect(container.textContent).toContain('Save Army')
     expect(container.textContent).toContain('My Armies')
     expect(container.textContent).toContain('Share Army')
     expect(container.textContent).toContain('Subscribe')
@@ -194,6 +195,7 @@ describe('AoS 4 home presentation', () => {
     act(() => {
       Simulate.click(findButton('My Armies')!)
       Simulate.click(findButton('Share Army')!)
+      Simulate.click(findButton('Save Army')!)
     })
 
     /*
@@ -202,6 +204,7 @@ describe('AoS 4 home presentation', () => {
      */
     expect(navigate).toHaveBeenNthCalledWith(1, '/subscribe', { state: { featureName: 'My Armies' } })
     expect(navigate).toHaveBeenNthCalledWith(2, '/subscribe', { state: { featureName: 'Share Army' } })
+    expect(navigate).toHaveBeenNthCalledWith(3, '/subscribe', { state: { featureName: 'Save Army' } })
 
     await act(async () => {
       Simulate.click(findButton('Import Army')!)

--- a/src/tests/aos4/toolbarSaveControls.test.tsx
+++ b/src/tests/aos4/toolbarSaveControls.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import Toolbar from 'components/input/toolbar/toolbar'
+import { act } from 'react'
+import { render, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('context/useTheme', () => ({
+  useTheme: () => ({ theme: { genericButtonBlock: 'btn btn-block btn-outline-dark' } }),
+}))
+
+const findButton = (container: HTMLElement, label: string): HTMLButtonElement | undefined =>
+  Array.from(container.querySelectorAll('button')).find(
+    candidate => candidate.textContent?.trim() === label
+  )
+
+describe('toolbar save controls', () => {
+  let container: HTMLDivElement
+
+  const baseProps = {
+    cloudArmyLinked: false,
+    hiddenCount: 0,
+    onClearArmy: vi.fn(),
+    onDownloadPdf: vi.fn(),
+    onImportArmy: vi.fn(),
+    onOpenSavedArmies: vi.fn(),
+    onSaveArmy: vi.fn(),
+    onShareArmy: vi.fn(),
+    onShowAll: vi.fn(),
+    onUpdateArmy: vi.fn(),
+    updateArmyStatus: 'idle' as const,
+  }
+
+  beforeEach(() => {
+    baseProps.onSaveArmy.mockReset()
+    baseProps.onUpdateArmy.mockReset()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  it('offers a single Save Army button while the army is not linked to a cloud army', () => {
+    act(() => {
+      render(<Toolbar {...baseProps} />, container)
+    })
+
+    expect(findButton(container, 'Save Army')).not.toBeUndefined()
+    expect(findButton(container, 'Update Army')).toBeUndefined()
+    expect(findButton(container, 'Save As')).toBeUndefined()
+
+    act(() => findButton(container, 'Save Army')!.click())
+    expect(baseProps.onSaveArmy).toHaveBeenCalledTimes(1)
+  })
+
+  it('splits saving into Update Army and Save As once the army mirrors a cloud army', () => {
+    act(() => {
+      render(<Toolbar {...baseProps} cloudArmyLinked />, container)
+    })
+
+    expect(findButton(container, 'Save Army')).toBeUndefined()
+    expect(findButton(container, 'Save As')).not.toBeUndefined()
+
+    act(() => findButton(container, 'Update Army')!.click())
+    expect(baseProps.onUpdateArmy).toHaveBeenCalledTimes(1)
+
+    act(() => findButton(container, 'Save As')!.click())
+    expect(baseProps.onSaveArmy).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports update progress and completion on the Update Army button itself', () => {
+    act(() => {
+      render(<Toolbar {...baseProps} cloudArmyLinked updateArmyStatus="updating" />, container)
+    })
+    expect(findButton(container, 'Updating…')?.disabled).toBe(true)
+
+    act(() => {
+      render(<Toolbar {...baseProps} cloudArmyLinked updateArmyStatus="updated" />, container)
+    })
+    expect(findButton(container, 'Updated')?.disabled).toBe(false)
+  })
+})


### PR DESCRIPTION
## Why

Saving an army was hidden inside the My Armies modal (the "Save current army" card), so the most common cloud action took two steps and wasn't discoverable from the toolbar.

## What

- **Unlinked army** (default): the toolbar shows a **Save Army** button that opens a small dialog — name prefilled, one Save button. Saving creates the cloud army and links the current document to it.
- **Cloud-linked army** (after saving, or after Load / Save new / Update from current in My Armies): the toolbar instead shows **Update Army** (one-click push to the linked save, with "Updating…" / "Updated" feedback on the button and an alert under the toolbar on failure) and **Save As** (same dialog, creates and re-links to a new cloud army).
- The link is session-only, in memory, and drops when the document stops being that army: Clear Army, faction switch, import, incoming share link, or deleting the linked save remotely.
- Both actions are subscriber-gated exactly like My Armies / Share Army (non-subscribers land on /subscribe with the feature named).
- My Armies moves to a cloud icon so two toolbar controls don't share the save icon.

Internals: `withName` is extracted from `savedArmiesModal.tsx` into a shared helper; `SavedArmiesModal` gains optional `onLinked`/`onDeleted` callbacks; `useArmyCollection` exports `messageForError`. `bundleBoundaries.test.ts` asserted Home's collection import as an exact string — loosened to a pattern with the same intent (main must not import the collection module, Home must).

## Testing

- `tsc --noEmit`, `eslint src --max-warnings 0`: clean
- Full vitest suite: 3316 passed; `pwaBuild.test.ts` (18) passes after `yarn build`
- New `toolbarSaveControls.test.tsx` covers the linked/unlinked toolbar states and status labels; `accountCapabilitiesUi` covers the new dialog (save, link, stays open on failure) and the modal's link/delete callbacks; `homePresentation` covers the Save Army button and its /subscribe gating

Manual check: on 5173 as a dev subscriber — save an unlinked army (button splits into Update Army / Save As), edit and Update (button feedback), Save As (new cloud army in My Armies), then Clear Army (single Save Army button returns).