### PR TITLE
fix(ui): chip-sized toolbar buttons on wrap; Show Hidden only when needed

### DIFF
--- a/src/components/input/toolbar/toolbar.tsx
+++ b/src/components/input/toolbar/toolbar.tsx
@@ -27,7 +27,13 @@ interface ToolbarProps {
   updateArmyStatus: 'idle' | 'updating' | 'updated'
 }
 
-const buttonWrapperClass = 'col-6 col-sm-4 col-lg px-2 pb-2'
+/*
+ * `col-lg-auto`, not `col-lg`: equal-split columns made any button that wrapped onto its own line
+ * grow to the full container width. Content-sized cells keep a wrapped button chip-sized and
+ * centred; the `.ToolbarButtonCell` floor in index.scss keeps the chips visually even across
+ * labels as short as "Save As".
+ */
+const buttonWrapperClass = 'col-6 col-sm-4 col-lg-auto px-2 pb-2 ToolbarButtonCell'
 
 const ToolbarButton = ({
   children,
@@ -131,12 +137,15 @@ const Toolbar = ({
           Share Army
         </ToolbarButton>
       </div>
-      <div className={buttonWrapperClass}>
-        <ToolbarButton disabled={!hiddenCount} onClick={onShowAll}>
-          <MdVisibility className="me-2" />
-          Show Hidden{hiddenCount ? ` (${hiddenCount})` : ''}
-        </ToolbarButton>
-      </div>
+      {/* Absent, not disabled, until a reminder is hidden: a control with nothing to act on is noise. */}
+      {hiddenCount > 0 && (
+        <div className={buttonWrapperClass}>
+          <ToolbarButton onClick={onShowAll}>
+            <MdVisibility className="me-2" />
+            Show Hidden ({hiddenCount})
+          </ToolbarButton>
+        </div>
+      )}
     </div>
   </div>
 )

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -99,6 +99,18 @@ small {
   min-height: 44px;
 }
 
+/*
+ * At the large breakpoint the toolbar cells are content-sized (`col-lg-auto`) so a button that
+ * wraps onto its own line stays chip-sized instead of growing to the full container width, which
+ * is what equal-split `col-lg` columns did once the row gained its seventh and eighth buttons.
+ * The floor keeps the chips visually even, since labels range from "Save As" to "Download PDF".
+ */
+@media (min-width: 992px) {
+  .ToolbarButtonCell {
+    min-width: 9rem;
+  }
+}
+
 .TapTarget {
   display: inline-flex;
   align-items: center;

--- a/src/tests/aos4/toolbarSaveControls.test.tsx
+++ b/src/tests/aos4/toolbarSaveControls.test.tsx
@@ -10,9 +10,7 @@ vi.mock('context/useTheme', () => ({
 }))
 
 const findButton = (container: HTMLElement, label: string): HTMLButtonElement | undefined =>
-  Array.from(container.querySelectorAll('button')).find(
-    candidate => candidate.textContent?.trim() === label
-  )
+  Array.from(container.querySelectorAll('button')).find(candidate => candidate.textContent?.trim() === label)
 
 describe('toolbar save controls', () => {
   let container: HTMLDivElement
@@ -83,5 +81,25 @@ describe('toolbar save controls', () => {
       render(<Toolbar {...baseProps} cloudArmyLinked updateArmyStatus="updated" />, container)
     })
     expect(findButton(container, 'Updated')?.disabled).toBe(false)
+  })
+  it('offers Show Hidden only once a reminder is hidden, absent rather than disabled at zero', () => {
+    act(() => {
+      render(<Toolbar {...baseProps} />, container)
+    })
+    expect(
+      Array.from(container.querySelectorAll('button')).find(button =>
+        button.textContent?.includes('Show Hidden')
+      )
+    ).toBeUndefined()
+
+    act(() => {
+      render(<Toolbar {...baseProps} hiddenCount={3} />, container)
+    })
+    const showHidden = findButton(container, 'Show Hidden (3)')
+    expect(showHidden).not.toBeUndefined()
+    expect(showHidden!.disabled).toBe(false)
+
+    act(() => showHidden!.click())
+    expect(baseProps.onShowAll).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary

Two toolbar polish fixes from testing the new Save Army row:

- **No more full-width orphan buttons.** The row's equal-split `col-lg` columns made any button that wrapped onto its own line grow to the entire container width - routine now that the row can hold eight buttons. Cells are content-sized at lg+ (`col-lg-auto`) with a 9rem floor so the chips stay visually even, and a wrapped button stays chip-sized and centred.
- **Show Hidden appears only when something is hidden.** It used to render as a disabled placeholder at zero; it now renders only once a reminder is hidden, always carrying its count: "Show Hidden (3)".

## Verification

`yarn tsc --noEmit`, eslint and Prettier on the changed files, and the toolbar and Home presentation suites (13 tests) pass, including a new test pinning absent-at-zero, present-with-count, and the click wiring.
