### PR TITLE
fix: stored armies and reminder preferences survive rules updates

### DIFF
--- a/src/aos4/reminders/reminderIdentity.ts
+++ b/src/aos4/reminders/reminderIdentity.ts
@@ -30,3 +30,12 @@ export const reminderOccurrenceId = (
   abilityId: CanonicalId<'ability'>,
   timing: AbilityTiming
 ): ReminderOccurrenceId => `reminder:${abilityId}@${semanticTimingKey(timing)}` as ReminderOccurrenceId
+
+/**
+ * The canonical ability ID an occurrence ID embeds, or undefined for a foreign shape. Ability IDs
+ * carry no `@`, so the first `@` always separates identity from the semantic timing key.
+ */
+export const reminderOccurrenceAbilityId = (occurrenceId: string): CanonicalId<'ability'> | undefined => {
+  const match = /^reminder:(ability:[^@]+)@./.exec(occurrenceId)
+  return match ? (match[1] as CanonicalId<'ability'>) : undefined
+}

--- a/src/aos4/state/armyDocument.ts
+++ b/src/aos4/state/armyDocument.ts
@@ -182,12 +182,18 @@ export const deserializeAos4ArmyDocument = (
     })
   }
 
+  /*
+   * A selection the catalog no longer carries is a rules update's doing, not the user's: a
+   * battletome rewrite can retire a warscroll the army legitimately held. Filtering the dead ID
+   * with a warning keeps the rest of the army alive; failing the whole document here used to reset
+   * a stored army to the default the moment one of its units left the catalog.
+   */
   const entityIds = new Set(catalog.entities.map(entity => entity.id))
   const explicitSelectionIds = (value.explicitSelectionIds as string[]).filter(id => {
     if (entityIds.has(id as CanonicalId)) return true
     diagnostics.push({
       code: 'missing-selection',
-      severity: 'error',
+      severity: 'warning',
       message: `Army document refers to missing selection ${id}`,
       subject: id,
     })

--- a/src/aos4/view/reminders.ts
+++ b/src/aos4/view/reminders.ts
@@ -14,11 +14,12 @@ import {
 import {
   gameWindowKey,
   projectReminders,
+  reminderOccurrenceAbilityId,
   type ProjectedReminder,
   type ReminderOccurrenceId,
 } from '../reminders'
 import { resolveSelection } from '../select'
-import type { Aos4ArmyDocument } from '../state'
+import { createAos4ArmyDocument, type Aos4ArmyDocument } from '../state'
 
 const phaseNames = new Map(TURN_PHASES.map(phase => [phase.id, phase.name]))
 
@@ -478,3 +479,52 @@ export const createPrintableAos4Reminders = (
   document: Aos4ArmyDocument
 ): Aos4ReminderViewModel[] =>
   createAos4ReminderViewModel(catalog, document).filter(reminder => !reminder.hidden)
+
+/** One projected reminder occurrence, as the preference migration needs to see it. */
+export interface Aos4ReminderOccurrence {
+  id: ReminderOccurrenceId
+  abilityIds: readonly CanonicalId<'ability'>[]
+}
+
+/**
+ * Re-keys hidden/note/order preferences a timing change stranded: the occurrence ID embeds the
+ * semantic timing, so when a rules update moves an ability's timing the stored preference points at
+ * an occurrence that no longer projects.
+ *
+ * The rule: a stale preference migrates only when its ability currently projects EXACTLY ONE
+ * occurrence and that occurrence carries no preference of its own. An ability projecting several
+ * timings is ambiguous — there is no way to know which occurrence the user meant — so the stale
+ * preference is kept untouched rather than guessed at (it keys nothing and is harmless, and it
+ * comes back to life if the occurrence returns). Returns the same document instance when nothing
+ * migrates, so callers can apply it through setState-style updates without looping.
+ */
+export const migrateAos4ReminderPreferences = (
+  document: Aos4ArmyDocument,
+  occurrences: readonly Aos4ReminderOccurrence[]
+): Aos4ArmyDocument => {
+  const entries = Object.entries(document.reminderPreferences)
+  if (!entries.length) return document
+  const currentIds = new Set<string>(occurrences.map(occurrence => occurrence.id))
+  const occurrencesByAbilityId = new Map<string, Aos4ReminderOccurrence[]>()
+  occurrences.forEach(occurrence =>
+    occurrence.abilityIds.forEach(abilityId => {
+      occurrencesByAbilityId.set(abilityId, [...(occurrencesByAbilityId.get(abilityId) ?? []), occurrence])
+    })
+  )
+  let migrated = false
+  const preferences = { ...document.reminderPreferences }
+  entries.forEach(([occurrenceId, preference]) => {
+    if (!preference || currentIds.has(occurrenceId)) return
+    const abilityId = reminderOccurrenceAbilityId(occurrenceId)
+    if (!abilityId) return
+    const candidates = occurrencesByAbilityId.get(abilityId) ?? []
+    if (candidates.length !== 1) return
+    const target = candidates[0]
+    if (preferences[target.id]) return
+    delete preferences[occurrenceId as ReminderOccurrenceId]
+    preferences[target.id] = preference
+    migrated = true
+  })
+  if (!migrated) return document
+  return createAos4ArmyDocument({ ...document, reminderPreferences: preferences })
+}

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -15,6 +15,7 @@ import {
   createAos4BuilderViewModel,
   createAos4ReminderSourceLinkResolver,
   createAos4ReminderViewModel,
+  migrateAos4ReminderPreferences,
   type Aos4ReminderViewModel,
 } from '../../aos4/view'
 import AppBanner from 'components/info/banners/app_banner'
@@ -200,6 +201,20 @@ const HomeContent = () => {
       // Browser storage can be unavailable in privacy modes. The in-memory document remains usable.
     }
   }, [document])
+
+  /*
+   * A rules update that moves an ability's timing moves its reminder occurrence ID, stranding any
+   * hidden/note/order preference keyed on the old one. The migration is idempotent and returns the
+   * same document instance when nothing is stranded, so riding setDocument here persists a remap
+   * through the save effect above without ever looping.
+   */
+  useEffect(() => {
+    const occurrences = reminders.map(reminder => ({
+      id: reminder.id,
+      abilityIds: reminder.projected.abilityIds,
+    }))
+    setDocument(current => migrateAos4ReminderPreferences(current, occurrences))
+  }, [reminders])
 
   const setSelections = (groupIds: CanonicalId[], selectedIds: CanonicalId[]) => {
     setDocument(current => {
@@ -427,9 +442,7 @@ const HomeContent = () => {
             currentDocument={document}
             isOpen={savedArmiesModalIsOpen}
             onApply={setDocument}
-            onDeleted={deletedId =>
-              setCloudArmyId(current => (current === deletedId ? undefined : current))
-            }
+            onDeleted={deletedId => setCloudArmyId(current => (current === deletedId ? undefined : current))}
             onLinked={setCloudArmyId}
           />
         </Suspense>

--- a/src/tests/aos4/armySurvival.test.ts
+++ b/src/tests/aos4/armySurvival.test.ts
@@ -1,0 +1,110 @@
+import {
+  REPRESENTATIVE_CATALOG as AOS4_CATALOG,
+  REPRESENTATIVE_CONTEXT_ID,
+  REPRESENTATIVE_EXPLICIT_SELECTION_IDS as AOS4_DEFAULT_SELECTION_IDS,
+} from '../../aos4/generated'
+import { AOS4_ARMY_STORAGE_KEY, loadAos4ArmyDocument } from '../../aos4/runtime'
+import {
+  createAos4ArmyDocument,
+  deserializeAos4ArmyDocument,
+  serializeAos4ArmyDocument,
+} from '../../aos4/state'
+import { describe, expect, it } from 'vitest'
+
+const DEAD_SELECTION_ID = 'warscroll:ffffffff-ffff-4fff-8fff-ffffffffffff'
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>()
+
+  get length() {
+    return this.values.size
+  }
+
+  clear() {
+    this.values.clear()
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key)
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+}
+
+const createDocument = () =>
+  createAos4ArmyDocument({
+    id: 'army:survival',
+    name: 'Enduring Stormcast Eternals',
+    rulesContextId: REPRESENTATIVE_CONTEXT_ID,
+    explicitSelectionIds: AOS4_DEFAULT_SELECTION_IDS,
+    reminderPreferences: {},
+  })
+
+/*
+ * A rules update that retires an entity the army holds must cost the army that one selection, not
+ * the whole document. These pin the survival contract at both layers: the deserializer filters the
+ * dead ID with a warning, and the browser-storage load keeps `source: 'storage'` instead of
+ * resetting to the default army.
+ */
+describe('stored army survival across catalog updates', () => {
+  it('survives a selection the catalog no longer carries, filtering it with a warning', () => {
+    const value = JSON.parse(serializeAos4ArmyDocument(createDocument()))
+    value.explicitSelectionIds.push(DEAD_SELECTION_ID)
+
+    const restored = deserializeAos4ArmyDocument(JSON.stringify(value), AOS4_CATALOG)
+
+    expect(restored.document?.explicitSelectionIds).toEqual(createDocument().explicitSelectionIds)
+    expect(restored.diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'missing-selection',
+        severity: 'warning',
+        subject: DEAD_SELECTION_ID,
+      }),
+    ])
+  })
+
+  it('no longer resets stored armies whose selection an update removed', () => {
+    const storage = new MemoryStorage()
+    const value = JSON.parse(serializeAos4ArmyDocument(createDocument()))
+    value.explicitSelectionIds.push(DEAD_SELECTION_ID)
+    storage.setItem(AOS4_ARMY_STORAGE_KEY, `${JSON.stringify(value, null, 2)}\n`)
+
+    const result = loadAos4ArmyDocument(storage, AOS4_CATALOG)
+
+    expect(result.source).toBe('storage')
+    expect(result.document.explicitSelectionIds).toEqual(createDocument().explicitSelectionIds)
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'missing-selection',
+        severity: 'warning',
+        subject: DEAD_SELECTION_ID,
+      }),
+    ])
+  })
+
+  it('keeps reminder preferences intact when a dead selection is filtered', () => {
+    const preferenced = createAos4ArmyDocument({
+      ...createDocument(),
+      reminderPreferences: {
+        ['reminder:ability:00000000-0000-4000-8000-000000000001@turn-phase:hero|activated|neutral|normal|unlimited' as never]:
+          { hidden: true, note: 'Keep this.' },
+      },
+    })
+    const value = JSON.parse(serializeAos4ArmyDocument(preferenced))
+    value.explicitSelectionIds.push(DEAD_SELECTION_ID)
+
+    const restored = deserializeAos4ArmyDocument(JSON.stringify(value), AOS4_CATALOG)
+
+    expect(restored.document?.reminderPreferences).toEqual(preferenced.reminderPreferences)
+  })
+})

