### PR TITLE
fix(theme): keep dark share links readable on focus

### DIFF
--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -315,6 +315,16 @@ small,
 }
 
 /*
+ * Bootstrap's `.form-control:focus` is more specific than a background utility and repaints an
+ * explicitly dark-themed input with the light body background. The text utility remains white, so
+ * the focused value disappears. Keep the override coupled to the explicit dark background class;
+ * light-theme controls retain Bootstrap's normal focus treatment.
+ */
+.form-control.bg-themeDarkBlueSecondary:focus {
+  background-color: $themeDarkBlueSecondary;
+}
+
+/*
  * 5.x added `appearance: none` to .form-control (to normalise date inputs in Safari). 4.6 did not,
  * and the import preview's ruleset picker is a <select class="form-control"> — under 5.x it loses
  * its native dropdown arrow and stops looking like a control at all. Bootstrap 5's answer is

--- a/src/tests/aos4/themeStyles.test.ts
+++ b/src/tests/aos4/themeStyles.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { join } from 'node:path'
+import { compile } from 'sass'
+import { describe, expect, it } from 'vitest'
+
+const css = compile(join(process.cwd(), 'src/css/index.scss'), {
+  loadPaths: [join(process.cwd(), 'node_modules')],
+  logger: {
+    debug: () => undefined,
+    warn: () => undefined,
+  },
+}).css
+
+describe('theme stylesheet', () => {
+  it('keeps explicitly dark form controls dark while focused', () => {
+    const style = document.createElement('style')
+    style.textContent = css
+    document.head.appendChild(style)
+
+    const expectFocusBackground = (className: string, expected?: string) => {
+      const input = document.createElement('input')
+      input.className = className
+      document.body.appendChild(input)
+
+      const background = getComputedStyle(input).backgroundColor
+      if (expected) expect(background).toBe(expected)
+      input.focus()
+      expect(getComputedStyle(input).backgroundColor).toBe(background)
+      input.remove()
+    }
+
+    expectFocusBackground('form-control bg-themeDarkBlueSecondary text-white', 'rgb(24, 38, 51)')
+    expectFocusBackground('form-control bg-white text-dark')
+    style.remove()
+  })
+})


### PR DESCRIPTION
---

### What kind of change does this PR introduce?

Bug fix. In dark mode, readonly share links now keep their Midnight Slate background while focused, so the white URL remains readable. Light-theme focus behavior is unchanged.

The regression test applies the compiled stylesheet to focused DOM controls and checks both theme paths. No generated artifacts changed. No production configuration or companion-service work is required.

### How can this change be tested?

- `yarn lint`
- `yarn tsc --noEmit`
- `yarn build`
- `yarn test --run` (98 files, 3,330 tests)
- `yarn data:aos4:verify:beta` (81,956 pass, 0 findings)
- Chrome computed-style check: the dark input remains `rgb(24, 38, 51)` before and after focus; the light input remains white.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
