### PR TITLE
fix(api): stop rejecting cloud armies whose selections no longer resolve

### DIFF
--- a/src/api/armyApi.ts
+++ b/src/api/armyApi.ts
@@ -1,5 +1,4 @@
 import { AOS4_CATALOG } from '../aos4/generated'
-import { resolveSelection } from '../aos4/select'
 import { deserializeAos4ArmyDocument, type Aos4ArmyDocument } from '../aos4/state'
 
 export interface RemoteArmy {
@@ -33,19 +32,17 @@ type Fetcher = typeof fetch
 
 const configuredEndpoint = (import.meta.env.VITE_ARMY_API_URL || '').replace(/\/+$/, '')
 
+/*
+ * Structural validation only. A stored army can hold a selection that no longer resolves in its
+ * rules context — a catalog update superseding an enhancement table does this to every army that
+ * picked from the replaced table — and the builder already tolerates such picks by ignoring them.
+ * Rejecting them here instead bricked saving and, worse, one stale army poisoned the whole cloud
+ * list. So a well-formed document always parses; selection resolution is the builder's concern.
+ */
 const parseDocument = (value: unknown): Aos4ArmyDocument => {
   const restored = deserializeAos4ArmyDocument(JSON.stringify(value), AOS4_CATALOG)
   if (!restored.document || restored.diagnostics.some(diagnostic => diagnostic.severity === 'error')) {
     throw new ArmyApiError('The service returned an incompatible army document.', 502)
-  }
-  const selection = resolveSelection(AOS4_CATALOG, {
-    explicitIds: restored.document.explicitSelectionIds,
-    rulesContextId: restored.document.rulesContextId,
-    ...(restored.document.allowsLegends ? { allowsLegends: true } : {}),
-    ...(restored.document.allowsHistorical ? { allowsHistorical: true } : {}),
-  })
-  if (selection.diagnostics.some(diagnostic => diagnostic.severity === 'error')) {
-    throw new ArmyApiError('The service returned an invalid army selection.', 502)
   }
   return restored.document
 }

--- a/src/tests/aos4/armyApi.test.ts
+++ b/src/tests/aos4/armyApi.test.ts
@@ -119,17 +119,53 @@ describe('AoS 4 army API client', () => {
     const fetcher = vi.fn().mockResolvedValue(jsonResponse([remoteArmy]))
     const armies = await createArmyApi('https://army.example', fetcher).listArmies('token')
     expect(armies).toEqual([remoteArmy])
+  })
 
-    const strippedFetcher = vi.fn().mockResolvedValue(
-      jsonResponse([
-        {
-          ...remoteArmy,
-          document: { ...legendsDocument, allowsLegends: undefined },
-        },
-      ])
-    )
-    await expect(
-      createArmyApi('https://army.example', strippedFetcher).listArmies('token')
-    ).rejects.toMatchObject({ status: 502 })
+  /*
+   * A selection that deserializes but no longer resolves in its rules context is a legitimately
+   * stale army, not service corruption: a catalog update that supersedes an enhancement table does
+   * this to every army that picked from the replaced table (the GHB 2026-27 replacement did, for
+   * eighteen factions), and the builder tolerates the pick by ignoring it. Rejecting it here
+   * bricked saving that army and poisoned the whole cloud list — one stale army made My Armies
+   * unusable. The Legends-only warscroll without its overlay flag reproduces the same state.
+   */
+  it('parses an army whose selection no longer resolves in its context instead of failing the list', async () => {
+    const legendsSelection = (() => {
+      for (const faction of AOS4_CATALOG.entities.filter(entity => entity.id.startsWith('faction:'))) {
+        const strict = resolveSelection(AOS4_CATALOG, {
+          explicitIds: [faction.id],
+          rulesContextId: document.rulesContextId,
+        })
+        const relaxed = resolveSelection(AOS4_CATALOG, {
+          explicitIds: [faction.id],
+          rulesContextId: document.rulesContextId,
+          allowsLegends: true,
+        })
+        const strictAvailable = new Set(strict.availableIds)
+        const legendsOnly = relaxed.availableIds.find(
+          id => id.startsWith('warscroll:') && !strictAvailable.has(id)
+        )
+        if (legendsOnly) return { factionId: faction.id, warscrollId: legendsOnly }
+      }
+      throw new Error('The catalog has no Legends-only warscroll to exercise')
+    })()
+
+    const staleDocument = {
+      ...document,
+      explicitSelectionIds: [legendsSelection.factionId, legendsSelection.warscrollId],
+    }
+    const remoteArmy = { id: 'cloud-stale', createdAt: 1, updatedAt: 2, document: staleDocument }
+
+    const listFetcher = vi.fn().mockResolvedValue(jsonResponse([remoteArmy]))
+    const armies = await createArmyApi('https://army.example', listFetcher).listArmies('token')
+    expect(armies).toEqual([remoteArmy])
+
+    const saveFetcher = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ id: 'cloud-stale', createdAt: 1, updatedAt: 1, document: staleDocument }, 201)
+      )
+    const saved = await createArmyApi('https://army.example', saveFetcher).createArmy(staleDocument, 'token')
+    expect(saved.document).toEqual(staleDocument)
   })
 })


### PR DESCRIPTION
## Summary

Saving or listing cloud armies fails with "The service returned an invalid army selection." for any army holding a selection that no longer resolves in its rules context. #1953's GHB 2026-27 enhancement-table replacement put every army that had picked from a replaced battletome table into exactly that state, so this is live on production for those armies: saving fails, and one such army in the cloud list bricks the entire My Armies modal.

## Root cause

`armyApi.parseDocument` re-ran `resolveSelection` on every document the service returned and threw on any error-severity diagnostic. `inapplicable-explicit-selection` is an error diagnostic, but it describes a legitimately stale army, not service corruption - and the builder already tolerates such picks by ignoring them.

## The fix

The API client now validates structure only (schema, required fields, known entity ids). A well-formed document always parses; selection resolution stays the builder's concern, same as the local-storage load path.

## Deliberate contract change - flagged for your call

The Legends round-trip test previously asserted the strict behavior: a service response missing the `allowsLegends` flag was rejected with a 502. That strictness is what bricked the list, and "service stripped a field" is indistinguishable from "army went stale under a newer catalog" from the document alone. With this change a stripped flag degrades to an ignored pick (army loads, that unit's reminders absent) instead of a hard failure. The new test pins the tolerant contract using the same Legends-only fixture.

## Possible follow-up (not in this PR)

Armies holding a superseded battletome enhancement pick could be migrated to the seasonal replacement on load - the importer already carries that mapping since #1953 - so players keep the trait instead of silently losing its reminders.

## Verification

`yarn tsc --noEmit`, eslint and Prettier on the changed files, and `yarn vitest run` for armyApi, armyCollection, and sharedArmyUi (9 tests, 3 files) all pass. Reproduced the failure shape in-test: a catalog-known but context-inapplicable selection now round-trips through list and save instead of throwing.