--- a/src/tests/aos4/reminderPreferenceMigration.test.ts
+++ b/src/tests/aos4/reminderPreferenceMigration.test.ts
@@ -1,0 +1,134 @@
+import {
+  REPRESENTATIVE_CATALOG,
+  REPRESENTATIVE_CONTEXT_ID,
+  REPRESENTATIVE_EXPLICIT_SELECTION_IDS,
+  REPRESENTATIVE_IDS,
+} from '../../aos4/generated'
+import { reminderOccurrenceId } from '../../aos4/reminders'
+import {
+  createAos4ArmyDocument,
+  deserializeAos4ArmyDocument,
+  serializeAos4ArmyDocument,
+  type Aos4ArmyDocument,
+} from '../../aos4/state'
+import {
+  createAos4ReminderViewModel,
+  migrateAos4ReminderPreferences,
+  type Aos4ReminderOccurrence,
+} from '../../aos4/view'
+import { describe, expect, it } from 'vitest'
+
+const IDS = REPRESENTATIVE_IDS
+
+const makeDocument = (reminderPreferences: Aos4ArmyDocument['reminderPreferences'] = {}): Aos4ArmyDocument =>
+  createAos4ArmyDocument({
+    id: 'army:preference-migration',
+    name: 'Migrating Stormcast',
+    rulesContextId: REPRESENTATIVE_CONTEXT_ID,
+    explicitSelectionIds: [...REPRESENTATIVE_EXPLICIT_SELECTION_IDS],
+    reminderPreferences,
+  })
+
+const occurrencesOf = (reminders: ReturnType<typeof createAos4ReminderViewModel>): Aos4ReminderOccurrence[] =>
+  reminders.map(reminder => ({ id: reminder.id, abilityIds: reminder.projected.abilityIds }))
+
+/*
+ * A rules update that moves an ability's timing moves its reminder occurrence ID, which used to
+ * strand any hidden/note/order preference keyed on the old one. The migration re-keys a stranded
+ * preference only when the answer is unambiguous.
+ */
+describe('reminder preference migration across timing changes', () => {
+  const baseReminders = () => createAos4ReminderViewModel(REPRESENTATIVE_CATALOG, makeDocument())
+
+  const stalwart = () => {
+    const reminder = baseReminders().find(candidate => candidate.name === 'Stalwart Defenders')
+    expect(reminder).toBeDefined()
+    return reminder!
+  }
+
+  it('migrates hidden and note preferences when the sole occurrence of an ability moved', () => {
+    const current = stalwart()
+    const abilityId = IDS.abilities.stalwartDefenders
+    const oldId = reminderOccurrenceId(abilityId, {
+      ...current.projected.timing,
+      window: { kind: 'battle-end' },
+    })
+    expect(oldId).not.toBe(current.id)
+
+    const document = makeDocument({ [oldId]: { hidden: true, note: 'Front line only.', order: 2 } })
+    const migrated = migrateAos4ReminderPreferences(document, occurrencesOf(baseReminders()))
+
+    expect(migrated.reminderPreferences[oldId]).toBeUndefined()
+    expect(migrated.reminderPreferences[current.id]).toEqual({
+      hidden: true,
+      note: 'Front line only.',
+      order: 2,
+    })
+
+    // The migration persists: it survives the serializer round-trip Home's save path performs.
+    const restored = deserializeAos4ArmyDocument(serializeAos4ArmyDocument(migrated), REPRESENTATIVE_CATALOG)
+    expect(restored.diagnostics).toEqual([])
+    expect(restored.document?.reminderPreferences[current.id]).toEqual({
+      hidden: true,
+      note: 'Front line only.',
+      order: 2,
+    })
+
+    // The relocated reminder renders with its migrated preferences.
+    const view = createAos4ReminderViewModel(REPRESENTATIVE_CATALOG, migrated)
+    expect(view.find(reminder => reminder.id === current.id)).toMatchObject({
+      hidden: true,
+      note: 'Front line only.',
+    })
+  })
+
+  it('never conflates a multi-timing ability: an ambiguous preference is kept, not migrated', () => {
+    const current = stalwart()
+    const abilityId = IDS.abilities.stalwartDefenders
+    const secondTimingId = reminderOccurrenceId(abilityId, {
+      ...current.projected.timing,
+      window: { kind: 'battle-start' },
+    })
+    const staleId = reminderOccurrenceId(abilityId, {
+      ...current.projected.timing,
+      window: { kind: 'battle-end' },
+    })
+    const occurrences: Aos4ReminderOccurrence[] = [
+      { id: current.id, abilityIds: [abilityId] },
+      { id: secondTimingId, abilityIds: [abilityId] },
+    ]
+
+    const document = makeDocument({ [staleId]: { hidden: true } })
+    const migrated = migrateAos4ReminderPreferences(document, occurrences)
+
+    expect(migrated).toBe(document)
+    expect(migrated.reminderPreferences[staleId]).toEqual({ hidden: true })
+    expect(migrated.reminderPreferences[current.id]).toBeUndefined()
+    expect(migrated.reminderPreferences[secondTimingId]).toBeUndefined()
+  })
+
+  it('keeps a stale preference when the target occurrence already carries its own', () => {
+    const current = stalwart()
+    const abilityId = IDS.abilities.stalwartDefenders
+    const staleId = reminderOccurrenceId(abilityId, {
+      ...current.projected.timing,
+      window: { kind: 'battle-end' },
+    })
+
+    const document = makeDocument({
+      [staleId]: { note: 'Older note.' },
+      [current.id]: { note: 'Current note.' },
+    })
+    const migrated = migrateAos4ReminderPreferences(document, occurrencesOf(baseReminders()))
+
+    expect(migrated).toBe(document)
+    expect(migrated.reminderPreferences[current.id]).toEqual({ note: 'Current note.' })
+    expect(migrated.reminderPreferences[staleId]).toEqual({ note: 'Older note.' })
+  })
+
+  it('returns the same document when every preference still keys a live occurrence', () => {
+    const current = stalwart()
+    const document = makeDocument({ [current.id]: { hidden: true } })
+    expect(migrateAos4ReminderPreferences(document, occurrencesOf(baseReminders()))).toBe(document)
+  })
+})

