### PR TITLE
feat(cloud-armies): rebuild Save, Update, and My Armies around a durable cloud link

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -277,6 +277,22 @@ Muted text is expressed as opacity rather than a separate token: `text-white-75`
 (`theme.cardBody`, `theme.text`, `theme.reminderHeader`), and light and dark supply their own
 values. A literal hex in a component is a defect — it will be wrong in one of the two themes.
 
+**The Alert Surface Rule.** A Bootstrap `alert-*` keeps its light palette in *both* themes. Nothing
+in this product sets `data-bs-theme`, so the alert backgrounds never invert — `alert-info` is
+`#d1ecf1` on a Midnight Slate page exactly as it is on a white one.
+
+An alert is therefore the one surface where the Slot Rule runs backwards. A slot exists so light and
+dark can supply their own value; on an alert, the dark value is resolved against a light ground and
+the contrast inverts. `theme.genericButton` and `theme.modalConfirmClass` are both
+`btn-outline-light` in dark theme, and on `alert-info` they measured **1.17:1** — the Load
+confirmation in `My Armies` was invisible to every dark-theme subscriber until #1963.
+
+So an alert may only carry colours that do not vary by theme: its own text, and a control whose
+class is the same string in both themes (`theme.secondaryButton`, or a literal Bootstrap signal
+class like `btn-danger`). Never a slot that differs between `light.ts` and `dark.ts` — check the two
+files before putting any slot on an alert, and prefer moving the control onto the surrounding themed
+surface instead.
+
 **The Meaning-Only Colour Rule.** Colour marks structure (Signal Teal = section header) or
 authorship (Note Blue = the player's own words). It never decorates, and it never carries
 information alone: the reminder tags pair every tone with a distinct text label, because the tone
@@ -522,6 +538,15 @@ standing guidance. They render inline in the modal or panel that owns the action
 sits where the failure happened. They carry `role="alert"` where the content is not present at
 first render.
 
+An alert may carry a control that recovers from what it reports — the retry on `/profile` and
+`/subscribe`, the dismiss on the notification banner — and its class must be theme-invariant, per
+The Alert Surface Rule.
+
+It never carries a *decision*. A confirmation goes on the themed surface of whatever it is
+confirming, adjacent to the control that raised it, for two reasons: the alert's live-region role
+announces its text without moving focus to anything inside it, and an alert placed after the list it
+refers to can be arbitrarily far from the row that raised it. `My Armies` did both until #1963.
+
 ### Inputs / Fields
 
 - **Text inputs:** Bootstrap `form-control` (12 uses), `form-control-sm` in dense modal rows. Always
@@ -637,6 +662,9 @@ to switch itself on during an upgrade.
   visible keyboard-focus indicator.
 - **Don't** hardcode a hex in a component, or reach for `$themeRed`, `$themeYellow`, or
   `$themeDarkBlueTertiary` — they are declared but unused and are not part of the system.
+- **Don't** put a theme-varying slot inside a Bootstrap `alert-*`, or a decision of any kind. Alert
+  palettes stay light in both themes, so `btn-outline-light` vanishes on one — this shipped at
+  1.17:1. See The Alert Surface Rule.
 - **Don't** change heading level to change text size. Set the size in `.CardHeaderTitle`.
 - **Don't** use uppercase outside the timing tags.
 - **Don't** use a filled button for a reversible action. Filled (`btn-primary`) is reserved for the

--- a/src/components/input/armySharing/shareArmyModal.tsx
+++ b/src/components/input/armySharing/shareArmyModal.tsx
@@ -2,7 +2,8 @@ import type { Aos4ArmyDocument } from '../../../aos4/state'
 import GenericModal from 'components/modals/generic/generic_modal'
 import { useArmyCollection } from 'context/useArmyCollection'
 import { useTheme } from 'context/useTheme'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { MdCheck, MdContentCopy } from 'react-icons/md'
 
 interface ShareArmyModalProps {
   closeModal: () => void
@@ -12,14 +13,24 @@ interface ShareArmyModalProps {
 
 const ShareArmyModal = ({ closeModal, document, isOpen }: ShareArmyModalProps) => {
   const { collectionError, configured, createShare } = useArmyCollection()
-  const { theme } = useTheme()
+  const { isDark, theme } = useTheme()
   const [shareUrl, setShareUrl] = useState<string>()
   const [isCreating, setIsCreating] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [copyError, setCopyError] = useState<string>()
+  const linkRef = useRef<HTMLInputElement>(null)
+
+  // The confirmation is transient, matching the toolbar's Update Army. Same 2.5s, same reason.
+  useEffect(() => {
+    if (!copied) return
+    const timer = window.setTimeout(() => setCopied(false), 2500)
+    return () => window.clearTimeout(timer)
+  }, [copied])
 
   const create = async () => {
     setIsCreating(true)
     setCopied(false)
+    setCopyError(undefined)
     try {
       setShareUrl((await createShare(document)).url)
     } catch {
@@ -29,13 +40,22 @@ const ShareArmyModal = ({ closeModal, document, isOpen }: ShareArmyModalProps) =
     }
   }
 
+  /*
+   * One handler behind three affordances: the field itself, the icon beside it, and the labelled
+   * button. Selecting the text as well as writing it to the clipboard means the copy is still there
+   * to take by hand when the Clipboard API is unavailable — it needs a secure context, and the
+   * player may well be on a venue's http captive portal.
+   */
   const copy = async () => {
     if (!shareUrl) return
+    linkRef.current?.select()
     try {
       await navigator.clipboard.writeText(shareUrl)
       setCopied(true)
+      setCopyError(undefined)
     } catch {
       setCopied(false)
+      setCopyError('Your browser would not let the page copy. The link is selected — copy it yourself.')
     }
   }
 
@@ -49,9 +69,12 @@ const ShareArmyModal = ({ closeModal, document, isOpen }: ShareArmyModalProps) =
               Create a read-only link. Opening it previews a copy before replacing local work.
             </p>
           </div>
-          <button aria-label="Close share army" className={theme.modalDangerClass} onClick={closeModal}>
-            ×
-          </button>
+          <button
+            aria-label="Close Share Army"
+            className={`btn-close TapTargetOverlay flex-shrink-0 ${isDark ? 'btn-close-white' : ''}`}
+            onClick={closeModal}
+            type="button"
+          />
         </div>
 
         {!configured && (
@@ -70,19 +93,51 @@ const ShareArmyModal = ({ closeModal, document, isOpen }: ShareArmyModalProps) =
             <label className="fw-bold" htmlFor="share-army-url">
               Share link
             </label>
-            <input
-              className={`form-control ${theme.bgColor} ${theme.text}`}
-              id="share-army-url"
-              readOnly
-              value={shareUrl}
-            />
-            <button className={`${theme.modalConfirmClass} d-block w-100 mt-3`} onClick={() => void copy()}>
+            <div className="input-group">
+              {/*
+               * The field is the obvious thing to reach for, so it copies too. `readOnly` rather
+               * than `disabled` keeps it selectable and reachable by keyboard.
+               */}
+              <input
+                className={`form-control CopyableLink ${theme.bgColor} ${theme.text}`}
+                id="share-army-url"
+                onClick={() => void copy()}
+                onFocus={event => event.target.select()}
+                readOnly
+                ref={linkRef}
+                title="Click to copy"
+                value={shareUrl}
+              />
+              <button
+                aria-label={copied ? 'Share link copied' : 'Copy share link'}
+                className={`${theme.genericButton} TapTarget`}
+                onClick={() => void copy()}
+                title={copied ? 'Copied' : 'Copy link'}
+                type="button"
+              >
+                {copied ? <MdCheck aria-hidden /> : <MdContentCopy aria-hidden />}
+              </button>
+            </div>
+
+            <button
+              className="btn btn-primary d-block w-100 mt-3 TapTargetBlock"
+              onClick={() => void copy()}
+              type="button"
+            >
               {copied ? 'Copied' : 'Copy link'}
             </button>
+
+            {/*
+             * Announced rather than left to the label swap alone: two of the three triggers change
+             * nothing a screen reader would notice on their own.
+             */}
+            <p className={`small mt-2 mb-0 ${theme.textMuted}`} role="status">
+              {copied ? 'Link copied to your clipboard.' : copyError}
+            </p>
           </>
         ) : (
           <button
-            className={`${theme.modalSuccessClass} d-block w-100`}
+            className="btn btn-primary d-block w-100 TapTargetBlock"
             disabled={!configured}
             onClick={() => void create()}
             type="button"

--- a/src/components/input/cloudArmies/armySummary.ts
+++ b/src/components/input/cloudArmies/armySummary.ts
@@ -1,0 +1,42 @@
+import { AOS4_CATALOG } from '../../../aos4/generated'
+import type { Aos4ArmyDocument } from '../../../aos4/state'
+
+/*
+ * What a saved army looks like in a list.
+ *
+ * The rows used to read "15 selections", which is `explicitSelectionIds.length` — the internal
+ * field name, and a number no player recognises. A player recognises the faction they brought and
+ * roughly how many units are in it, so that is what a row says now. Both are read off the canonical
+ * ID prefix (`faction:`, `warscroll:`) rather than by resolving the selection, because a row is
+ * rendered once per saved army and resolution is the builder's much heavier job.
+ */
+const entityNames = new Map(AOS4_CATALOG.entities.map(entity => [entity.id as string, entity.name]))
+
+export interface CloudArmySummary {
+  /** Absent when the stored faction is no longer in the catalog, or the army never picked one. */
+  factionName?: string
+  unitCount: number
+}
+
+export const summarizeCloudArmy = (document: Aos4ArmyDocument): CloudArmySummary => {
+  const factionSelectionId = document.explicitSelectionIds.find(id => id.startsWith('faction:'))
+  const factionName = factionSelectionId ? entityNames.get(factionSelectionId) : undefined
+
+  return {
+    ...(factionName ? { factionName } : {}),
+    unitCount: document.explicitSelectionIds.filter(id => id.startsWith('warscroll:')).length,
+  }
+}
+
+/*
+ * "Aug 16, 2026, 2:45 PM". The list previously showed a date only, so two armies saved on the same
+ * day — the normal case when a roster is re-imported between rounds — were indistinguishable.
+ */
+export const formatSavedAt = (updatedAt: number): string =>
+  new Date(updatedAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+
+export const describeCloudArmy = (document: Aos4ArmyDocument, updatedAt: number): string => {
+  const { factionName, unitCount } = summarizeCloudArmy(document)
+  const units = `${unitCount} ${unitCount === 1 ? 'unit' : 'units'}`
+  return [factionName, units, `saved ${formatSavedAt(updatedAt)}`].filter(Boolean).join(' · ')
+}

--- a/src/components/input/cloudArmies/saveArmyModal.tsx
+++ b/src/components/input/cloudArmies/saveArmyModal.tsx
@@ -119,12 +119,18 @@ const SaveArmyModal = ({ closeModal, currentDocument, isOpen, onSaved }: SaveArm
            * the thing that pays for a careless duplicate, so the alternative is offered here rather
            * than discovered later in a list of same-named rows.
            */
-          <div className="alert alert-warning mt-3" role="status">
-            <p className="mb-1">
-              You already have a saved army called <strong>{existing.document.name}</strong>, saved{' '}
-              {formatSavedAt(existing.updatedAt)}.
-            </p>
-            <p className="small mb-2">Saving now adds a second army with the same name.</p>
+          <div className="alert alert-warning mt-3">
+            {/*
+             * The live region wraps the message, not the control: an announced region containing a
+             * focusable button is read out without focus ever reaching it.
+             */}
+            <div role="status">
+              <p className="mb-1">
+                You already have a saved army called <strong>{existing.document.name}</strong>, saved{' '}
+                {formatSavedAt(existing.updatedAt)}.
+              </p>
+              <p className="small mb-2">Saving now adds a second army with the same name.</p>
+            </div>
             <button
               className="btn btn-danger btn-sm TapTarget"
               disabled={isSaving}

--- a/src/components/input/cloudArmies/saveArmyModal.tsx
+++ b/src/components/input/cloudArmies/saveArmyModal.tsx
@@ -1,29 +1,42 @@
 import type { Aos4ArmyDocument } from '../../../aos4/state'
+import { formatSavedAt } from './armySummary'
 import { withName } from './withName'
 import GenericModal from 'components/modals/generic/generic_modal'
 import { useArmyCollection } from 'context/useArmyCollection'
 import { useTheme } from 'context/useTheme'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 interface SaveArmyModalProps {
   closeModal: () => void
   currentDocument: Aos4ArmyDocument
   isOpen: boolean
-  onSaved: (document: Aos4ArmyDocument, cloudArmyId: string) => void
+  onSaved: (document: Aos4ArmyDocument, cloudArmyId: string, name: string) => void
 }
 
 const SaveArmyModal = ({ closeModal, currentDocument, isOpen, onSaved }: SaveArmyModalProps) => {
-  const { collectionError, configured, createArmy } = useArmyCollection()
-  const { theme } = useTheme()
+  const { armies, collectionError, configured, createArmy, refreshArmies, updateArmy } = useArmyCollection()
+  const { isDark, theme } = useTheme()
   const [saveName, setSaveName] = useState(currentDocument.name)
   const [isSaving, setIsSaving] = useState(false)
 
-  const saveNew = async () => {
+  /*
+   * The collection is fetched so the name below can be checked against it. Saving twice under one
+   * name used to produce two rows with byte-identical labels and no warning, which is how a
+   * collection fills up with armies nobody can tell apart.
+   */
+  useEffect(() => {
+    if (isOpen) void refreshArmies()
+  }, [isOpen, refreshArmies])
+
+  const trimmedName = saveName.trim()
+  const existing = armies.find(army => army.document.name.trim().toLowerCase() === trimmedName.toLowerCase())
+
+  const save = async (operation: () => Promise<{ id: string }>) => {
     setIsSaving(true)
     try {
       const savedDocument = withName(currentDocument, saveName)
-      const created = await createArmy(savedDocument)
-      onSaved(savedDocument, created.id)
+      const saved = await operation()
+      onSaved(savedDocument, saved.id, savedDocument.name)
       closeModal()
     } catch {
       // The collection context exposes the service error beside the controls.
@@ -32,17 +45,27 @@ const SaveArmyModal = ({ closeModal, currentDocument, isOpen, onSaved }: SaveArm
     }
   }
 
+  const saveNew = () => save(() => createArmy(withName(currentDocument, saveName)))
+
+  const updateExisting = () => {
+    if (!existing) return
+    return save(() => updateArmy(existing.id, withName(currentDocument, saveName)))
+  }
+
   return (
     <GenericModal closeModal={closeModal} isOpen={isOpen} isProcessing={isSaving} label="Save Army">
       <div className={`aos4-account-modal ${theme.text}`}>
         <div className="d-flex align-items-start justify-content-between mb-3">
           <div>
             <h2 className="h4 mb-1">Save Army</h2>
-            <p className="small mb-0">Save this army to your cloud armies.</p>
+            <p className="small mb-0">Save this army to your account, on every device you sign in on.</p>
           </div>
-          <button aria-label="Close save army" className={theme.modalDangerClass} onClick={closeModal}>
-            ×
-          </button>
+          <button
+            aria-label="Close Save Army"
+            className={`btn-close TapTargetOverlay flex-shrink-0 ${isDark ? 'btn-close-white' : ''}`}
+            onClick={closeModal}
+            type="button"
+          />
         </div>
 
         {!configured && (
@@ -56,26 +79,62 @@ const SaveArmyModal = ({ closeModal, currentDocument, isOpen, onSaved }: SaveArm
           </div>
         )}
 
-        <label className="fw-bold" htmlFor="save-army-name">
-          Army name
-        </label>
-        <div className="input-group">
-          <input
-            className={`form-control ${theme.bgColor} ${theme.text}`}
-            id="save-army-name"
-            maxLength={200}
-            onChange={event => setSaveName(event.target.value)}
-            value={saveName}
-          />
-          <button
-            className={theme.modalSuccessClass}
-            disabled={!configured || !saveName.trim() || isSaving}
-            onClick={() => void saveNew()}
-            type="button"
-          >
-            Save
-          </button>
-        </div>
+        <form
+          onSubmit={event => {
+            event.preventDefault()
+            void saveNew()
+          }}
+        >
+          <label className="fw-bold" htmlFor="save-army-name">
+            Army name
+          </label>
+          <div className="input-group">
+            <input
+              className={`form-control ${theme.bgColor} ${theme.text}`}
+              id="save-army-name"
+              maxLength={200}
+              onChange={event => setSaveName(event.target.value)}
+              value={saveName}
+            />
+            {/*
+             * `btn-primary`, not `theme.modalSuccessClass`. That slot is filled green in light
+             * theme and outlined in dark, so the one control that commits carried two different
+             * weights depending on the theme — and its filled form put white text on Bootstrap's
+             * green at 3.13:1, under the 4.5:1 floor. Action Blue is DESIGN.md's commit colour and
+             * measures 4.68:1.
+             */}
+            <button
+              className="btn btn-primary TapTarget"
+              disabled={!configured || !trimmedName || isSaving}
+              type="submit"
+            >
+              Save
+            </button>
+          </div>
+        </form>
+
+        {existing && (
+          /*
+           * Not a block — "Save As" exists precisely to make a second copy — but the collection is
+           * the thing that pays for a careless duplicate, so the alternative is offered here rather
+           * than discovered later in a list of same-named rows.
+           */
+          <div className="alert alert-warning mt-3" role="status">
+            <p className="mb-1">
+              You already have a saved army called <strong>{existing.document.name}</strong>, saved{' '}
+              {formatSavedAt(existing.updatedAt)}.
+            </p>
+            <p className="small mb-2">Saving now adds a second army with the same name.</p>
+            <button
+              className="btn btn-danger btn-sm TapTarget"
+              disabled={isSaving}
+              onClick={() => void updateExisting()}
+              type="button"
+            >
+              Overwrite it instead
+            </button>
+          </div>
+        )}
       </div>
     </GenericModal>
   )

--- a/src/components/input/cloudArmies/savedArmiesModal.tsx
+++ b/src/components/input/cloudArmies/savedArmiesModal.tsx
@@ -13,8 +13,8 @@ interface SavedArmiesModalProps {
   /** The cloud army the on-screen document is a copy of, so its row can say so. */
   linkedCloudArmyId?: string
   onApply: (document: Aos4ArmyDocument) => void
-  /** The current document became a copy of this cloud army. */
-  onLinked?: (cloudArmyId: string, name: string) => void
+  /** The current document became a copy of this cloud army, and is exactly `document`. */
+  onLinked?: (cloudArmyId: string, name: string, document: Aos4ArmyDocument) => void
   onDeleted?: (cloudArmyId: string) => void
 }
 
@@ -89,7 +89,7 @@ const SavedArmiesModal = ({
 
   const confirmLoad = (army: RemoteArmy) => {
     onApply(army.document)
-    onLinked?.(army.id, army.document.name)
+    onLinked?.(army.id, army.document.name, army.document)
     closeModal()
   }
 

--- a/src/components/input/cloudArmies/savedArmiesModal.tsx
+++ b/src/components/input/cloudArmies/savedArmiesModal.tsx
@@ -9,24 +9,23 @@ import { useEffect, useState } from 'react'
 
 interface SavedArmiesModalProps {
   closeModal: () => void
-  currentDocument: Aos4ArmyDocument
   isOpen: boolean
   /** The cloud army the on-screen document is a copy of, so its row can say so. */
   linkedCloudArmyId?: string
   onApply: (document: Aos4ArmyDocument) => void
-  /** The current document became a copy of this cloud army (loaded, or replaced from current). */
+  /** The current document became a copy of this cloud army. */
   onLinked?: (cloudArmyId: string, name: string) => void
   onDeleted?: (cloudArmyId: string) => void
 }
 
 /*
- * One decision at a time. `load`, `replace` and `delete` each swap the row's action strip for a
- * confirmation *in that row*; `rename` swaps it for an edit field. Holding them in one value rather
- * than three independent pieces of state is what makes them mutually exclusive — the previous
- * version could have a load confirmation open on one row and a delete confirmation on another, on
- * top of a stale success alert.
+ * One decision at a time. `load` and `delete` each swap the row's action strip for a confirmation
+ * *in that row*; `rename` swaps it for an edit field. Holding them in one value rather than
+ * independent pieces of state is what makes them mutually exclusive — the previous version could
+ * have a load confirmation open on one row and a delete confirmation on another, on top of a stale
+ * success alert.
  */
-type PendingKind = 'load' | 'replace' | 'delete' | 'rename'
+type PendingKind = 'load' | 'delete' | 'rename'
 interface PendingAction {
   id: string
   kind: PendingKind
@@ -34,7 +33,6 @@ interface PendingAction {
 
 const SavedArmiesModal = ({
   closeModal,
-  currentDocument,
   isOpen,
   linkedCloudArmyId,
   onApply,
@@ -82,19 +80,6 @@ const SavedArmiesModal = ({
     mutate(async () => {
       await updateArmy(army.id, withName(army.document, renameDraft))
     }, `Renamed to ${renameDraft.trim()}.`)
-
-  /*
-   * The saved army keeps its own name and takes the on-screen army's contents, so a row never
-   * silently retitles itself. The local document then takes that name too, because after this the
-   * two really are the same army — which is the claim the toolbar's Update Army rests on.
-   */
-  const replaceFromCurrent = (army: RemoteArmy) =>
-    mutate(async () => {
-      const replacement = withName(currentDocument, army.document.name)
-      await updateArmy(army.id, replacement)
-      onApply(replacement)
-      onLinked?.(army.id, army.document.name)
-    }, `${army.document.name} now matches the army on screen.`)
 
   const confirmDelete = (army: RemoteArmy) =>
     mutate(async () => {
@@ -178,13 +163,6 @@ const SavedArmiesModal = ({
           className: commitButton,
           run: () => confirmLoad(army),
         },
-        replace: {
-          prompt: `Replace ${army.document.name} with the army on screen?`,
-          detail: 'The saved copy is overwritten and cannot be recovered.',
-          action: 'Replace saved army',
-          className: destroyButton,
-          run: () => void replaceFromCurrent(army),
-        },
         delete: {
           prompt: `Delete ${army.document.name}?`,
           detail: 'It is removed from your account on every device. This cannot be undone.',
@@ -227,9 +205,6 @@ const SavedArmiesModal = ({
           type="button"
         >
           Rename
-        </button>
-        <button className={rowButton} onClick={() => openPending(army.id, 'replace')} type="button">
-          Replace with current
         </button>
         {/*
          * Pushed away from the three save-shaped actions rather than tinted red. Separation is what

--- a/src/components/input/cloudArmies/savedArmiesModal.tsx
+++ b/src/components/input/cloudArmies/savedArmiesModal.tsx
@@ -1,64 +1,75 @@
 import type { RemoteArmy } from '../../../api/armyApi'
 import type { Aos4ArmyDocument } from '../../../aos4/state'
+import { describeCloudArmy } from './armySummary'
 import { withName } from './withName'
 import GenericModal from 'components/modals/generic/generic_modal'
 import { useArmyCollection } from 'context/useArmyCollection'
 import { useTheme } from 'context/useTheme'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 interface SavedArmiesModalProps {
   closeModal: () => void
   currentDocument: Aos4ArmyDocument
   isOpen: boolean
+  /** The cloud army the on-screen document is a copy of, so its row can say so. */
+  linkedCloudArmyId?: string
   onApply: (document: Aos4ArmyDocument) => void
-  /** The current document became a copy of this cloud army (saved, updated from current, or loaded). */
-  onLinked?: (cloudArmyId: string) => void
+  /** The current document became a copy of this cloud army (loaded, or replaced from current). */
+  onLinked?: (cloudArmyId: string, name: string) => void
   onDeleted?: (cloudArmyId: string) => void
+}
+
+/*
+ * One decision at a time. `load`, `replace` and `delete` each swap the row's action strip for a
+ * confirmation *in that row*; `rename` swaps it for an edit field. Holding them in one value rather
+ * than three independent pieces of state is what makes them mutually exclusive — the previous
+ * version could have a load confirmation open on one row and a delete confirmation on another, on
+ * top of a stale success alert.
+ */
+type PendingKind = 'load' | 'replace' | 'delete' | 'rename'
+interface PendingAction {
+  id: string
+  kind: PendingKind
 }
 
 const SavedArmiesModal = ({
   closeModal,
   currentDocument,
   isOpen,
+  linkedCloudArmyId,
   onApply,
   onDeleted,
   onLinked,
 }: SavedArmiesModalProps) => {
-  const {
-    armies,
-    collectionError,
-    collectionLoading,
-    configured,
-    createArmy,
-    deleteArmy,
-    refreshArmies,
-    updateArmy,
-  } = useArmyCollection()
-  const { theme } = useTheme()
-  const [saveName, setSaveName] = useState(currentDocument.name)
-  const [draftNames, setDraftNames] = useState<Record<string, string>>({})
-  const [pendingLoad, setPendingLoad] = useState<RemoteArmy>()
-  const [pendingDeleteId, setPendingDeleteId] = useState<string>()
+  const { armies, collectionError, collectionLoading, configured, deleteArmy, refreshArmies, updateArmy } =
+    useArmyCollection()
+  const { isDark, theme } = useTheme()
+  const [pending, setPending] = useState<PendingAction>()
+  const [renameDraft, setRenameDraft] = useState('')
   const [isMutating, setIsMutating] = useState(false)
   const [message, setMessage] = useState<string>()
-
-  useEffect(() => {
-    setDraftNames(current =>
-      Object.fromEntries(armies.map(army => [army.id, current[army.id] ?? army.document.name]))
-    )
-  }, [armies])
 
   useEffect(() => {
     if (isOpen) void refreshArmies()
   }, [isOpen, refreshArmies])
 
-  const selectedCount = useMemo(() => pendingLoad?.document.explicitSelectionIds.length ?? 0, [pendingLoad])
+  /*
+   * A report of what just happened must never outlive the thing it describes. Opening any new
+   * decision clears it, so the player is never reading "Army saved." while looking at a delete
+   * confirmation for a different army.
+   */
+  const openPending = (id: string, kind: PendingKind, currentName = '') => {
+    setMessage(undefined)
+    setRenameDraft(currentName)
+    setPending({ id, kind })
+  }
 
   const mutate = async (operation: () => Promise<void>, success: string) => {
     setIsMutating(true)
     setMessage(undefined)
     try {
       await operation()
+      setPending(undefined)
       setMessage(success)
     } catch {
       // The collection context exposes the service error beside the controls.
@@ -67,34 +78,174 @@ const SavedArmiesModal = ({
     }
   }
 
-  const saveNew = () =>
-    mutate(async () => {
-      const savedDocument = withName(currentDocument, saveName)
-      const created = await createArmy(savedDocument)
-      onApply(savedDocument)
-      onLinked?.(created.id)
-    }, 'Army saved.')
-
   const rename = (army: RemoteArmy) =>
     mutate(async () => {
-      await updateArmy(army.id, withName(army.document, draftNames[army.id] ?? army.document.name))
-    }, 'Saved army renamed.')
+      await updateArmy(army.id, withName(army.document, renameDraft))
+    }, `Renamed to ${renameDraft.trim()}.`)
 
-  const updateFromCurrent = (army: RemoteArmy) =>
+  /*
+   * The saved army keeps its own name and takes the on-screen army's contents, so a row never
+   * silently retitles itself. The local document then takes that name too, because after this the
+   * two really are the same army — which is the claim the toolbar's Update Army rests on.
+   */
+  const replaceFromCurrent = (army: RemoteArmy) =>
     mutate(async () => {
-      const savedDocument = withName(currentDocument, draftNames[army.id] ?? currentDocument.name)
-      await updateArmy(army.id, savedDocument)
-      onApply(savedDocument)
-      onLinked?.(army.id)
-    }, 'Saved army updated from the current army.')
+      const replacement = withName(currentDocument, army.document.name)
+      await updateArmy(army.id, replacement)
+      onApply(replacement)
+      onLinked?.(army.id, army.document.name)
+    }, `${army.document.name} now matches the army on screen.`)
 
   const confirmDelete = (army: RemoteArmy) =>
     mutate(async () => {
       await deleteArmy(army.id)
-      setPendingDeleteId(undefined)
-      if (pendingLoad?.id === army.id) setPendingLoad(undefined)
       onDeleted?.(army.id)
-    }, 'Saved army deleted.')
+    }, `Deleted ${army.document.name}.`)
+
+  const confirmLoad = (army: RemoteArmy) => {
+    onApply(army.document)
+    onLinked?.(army.id, army.document.name)
+    closeModal()
+  }
+
+  const rowButton = `${theme.genericButton} btn-sm TapTarget`
+  const cancelButton = `${theme.genericButton} btn-sm TapTarget`
+  /*
+   * Filled, because these are the controls that commit — outline is for everything reversible. Both
+   * fills are literal Bootstrap signal classes rather than theme slots, so a confirmation reads the
+   * same in light and dark: the slots are asymmetric (`modalSuccessClass` is filled in one theme and
+   * outlined in the other), which would give the same decision two different weights.
+   *
+   * `btn-primary` and not `btn-success`: Action Blue carries white text at 4.68:1 and Bootstrap's
+   * green at 3.13:1, under the 4.5:1 this product treats as correctness. `btn-danger` clears it at
+   * 4.53:1. This is the same reasoning that moved $primary off Bootstrap's default — see DESIGN.md.
+   */
+  const commitButton = 'btn btn-primary btn-sm TapTarget'
+  const destroyButton = 'btn btn-danger btn-sm TapTarget'
+
+  const renderActions = (army: RemoteArmy) => {
+    const isPending = pending?.id === army.id
+
+    if (isPending && pending.kind === 'rename') {
+      return (
+        <form
+          className="CloudArmyConfirm"
+          onSubmit={event => {
+            event.preventDefault()
+            void rename(army)
+          }}
+        >
+          <label className="visually-hidden" htmlFor={`army-name-${army.id}`}>
+            New name for {army.document.name}
+          </label>
+          <input
+            autoFocus
+            className={`form-control form-control-sm ${theme.bgColor} ${theme.text}`}
+            id={`army-name-${army.id}`}
+            maxLength={200}
+            onChange={event => setRenameDraft(event.target.value)}
+            value={renameDraft}
+          />
+          <div className="CloudArmyActions mt-2">
+            <button
+              className={commitButton}
+              disabled={isMutating || !renameDraft.trim() || renameDraft.trim() === army.document.name}
+              type="submit"
+            >
+              Save name
+            </button>
+            <button className={cancelButton} onClick={() => setPending(undefined)} type="button">
+              Cancel
+            </button>
+          </div>
+        </form>
+      )
+    }
+
+    if (isPending && pending.kind !== 'rename') {
+      /*
+       * Every confirmation renders here, inside the row it belongs to. The version this replaced put
+       * the load confirmation after the whole list, where with eight saved armies it landed 198px
+       * below the modal on a desktop and 822px below on a phone — so "Load" looked like it did
+       * nothing. It also sat in a Bootstrap `alert-info`, whose light background is the same in both
+       * themes, so the outline-light buttons on it measured 1.17:1 in dark theme.
+       */
+      const confirmations = {
+        load: {
+          prompt: `Load ${army.document.name}?`,
+          detail: 'The army on screen is replaced. Anything unsaved on it is lost.',
+          action: 'Load this army',
+          className: commitButton,
+          run: () => confirmLoad(army),
+        },
+        replace: {
+          prompt: `Replace ${army.document.name} with the army on screen?`,
+          detail: 'The saved copy is overwritten and cannot be recovered.',
+          action: 'Replace saved army',
+          className: destroyButton,
+          run: () => void replaceFromCurrent(army),
+        },
+        delete: {
+          prompt: `Delete ${army.document.name}?`,
+          detail: 'It is removed from your account on every device. This cannot be undone.',
+          action: 'Delete this army',
+          className: destroyButton,
+          run: () => void confirmDelete(army),
+        },
+      }[pending.kind]
+
+      return (
+        <div aria-label={confirmations.prompt} className="CloudArmyConfirm" role="group">
+          <p className="mb-1 fw-bold">{confirmations.prompt}</p>
+          <p className={`small mb-2 ${theme.textMuted}`}>{confirmations.detail}</p>
+          <div className="CloudArmyActions">
+            <button
+              autoFocus
+              className={confirmations.className}
+              disabled={isMutating}
+              onClick={confirmations.run}
+              type="button"
+            >
+              {confirmations.action}
+            </button>
+            <button className={cancelButton} onClick={() => setPending(undefined)} type="button">
+              Cancel
+            </button>
+          </div>
+        </div>
+      )
+    }
+
+    return (
+      <div className="CloudArmyActions">
+        <button className={rowButton} onClick={() => openPending(army.id, 'load')} type="button">
+          Load
+        </button>
+        <button
+          className={rowButton}
+          onClick={() => openPending(army.id, 'rename', army.document.name)}
+          type="button"
+        >
+          Rename
+        </button>
+        <button className={rowButton} onClick={() => openPending(army.id, 'replace')} type="button">
+          Replace with current
+        </button>
+        {/*
+         * Pushed away from the three save-shaped actions rather than tinted red. Separation is what
+         * stops a mis-tap on a phone, where these wrap to two lines; the colour is spent on the
+         * confirmation instead, so nothing is loud until something is about to be destroyed.
+         */}
+        <button
+          className={`${rowButton} CloudArmyDelete`}
+          onClick={() => openPending(army.id, 'delete')}
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
+    )
+  }
 
   return (
     <GenericModal closeModal={closeModal} isOpen={isOpen} isProcessing={isMutating} label="My Armies">
@@ -102,11 +253,19 @@ const SavedArmiesModal = ({
         <div className="d-flex align-items-start justify-content-between mb-3">
           <div>
             <h2 className="h4 mb-1">My Armies</h2>
-            <p className="small mb-0">Save and load AoS 4 armies across your devices.</p>
+            <p className="small mb-0">Load a saved army, or manage the ones on your account.</p>
           </div>
-          <button aria-label="Close saved armies" className={theme.modalDangerClass} onClick={closeModal}>
-            ×
-          </button>
+          {/*
+           * `btn-close`, the same control the notification banner uses. It was `theme.modalDangerClass`,
+           * which is a filled red button in dark theme — making Close the loudest control in the modal
+           * and visually identical to Delete.
+           */}
+          <button
+            aria-label="Close My Armies"
+            className={`btn-close TapTargetOverlay flex-shrink-0 ${isDark ? 'btn-close-white' : ''}`}
+            onClick={closeModal}
+            type="button"
+          />
         </div>
 
         {!configured && (
@@ -125,139 +284,37 @@ const SavedArmiesModal = ({
           </div>
         )}
 
-        <div className="card mb-3">
-          <div className={`card-body ${theme.cardBody}`}>
-            <label className="fw-bold" htmlFor="saved-army-name">
-              Save current army
-            </label>
-            <div className="input-group">
-              <input
-                className={`form-control ${theme.bgColor} ${theme.text}`}
-                id="saved-army-name"
-                maxLength={200}
-                onChange={event => setSaveName(event.target.value)}
-                value={saveName}
-              />
-              {/*
-                Bootstrap 5 removed the .input-group-append wrapper: an input group's children are
-                now direct flex items, and the trailing control's square inner corners come from
-                `.input-group > :not(:first-child)`. The button is unchanged.
-              */}
-              <button
-                className={theme.modalSuccessClass}
-                disabled={!configured || !saveName.trim()}
-                onClick={() => void saveNew()}
-                type="button"
-              >
-                Save new
-              </button>
-            </div>
-          </div>
-        </div>
-
-        {collectionLoading ? (
+        {collectionLoading && armies.length === 0 ? (
           <p role="status">Loading saved armies…</p>
         ) : armies.length === 0 ? (
-          <p className="small">No cloud armies saved yet.</p>
+          <div className="CloudArmyEmpty">
+            <p className="mb-1 fw-bold">No armies saved yet.</p>
+            <p className={`small mb-0 ${theme.textMuted}`}>
+              Build an army, then choose <strong>Save Army</strong> in the toolbar. It will be here on every
+              device you sign in on.
+            </p>
+          </div>
         ) : (
-          <div aria-label="Saved armies" className="list-group">
+          <ul aria-label="Saved armies" className="list-group">
             {armies.map(army => (
-              <div className={`list-group-item ${theme.cardBody} ${theme.text}`} key={army.id}>
-                <label className="visually-hidden" htmlFor={`army-name-${army.id}`}>
-                  Saved army name
-                </label>
-                <input
-                  className={`form-control form-control-sm mb-2 ${theme.bgColor} ${theme.text}`}
-                  id={`army-name-${army.id}`}
-                  maxLength={200}
-                  onChange={event =>
-                    setDraftNames(current => ({ ...current, [army.id]: event.target.value }))
-                  }
-                  value={draftNames[army.id] ?? army.document.name}
-                />
-                <p className="small mb-2">
-                  {army.document.explicitSelectionIds.length} selections · updated{' '}
-                  {new Date(army.updatedAt).toLocaleDateString()}
-                </p>
-                <div className="d-flex flex-wrap">
-                  <button
-                    className={`${theme.genericButton} btn-sm me-2 mb-2`}
-                    onClick={() => setPendingLoad(army)}
-                    type="button"
-                  >
-                    Load
-                  </button>
-                  <button
-                    className={`${theme.genericButton} btn-sm me-2 mb-2`}
-                    onClick={() => void rename(army)}
-                    type="button"
-                  >
-                    Rename
-                  </button>
-                  <button
-                    className={`${theme.genericButton} btn-sm me-2 mb-2`}
-                    onClick={() => void updateFromCurrent(army)}
-                    type="button"
-                  >
-                    Update from current
-                  </button>
-                  {pendingDeleteId === army.id ? (
-                    <>
-                      <button
-                        className={`${theme.modalDangerClass} btn-sm me-2 mb-2`}
-                        onClick={() => void confirmDelete(army)}
-                        type="button"
-                      >
-                        Confirm delete
-                      </button>
-                      <button
-                        className={`${theme.genericButton} btn-sm mb-2`}
-                        onClick={() => setPendingDeleteId(undefined)}
-                        type="button"
-                      >
-                        Cancel
-                      </button>
-                    </>
-                  ) : (
-                    <button
-                      className={`${theme.modalDangerClass} btn-sm mb-2`}
-                      onClick={() => setPendingDeleteId(army.id)}
-                      type="button"
-                    >
-                      Delete
-                    </button>
+              <li className={`list-group-item ${theme.cardBody} ${theme.text}`} key={army.id}>
+                <div className="d-flex align-items-baseline flex-wrap gap-2">
+                  <h3 className="h6 mb-0">{army.document.name}</h3>
+                  {army.id === linkedCloudArmyId && (
+                    /*
+                     * Plain text, not a badge: this is a state readout rather than an attention
+                     * marker, and the saturated tones stay reserved for meaning elsewhere.
+                     */
+                    <span className={`small fw-bold ${theme.textMuted}`}>On screen now</span>
                   )}
                 </div>
-              </div>
+                <p className={`small mb-2 ${theme.textMuted}`}>
+                  {describeCloudArmy(army.document, army.updatedAt)}
+                </p>
+                {renderActions(army)}
+              </li>
             ))}
-          </div>
-        )}
-
-        {pendingLoad && (
-          <div className="alert alert-info mt-3" role="alert">
-            <strong>Replace the current army with {pendingLoad.document.name}?</strong>
-            <p className="small mb-2">
-              {selectedCount} selections in {pendingLoad.document.rulesContextId}
-            </p>
-            <button
-              className={`${theme.modalConfirmClass} btn-sm me-2`}
-              onClick={() => {
-                onApply(pendingLoad.document)
-                onLinked?.(pendingLoad.id)
-                closeModal()
-              }}
-              type="button"
-            >
-              Replace current army
-            </button>
-            <button
-              className={`${theme.genericButton} btn-sm`}
-              onClick={() => setPendingLoad(undefined)}
-              type="button"
-            >
-              Keep current army
-            </button>
-          </div>
+          </ul>
         )}
       </div>
     </GenericModal>

--- a/src/components/input/toolbar/toolbar.tsx
+++ b/src/components/input/toolbar/toolbar.tsx
@@ -14,6 +14,8 @@ import {
 interface ToolbarProps {
   /** The current army mirrors a cloud army, so saving splits into Update Army and Save As. */
   cloudArmyLinked: boolean
+  /** Name of that cloud army, so Update Army is never a write to an unnamed target. */
+  cloudArmyName?: string
   hiddenCount: number
   onClearArmy: () => void
   onDownloadPdf: () => void
@@ -67,6 +69,7 @@ const updateArmyLabel = (status: ToolbarProps['updateArmyStatus']): string => {
 
 const Toolbar = ({
   cloudArmyLinked,
+  cloudArmyName,
   hiddenCount,
   onClearArmy,
   onDownloadPdf,
@@ -78,76 +81,96 @@ const Toolbar = ({
   onUpdateArmy,
   subscriberActionDisabled,
   updateArmyStatus,
-}: ToolbarProps) => (
-  <div className="container d-print-none">
-    <div className="row justify-content-center pt-3">
-      <div className={buttonWrapperClass}>
-        <ToolbarButton onClick={onClearArmy}>
-          <FaTrash className="me-2" />
-          Clear Army
-        </ToolbarButton>
-      </div>
-      <div className={buttonWrapperClass}>
-        <ToolbarButton onClick={onDownloadPdf}>
-          <MdFileDownload className="me-2" />
-          Download PDF
-        </ToolbarButton>
-      </div>
-      <div className={buttonWrapperClass}>
-        <ToolbarButton onClick={onImportArmy}>
-          <MdFileUpload className="me-2" />
-          Import Army
-        </ToolbarButton>
-      </div>
-      {cloudArmyLinked ? (
-        <>
-          <div className={buttonWrapperClass}>
-            <ToolbarButton
-              disabled={subscriberActionDisabled || updateArmyStatus === 'updating'}
-              onClick={onUpdateArmy}
-            >
-              <MdCloudUpload className="me-2" />
-              {updateArmyLabel(updateArmyStatus)}
-            </ToolbarButton>
-          </div>
+}: ToolbarProps) => {
+  const { theme } = useTheme()
+
+  return (
+    <div className="container d-print-none">
+      <div className="row justify-content-center pt-3">
+        <div className={buttonWrapperClass}>
+          <ToolbarButton onClick={onClearArmy}>
+            <FaTrash className="me-2" />
+            Clear Army
+          </ToolbarButton>
+        </div>
+        <div className={buttonWrapperClass}>
+          <ToolbarButton onClick={onDownloadPdf}>
+            <MdFileDownload className="me-2" />
+            Download PDF
+          </ToolbarButton>
+        </div>
+        <div className={buttonWrapperClass}>
+          <ToolbarButton onClick={onImportArmy}>
+            <MdFileUpload className="me-2" />
+            Import Army
+          </ToolbarButton>
+        </div>
+        {cloudArmyLinked ? (
+          <>
+            {/*
+             * A wider floor than its siblings, because this is the one cell whose label changes.
+             * "Updating…" and "Updated" are both narrower than "Update Army", so a content-sized cell
+             * shrank mid-save and the centred row slid every other button 8px sideways, twice.
+             */}
+            <div className={`${buttonWrapperClass} ToolbarButtonCell--status`}>
+              <ToolbarButton
+                disabled={subscriberActionDisabled || updateArmyStatus === 'updating'}
+                onClick={onUpdateArmy}
+              >
+                <MdCloudUpload className="me-2" />
+                {updateArmyLabel(updateArmyStatus)}
+              </ToolbarButton>
+            </div>
+            <div className={buttonWrapperClass}>
+              <ToolbarButton disabled={subscriberActionDisabled} onClick={onSaveArmy}>
+                <MdSaveAs className="me-2" />
+                Save As
+              </ToolbarButton>
+            </div>
+          </>
+        ) : (
           <div className={buttonWrapperClass}>
             <ToolbarButton disabled={subscriberActionDisabled} onClick={onSaveArmy}>
-              <MdSaveAs className="me-2" />
-              Save As
+              <MdSave className="me-2" />
+              Save Army
             </ToolbarButton>
           </div>
-        </>
-      ) : (
+        )}
         <div className={buttonWrapperClass}>
-          <ToolbarButton disabled={subscriberActionDisabled} onClick={onSaveArmy}>
-            <MdSave className="me-2" />
-            Save Army
+          <ToolbarButton disabled={subscriberActionDisabled} onClick={onOpenSavedArmies}>
+            <MdCloud className="me-2" />
+            My Armies
           </ToolbarButton>
         </div>
-      )}
-      <div className={buttonWrapperClass}>
-        <ToolbarButton disabled={subscriberActionDisabled} onClick={onOpenSavedArmies}>
-          <MdCloud className="me-2" />
-          My Armies
-        </ToolbarButton>
-      </div>
-      <div className={buttonWrapperClass}>
-        <ToolbarButton disabled={subscriberActionDisabled} onClick={onShareArmy}>
-          <MdShare className="me-2" />
-          Share Army
-        </ToolbarButton>
-      </div>
-      {/* Absent, not disabled, until a reminder is hidden: a control with nothing to act on is noise. */}
-      {hiddenCount > 0 && (
         <div className={buttonWrapperClass}>
-          <ToolbarButton onClick={onShowAll}>
-            <MdVisibility className="me-2" />
-            Show Hidden ({hiddenCount})
+          <ToolbarButton disabled={subscriberActionDisabled} onClick={onShareArmy}>
+            <MdShare className="me-2" />
+            Share Army
           </ToolbarButton>
         </div>
+        {/* Absent, not disabled, until a reminder is hidden: a control with nothing to act on is noise. */}
+        {hiddenCount > 0 && (
+          <div className={buttonWrapperClass}>
+            <ToolbarButton onClick={onShowAll}>
+              <MdVisibility className="me-2" />
+              Show Hidden ({hiddenCount})
+            </ToolbarButton>
+          </div>
+        )}
+      </div>
+
+      {/*
+       * Update Army is a write to a record on the player's account. Naming that record here is what
+       * stops it being an overwrite of something they can only identify from memory — which was the
+       * state of things when two same-named armies were trivial to create.
+       */}
+      {cloudArmyLinked && cloudArmyName && (
+        <p className={`small text-center mb-0 pb-2 ${theme.textMuted}`}>
+          Cloud army: <strong>{cloudArmyName}</strong>
+        </p>
       )}
     </div>
-  </div>
-)
+  )
+}
 
 export default Toolbar

--- a/src/components/input/toolbar/toolbar.tsx
+++ b/src/components/input/toolbar/toolbar.tsx
@@ -16,6 +16,8 @@ interface ToolbarProps {
   cloudArmyLinked: boolean
   /** Name of that cloud army, so Update Army is never a write to an unnamed target. */
   cloudArmyName?: string
+  /** The army on screen differs from the saved copy, so Update Army has something to write. */
+  cloudArmyHasChanges?: boolean
   hiddenCount: number
   onClearArmy: () => void
   onDownloadPdf: () => void
@@ -70,6 +72,7 @@ const updateArmyLabel = (status: ToolbarProps['updateArmyStatus']): string => {
 const Toolbar = ({
   cloudArmyLinked,
   cloudArmyName,
+  cloudArmyHasChanges,
   hiddenCount,
   onClearArmy,
   onDownloadPdf,
@@ -83,6 +86,12 @@ const Toolbar = ({
   updateArmyStatus,
 }: ToolbarProps) => {
   const { theme } = useTheme()
+  /*
+   * Absent, not disabled, when there is nothing to save — the rule Show Hidden follows. It stays
+   * through "Updating…" and "Updated" so the confirmation is not yanked away by the very save that
+   * earned it; the button then leaves, and the line below says the army is up to date.
+   */
+  const showUpdateArmy = cloudArmyLinked && (cloudArmyHasChanges || updateArmyStatus !== 'idle')
 
   return (
     <div className="container d-print-none">
@@ -107,20 +116,22 @@ const Toolbar = ({
         </div>
         {cloudArmyLinked ? (
           <>
-            {/*
-             * A wider floor than its siblings, because this is the one cell whose label changes.
-             * "Updating…" and "Updated" are both narrower than "Update Army", so a content-sized cell
-             * shrank mid-save and the centred row slid every other button 8px sideways, twice.
-             */}
-            <div className={`${buttonWrapperClass} ToolbarButtonCell--status`}>
-              <ToolbarButton
-                disabled={subscriberActionDisabled || updateArmyStatus === 'updating'}
-                onClick={onUpdateArmy}
-              >
-                <MdCloudUpload className="me-2" />
-                {updateArmyLabel(updateArmyStatus)}
-              </ToolbarButton>
-            </div>
+            {showUpdateArmy && (
+              /*
+               * A wider floor than its siblings, because this is the one cell whose label changes.
+               * "Updating…" and "Updated" are both narrower than "Update Army", so a content-sized
+               * cell shrank mid-save and the centred row slid every other button 8px sideways.
+               */
+              <div className={`${buttonWrapperClass} ToolbarButtonCell--status`}>
+                <ToolbarButton
+                  disabled={subscriberActionDisabled || updateArmyStatus === 'updating'}
+                  onClick={onUpdateArmy}
+                >
+                  <MdCloudUpload className="me-2" />
+                  {updateArmyLabel(updateArmyStatus)}
+                </ToolbarButton>
+              </div>
+            )}
             <div className={buttonWrapperClass}>
               <ToolbarButton disabled={subscriberActionDisabled} onClick={onSaveArmy}>
                 <MdSaveAs className="me-2" />
@@ -167,6 +178,11 @@ const Toolbar = ({
       {cloudArmyLinked && cloudArmyName && (
         <p className={`small text-center mb-0 pb-2 ${theme.textMuted}`}>
           Cloud army: <strong>{cloudArmyName}</strong>
+          {/*
+           * Said in words, because the absence of a button is not a message. Without this, an army
+           * that is already saved and one whose Update Army has simply gone missing look the same.
+           */}
+          {cloudArmyHasChanges ? ' · unsaved changes' : ' · up to date'}
         </p>
       )}
     </div>

--- a/src/components/modals/generic/generic_modal.tsx
+++ b/src/components/modals/generic/generic_modal.tsx
@@ -22,24 +22,45 @@ const GenericModal = ({
   isProcessing = false,
 }: React.PropsWithChildren<IGenericModalProps>) => {
   const { isDark } = useTheme()
-  const modalClassName = `Modal-${isProcessing ? 'Transparent' : isDark ? 'Dark' : 'Light'}`
 
   return (
     <Modal
-      className={modalClassName}
+      className={isDark ? 'Modal-Dark' : 'Modal-Light'}
       contentLabel={label}
       isOpen={isOpen}
       onRequestClose={closeModal}
       overlayClassName="Modal-Overlay"
     >
-      <div className="container">
-        {isProcessing && <ModalSpinner />}
-        <div hidden={isProcessing}>{children}</div>
+      {/*
+       * The content stays mounted and on screen while a request is in flight. It used to be
+       * `hidden`, which `display: none`s the whole subtree: the list, the headings and any live
+       * alert vanished for the duration of every mutation, and the browser dropped focus to <body>
+       * because the focused control had just been removed from the layout. Dimming keeps the
+       * player's place, keeps focus where it was, and still reads as busy.
+       */}
+      {/*
+       * `px-0`: `.Modal-*` already pads itself, so the container's 15px gutters were spent twice.
+       * On a 390px phone that pushed `.aos4-account-modal` past the modal's own
+       * `max-width: calc(100vw - 2rem)` and left the dialog scrolling sideways by 6px.
+       */}
+      <div className="container px-0 ModalContent" aria-busy={isProcessing}>
+        <div className={isProcessing ? 'ModalContent-Busy' : undefined}>{children}</div>
+        {isProcessing && (
+          <div className="ModalContent-Spinner">
+            <ModalSpinner isDark={isDark} />
+          </div>
+        )}
       </div>
     </Modal>
   )
 }
 
+/*
+ * `isDark` was declared with a default and never passed by the one call site, so the spinner always
+ * rendered `text-dark` (#343a40) — and it was drawn on a transparent modal over a 90%-black scrim,
+ * which composites to about #191919. That is 1.53:1, under WCAG 1.4.11's 3:1 for a meaningful
+ * graphic, and it was identical in both themes.
+ */
 const ModalSpinner = ({ isDark = false }: { isDark?: boolean }) => (
   <div className="d-flex flex-row justify-content-center">
     <Spinner variant={isDark ? 'light-gray' : 'dark'} size="large" />

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -28,10 +28,12 @@ import { Header } from 'components/page/homeHeader'
 import { ArmyCollectionProvider, messageForError, useArmyCollection } from 'context/useArmyCollection'
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
 import { logFactionSelection, logGameModeChange, logPdfDownload } from 'utils/analytics'
+import { clearCloudArmyLink, readCloudArmyLink, writeCloudArmyLink } from 'utils/cloudArmyLink'
 import { consumePendingShareId } from 'utils/shareLink'
 
 const ImportArmyModal = lazy(() => import('components/input/importArmy/importArmyModal'))
 const PrintModal = lazy(() => import('components/print/printModal'))
+const ClearArmyModal = lazy(() => import('components/modals/generic/generic_destructive_modal'))
 const SaveArmyModal = lazy(() => import('components/input/cloudArmies/saveArmyModal'))
 const SavedArmiesModal = lazy(() => import('components/input/cloudArmies/savedArmiesModal'))
 const ShareArmyModal = lazy(() => import('components/input/armySharing/shareArmyModal'))
@@ -86,22 +88,29 @@ const SkipToReminders = () => (
 )
 
 const HomeContent = () => {
-  const { updateArmy } = useArmyCollection()
+  const { armies, updateArmy } = useArmyCollection()
   const [document, setDocument] = useState(loadDocument)
   const [isGameMode, setIsGameMode] = useState(false)
   const [importModalIsOpen, setImportModalIsOpen] = useState(false)
   const [savedArmiesModalIsOpen, setSavedArmiesModalIsOpen] = useState(false)
   const [saveArmyModalIsOpen, setSaveArmyModalIsOpen] = useState(false)
   const [shareModalIsOpen, setShareModalIsOpen] = useState(false)
+  const [clearArmyModalIsOpen, setClearArmyModalIsOpen] = useState(false)
   const [pendingShareId, setPendingShareId] = useState(() => consumePendingShareId())
   const [printModalIsOpen, setPrintModalIsOpen] = useState(false)
   /*
-   * Which cloud army the current document is a copy of, if any. Held in memory only: it starts a
-   * session unlinked, links through the save/load flows, and unlinks when the document stops being
-   * that army (clear, faction switch, import, incoming share, remote delete). It decides whether
-   * the toolbar offers one-click Update Army alongside Save As, or a single Save Army.
+   * Which cloud army the current document is a copy of, if any. It links through the save/load
+   * flows and unlinks when the document stops being that army (clear, faction switch, import,
+   * incoming share, remote delete). It decides whether the toolbar offers one-click Update Army
+   * alongside Save As, or a single Save Army.
+   *
+   * Persisted, because the document it describes is. Holding it in memory alone meant every reload
+   * — a service-worker update, a backgrounded tab, a phone reclaiming the page — silently dropped
+   * back to Save Army, and the next save forked a duplicate of the army the player thought they
+   * were updating. See utils/cloudArmyLink.
    */
-  const [cloudArmyId, setCloudArmyId] = useState<string>()
+  const [cloudArmyLink, setCloudArmyLink] = useState(readCloudArmyLink)
+  const cloudArmyId = cloudArmyLink?.id
   const [updateArmyStatus, setUpdateArmyStatus] = useState<'idle' | 'updating' | 'updated'>('idle')
   const [updateArmyError, setUpdateArmyError] = useState<string>()
   const savedArmiesAction = useSubscriberAction({
@@ -136,8 +145,15 @@ const HomeContent = () => {
     onAuthorized: () => void updateCloudArmy(),
     origin: 'UpdateArmy',
   })
+  const linkCloudArmy = (id: string, name: string) => {
+    const link = { id, name }
+    setCloudArmyLink(link)
+    writeCloudArmyLink(link)
+    setUpdateArmyError(undefined)
+  }
   const unlinkCloudArmy = () => {
-    setCloudArmyId(undefined)
+    setCloudArmyLink(undefined)
+    clearCloudArmyLink()
     setUpdateArmyError(undefined)
   }
 
@@ -146,6 +162,27 @@ const HomeContent = () => {
     const timer = window.setTimeout(() => setUpdateArmyStatus('idle'), 2500)
     return () => window.clearTimeout(timer)
   }, [updateArmyStatus])
+
+  /*
+   * A link restored from storage can name an army deleted on another device. Reconciled only
+   * against a collection that actually loaded — an empty list is what a failed fetch looks like
+   * too, and unlinking on that would undo the persistence this exists to provide.
+   */
+  const cloudArmyName = cloudArmyLink?.name
+  useEffect(() => {
+    if (!cloudArmyId || armies.length === 0) return
+    const linked = armies.find(army => army.id === cloudArmyId)
+    if (!linked) {
+      setCloudArmyLink(undefined)
+      clearCloudArmyLink()
+      return
+    }
+    // A rename in My Armies must reach the label the toolbar shows for the same record.
+    if (linked.document.name === cloudArmyName) return
+    const link = { id: cloudArmyId, name: linked.document.name }
+    setCloudArmyLink(link)
+    writeCloudArmyLink(link)
+  }, [armies, cloudArmyId, cloudArmyName])
   const factions = useMemo(
     () =>
       selectableFactions
@@ -377,8 +414,9 @@ const HomeContent = () => {
       {!isGameMode && (
         <Toolbar
           cloudArmyLinked={Boolean(cloudArmyId)}
+          {...(cloudArmyName ? { cloudArmyName } : {})}
           hiddenCount={hiddenCount}
-          onClearArmy={clearArmy}
+          onClearArmy={() => setClearArmyModalIsOpen(true)}
           onDownloadPdf={() => setPrintModalIsOpen(true)}
           onImportArmy={() => setImportModalIsOpen(true)}
           onOpenSavedArmies={savedArmiesAction.run}
@@ -441,9 +479,12 @@ const HomeContent = () => {
             closeModal={() => setSavedArmiesModalIsOpen(false)}
             currentDocument={document}
             isOpen={savedArmiesModalIsOpen}
+            {...(cloudArmyId ? { linkedCloudArmyId: cloudArmyId } : {})}
             onApply={setDocument}
-            onDeleted={deletedId => setCloudArmyId(current => (current === deletedId ? undefined : current))}
-            onLinked={setCloudArmyId}
+            onDeleted={deletedId => {
+              if (deletedId === cloudArmyId) unlinkCloudArmy()
+            }}
+            onLinked={linkCloudArmy}
           />
         </Suspense>
       )}
@@ -454,9 +495,9 @@ const HomeContent = () => {
             closeModal={() => setSaveArmyModalIsOpen(false)}
             currentDocument={document}
             isOpen={saveArmyModalIsOpen}
-            onSaved={(savedDocument, savedCloudArmyId) => {
+            onSaved={(savedDocument, savedCloudArmyId, savedName) => {
               setDocument(savedDocument)
-              setCloudArmyId(savedCloudArmyId)
+              linkCloudArmy(savedCloudArmyId, savedName)
             }}
           />
         </Suspense>
@@ -482,6 +523,25 @@ const HomeContent = () => {
               setDocument(nextDocument)
             }}
             shareId={pendingShareId}
+          />
+        </Suspense>
+      )}
+
+      {/*
+       * Clear Army fired on one tap and took the notes, hidden flags and ordering with it — the
+       * only content on this screen the player wrote themselves, and the only one with no copy
+       * anywhere else. It is the one action here that earns an interruption.
+       */}
+      {clearArmyModalIsOpen && (
+        <Suspense fallback={null}>
+          <ClearArmyModal
+            bodyText="This empties the builder and discards the notes, hidden reminders, and ordering you set for this army. Armies saved to your account are not affected."
+            closeModal={() => setClearArmyModalIsOpen(false)}
+            confirmText="Clear army"
+            denyText="Keep it"
+            headerText="Clear this army?"
+            isOpen={clearArmyModalIsOpen}
+            onConfirm={clearArmy}
           />
         </Suspense>
       )}

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -477,7 +477,6 @@ const HomeContent = () => {
         <Suspense fallback={null}>
           <SavedArmiesModal
             closeModal={() => setSavedArmiesModalIsOpen(false)}
-            currentDocument={document}
             isOpen={savedArmiesModalIsOpen}
             {...(cloudArmyId ? { linkedCloudArmyId: cloudArmyId } : {})}
             onApply={setDocument}

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -10,7 +10,12 @@ import {
   saveAos4ArmyDocument,
 } from '../../aos4/runtime'
 import { resolveSelection } from '../../aos4/select'
-import { createAos4ArmyDocument, setAos4ReminderPreference, type Aos4ArmyDocument } from '../../aos4/state'
+import {
+  createAos4ArmyDocument,
+  serializeAos4ArmyDocument,
+  setAos4ReminderPreference,
+  type Aos4ArmyDocument,
+} from '../../aos4/state'
 import {
   createAos4BuilderViewModel,
   createAos4ReminderSourceLinkResolver,
@@ -111,6 +116,15 @@ const HomeContent = () => {
    */
   const [cloudArmyLink, setCloudArmyLink] = useState(readCloudArmyLink)
   const cloudArmyId = cloudArmyLink?.id
+  const cloudArmyName = cloudArmyLink?.name
+  /*
+   * Whether the army on screen has moved away from the copy on the account. Update Army is offered
+   * only when it has something to write — the same absent-rather-than-disabled rule Show Hidden
+   * follows. A link stored before signatures existed has none, and reports changed: offering a save
+   * that may be unnecessary is the safe side of that guess.
+   */
+  const cloudArmyHasChanges =
+    Boolean(cloudArmyId) && serializeAos4ArmyDocument(document) !== cloudArmyLink?.savedSignature
   const [updateArmyStatus, setUpdateArmyStatus] = useState<'idle' | 'updating' | 'updated'>('idle')
   const [updateArmyError, setUpdateArmyError] = useState<string>()
   const savedArmiesAction = useSubscriberAction({
@@ -128,12 +142,25 @@ const HomeContent = () => {
     onAuthorized: () => setSaveArmyModalIsOpen(true),
     origin: 'SaveArmy',
   })
+  /*
+   * Called at every point the local document becomes a copy of a cloud army — loaded, saved, saved
+   * as, or updated — and records what that copy looked like, so the toolbar can tell later whether
+   * it has moved.
+   */
+  const linkCloudArmy = (id: string, name: string, savedDocument: Aos4ArmyDocument) => {
+    const link = { id, name, savedSignature: serializeAos4ArmyDocument(savedDocument) }
+    setCloudArmyLink(link)
+    writeCloudArmyLink(link)
+    setUpdateArmyError(undefined)
+  }
   const updateCloudArmy = async () => {
-    if (!cloudArmyId) return
+    if (!cloudArmyId || !cloudArmyName) return
     setUpdateArmyStatus('updating')
     setUpdateArmyError(undefined)
     try {
       await updateArmy(cloudArmyId, document)
+      // The army on screen is now what the account holds, so it becomes the new baseline.
+      linkCloudArmy(cloudArmyId, cloudArmyName, document)
       setUpdateArmyStatus('updated')
     } catch (error) {
       setUpdateArmyStatus('idle')
@@ -145,12 +172,6 @@ const HomeContent = () => {
     onAuthorized: () => void updateCloudArmy(),
     origin: 'UpdateArmy',
   })
-  const linkCloudArmy = (id: string, name: string) => {
-    const link = { id, name }
-    setCloudArmyLink(link)
-    writeCloudArmyLink(link)
-    setUpdateArmyError(undefined)
-  }
   const unlinkCloudArmy = () => {
     setCloudArmyLink(undefined)
     clearCloudArmyLink()
@@ -168,7 +189,6 @@ const HomeContent = () => {
    * against a collection that actually loaded — an empty list is what a failed fetch looks like
    * too, and unlinking on that would undo the persistence this exists to provide.
    */
-  const cloudArmyName = cloudArmyLink?.name
   useEffect(() => {
     if (!cloudArmyId || armies.length === 0) return
     const linked = armies.find(army => army.id === cloudArmyId)
@@ -177,11 +197,15 @@ const HomeContent = () => {
       clearCloudArmyLink()
       return
     }
-    // A rename in My Armies must reach the label the toolbar shows for the same record.
+    // A rename in My Armies must reach the label the toolbar shows for the same record. The
+    // signature is left alone: renaming the saved army does not change the army on screen.
     if (linked.document.name === cloudArmyName) return
-    const link = { id: cloudArmyId, name: linked.document.name }
-    setCloudArmyLink(link)
-    writeCloudArmyLink(link)
+    setCloudArmyLink(current => {
+      if (!current) return current
+      const link = { ...current, name: linked.document.name }
+      writeCloudArmyLink(link)
+      return link
+    })
   }, [armies, cloudArmyId, cloudArmyName])
   const factions = useMemo(
     () =>
@@ -415,6 +439,7 @@ const HomeContent = () => {
         <Toolbar
           cloudArmyLinked={Boolean(cloudArmyId)}
           {...(cloudArmyName ? { cloudArmyName } : {})}
+          cloudArmyHasChanges={cloudArmyHasChanges}
           hiddenCount={hiddenCount}
           onClearArmy={() => setClearArmyModalIsOpen(true)}
           onDownloadPdf={() => setPrintModalIsOpen(true)}
@@ -496,7 +521,7 @@ const HomeContent = () => {
             isOpen={saveArmyModalIsOpen}
             onSaved={(savedDocument, savedCloudArmyId, savedName) => {
               setDocument(savedDocument)
-              linkCloudArmy(savedCloudArmyId, savedName)
+              linkCloudArmy(savedCloudArmyId, savedName, savedDocument)
             }}
           />
         </Suspense>

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -776,6 +776,11 @@ small {
   padding: 1rem 0;
 }
 
+/* The share link copies when clicked, so it has to look clickable rather than like a dead field. */
+.CopyableLink {
+  cursor: pointer;
+}
+
 /* Dropzone */
 .dropzone {
   flex: 1;

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -109,6 +109,14 @@ small {
   .ToolbarButtonCell {
     min-width: 9rem;
   }
+
+  /*
+   * The Update Army cell alone reserves the width of its widest label, so the swap through
+   * "Updating…" and "Updated" cannot resize the cell and slide the centred row sideways.
+   */
+  .ToolbarButtonCell--status {
+    min-width: 11rem;
+  }
 }
 
 .TapTarget {
@@ -695,11 +703,6 @@ small {
   background-color: $themeDarkBlueSecondary;
 }
 
-.Modal-Transparent {
-  @extend .Modal-Light;
-  background-color: rgba(0, 0, 0, 0);
-}
-
 .Modal-Overlay {
   position: fixed;
   top: 0;
@@ -715,6 +718,62 @@ small {
 
 .aos4-account-modal {
   width: min(46rem, calc(100vw - 4rem));
+}
+
+/*
+ * A modal keeps its own surface while a request is in flight, and the spinner sits over it. The
+ * previous treatment swapped the box to a fully transparent variant and `hidden` the content, so
+ * the whole dialog appeared to vanish mid-save.
+ */
+.ModalContent {
+  position: relative;
+}
+
+.ModalContent-Busy {
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.ModalContent-Spinner {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/*
+ * Saved-army rows.
+ *
+ * The three save-shaped actions pack from the left and Delete is pushed to the far end of whichever
+ * line it lands on. On a phone the strip wraps, and the previous flat order put Delete immediately
+ * beside the overwrite action with 8px between them — the two controls a player must never confuse,
+ * adjacent, in the one-hand-and-dice scene the product is designed for.
+ */
+.CloudArmyActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.CloudArmyDelete {
+  margin-left: auto;
+}
+
+/*
+ * Confirmations render in the row that raised them, so they inherit its surface and need no box of
+ * their own — and crucially no Bootstrap `alert-*`, whose light background is identical in both
+ * themes and rendered the outline-light confirm buttons at 1.17:1 in dark.
+ */
+.CloudArmyConfirm {
+  padding-top: 0.25rem;
+}
+
+.CloudArmyEmpty {
+  padding: 1rem 0;
 }
 
 /* Dropzone */

--- a/src/tests/aos4/accountCapabilitiesUi.test.tsx
+++ b/src/tests/aos4/accountCapabilitiesUi.test.tsx
@@ -120,10 +120,7 @@ describe('saved-army and sharing controls', () => {
       onLinked: vi.fn(),
     }
     act(() => {
-      render(
-        <SavedArmiesModal currentDocument={currentDocument} isOpen {...handlers} {...props} />,
-        container
-      )
+      render(<SavedArmiesModal isOpen {...handlers} {...props} />, container)
     })
     return handlers
   }
@@ -150,24 +147,19 @@ describe('saved-army and sharing controls', () => {
     expect(closeModal).toHaveBeenCalled()
   })
 
-  it('confirms before overwriting a saved army, and keeps that army its own name', async () => {
-    const { onApply, onLinked } = renderSavedArmies()
+  it('offers no way to overwrite a saved army from the list', () => {
+    renderSavedArmies()
 
+    /*
+     * Removed deliberately. It answered a question nobody asks — "overwrite that saved army with
+     * this different one" — while being the only unrecoverable action in the modal. Updating the
+     * army you are actually working on is the toolbar's Update Army, which now has a durable and
+     * named target; overwriting a same-named army is offered by Save Army where it is unambiguous.
+     */
     const [row] = rows()
-    act(() => findButton(row, 'Replace with current').click())
+    expect(queryButton(row, 'Replace with current')).toBeUndefined()
+    expect(row.textContent).not.toContain('Replace')
     expect(collection.updateArmy).not.toHaveBeenCalled()
-    expect(row.textContent).toContain('Replace Saved Stormhost with the army on screen?')
-
-    await act(async () => {
-      findButton(container, 'Replace saved army').click()
-      await Promise.resolve()
-    })
-    expect(collection.updateArmy).toHaveBeenCalledWith(
-      'cloud-1',
-      expect.objectContaining({ name: 'Saved Stormhost' })
-    )
-    expect(onApply).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'Saved Stormhost' }))
-    expect(onLinked).toHaveBeenLastCalledWith('cloud-1', 'Saved Stormhost')
   })
 
   it('confirms a delete in place and names what is being deleted', async () => {
@@ -343,5 +335,62 @@ describe('saved-army and sharing controls', () => {
       'https://aosreminders.com/?army=abcdefghijklmnopqrstuvwx'
     )
     expect(container.textContent).toContain('Copied')
+  })
+
+  it('copies the share link from the field itself and from the icon beside it', async () => {
+    const clipboard = { writeText: vi.fn().mockResolvedValue(undefined) }
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: clipboard })
+    act(() => {
+      render(<ShareArmyModal closeModal={vi.fn()} document={currentDocument} isOpen />, container)
+    })
+    await act(async () => {
+      findButton(container, 'Create share link').click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // Icon-only, so it is found by its accessible name rather than its text.
+    const iconButton = container.querySelector<HTMLButtonElement>('button[aria-label="Copy share link"]')
+    expect(iconButton).not.toBeNull()
+
+    const field = container.querySelector<HTMLInputElement>('#share-army-url')!
+    await act(async () => {
+      Simulate.click(field)
+      await Promise.resolve()
+    })
+    expect(clipboard.writeText).toHaveBeenCalledTimes(1)
+    // The name follows the state, so the confirmation reaches a screen reader too.
+    expect(iconButton!.getAttribute('aria-label')).toBe('Share link copied')
+
+    await act(async () => {
+      iconButton!.click()
+      await Promise.resolve()
+    })
+    expect(clipboard.writeText).toHaveBeenCalledTimes(2)
+    expect(clipboard.writeText).toHaveBeenLastCalledWith(
+      'https://aosreminders.com/?army=abcdefghijklmnopqrstuvwx'
+    )
+    expect(container.textContent).toContain('Link copied to your clipboard.')
+  })
+
+  it('tells the player to copy by hand when the browser blocks the clipboard', async () => {
+    const clipboard = { writeText: vi.fn().mockRejectedValue(new Error('denied')) }
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: clipboard })
+    act(() => {
+      render(<ShareArmyModal closeModal={vi.fn()} document={currentDocument} isOpen />, container)
+    })
+    await act(async () => {
+      findButton(container, 'Create share link').click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      findButton(container, 'Copy link').click()
+      await Promise.resolve()
+    })
+    // The Clipboard API needs a secure context, which a venue's captive portal will not give.
+    expect(container.textContent).toContain('copy it yourself')
+    expect(container.textContent).not.toContain('Copied')
   })
 })

--- a/src/tests/aos4/accountCapabilitiesUi.test.tsx
+++ b/src/tests/aos4/accountCapabilitiesUi.test.tsx
@@ -27,6 +27,7 @@ vi.mock('context/useArmyCollection', () => ({
 
 vi.mock('context/useTheme', () => ({
   useTheme: () => ({
+    isDark: false,
     theme: {
       bgColor: 'bg-white',
       cardBody: 'card-body',
@@ -35,6 +36,7 @@ vi.mock('context/useTheme', () => ({
       modalDangerClass: 'btn btn-danger',
       modalSuccessClass: 'btn btn-success',
       text: 'text-dark',
+      textMuted: 'text-muted',
     },
   }),
 }))
@@ -56,6 +58,9 @@ const findButton = (container: HTMLElement, label: string): HTMLButtonElement =>
   return button
 }
 
+const queryButton = (container: HTMLElement, label: string) =>
+  Array.from(container.querySelectorAll('button')).find(candidate => candidate.textContent?.trim() === label)
+
 describe('saved-army and sharing controls', () => {
   let container: HTMLDivElement
   const currentDocument = createDefaultAos4ArmyDocument()
@@ -66,6 +71,14 @@ describe('saved-army and sharing controls', () => {
     updatedAt: 2,
     document: savedDocument,
   }
+  const otherArmy = {
+    id: 'cloud-2',
+    createdAt: 1,
+    updatedAt: 3,
+    document: { ...currentDocument, name: 'Kruleboyz Tourney' },
+  }
+
+  const rows = () => Array.from(container.querySelectorAll<HTMLLIElement>('li.list-group-item'))
 
   beforeEach(() => {
     container = document.createElement('div')
@@ -99,51 +112,138 @@ describe('saved-army and sharing controls', () => {
     vi.restoreAllMocks()
   })
 
-  it('saves explicitly, previews before load, and confirms delete', async () => {
-    const closeModal = vi.fn()
-    const onApply = vi.fn()
-    const onDeleted = vi.fn()
-    const onLinked = vi.fn()
+  const renderSavedArmies = (props: Partial<React.ComponentProps<typeof SavedArmiesModal>> = {}) => {
+    const handlers = {
+      closeModal: vi.fn(),
+      onApply: vi.fn(),
+      onDeleted: vi.fn(),
+      onLinked: vi.fn(),
+    }
     act(() => {
       render(
-        <SavedArmiesModal
-          closeModal={closeModal}
-          currentDocument={currentDocument}
-          isOpen
-          onApply={onApply}
-          onDeleted={onDeleted}
-          onLinked={onLinked}
-        />,
+        <SavedArmiesModal currentDocument={currentDocument} isOpen {...handlers} {...props} />,
         container
       )
     })
+    return handlers
+  }
 
-    const saveName = container.querySelector<HTMLInputElement>('#saved-army-name')!
-    saveName.value = 'Tournament Army'
-    act(() => Simulate.change(saveName))
+  it('confirms a load inside the row that raised it, and never prints a canonical id', () => {
+    const { closeModal, onApply, onLinked } = renderSavedArmies()
+
+    const [row] = rows()
+    act(() => findButton(row, 'Load').click())
+
+    /*
+     * The structural guard, not a cosmetic one. The confirmation used to render after the whole
+     * list, where with eight saved armies it landed hundreds of pixels below the visible modal and
+     * "Load" appeared to do nothing at all.
+     */
+    const confirm = findButton(container, 'Load this army')
+    expect(row.contains(confirm)).toBe(true)
+    expect(row.textContent).toContain('Load Saved Stormhost?')
+    expect(container.textContent).not.toContain('rules-context:')
+
+    act(() => confirm.click())
+    expect(onApply).toHaveBeenLastCalledWith(savedDocument)
+    expect(onLinked).toHaveBeenLastCalledWith('cloud-1', 'Saved Stormhost')
+    expect(closeModal).toHaveBeenCalled()
+  })
+
+  it('confirms before overwriting a saved army, and keeps that army its own name', async () => {
+    const { onApply, onLinked } = renderSavedArmies()
+
+    const [row] = rows()
+    act(() => findButton(row, 'Replace with current').click())
+    expect(collection.updateArmy).not.toHaveBeenCalled()
+    expect(row.textContent).toContain('Replace Saved Stormhost with the army on screen?')
+
     await act(async () => {
-      findButton(container, 'Save new').click()
+      findButton(container, 'Replace saved army').click()
       await Promise.resolve()
     })
-    expect(collection.createArmy).toHaveBeenCalledWith(expect.objectContaining({ name: 'Tournament Army' }))
-    expect(onLinked).toHaveBeenLastCalledWith('cloud-1')
+    expect(collection.updateArmy).toHaveBeenCalledWith(
+      'cloud-1',
+      expect.objectContaining({ name: 'Saved Stormhost' })
+    )
+    expect(onApply).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'Saved Stormhost' }))
+    expect(onLinked).toHaveBeenLastCalledWith('cloud-1', 'Saved Stormhost')
+  })
 
-    act(() => findButton(container, 'Load').click())
-    expect(container.textContent).toContain('Replace the current army with Saved Stormhost?')
-    act(() => findButton(container, 'Replace current army').click())
-    expect(onApply).toHaveBeenLastCalledWith(savedDocument)
-    expect(onLinked).toHaveBeenLastCalledWith('cloud-1')
+  it('confirms a delete in place and names what is being deleted', async () => {
+    const { onDeleted } = renderSavedArmies()
 
-    act(() => findButton(container, 'Delete').click())
+    const [row] = rows()
+    act(() => findButton(row, 'Delete').click())
+    expect(collection.deleteArmy).not.toHaveBeenCalled()
+    expect(row.textContent).toContain('Delete Saved Stormhost?')
+
     await act(async () => {
-      findButton(container, 'Confirm delete').click()
+      findButton(container, 'Delete this army').click()
       await Promise.resolve()
     })
     expect(collection.deleteArmy).toHaveBeenCalledWith('cloud-1')
     expect(onDeleted).toHaveBeenCalledWith('cloud-1')
   })
 
-  it('saves the current army from the dedicated Save Army dialog and links the result', async () => {
+  it('renames through an explicit edit, and refuses a rename that changes nothing', async () => {
+    renderSavedArmies()
+
+    const [row] = rows()
+    act(() => findButton(row, 'Rename').click())
+
+    const input = container.querySelector<HTMLInputElement>('#army-name-cloud-1')!
+    expect(input.value).toBe('Saved Stormhost')
+    // Unchanged, so there is nothing to save — the previous version reported success for a no-op.
+    expect(findButton(container, 'Save name').disabled).toBe(true)
+
+    input.value = 'Grand Alliance Order'
+    act(() => Simulate.change(input))
+    expect(findButton(container, 'Save name').disabled).toBe(false)
+
+    await act(async () => {
+      Simulate.submit(container.querySelector('form')!)
+      await Promise.resolve()
+    })
+    expect(collection.updateArmy).toHaveBeenCalledWith(
+      'cloud-1',
+      expect.objectContaining({ name: 'Grand Alliance Order' })
+    )
+  })
+
+  it('keeps one decision open at a time across rows', () => {
+    collection.armies = [remoteArmy, otherArmy]
+    renderSavedArmies()
+
+    const [first, second] = rows()
+    act(() => findButton(first, 'Delete').click())
+    expect(queryButton(container, 'Delete this army')).toBeTruthy()
+
+    act(() => findButton(second, 'Load').click())
+    expect(queryButton(container, 'Delete this army')).toBeUndefined()
+    expect(second.contains(findButton(container, 'Load this army'))).toBe(true)
+  })
+
+  it('marks the army the on-screen document came from', () => {
+    collection.armies = [remoteArmy, otherArmy]
+    renderSavedArmies({ linkedCloudArmyId: 'cloud-2' })
+
+    const [first, second] = rows()
+    expect(first.textContent).not.toContain('On screen now')
+    expect(second.textContent).toContain('On screen now')
+  })
+
+  it('offers no way to create an army from the list, and guides an empty account to the toolbar', () => {
+    collection.armies = []
+    renderSavedArmies()
+
+    expect(container.querySelector('#saved-army-name')).toBeNull()
+    expect(queryButton(container, 'Save new')).toBeUndefined()
+    expect(container.textContent).toContain('No armies saved yet')
+    expect(container.textContent).toContain('Save Army')
+  })
+
+  it('saves the current army from the dedicated Save Army dialog and links the result by name', async () => {
     const closeModal = vi.fn()
     const onSaved = vi.fn()
     collection.createArmy.mockResolvedValue({ ...remoteArmy, id: 'cloud-9' })
@@ -157,14 +257,46 @@ describe('saved-army and sharing controls', () => {
     const nameInput = container.querySelector<HTMLInputElement>('#save-army-name')!
     nameInput.value = 'Tournament Army'
     act(() => Simulate.change(nameInput))
+    // Submitting the form, because a phone keyboard's "Go" has to reach the same action as the button.
     await act(async () => {
-      findButton(container, 'Save').click()
+      Simulate.submit(container.querySelector('form')!)
       await Promise.resolve()
     })
 
     expect(collection.createArmy).toHaveBeenCalledWith(expect.objectContaining({ name: 'Tournament Army' }))
-    expect(onSaved).toHaveBeenCalledWith(expect.objectContaining({ name: 'Tournament Army' }), 'cloud-9')
+    expect(onSaved).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Tournament Army' }),
+      'cloud-9',
+      'Tournament Army'
+    )
     expect(closeModal).toHaveBeenCalled()
+  })
+
+  it('warns when the name is already taken and offers to overwrite that army instead', async () => {
+    const onSaved = vi.fn()
+    act(() => {
+      render(
+        <SaveArmyModal closeModal={vi.fn()} currentDocument={currentDocument} isOpen onSaved={onSaved} />,
+        container
+      )
+    })
+
+    expect(queryButton(container, 'Overwrite it instead')).toBeUndefined()
+
+    const nameInput = container.querySelector<HTMLInputElement>('#save-army-name')!
+    nameInput.value = 'Saved Stormhost'
+    act(() => Simulate.change(nameInput))
+    expect(container.textContent).toContain('You already have a saved army called')
+
+    await act(async () => {
+      findButton(container, 'Overwrite it instead').click()
+      await Promise.resolve()
+    })
+    expect(collection.createArmy).not.toHaveBeenCalled()
+    expect(collection.updateArmy).toHaveBeenCalledWith(
+      'cloud-1',
+      expect.objectContaining({ name: 'Saved Stormhost' })
+    )
   })
 
   it('keeps the Save Army dialog open and shows the service error when saving fails', async () => {

--- a/src/tests/aos4/accountCapabilitiesUi.test.tsx
+++ b/src/tests/aos4/accountCapabilitiesUi.test.tsx
@@ -143,7 +143,8 @@ describe('saved-army and sharing controls', () => {
 
     act(() => confirm.click())
     expect(onApply).toHaveBeenLastCalledWith(savedDocument)
-    expect(onLinked).toHaveBeenLastCalledWith('cloud-1', 'Saved Stormhost')
+    // The document travels with the link so the caller can record it as the saved baseline.
+    expect(onLinked).toHaveBeenLastCalledWith('cloud-1', 'Saved Stormhost', savedDocument)
     expect(closeModal).toHaveBeenCalled()
   })
 

--- a/src/tests/aos4/cloudArmyLink.test.ts
+++ b/src/tests/aos4/cloudArmyLink.test.ts
@@ -1,0 +1,62 @@
+import { clearCloudArmyLink, readCloudArmyLink, writeCloudArmyLink } from 'utils/cloudArmyLink'
+import { describe, expect, it } from 'vitest'
+
+const createStorage = (initial: Record<string, string> = {}) => {
+  const values = new Map(Object.entries(initial))
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => void values.set(key, value),
+    removeItem: (key: string) => void values.delete(key),
+    entries: () => Object.fromEntries(values),
+  }
+}
+
+const throwingStorage = {
+  getItem: () => {
+    throw new Error('storage disabled')
+  },
+  setItem: () => {
+    throw new Error('storage disabled')
+  },
+  removeItem: () => {
+    throw new Error('storage disabled')
+  },
+}
+
+describe('cloud army link', () => {
+  it('survives a reload, which is the whole point of writing it down', () => {
+    const storage = createStorage()
+    writeCloudArmyLink({ id: 'cloud-1', name: 'Kruleboyz Tourney' }, storage)
+
+    // A second read models the next page load: the document comes back from storage, and so must
+    // the record it is a copy of. In memory alone, every refresh forked a duplicate on the next save.
+    expect(readCloudArmyLink(storage)).toEqual({ id: 'cloud-1', name: 'Kruleboyz Tourney' })
+  })
+
+  it('reads nothing when no link was written', () => {
+    expect(readCloudArmyLink(createStorage())).toBeUndefined()
+  })
+
+  it('clears the link so an unlinked document never claims a cloud army', () => {
+    const storage = createStorage()
+    writeCloudArmyLink({ id: 'cloud-1', name: 'Kruleboyz Tourney' }, storage)
+    clearCloudArmyLink(storage)
+
+    expect(readCloudArmyLink(storage)).toBeUndefined()
+    expect(storage.entries()).toEqual({})
+  })
+
+  it('ignores stored values that are not a link rather than trusting a partial one', () => {
+    const key = 'aos-reminders:aos4:cloud-army-link:v1'
+    expect(readCloudArmyLink(createStorage({ [key]: 'not json' }))).toBeUndefined()
+    expect(readCloudArmyLink(createStorage({ [key]: '{"name":"No id"}' }))).toBeUndefined()
+    expect(readCloudArmyLink(createStorage({ [key]: '{"id":"","name":"Empty id"}' }))).toBeUndefined()
+    expect(readCloudArmyLink(createStorage({ [key]: '{"id":"cloud-1"}' }))).toBeUndefined()
+  })
+
+  it('stays quiet when browser storage is unavailable, as it is in some privacy modes', () => {
+    expect(() => writeCloudArmyLink({ id: 'cloud-1', name: 'Any' }, throwingStorage)).not.toThrow()
+    expect(() => clearCloudArmyLink(throwingStorage)).not.toThrow()
+    expect(readCloudArmyLink(throwingStorage)).toBeUndefined()
+  })
+})

--- a/src/tests/aos4/cloudArmyLink.test.ts
+++ b/src/tests/aos4/cloudArmyLink.test.ts
@@ -46,6 +46,22 @@ describe('cloud army link', () => {
     expect(storage.entries()).toEqual({})
   })
 
+  it('carries the saved signature, which is what lets the toolbar tell saved from changed', () => {
+    const storage = createStorage()
+    writeCloudArmyLink({ id: 'cloud-1', name: 'Kruleboyz Tourney', savedSignature: '{"a":1}' }, storage)
+
+    expect(readCloudArmyLink(storage)?.savedSignature).toBe('{"a":1}')
+  })
+
+  it('reads a link written before signatures existed, and reports no signature', () => {
+    // Absent rather than wrong: the caller treats "no signature" as changed, which offers a save
+    // that may be unnecessary instead of hiding one that is not.
+    const key = 'aos-reminders:aos4:cloud-army-link:v1'
+    const stored = createStorage({ [key]: '{"id":"cloud-1","name":"Kruleboyz Tourney"}' })
+
+    expect(readCloudArmyLink(stored)).toEqual({ id: 'cloud-1', name: 'Kruleboyz Tourney' })
+  })
+
   it('ignores stored values that are not a link rather than trusting a partial one', () => {
     const key = 'aos-reminders:aos4:cloud-army-link:v1'
     expect(readCloudArmyLink(createStorage({ [key]: 'not json' }))).toBeUndefined()

--- a/src/tests/aos4/genericModalBusyState.test.tsx
+++ b/src/tests/aos4/genericModalBusyState.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import GenericModal from 'components/modals/generic/generic_modal'
+import { act } from 'react'
+import { render, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const theme = vi.hoisted(() => ({ isDark: false }))
+
+vi.mock('context/useTheme', () => ({
+  useTheme: () => ({ isDark: theme.isDark, theme: { text: 'text-dark' } }),
+}))
+
+/*
+ * The account modals mock GenericModal away, which is exactly why its processing state could ship
+ * blanking the whole dialog. These assertions are about the real component.
+ */
+describe('generic modal processing state', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    theme.isDark = false
+    container = document.createElement('div')
+    container.id = 'root'
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  const renderModal = (isProcessing: boolean) => {
+    act(() => {
+      render(
+        <GenericModal closeModal={vi.fn()} isOpen isProcessing={isProcessing} label="Test Modal">
+          <button type="button">Saved army action</button>
+          <div className="alert alert-danger">Something went wrong</div>
+        </GenericModal>,
+        container
+      )
+    })
+    return document.querySelector<HTMLElement>('.ModalContent')!
+  }
+
+  it('keeps the content mounted and visible while a request is in flight', () => {
+    const content = renderModal(true)
+
+    /*
+     * The regression this guards: the body used to be wrapped in `hidden`, which display:none's the
+     * subtree. The list, the headings and any live alert vanished mid-save, and because the focused
+     * control went with them the browser dropped focus to <body> and nothing put it back.
+     */
+    expect(document.querySelector('[hidden]')).toBeNull()
+    expect(content.textContent).toContain('Saved army action')
+    expect(content.textContent).toContain('Something went wrong')
+    expect(content.getAttribute('aria-busy')).toBe('true')
+    expect(content.querySelector('.ModalContent-Busy')).not.toBeNull()
+    expect(content.querySelector('.ModalContent-Spinner')).not.toBeNull()
+  })
+
+  it('reports the busy state to assistive technology through a live region', () => {
+    const content = renderModal(true)
+    const status = content.querySelector('[role="status"]')
+
+    expect(status).not.toBeNull()
+    expect(status!.textContent).toContain('Loading')
+  })
+
+  it('leaves no busy affordance behind once the request settles', () => {
+    const content = renderModal(false)
+
+    expect(content.getAttribute('aria-busy')).toBe('false')
+    expect(content.querySelector('.ModalContent-Busy')).toBeNull()
+    expect(content.querySelector('.ModalContent-Spinner')).toBeNull()
+  })
+
+  it('keeps the modal on its own themed surface rather than going transparent', () => {
+    renderModal(true)
+    expect(document.querySelector('.Modal-Light')).not.toBeNull()
+    expect(document.querySelector('.Modal-Transparent')).toBeNull()
+  })
+
+  it('draws the spinner for the active theme, so it is never dark-on-dark', () => {
+    // `isDark` was declared on the spinner and never passed, so it rendered `text-dark` in both
+    // themes — 1.53:1 against the composited scrim.
+    renderModal(true)
+    expect(document.querySelector('.ModalContent-Spinner .text-dark')).not.toBeNull()
+
+    act(() => {
+      unmountComponentAtNode(container)
+    })
+    theme.isDark = true
+    renderModal(true)
+    expect(document.querySelector('.ModalContent-Spinner .text-dark')).toBeNull()
+  })
+})

--- a/src/tests/aos4/toolbarSaveControls.test.tsx
+++ b/src/tests/aos4/toolbarSaveControls.test.tsx
@@ -64,7 +64,7 @@ describe('toolbar save controls', () => {
 
   it('splits saving into Update Army and Save As once the army mirrors a cloud army', () => {
     act(() => {
-      render(<Toolbar {...baseProps} cloudArmyLinked />, container)
+      render(<Toolbar {...baseProps} cloudArmyLinked cloudArmyHasChanges />, container)
     })
 
     expect(findButton(container, 'Save Army')).toBeUndefined()
@@ -75,6 +75,43 @@ describe('toolbar save controls', () => {
 
     act(() => findButton(container, 'Save As')!.click())
     expect(baseProps.onSaveArmy).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers Update Army only while the army differs from the saved copy', () => {
+    act(() => {
+      render(<Toolbar {...baseProps} cloudArmyLinked cloudArmyName="Kruleboyz Tourney" />, container)
+    })
+    // Nothing to write, so the control is absent rather than disabled — the Show Hidden rule.
+    expect(findButton(container, 'Update Army')).toBeUndefined()
+    expect(findButton(container, 'Save As')).not.toBeUndefined()
+    expect(container.textContent).toContain('up to date')
+
+    act(() => {
+      render(
+        <Toolbar {...baseProps} cloudArmyLinked cloudArmyName="Kruleboyz Tourney" cloudArmyHasChanges />,
+        container
+      )
+    })
+    expect(findButton(container, 'Update Army')).not.toBeUndefined()
+    expect(container.textContent).toContain('unsaved changes')
+  })
+
+  it('keeps Update Army through its own confirmation, so the save does not hide its own result', () => {
+    // The army is clean the instant the write lands; without this the "Updated" flash never shows.
+    act(() => {
+      render(<Toolbar {...baseProps} cloudArmyLinked updateArmyStatus="updating" />, container)
+    })
+    expect(findButton(container, 'Updating…')).not.toBeUndefined()
+
+    act(() => {
+      render(<Toolbar {...baseProps} cloudArmyLinked updateArmyStatus="updated" />, container)
+    })
+    expect(findButton(container, 'Updated')).not.toBeUndefined()
+
+    act(() => {
+      render(<Toolbar {...baseProps} cloudArmyLinked updateArmyStatus="idle" />, container)
+    })
+    expect(findButton(container, 'Update Army')).toBeUndefined()
   })
 
   it('names the cloud army Update Army writes to, and only while one is linked', () => {

--- a/src/tests/aos4/toolbarSaveControls.test.tsx
+++ b/src/tests/aos4/toolbarSaveControls.test.tsx
@@ -5,8 +5,14 @@ import { act } from 'react'
 import { render, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+// The real values from src/theme/light.ts. `btn-block` was Bootstrap 4 and no longer exists.
 vi.mock('context/useTheme', () => ({
-  useTheme: () => ({ theme: { genericButtonBlock: 'btn btn-block btn-outline-dark' } }),
+  useTheme: () => ({
+    theme: {
+      genericButtonBlock: 'btn btn-outline-dark d-block w-100',
+      textMuted: 'text-muted',
+    },
+  }),
 }))
 
 const findButton = (container: HTMLElement, label: string): HTMLButtonElement | undefined =>
@@ -69,6 +75,20 @@ describe('toolbar save controls', () => {
 
     act(() => findButton(container, 'Save As')!.click())
     expect(baseProps.onSaveArmy).toHaveBeenCalledTimes(1)
+  })
+
+  it('names the cloud army Update Army writes to, and only while one is linked', () => {
+    act(() => {
+      render(<Toolbar {...baseProps} cloudArmyName="Kruleboyz Tourney" />, container)
+    })
+    // Unlinked: there is no Update Army, so there is nothing to name.
+    expect(container.textContent).not.toContain('Kruleboyz Tourney')
+
+    act(() => {
+      render(<Toolbar {...baseProps} cloudArmyLinked cloudArmyName="Kruleboyz Tourney" />, container)
+    })
+    expect(container.textContent).toContain('Cloud army:')
+    expect(container.textContent).toContain('Kruleboyz Tourney')
   })
 
   it('reports update progress and completion on the Update Army button itself', () => {

--- a/src/tests/support/reactTestHelpers.ts
+++ b/src/tests/support/reactTestHelpers.ts
@@ -79,6 +79,15 @@ export const Simulate = {
     element.dispatchEvent(new Event(changeEventFor(element), { bubbles: true, cancelable: true }))
   },
 
+  /*
+   * Dispatched directly rather than by clicking the submit button: jsdom logs a "not implemented"
+   * error when a real form submission reaches navigation, and React's own handler is what the
+   * assertion is about.
+   */
+  submit: (element: Element): void => {
+    element.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+  },
+
   drop: (element: Element, eventData: { dataTransfer: unknown }): void => {
     const event = new Event('drop', { bubbles: true, cancelable: true })
     Object.defineProperty(event, 'dataTransfer', { value: eventData.dataTransfer })

--- a/src/utils/cloudArmyLink.ts
+++ b/src/utils/cloudArmyLink.ts
@@ -1,0 +1,61 @@
+/*
+ * Which cloud army the local document is a copy of.
+ *
+ * The document itself is written to `aos-reminders:aos4:army:v1` and survives a reload; the link to
+ * its cloud record used to live in React state alone, so one refresh — a service-worker update, a
+ * backgrounded tab, a phone reclaiming memory — silently turned "Update Army" back into
+ * "Save Army", and the next save forked a duplicate instead of updating. At a tournament that
+ * accumulates identically-named armies nobody can tell apart.
+ *
+ * The link is stored beside the document rather than inside it, because a document travels: it is
+ * serialized into share links and read back by the import path, and neither should carry one
+ * account's private record id. Anything that falsifies "this document IS that cloud army" clears
+ * the link — see `unlinkCloudArmy` in Home.
+ */
+const CLOUD_ARMY_LINK_STORAGE_KEY = 'aos-reminders:aos4:cloud-army-link:v1'
+
+export interface CloudArmyLink {
+  id: string
+  /** Last known name of the cloud record, so the toolbar can name the target before the list loads. */
+  name: string
+}
+
+const isLink = (value: unknown): value is CloudArmyLink =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as CloudArmyLink).id === 'string' &&
+  Boolean((value as CloudArmyLink).id) &&
+  typeof (value as CloudArmyLink).name === 'string'
+
+export const readCloudArmyLink = (
+  storage: Pick<Storage, 'getItem'> = window.localStorage
+): CloudArmyLink | undefined => {
+  try {
+    const stored = storage.getItem(CLOUD_ARMY_LINK_STORAGE_KEY)
+    if (!stored) return undefined
+    const parsed: unknown = JSON.parse(stored)
+    return isLink(parsed) ? { id: parsed.id, name: parsed.name } : undefined
+  } catch {
+    // Browser storage can be unavailable in privacy modes, and a hand-edited value is not ours.
+    return undefined
+  }
+}
+
+export const writeCloudArmyLink = (
+  link: CloudArmyLink,
+  storage: Pick<Storage, 'setItem'> = window.localStorage
+): void => {
+  try {
+    storage.setItem(CLOUD_ARMY_LINK_STORAGE_KEY, JSON.stringify(link))
+  } catch {
+    // The in-memory link remains usable for this session.
+  }
+}
+
+export const clearCloudArmyLink = (storage: Pick<Storage, 'removeItem'> = window.localStorage): void => {
+  try {
+    storage.removeItem(CLOUD_ARMY_LINK_STORAGE_KEY)
+  } catch {
+    // Nothing to recover from; the caller has already dropped its own copy.
+  }
+}

--- a/src/utils/cloudArmyLink.ts
+++ b/src/utils/cloudArmyLink.ts
@@ -18,6 +18,15 @@ export interface CloudArmyLink {
   id: string
   /** Last known name of the cloud record, so the toolbar can name the target before the list loads. */
   name: string
+  /**
+   * The serialized document as it stands on the account, so the toolbar can tell whether the army
+   * on screen has moved away from it. `serializeAos4ArmyDocument` normalizes sort order and drops
+   * empty preferences, so this compares by content and never reports a difference that isn't one.
+   *
+   * Optional: a link written before this field existed reports "changed", which is the safe
+   * default — it offers a save that may be unnecessary rather than hiding one that is not.
+   */
+  savedSignature?: string
 }
 
 const isLink = (value: unknown): value is CloudArmyLink =>
@@ -25,7 +34,8 @@ const isLink = (value: unknown): value is CloudArmyLink =>
   value !== null &&
   typeof (value as CloudArmyLink).id === 'string' &&
   Boolean((value as CloudArmyLink).id) &&
-  typeof (value as CloudArmyLink).name === 'string'
+  typeof (value as CloudArmyLink).name === 'string' &&
+  ['string', 'undefined'].includes(typeof (value as CloudArmyLink).savedSignature)
 
 export const readCloudArmyLink = (
   storage: Pick<Storage, 'getItem'> = window.localStorage
@@ -34,7 +44,12 @@ export const readCloudArmyLink = (
     const stored = storage.getItem(CLOUD_ARMY_LINK_STORAGE_KEY)
     if (!stored) return undefined
     const parsed: unknown = JSON.parse(stored)
-    return isLink(parsed) ? { id: parsed.id, name: parsed.name } : undefined
+    if (!isLink(parsed)) return undefined
+    return {
+      id: parsed.id,
+      name: parsed.name,
+      ...(parsed.savedSignature ? { savedSignature: parsed.savedSignature } : {}),
+    }
   } catch {
     // Browser storage can be unavailable in privacy modes, and a hand-edited value is not ours.
     return undefined


### PR DESCRIPTION

---

## Follow-up (ad8ee151)

**Share Army now copies three ways.** The link field is click-to-copy, with a copy icon beside it and the labelled button below. All three run one handler and share one confirmation. Each also selects the field's text: the Clipboard API needs a secure context and a venue's captive portal will not give one, so a blocked copy now leaves the link selected and says to copy it by hand rather than failing silently. Share Army also picks up the neutral `btn-close` and 44px targets the other two account modals took — its close control was a filled red button in dark theme.

**`Replace with current` is removed from My Armies.** It answered a question nobody asks — *overwrite that saved army with this different one* — while being the only unrecoverable action left in the modal. Updating the army you are actually working on is the toolbar's `Update Army`, which now has a durable, named target; overwriting a same-named army is offered by `Save Army`, where it is unambiguous. The row is `Load`, `Rename`, and a separated `Delete`. `currentDocument` is no longer a prop of the modal.

**DESIGN.md gains The Alert Surface Rule.** Alert palettes stay light in both themes because nothing in this product sets `data-bs-theme`, which makes an alert the one surface where the Slot Rule runs backwards — a slot's dark value gets resolved against a light ground. That is what put the Load confirmation at 1.17:1. The rule is scoped to what is actually true here: theme-invariant controls on alerts are fine and already ship on `/profile` and `/subscribe`; theme-varying slots, and decisions of any kind, are not.

Re-verified: 104 files / **3367 tests**, lint, tsc, build, detector 0 findings. Both copy paths driven in the browser — the success path (link selected, check icon, "Link copied to your clipboard.") and the blocked-clipboard path.


## Follow-up (3572abca)

**`Update Army` appears only when there is something to update.** The link now records the serialized document as it stands on the account, and the control is absent — not disabled — while the army on screen matches it. Same rule `Show Hidden` follows.

The comparison is exact: `serializeAos4ArmyDocument` runs the document through `createAos4ArmyDocument` first, which sorts selection ids, sorts preference keys, drops empty preferences and trims the name. It cannot report a difference that isn't one. The baseline is set wherever the local document becomes a copy of a cloud army — loaded, saved, saved as, updated.

Two details that make it read right:

- The button **stays through `Updating…` and `Updated`**. The army goes clean the instant the write lands, so gating on changes alone would delete the confirmation the save had just earned. Observed live: `Updating… | unsaved changes` → `Updated | up to date` → button absent.
- The status line names the state — `Cloud army: Skaven 13 · up to date` / `· unsaved changes`. The absence of a button is not a message; without this, an army that is already saved looks identical to one whose control went missing.

A link stored before signatures existed carries none and reports changed, which offers a save that may be unnecessary rather than hiding one that is not.

Verified live: load → `up to date`, no button; hide one reminder → `unsaved changes`, button returns; update → full confirmation sequence; reload → still `up to date`. 104 files / **3371 tests**, lint, tsc, build, detector 0 findings.