--- a/src/tests/aos4/representativeSlice.test.ts
+++ b/src/tests/aos4/representativeSlice.test.ts
@@ -259,7 +259,7 @@ describe('AoS 4 representative vertical slice', () => {
     }
   })
 
-  it('rejects incompatible or dangling army documents without calling a remote API', () => {
+  it('rejects incompatible schemas and survives dangling selections without calling a remote API', () => {
     expect(deserializeAos4ArmyDocument(JSON.stringify({ schemaVersion: 0 }), AOS4_CATALOG)).toEqual({
       diagnostics: [
         expect.objectContaining({
@@ -269,12 +269,19 @@ describe('AoS 4 representative vertical slice', () => {
       ],
     })
 
+    // A catalog update that removed a selected entity must not cost the user their army: the dead
+    // selection is filtered with a warning and the document survives (the storage-level round trip
+    // lives in armySurvival.test.ts).
     const document = JSON.parse(serializeAos4ArmyDocument(createDocument()))
     document.explicitSelectionIds.push('warscroll:ffffffff-ffff-4fff-8fff-ffffffffffff')
     const result = deserializeAos4ArmyDocument(JSON.stringify(document), AOS4_CATALOG)
-    expect(result.document).toBeUndefined()
+    expect(result.document?.explicitSelectionIds).toEqual(createDocument().explicitSelectionIds)
     expect(result.diagnostics).toContainEqual(
-      expect.objectContaining({ code: 'missing-selection', severity: 'error' })
+      expect.objectContaining({
+        code: 'missing-selection',
+        severity: 'warning',
+        subject: 'warscroll:ffffffff-ffff-4fff-8fff-ffffffffffff',
+      })
     )
   })
 })


### PR DESCRIPTION
## Summary

Extracts the two standalone player-facing robustness improvements from the army-changelog branch so they land regardless of whether that feature ships. Both address the same failure: a GW rules update changing the catalog used to quietly destroy user data.

- **Stored armies survive a removed selection.** A selection the catalog no longer carries was a fatal deserialize error, so the moment a battletome rewrite retired one warscroll an army held, loading reset the whole stored army to the default document. The dead ID is now filtered with a `missing-selection` warning and everything else survives - remaining selections, name, and reminder preferences.
- **Reminder preferences follow a timing move.** Occurrence IDs embed the semantic timing, so an update that moves an ability to a different phase stranded any hidden/note/order preference keyed on the old occurrence. A load-time migration re-keys a stranded preference when its ability projects exactly one occurrence and that occurrence carries no preference of its own; ambiguous cases (an ability projecting several timings) are deliberately kept untouched rather than guessed at. The migration is idempotent and persists through the normal save path.

## Relation to the changelog branch

Ported from `feat/army-changelog` with the changelog-specific parts removed (removal-record bookkeeping, changed markers). If that branch is carried forward it will pick these up on its next master merge; if it is abandoned, these keep their value on their own.

## Verification

`yarn tsc --noEmit`, eslint and Prettier on the changed files; armySurvival, reminderPreferenceMigration, representativeSlice, and homePresentation suites all pass (26 tests), including new tests pinning: dead-selection filtering at both the deserializer and browser-storage layers, preferences surviving the filter, the unambiguous migration with its serializer round-trip, the multi-timing ambiguity guard, and same-instance no-op behavior.
