### PR TITLE
fix(ui): weight the modal family's buttons by what each one does

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -277,21 +277,46 @@ Muted text is expressed as opacity rather than a separate token: `text-white-75`
 (`theme.cardBody`, `theme.text`, `theme.reminderHeader`), and light and dark supply their own
 values. A literal hex in a component is a defect — it will be wrong in one of the two themes.
 
+Three slots are deliberately the *same string* in both themes and are declared once, in
+`invariantButtons` in `theme/helperClasses`, so the two theme files cannot drift apart:
+`theme.commitButton` (`btn-primary`), `theme.destructiveButton` (`btn-danger`), and
+`theme.alertActionButton` (`btn-sm btn-outline-dark`). The first two carry a *decision*, and a
+decision must read with the same weight in both themes; the third lives on an alert, below. A
+`themeButtonSlots` test asserts the invariance, because the failure it prevents is invisible in
+whichever theme you happen to be developing in.
+
+That is the whole invariant set. Everything else that varies by surface still varies by theme.
+
 **The Alert Surface Rule.** A Bootstrap `alert-*` keeps its light palette in *both* themes. Nothing
 in this product sets `data-bs-theme`, so the alert backgrounds never invert — `alert-info` is
 `#d1ecf1` on a Midnight Slate page exactly as it is on a white one.
 
 An alert is therefore the one surface where the Slot Rule runs backwards. A slot exists so light and
 dark can supply their own value; on an alert, the dark value is resolved against a light ground and
-the contrast inverts. `theme.genericButton` and `theme.modalConfirmClass` are both
-`btn-outline-light` in dark theme, and on `alert-info` they measured **1.17:1** — the Load
-confirmation in `My Armies` was invisible to every dark-theme subscriber until #1963.
+the contrast inverts. `theme.genericButton` was `btn-outline-light` in dark theme, and on
+`alert-info` it measured **1.17:1** — the Load confirmation in `My Armies` was invisible to every
+dark-theme subscriber until #1963.
 
-So an alert may only carry colours that do not vary by theme: its own text, and a control whose
-class is the same string in both themes (`theme.secondaryButton`, or a literal Bootstrap signal
-class like `btn-danger`). Never a slot that differs between `light.ts` and `dark.ts` — check the two
-files before putting any slot on an alert, and prefer moving the control onto the surrounding themed
-surface instead.
+A control on an alert therefore has to clear **two** bars, and the second is the one that is easy to
+miss:
+
+1. **Theme-invariant.** Its class must be the same string in both themes — `theme.alertActionButton`,
+   `theme.commitButton`, `theme.destructiveButton`, or a literal Bootstrap signal class. Never a slot
+   that differs between `light.ts` and `dark.ts`; check the two files before putting any slot on an
+   alert.
+2. **4.5:1 against the alert's own fixed background.** Invariance only guarantees the control is
+   equally wrong in both themes. `btn-outline-secondary` draws its ink at `#6c757d`, which on
+   `alert-warning` `#fff3cd` measures **4.23:1** — theme-invariant, and still under the floor. It
+   was the retry control on `/profile` and `/subscribe` until this was written down. `btn-success`
+   fails the same way from the other direction: white on `#28a745` is **3.13:1**, and it was the
+   `Resubscribe` link on the expired-subscription alert.
+
+`theme.alertActionButton` exists to be the answer to both: `btn-outline-dark` puts `#343a40` ink on
+`alert-warning` at 10.4:1, and clears every other alert background by at least 8.6:1. (`$dark` is
+pinned to 4.6's `$gray-800`, so the ink is `#343a40` and not Bootstrap 5's `#212529` — a small
+reminder to measure in the compiled bundle rather than from the framework's documented default.)
+Where the control does not recover from what the alert reports, prefer moving it onto the
+surrounding themed surface instead.
 
 **The Meaning-Only Colour Rule.** Colour marks structure (Signal Teal = section header) or
 authorship (Note Blue = the player's own words). It never decorates, and it never carries
@@ -484,10 +509,28 @@ varies; the instruments do not.
   `me-2` and a `text-nowrap` label. Outline rather than filled because seven of them sit in one
   row — seven filled buttons would out-shout the reminders below.
 - **Navbar:** `btn btn-outline-light btn-sm mx-2` against the teal masthead.
-- **Commitment (`btn-primary`, Action Blue):** the only *filled* buttons in the product, reserved
-  for the moment money or an account changes — the three Subscribe CTAs, gift purchase, redemption.
-  Filled-vs-outline is the hierarchy: outline for everything reversible, filled for the one control
-  that commits. `btn-success` and `btn-danger` fill likewise for confirm and destroy in modals.
+- **Commitment (`theme.commitButton`, `btn-primary`, Action Blue):** the only *filled* buttons in
+  the product, reserved for the one control in a view that commits — the three Subscribe CTAs, gift
+  purchase, redemption, and in the modal family `Save`, `Import Army`, `Load a copy`,
+  `Load this army`, `Download PDF`, `Create share link`. Filled-vs-outline is the hierarchy: outline
+  for everything reversible, filled for the one control that commits. `theme.destructiveButton`
+  (`btn-danger`) fills likewise for the control that destroys — the row `Delete` in `My Armies`,
+  `Overwrite it instead` in `Save Army`, and the confirm in `GenericDestructiveModal`.
+  `btn-success` fills nothing: white on Bootstrap's green measures 3.13:1, under the 4.5:1 floor,
+  and green as a *commit* colour also collided with green as a *confirmed-write* colour on alerts.
+- **Cancel and close:** always `theme.genericButton`, or `btn-close` where a modal has a corner
+  dismiss. Red is for destroying data, never for leaving. Four controls whose job was cancel or
+  close — in `Import Army` (twice), `Shared Army`, and `Print` — carried `modalDangerClass` and
+  rendered as filled red in dark theme, which made the way out of each modal its loudest element.
+- **Segmented / pressed:** Bootstrap's own `.active` on `theme.genericButton`, alongside
+  `aria-pressed` — the `Paste roster` / `Upload roster` pair in `Import Army`. The selected segment
+  fills with the outline button's own ink (11.5:1 in light, 19.9:1 in dark) rather than taking a
+  signal colour, so "the one you picked" does not read as a status. It was `btn-info`, at 3.04:1.
+- **The filled signal classes that are not used:** `btn-success` (3.13:1) and `btn-info` (3.04:1)
+  both put white on a mid-tone at ratios under the floor, and neither appears in the codebase.
+  `btn-warning` and `btn-light` take dark text and pass, but have no role here. If a new filled
+  colour is ever needed, measure it in the compiled bundle first — `$min-contrast-ratio` is pinned
+  to 2.5 to preserve 4.6's text-colour choices, so Bootstrap will *not* stop you.
 - **Width:** full-width is the dominant shape — `d-block w-100`, 14 uses (Bootstrap 5 dropped
   `.btn-block`). Buttons in this product are full-width in
   their column far more often than they are inline.
@@ -539,13 +582,21 @@ sits where the failure happened. They carry `role="alert"` where the content is 
 first render.
 
 An alert may carry a control that recovers from what it reports — the retry on `/profile` and
-`/subscribe`, the dismiss on the notification banner — and its class must be theme-invariant, per
-The Alert Surface Rule.
+`/subscribe` (`theme.alertActionButton`), the dismiss on the notification banner. Its class must
+clear both bars in The Alert Surface Rule: theme-invariant *and* 4.5:1 against the alert's own
+background.
 
 It never carries a *decision*. A confirmation goes on the themed surface of whatever it is
 confirming, adjacent to the control that raised it, for two reasons: the alert's live-region role
 announces its text without moving focus to anything inside it, and an alert placed after the list it
 refers to can be arbitrarily far from the row that raised it. `My Armies` did both until #1963.
+
+One live exception, and it is unresolved rather than blessed: `Overwrite it instead` in `Save Army`
+is a decision sitting on an `alert-warning`. It is placed there because the duplicate-name warning
+is the only place the alternative makes sense, and the alert wraps its message in `role="status"`
+with the button *outside* the live region so focus can reach it. It clears both contrast bars
+(`theme.destructiveButton`, 4.53:1). It still contradicts this paragraph, and the honest fix is
+probably to move the pair onto the modal's own surface. Treat it as open.
 
 ### Inputs / Fields
 
@@ -569,7 +620,9 @@ refers to can be arbitrarily far from the row that raised it. `My Armies` did bo
   accompanied by `visually-hidden` "Loading..." text under `role="status"`, so the state is announced and
   not merely animated.
 - **Suspense fallbacks:** `LoadingHeader` and `LoadingBody` stand in for the navbar and routed
-  content, so the masthead does not collapse while a lazy route resolves.
+  content, so the masthead does not collapse while a lazy route resolves. `LoadingBody` is two
+  static lines and stays that way — a pulse and a fade were built for it and deliberately rejected.
+  See The Dead Class Rule.
 
 ### Cards / Containers
 
@@ -607,30 +660,40 @@ the opposite mode is a dead stop in the tab order.
 ### Named Rules
 
 **The Dead Class Rule.** A class in JSX that no rule defines is a design intention that silently
-never happened, and this codebase has a habit of them. Checked against the compiled bundle, five
+never happened, and this codebase has a habit of them. Checked against the compiled bundle, three
 are live in `src/components/` today:
 
 | Class | Where | What was intended |
 | --- | --- | --- |
-| `pulsate-fwd` | `helpers/suspenseFallbacks.tsx` | A pulse on the loading heading |
-| `fade-out` | `helpers/suspenseFallbacks.tsx` | A fade on "Loading…" |
 | `btn-pill` | `payment/pricingPlans.tsx` | A rounded Subscribe CTA (`rounded-pill` is the real class) |
 | `btn-md` | `routes/Profile.tsx` | A medium button; Bootstrap only ships `btn-sm`/`btn-lg` |
 | `pricing-card-title` | `payment/pricingPlans.tsx` | Carried over from a Bootstrap example |
 
-The first two matter most to this record. The product has essentially no motion — the only
-transition in the stylesheet is the dropzone's border on drag-over — and that reads as a deliberate
-choice fitting the use scene. But the loading screen *asked* for a pulse and a fade and got neither,
-so the absence of motion there is an accident, not a decision. Treat it as open rather than settled.
+`pulsate-fwd` and `fade-out` on the suspense fallback left this table by being **removed**, and that
+closes the one question this record used to carry as open. It said the loading screen "asked for a
+pulse and a fade and got neither, so the absence of motion there is an accident, not a decision",
+and to treat it as unsettled.
+
+It is settled: the loading screen holds still. Both animations were built and reviewed against the
+real fallback in both themes before the call was made, so this is a decision about the product and
+not an omission — the pulse read as more presence than a two-line placeholder wants, and the
+product's stillness turned out to be worth more than the reassurance it bought. The classes are
+gone from `suspenseFallbacks.tsx` rather than left sitting there, because a dead class is exactly
+what would let this switch itself back on during a future stylesheet change.
+
+So the product has essentially no motion, and now by decision at every point: the only transition in
+the stylesheet is the dropzone's border on drag-over. Do not define `pulsate-fwd` or `fade-out`.
+Adding motion anywhere is a design change that needs asking for, and the reminders surface is the
+last place to try it.
 
 Verify a new utility class exists before relying on it — `grep` the compiled CSS, not your memory of
-which Bootstrap version this is. A seventh entry, `g-0` on the FAQ row, left this table in the 5.3
-upgrade: it was Bootstrap 5 syntax written while the project was still on 4.6, so it had never done
-anything, and the upgrade would have brought it to life and narrowed every FAQ card. It was deleted
-rather than honoured, because reviving a style that has never shipped is a design change. An eighth,
-`h-md-250` on the same row, left with the FAQ rebuild that replaced that layout outright. That is
-the general remedy for this table: a dead class is removed or implemented deliberately, never left
-to switch itself on during an upgrade.
+which Bootstrap version this is. Two more entries left this table the same way. `g-0` on the FAQ row
+was Bootstrap 5 syntax written while the project was still on 4.6, so it had never done anything,
+and the 5.3 upgrade would have brought it to life and narrowed every FAQ card. It was deleted rather
+than honoured, because reviving a style that has never shipped is a design change — the same
+reasoning that retired `pulsate-fwd` and `fade-out`. `h-md-250` on the same row left with the FAQ
+rebuild that replaced that layout outright. That is the general remedy for this table: a dead class
+is removed or implemented deliberately, never left to switch itself on during an upgrade.
 
 ## Do's and Don'ts
 
@@ -664,7 +727,9 @@ to switch itself on during an upgrade.
   `$themeDarkBlueTertiary` — they are declared but unused and are not part of the system.
 - **Don't** put a theme-varying slot inside a Bootstrap `alert-*`, or a decision of any kind. Alert
   palettes stay light in both themes, so `btn-outline-light` vanishes on one — this shipped at
-  1.17:1. See The Alert Surface Rule.
+  1.17:1. And don't stop at invariance: `btn-outline-secondary` (4.23:1 on `alert-warning`) and
+  `btn-success` (3.13:1) are the same string in both themes and both shipped under the floor. Reach
+  for `theme.alertActionButton`. See The Alert Surface Rule.
 - **Don't** change heading level to change text size. Set the size in `.CardHeaderTitle`.
 - **Don't** use uppercase outside the timing tags.
 - **Don't** use a filled button for a reversible action. Filled (`btn-primary`) is reserved for the

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -185,10 +185,19 @@ occurrence, Legends, Spearhead, General's Handbook 2026-27 (`Scourge of Aqshy`).
   (`src/tests/fixtures/aos4/import/new-recruit/`), captured from opted-in accounts and
   self-checking across all three formats.
 - **A mobile and accessibility audit**, `docs/design/2026-07-30-mobile-accessibility-audit.md`
-  (score 14/20), superseding the 2026-07-28 pass (11/20), which is retained as history. It closes
-  17 of the prior 23 findings including the sole P0, and leaves two P1s: target sizes below the
-  24px WCAG 2.5.8 floor across 85 timing tags, the mode switch, and the navbar; and a 1.42MB
-  gzipped initial chunk carrying the generated corpus. Neither is a data or rules defect.
+  (score 14/20), superseding the 2026-07-28 pass (11/20), which is retained as history. It closed
+  17 of the prior 23 findings including the sole P0, and left two P1s. Re-measured against the
+  compiled bundle on 2026-08-16, both have moved and neither is closed:
+  - **Target sizes below the 24px WCAG 2.5.8 floor.** The 85 timing tags and the navbar are
+    fixed — the tags carry a 24px `::after` hit box that leaves the 20px chip's density intact,
+    and the navbar takes `.TapTarget`/`.TapTargetOverlay` to 44px. **The Edit/Play switch is
+    still 20px tall** (`react-switch`, `height={20} width={80}`), which is the whole of what
+    remains of this P1 — and it is the product's one mode control, on the one-handed screen.
+  - **The initial chunk.** Now 1.21MB gzipped (`aos4-catalog-data`, 12.7MB raw), down from
+    1.42MB. It is not in the entry HTML, but it is a static dependency of the lazily-loaded
+    `Home` route, so every player still waits for it before the reminders surface renders.
+
+  Neither is a data or rules defect.
 
 **Absences that future work must not fabricate**: there are no testimonials, no case studies, no
 press, no usage or subscriber metrics, and no benchmark data. Nothing in this repository supports a

--- a/src/components/helpers/suspenseFallbacks.tsx
+++ b/src/components/helpers/suspenseFallbacks.tsx
@@ -52,9 +52,16 @@ export const LoadingBody = () => {
 
   return (
     <div className={containerClass}>
+      {/*
+       * No motion here, deliberately — see The Dead Class Rule in DESIGN.md. The heading and the
+       * "Loading..." line carried `pulsate-fwd` and `fade-out` for years with no rule defining
+       * either. The question of whether to honour them or drop them was settled in favour of
+       * dropping them: this screen holds still like the rest of the product. Do not re-add the
+       * classes, and do not define those names in the stylesheet.
+       */}
       <div className="col text-center">
-        <h3 className={`pulsate-fwd ${theme.text}`}>AoS Reminders</h3>
-        <p className={`lead ${theme.textMuted} fade-out`}>Loading...</p>
+        <h3 className={theme.text}>AoS Reminders</h3>
+        <p className={`lead ${theme.textMuted}`}>Loading...</p>
       </div>
     </div>
   )

--- a/src/components/input/armySharing/shareArmyModal.tsx
+++ b/src/components/input/armySharing/shareArmyModal.tsx
@@ -120,7 +120,7 @@ const ShareArmyModal = ({ closeModal, document, isOpen }: ShareArmyModalProps) =
             </div>
 
             <button
-              className="btn btn-primary d-block w-100 mt-3 TapTargetBlock"
+              className={`${theme.commitButton} d-block w-100 mt-3 TapTargetBlock`}
               onClick={() => void copy()}
               type="button"
             >
@@ -137,7 +137,7 @@ const ShareArmyModal = ({ closeModal, document, isOpen }: ShareArmyModalProps) =
           </>
         ) : (
           <button
-            className="btn btn-primary d-block w-100 TapTargetBlock"
+            className={`${theme.commitButton} d-block w-100 TapTargetBlock`}
             disabled={!configured}
             onClick={() => void create()}
             type="button"

--- a/src/components/input/armySharing/sharedArmyModal.tsx
+++ b/src/components/input/armySharing/sharedArmyModal.tsx
@@ -1,6 +1,7 @@
 import { ArmyApi, type SharedArmy } from '../../../api/armyApi'
 import { AOS4_CATALOG } from '../../../aos4/generated'
 import { createAos4ArmyDocument, type Aos4ArmyDocument } from '../../../aos4/state'
+import { summarizeCloudArmy } from 'components/input/cloudArmies/armySummary'
 import GenericModal from 'components/modals/generic/generic_modal'
 import { useTheme } from 'context/useTheme'
 import { useEffect, useMemo, useState } from 'react'
@@ -31,6 +32,7 @@ const SharedArmyModal = ({
       share?.document.rulesContextId,
     [share?.document.rulesContextId]
   )
+  const summary = useMemo(() => (share ? summarizeCloudArmy(share.document) : { unitCount: 0 }), [share])
 
   useEffect(() => {
     let active = true
@@ -76,11 +78,20 @@ const SharedArmyModal = ({
         {share && (
           <>
             <p className="lead mb-1">{share.document.name}</p>
-            <dl>
-              <dt>Rules context</dt>
-              <dd>{contextName}</dd>
-              <dt>Selections</dt>
-              <dd>{share.document.explicitSelectionIds.length}</dd>
+            {/*
+             * The same three facts the import preview shows, in the same shape, because import and
+             * share are the two ways a roster built elsewhere arrives. This was "Rules context" and
+             * a raw "Selections" count — `explicitSelectionIds.length`, an internal field name and a
+             * number that counts factions and battle formations alongside units, so it matched
+             * nothing the player could see. "Ruleset" is the word the import preview already uses.
+             */}
+            <dl className="row mb-2">
+              <dt className="col-4">Faction</dt>
+              <dd className="col-8">{summary.factionName ?? 'Not declared'}</dd>
+              <dt className="col-4">Units</dt>
+              <dd className="col-8">{summary.unitCount}</dd>
+              <dt className="col-4">Ruleset</dt>
+              <dd className="col-8">{contextName}</dd>
             </dl>
             <p className="small">
               Loading creates a new local copy. It does not change the shared army or save it to your cloud
@@ -90,13 +101,17 @@ const SharedArmyModal = ({
         )}
         <div className="row mt-3">
           <div className="col-6">
-            <button className={`${theme.modalDangerClass} d-block w-100`} onClick={closeModal} type="button">
+            {/*
+             * Outline, not `btn-danger`: keeping the army you already have is the reversible way out
+             * of this modal, and it was the loudest control on the screen in dark theme.
+             */}
+            <button className={`${theme.genericButton} d-block w-100`} onClick={closeModal} type="button">
               Keep current army
             </button>
           </div>
           <div className="col-6">
             <button
-              className={`${theme.modalSuccessClass} d-block w-100`}
+              className={`${theme.commitButton} d-block w-100`}
               disabled={!share}
               onClick={apply}
               type="button"

--- a/src/components/input/cloudArmies/armySummary.ts
+++ b/src/components/input/cloudArmies/armySummary.ts
@@ -2,13 +2,15 @@ import { AOS4_CATALOG } from '../../../aos4/generated'
 import type { Aos4ArmyDocument } from '../../../aos4/state'
 
 /*
- * What a saved army looks like in a list.
+ * What an army the player did not build on screen looks like when it is described back to them —
+ * a row in `My Armies`, or the header of an incoming shared link.
  *
- * The rows used to read "15 selections", which is `explicitSelectionIds.length` — the internal
- * field name, and a number no player recognises. A player recognises the faction they brought and
- * roughly how many units are in it, so that is what a row says now. Both are read off the canonical
- * ID prefix (`faction:`, `warscroll:`) rather than by resolving the selection, because a row is
- * rendered once per saved army and resolution is the builder's much heavier job.
+ * Both used to read off `explicitSelectionIds.length` ("15 selections") — the internal field name,
+ * and a number that counts the faction and battle formation alongside the units, so it matched
+ * nothing the player could count. A player recognises the faction they brought and roughly how many
+ * units are in it, so that is what they get. Both are read off the canonical ID prefix (`faction:`,
+ * `warscroll:`) rather than by resolving the selection, because this renders once per army in a
+ * list and resolution is the builder's much heavier job.
  */
 const entityNames = new Map(AOS4_CATALOG.entities.map(entity => [entity.id as string, entity.name]))
 

--- a/src/components/input/cloudArmies/saveArmyModal.tsx
+++ b/src/components/input/cloudArmies/saveArmyModal.tsx
@@ -96,15 +96,8 @@ const SaveArmyModal = ({ closeModal, currentDocument, isOpen, onSaved }: SaveArm
               onChange={event => setSaveName(event.target.value)}
               value={saveName}
             />
-            {/*
-             * `btn-primary`, not `theme.modalSuccessClass`. That slot is filled green in light
-             * theme and outlined in dark, so the one control that commits carried two different
-             * weights depending on the theme — and its filled form put white text on Bootstrap's
-             * green at 3.13:1, under the 4.5:1 floor. Action Blue is DESIGN.md's commit colour and
-             * measures 4.68:1.
-             */}
             <button
-              className="btn btn-primary TapTarget"
+              className={`${theme.commitButton} TapTarget`}
               disabled={!configured || !trimmedName || isSaving}
               type="submit"
             >
@@ -132,7 +125,7 @@ const SaveArmyModal = ({ closeModal, currentDocument, isOpen, onSaved }: SaveArm
               <p className="small mb-2">Saving now adds a second army with the same name.</p>
             </div>
             <button
-              className="btn btn-danger btn-sm TapTarget"
+              className={`${theme.destructiveButton} btn-sm TapTarget`}
               disabled={isSaving}
               onClick={() => void updateExisting()}
               type="button"

--- a/src/components/input/cloudArmies/savedArmiesModal.tsx
+++ b/src/components/input/cloudArmies/savedArmiesModal.tsx
@@ -97,16 +97,11 @@ const SavedArmiesModal = ({
   const cancelButton = `${theme.genericButton} btn-sm TapTarget`
   /*
    * Filled, because these are the controls that commit — outline is for everything reversible. Both
-   * fills are literal Bootstrap signal classes rather than theme slots, so a confirmation reads the
-   * same in light and dark: the slots are asymmetric (`modalSuccessClass` is filled in one theme and
-   * outlined in the other), which would give the same decision two different weights.
-   *
-   * `btn-primary` and not `btn-success`: Action Blue carries white text at 4.68:1 and Bootstrap's
-   * green at 3.13:1, under the 4.5:1 this product treats as correctness. `btn-danger` clears it at
-   * 4.53:1. This is the same reasoning that moved $primary off Bootstrap's default — see DESIGN.md.
+   * slots are theme-invariant by construction (see `invariantButtons` in theme/helperClasses), so a
+   * confirmation reads with the same weight in light and dark.
    */
-  const commitButton = 'btn btn-primary btn-sm TapTarget'
-  const destroyButton = 'btn btn-danger btn-sm TapTarget'
+  const commitButton = `${theme.commitButton} btn-sm TapTarget`
+  const destroyButton = `${theme.destructiveButton} btn-sm TapTarget`
 
   const renderActions = (army: RemoteArmy) => {
     const isPending = pending?.id === army.id

--- a/src/components/input/importArmy/importArmyModal.tsx
+++ b/src/components/input/importArmy/importArmyModal.tsx
@@ -44,7 +44,7 @@ const ImportArmyModal = ({
   isOpen,
   onApply,
 }: ImportArmyModalProps) => {
-  const { theme } = useTheme()
+  const { isDark, theme } = useTheme()
   const [mode, setMode] = useState<ImportMode>('upload')
   const [text, setText] = useState('')
   const [decoded, setDecoded] = useState<Aos4ParsedRosterResult>()
@@ -188,20 +188,31 @@ const ImportArmyModal = ({
               Recruit .ros/.rosz/.json file.
             </p>
           </div>
+          {/*
+           * `btn-close`, the same control Save Army and My Armies use. It was
+           * `theme.modalDangerClass` — a filled red button in dark theme, which made Close the
+           * loudest thing in a modal whose job is to accept a roster. The glyph was a literal `×`
+           * with no accessible name of its own; `btn-close` draws the mark itself.
+           */}
           <button
             aria-label="Close import"
-            className={theme.modalDangerClass}
+            className={`btn-close TapTargetOverlay flex-shrink-0 ${isDark ? 'btn-close-white' : ''}`}
             onClick={closeModal}
             type="button"
-          >
-            ×
-          </button>
+          />
         </div>
 
+        {/*
+         * Bootstrap's own `.active`, not a signal colour. The selected segment was `btn-info`, whose
+         * white text on Info Cyan measures 3.04:1 — and cyan on this surface also read as a status,
+         * not as "this is the one you picked". `.active` fills the outline button the group is
+         * already made of: 11.5:1 in light theme, 19.9:1 in dark, and the pressed state is drawn by
+         * the same rule that draws `aria-pressed`.
+         */}
         <div aria-label="Import source" className="btn-group w-100 mb-3" role="group">
           <button
             aria-pressed={mode === 'paste'}
-            className={mode === 'paste' ? 'btn btn-info' : theme.genericButton}
+            className={`${theme.genericButton}${mode === 'paste' ? ' active' : ''}`}
             onClick={() => chooseMode('paste')}
             type="button"
           >
@@ -209,7 +220,7 @@ const ImportArmyModal = ({
           </button>
           <button
             aria-pressed={mode === 'upload'}
-            className={mode === 'upload' ? 'btn btn-info' : theme.genericButton}
+            className={`${theme.genericButton}${mode === 'upload' ? ' active' : ''}`}
             onClick={() => chooseMode('upload')}
             type="button"
           >
@@ -232,8 +243,12 @@ const ImportArmyModal = ({
               rows={10}
               value={text}
             />
+            {/*
+             * Outline: previewing is a look, not the commit. Filled belongs to `Import Army` below,
+             * which is the control that replaces the army on screen.
+             */}
             <button
-              className={`${theme.modalConfirmClass} d-block w-100 mt-3`}
+              className={`${theme.genericButton} d-block w-100 mt-3`}
               disabled={!text.trim()}
               onClick={previewText}
               type="button"
@@ -303,13 +318,13 @@ const ImportArmyModal = ({
 
         <div className="row mt-4">
           <div className="col-6">
-            <button className={`${theme.modalDangerClass} d-block w-100`} onClick={closeModal} type="button">
+            <button className={`${theme.genericButton} d-block w-100`} onClick={closeModal} type="button">
               Cancel
             </button>
           </div>
           <div className="col-6">
             <button
-              className={`${theme.modalSuccessClass} d-block w-100`}
+              className={`${theme.commitButton} d-block w-100`}
               disabled={!canApply}
               onClick={apply}
               type="button"

--- a/src/components/modals/generic/generic_destructive_modal.tsx
+++ b/src/components/modals/generic/generic_destructive_modal.tsx
@@ -77,10 +77,16 @@ const GenericDestructiveModal = ({
         </div>
       </div>
       <div className="d-flex flex-row justify-content-around">
-        <GenericButton className={`${theme.modalDangerClass} ${btnResponsiveClass}`} onClick={handleConfirm}>
+        {/*
+         * Filled danger on the confirm, outline on the deny. This is the one modal where red is
+         * correct — it is named `Destructive` and the confirm is what destroys — and it now matches
+         * the row confirmations in `My Armies`. The pair used to render outline-danger beside
+         * outline-dark in light theme, which gave the destroy and the escape the same weight.
+         */}
+        <GenericButton className={`${theme.destructiveButton} ${btnResponsiveClass}`} onClick={handleConfirm}>
           <FaCheck className="me-2" /> {confirmText}
         </GenericButton>
-        <GenericButton className={`${theme.modalConfirmClass} ${btnResponsiveClass}`} onClick={handleDeny}>
+        <GenericButton className={`${theme.genericButton} ${btnResponsiveClass}`} onClick={handleDeny}>
           {denyText}
         </GenericButton>
       </div>

--- a/src/components/modals/paypal_post_subscribe_modal.tsx
+++ b/src/components/modals/paypal_post_subscribe_modal.tsx
@@ -99,7 +99,7 @@ export const PaypalPostSubscribeModal = ({ closeModal, modalIsOpen, retryGrant }
       </div>
       <div className="row text-center">
         <div className="col px-0">
-          <GenericButton className={theme.modalConfirmClass} onClick={closeModal}>
+          <GenericButton className={theme.genericButton} onClick={closeModal}>
             Close
           </GenericButton>
         </div>

--- a/src/components/page/redemption.tsx
+++ b/src/components/page/redemption.tsx
@@ -1,5 +1,6 @@
 import GenericButton from 'components/input/generic_button'
 import Contact from 'components/page/contact'
+import { useTheme } from 'context/useTheme'
 import React from 'react'
 import { FaRegFrown, FaRegSmileBeam } from 'react-icons/fa'
 import { ROUTES } from 'utils/env'
@@ -7,34 +8,49 @@ import { ROUTES } from 'utils/env'
 export const RedemptionLogin = ({
   children,
   handleClick,
-}: React.PropsWithChildren<{ handleClick: (event: React.MouseEvent) => unknown }>) => (
-  <div>
-    {children}
-    {/* Standing account-flow guidance, so it takes the same .lead voice as the preamble above it. */}
-    <p className="lead">
-      First, you&apos;re going to need to create an account and log in. Once you&apos;ve done that, we&apos;ll
-      set your subscription up!
-    </p>
-    <GenericButton className="btn btn-primary btn-lg" onClick={handleClick}>
-      Log In / Sign Up
-    </GenericButton>
-  </div>
-)
+}: React.PropsWithChildren<{ handleClick: (event: React.MouseEvent) => unknown }>) => {
+  const { theme } = useTheme()
 
-export const RedemptionSuccess = () => (
-  // The outcome replaces the form in place, so it has to announce itself.
-  <div role="status">
-    {/* Sized by class, not by heading level: this sits under the page <h1>, so it is an <h2>. */}
-    <h2 className="h5">Woohoo! You&apos;re all set!</h2>
-    {/* The glyph was an <h2> whose only content was a decorative icon — an empty heading. */}
-    <div className="h2 my-2">
-      <FaRegSmileBeam aria-hidden="true" />
+  return (
+    <div>
+      {children}
+      {/* Standing account-flow guidance, so it takes the same .lead voice as the preamble above it. */}
+      <p className="lead">
+        First, you&apos;re going to need to create an account and log in. Once you&apos;ve done that,
+        we&apos;ll set your subscription up!
+      </p>
+      <GenericButton className={`${theme.commitButton} btn-lg`} onClick={handleClick}>
+        Log In / Sign Up
+      </GenericButton>
     </div>
-    <GenericButton className="btn btn-success btn-lg" onClick={() => window.location.replace(ROUTES.PROFILE)}>
-      Take me to my Profile!
-    </GenericButton>
-  </div>
-)
+  )
+}
+
+export const RedemptionSuccess = () => {
+  const { theme } = useTheme()
+
+  return (
+    // The outcome replaces the form in place, so it has to announce itself.
+    <div role="status">
+      {/* Sized by class, not by heading level: this sits under the page <h1>, so it is an <h2>. */}
+      <h2 className="h5">Woohoo! You&apos;re all set!</h2>
+      {/* The glyph was an <h2> whose only content was a decorative icon — an empty heading. */}
+      <div className="h2 my-2">
+        <FaRegSmileBeam aria-hidden="true" />
+      </div>
+      {/*
+       * Was `btn-success`, whose white text measures 3.13:1. This is the same control the login step
+       * above renders, one screen later, so it takes the same commit colour at 4.69:1.
+       */}
+      <GenericButton
+        className={`${theme.commitButton} btn-lg`}
+        onClick={() => window.location.replace(ROUTES.PROFILE)}
+      >
+        Take me to my Profile!
+      </GenericButton>
+    </div>
+  )
+}
 
 export const RedemptionError = ({ error, showButton }: { error: string; showButton: boolean }) => (
   <>

--- a/src/components/payment/giftSubscriptions.tsx
+++ b/src/components/payment/giftSubscriptions.tsx
@@ -259,7 +259,7 @@ const PlanComponent = ({ supportPlan }: { supportPlan: IGiftedSubscriptionPlans 
       <td>${(parseFloat(supportPlan.cost) * quantity).toFixed(2)}</td>
       <td>
         <GenericButton
-          className={`btn ${isMobile ? 'btn-sm' : ''} d-block w-100 btn-primary TapTargetBlock`}
+          className={`${theme.commitButton} ${isMobile ? 'btn-sm' : ''} d-block w-100 TapTargetBlock`}
           disabled={isAuthenticated && (quantity < 1 || isRedirecting)}
           onClick={isAuthenticated ? handleCheckout : login}
         >

--- a/src/components/payment/pricingPlans.tsx
+++ b/src/components/payment/pricingPlans.tsx
@@ -226,7 +226,7 @@ export const PlanComponent = (props: IPlanProps) => {
              */
             <GenericButton
               type="button"
-              className="btn d-block w-100 btn-primary TapTargetBlock py-2"
+              className={`${theme.commitButton} d-block w-100 TapTargetBlock py-2`}
               onClick={login}
             >
               Subscribe for {supportPlan.title}
@@ -259,7 +259,7 @@ export const PlanComponent = (props: IPlanProps) => {
                   <GenericButton
                     type="button"
                     aria-label={`Subscribe for ${supportPlan.title} with Stripe`}
-                    className="btn d-block btn-primary TapTargetBlock py-2 PaymentChoiceOption--stripe"
+                    className={`${theme.commitButton} d-block TapTargetBlock py-2 PaymentChoiceOption--stripe`}
                     disabled={isRedirecting}
                     onClick={handleStripeCheckout}
                   >

--- a/src/components/print/printModal.tsx
+++ b/src/components/print/printModal.tsx
@@ -183,13 +183,17 @@ const PrintModal = ({ closeModal, defaultFileName, isOpen, onDownloadPdf }: Prin
       */}
       <div className="row mx-3 mt-4 pb-3">
         <div className="col-12 pb-2">
-          <button className={`${theme.modalDangerClass} d-block w-100`} onClick={closeModal} type="button">
+          <button className={`${theme.genericButton} d-block w-100`} onClick={closeModal} type="button">
             Cancel
           </button>
         </div>
         <div className="col-12 pb-2">
+          {/*
+           * Filled: Download PDF is what this modal exists to do, and Cancel sits directly above it
+           * in the same column. With both outlined, the two read as equal weight.
+           */}
           <button
-            className={`${theme.modalConfirmClass} d-block w-100`}
+            className={`${theme.commitButton} d-block w-100`}
             disabled={isDownloadingPdf}
             onClick={() => void handleDownload()}
             type="button"

--- a/src/components/routes/Join.tsx
+++ b/src/components/routes/Join.tsx
@@ -70,6 +70,7 @@ const Preamble = () => (
 
 const RedeemSection = () => {
   const { user } = useAuth0()
+  const { theme } = useTheme()
   const getAccessToken = useApiAccessToken()
   const [couponId, setCouponId] = useState('')
   const [isRedeeming, setIsRedeeming] = useState(false)
@@ -150,7 +151,7 @@ const RedeemSection = () => {
           long enough, so a short code left the page with no visible way forward and nothing to
           explain why. Disabling it while the request is in flight stops a double redemption.
         */}
-        <GenericButton className="btn btn-primary btn-lg" disabled={!canRedeem} type="submit">
+        <GenericButton className={`${theme.commitButton} btn-lg`} disabled={!canRedeem} type="submit">
           {isRedeeming ? (
             <>
               <span aria-hidden="true" className="spinner-border spinner-border-sm me-2" role="status" />

--- a/src/components/routes/Profile.tsx
+++ b/src/components/routes/Profile.tsx
@@ -217,7 +217,7 @@ const SubscriptionInfoBody = () => {
         <br />
         <button
           type="button"
-          className={`${theme.secondaryButton} mt-2`}
+          className={`${theme.alertActionButton} mt-2`}
           onClick={() => void getSubscription()}
         >
           Check again
@@ -439,15 +439,28 @@ const ToggleTheme = () => {
   )
 }
 
-const SubscriptionExpired = () => (
-  /* `btn-md` was a dead class — Bootstrap 4.6 ships only btn-sm and btn-lg, so this was default size. */
-  <div className="alert alert-danger text-center mb-0" role="alert">
-    <strong>Your subscription has expired!</strong>
-    <br />
-    <Link to={ROUTES.SUBSCRIBE} className="btn btn-success mt-2" onClick={() => logClick('Resubscribe')}>
-      Resubscribe now!
-    </Link>
-  </div>
-)
+const SubscriptionExpired = () => {
+  const { theme } = useTheme()
+
+  return (
+    /* `btn-md` was a dead class — Bootstrap 4.6 ships only btn-sm and btn-lg, so this was default size. */
+    <div className="alert alert-danger text-center mb-0" role="alert">
+      <strong>Your subscription has expired!</strong>
+      <br />
+      {/*
+       * Action Blue, not `btn-success`. Both are theme-invariant, so both satisfy The Alert Surface
+       * Rule — but white on Bootstrap's green measures 3.13:1 and on $blue 4.69:1, and this control
+       * resubscribes, which is the commit colour's own job.
+       */}
+      <Link
+        to={ROUTES.SUBSCRIBE}
+        className={`${theme.commitButton} mt-2`}
+        onClick={() => logClick('Resubscribe')}
+      >
+        Resubscribe now!
+      </Link>
+    </div>
+  )
+}
 
 export default Profile

--- a/src/components/routes/Redeem.tsx
+++ b/src/components/routes/Redeem.tsx
@@ -103,6 +103,7 @@ const MissingRedemption = () => (
 
 const RedeemSection = () => {
   const { user } = useAuth0()
+  const { theme } = useTheme()
   const getAccessToken = useApiAccessToken()
   /*
    * Captured once. It used to be re-read on every render while handleRedeem cleared the cache
@@ -165,7 +166,7 @@ const RedeemSection = () => {
       </p>
       <p className="lead">If you&apos;re ready to redeem this gifted subscription, click the button below!</p>
       {/* Disabled while the request is in flight, so a second click cannot spend the gift twice. */}
-      <GenericButton className="btn btn-primary btn-lg" disabled={!canRedeem} onClick={handleRedeem}>
+      <GenericButton className={`${theme.commitButton} btn-lg`} disabled={!canRedeem} onClick={handleRedeem}>
         {isRedeeming ? (
           <>
             <span aria-hidden="true" className="spinner-border spinner-border-sm me-2" role="status" />

--- a/src/components/routes/Subscribe.tsx
+++ b/src/components/routes/Subscribe.tsx
@@ -199,7 +199,11 @@ const SubscriptionUnavailable = ({ error, onRetry }: { error: string; onRetry: (
             <br />
             We have not shown the plans, in case you are already subscribed.
             <br />
-            <button type="button" className={`${theme.secondaryButton} mt-2`} onClick={() => void onRetry()}>
+            <button
+              type="button"
+              className={`${theme.alertActionButton} mt-2`}
+              onClick={() => void onRetry()}
+            >
               Check again
             </button>
           </div>

--- a/src/tests/aos4/accountCapabilitiesUi.test.tsx
+++ b/src/tests/aos4/accountCapabilitiesUi.test.tsx
@@ -31,10 +31,9 @@ vi.mock('context/useTheme', () => ({
     theme: {
       bgColor: 'bg-white',
       cardBody: 'card-body',
+      commitButton: 'btn btn-primary',
+      destructiveButton: 'btn btn-danger',
       genericButton: 'btn btn-outline-dark',
-      modalConfirmClass: 'btn btn-info',
-      modalDangerClass: 'btn btn-danger',
-      modalSuccessClass: 'btn btn-success',
       text: 'text-dark',
       textMuted: 'text-muted',
     },

--- a/src/tests/aos4/accountRoutes.test.tsx
+++ b/src/tests/aos4/accountRoutes.test.tsx
@@ -42,15 +42,15 @@ const subscription = vi.hoisted(() => ({
 }))
 
 const theme = {
+  alertActionButton: 'btn btn-sm btn-outline-dark',
   bgColor: 'bg-light',
   card: 'card',
   cardBody: 'card-body',
+  commitButton: 'btn btn-primary',
+  destructiveButton: 'btn btn-danger',
   genericButton: 'btn btn-light',
   headerColor: 'header',
-  modalConfirmClass: 'btn btn-primary',
-  modalDangerClass: 'btn btn-danger',
   profileCardHeader: 'card-header',
-  secondaryButton: 'btn btn-sm btn-outline-secondary',
   text: 'text-dark',
 }
 

--- a/src/tests/aos4/importUi.test.tsx
+++ b/src/tests/aos4/importUi.test.tsx
@@ -43,10 +43,8 @@ vi.mock('context/useTheme', () => ({
     theme: {
       bgColor: 'bg-white',
       dropzone: 'dropzone',
+      commitButton: 'btn btn-primary',
       genericButton: 'btn btn-outline-dark',
-      modalConfirmClass: 'btn btn-outline-dark',
-      modalDangerClass: 'btn btn-outline-danger',
-      modalSuccessClass: 'btn btn-success',
       text: 'text-dark',
     },
   }),
@@ -292,6 +290,45 @@ describe('AoS 4 import modal', () => {
       selectionCount: 3,
       source: 'official-app-text',
     })
+  })
+
+  /*
+   * Import is the main entry path — most rosters are built elsewhere — and until this pass its
+   * three most prominent controls were all mis-weighted: Close was `modalDangerClass` (filled red
+   * in dark theme, the loudest thing in the modal), Import Army was `modalSuccessClass` (white on
+   * Bootstrap green at 3.13:1 in light theme, and merely outlined in dark), and Cancel was red
+   * beside it.
+   */
+  it('weights close, cancel, and commit by what each one does', () => {
+    const close = container.querySelector('button[aria-label="Close import"]')
+    expect(close?.className).toContain('btn-close')
+    expect(close?.className).not.toContain('btn-danger')
+
+    expect(findButton(container, 'Cancel').className).toContain('btn-outline-dark')
+    expect(findButton(container, 'Cancel').className).not.toContain('btn-danger')
+
+    const apply = findButton(container, 'Import Army')
+    expect(apply.className).toContain('btn-primary')
+    expect(apply.className).not.toContain('btn-success')
+  })
+
+  /*
+   * The selected source segment fills with Bootstrap's `.active` rather than `btn-info`, whose
+   * white text measured 3.04:1 — and which read as a status rather than as the pressed state.
+   */
+  it('marks the selected import source with the pressed state, not a signal colour', () => {
+    // The modal opens on the upload zone.
+    expect(findButton(container, 'Upload roster').getAttribute('aria-pressed')).toBe('true')
+    expect(findButton(container, 'Upload roster').className).toContain('active')
+    expect(findButton(container, 'Upload roster').className).not.toContain('btn-info')
+    expect(findButton(container, 'Paste roster').className).not.toContain('active')
+
+    act(() => {
+      Simulate.click(findButton(container, 'Paste roster'))
+    })
+
+    expect(findButton(container, 'Paste roster').className).toContain('active')
+    expect(findButton(container, 'Upload roster').className).not.toContain('active')
   })
 
   it('opens a reproducible GitHub report and downloads the exact failed pasted roster', async () => {

--- a/src/tests/aos4/printModalUi.test.tsx
+++ b/src/tests/aos4/printModalUi.test.tsx
@@ -8,8 +8,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('context/useTheme', () => ({
   useTheme: () => ({
     theme: {
-      modalConfirmClass: 'btn btn-info',
-      modalDangerClass: 'btn btn-danger',
+      commitButton: 'btn btn-primary',
+      genericButton: 'btn btn-outline-dark',
       text: 'text-dark',
     },
   }),
@@ -90,6 +90,29 @@ describe('PDF download modal', () => {
     })
 
     expect(closeModal).toHaveBeenCalledTimes(1)
+  })
+
+  /*
+   * Cancel sits directly above Download PDF in the same full-width column — the modal is
+   * shrink-to-fit, so they cannot share a row. With both outlined they read as equal weight, and
+   * Cancel was the *redder* of the two (`modalDangerClass`, filled in dark theme).
+   */
+  it('fills the download and leaves cancel outlined', () => {
+    act(() => {
+      render(
+        <PrintModal
+          closeModal={vi.fn()}
+          defaultFileName="Stormcast_Reminders"
+          isOpen
+          onDownloadPdf={vi.fn().mockResolvedValue(undefined)}
+        />,
+        container
+      )
+    })
+
+    expect(findButton(container, 'Download PDF').className).toContain('btn-primary')
+    expect(findButton(container, 'Cancel').className).toContain('btn-outline-dark')
+    expect(findButton(container, 'Cancel').className).not.toContain('btn-danger')
   })
 
   it('passes includeSummary false when the army summary checkbox is unchecked', async () => {

--- a/src/tests/aos4/sharedArmyUi.test.tsx
+++ b/src/tests/aos4/sharedArmyUi.test.tsx
@@ -17,8 +17,8 @@ vi.mock('../../api/armyApi', () => ({
 vi.mock('context/useTheme', () => ({
   useTheme: () => ({
     theme: {
-      modalDangerClass: 'btn btn-danger',
-      modalSuccessClass: 'btn btn-success',
+      commitButton: 'btn btn-primary',
+      genericButton: 'btn btn-outline-dark',
       text: 'text-dark',
     },
   }),
@@ -96,5 +96,65 @@ describe('shared army preview', () => {
       })
     )
     expect(closeModal).toHaveBeenCalledTimes(1)
+  })
+
+  /*
+   * Import is how most rosters arrive and share is its sibling, so the two say the same things in
+   * the same words. This preview used to read "Rules context" and a raw "Selections" count taken
+   * straight off `explicitSelectionIds.length` — an internal field name, and a number that counts
+   * the faction and battle formation alongside the units.
+   */
+  it('describes the share in the words the import preview uses', async () => {
+    armyApi.getShare.mockResolvedValue({
+      id: 'abcdefghijklmnopqrstuvwx',
+      createdAt: 1,
+      document: { ...createDefaultAos4ArmyDocument(), name: 'Shared Stormhost' },
+    })
+
+    await act(async () => {
+      render(
+        <SharedArmyModal closeModal={vi.fn()} isOpen onApply={vi.fn()} shareId="abcdefghijklmnopqrstuvwx" />,
+        container
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const labels = Array.from(container.querySelectorAll('dt')).map(term => term.textContent)
+    expect(labels).toEqual(['Faction', 'Units', 'Ruleset'])
+    expect(container.textContent).not.toContain('Selections')
+    expect(container.textContent).not.toContain('Rules context')
+  })
+
+  /*
+   * "Load a copy" replaces the army on screen and is the only control here that commits; "Keep
+   * current army" is the reversible way out. The pair used to render `modalSuccessClass` beside
+   * `modalDangerClass` — green-or-outline-green against red — so the escape was the loudest control
+   * in the modal in dark theme, and the commit changed weight between themes.
+   */
+  it('gives the commit the only fill and leaves the way out reversible', async () => {
+    armyApi.getShare.mockResolvedValue({
+      id: 'abcdefghijklmnopqrstuvwx',
+      createdAt: 1,
+      document: { ...createDefaultAos4ArmyDocument(), name: 'Shared Stormhost' },
+    })
+
+    await act(async () => {
+      render(
+        <SharedArmyModal closeModal={vi.fn()} isOpen onApply={vi.fn()} shareId="abcdefghijklmnopqrstuvwx" />,
+        container
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const byLabel = (label: string) =>
+      Array.from(container.querySelectorAll('button')).find(
+        candidate => candidate.textContent?.trim() === label
+      )
+
+    expect(byLabel('Load a copy')?.className).toContain('btn-primary')
+    expect(byLabel('Keep current army')?.className).toContain('btn-outline-dark')
+    expect(byLabel('Keep current army')?.className).not.toContain('btn-danger')
   })
 })

--- a/src/tests/aos4/themeButtonSlots.test.ts
+++ b/src/tests/aos4/themeButtonSlots.test.ts
@@ -1,0 +1,53 @@
+import DarkTheme from 'theme/dark'
+import LightTheme from 'theme/light'
+import { describe, expect, it } from 'vitest'
+
+/*
+ * The button slots that must NOT vary by theme, and why each one is on this list.
+ *
+ * This is the contract behind `invariantButtons` in theme/helperClasses. It is a test rather than a
+ * comment because the failure it guards is invisible in the theme you happen to be developing in:
+ * `modalSuccessClass` was `btn-success` in light and `btn-outline-success` in dark, so the single
+ * control that commits looked primary on one theme and secondary on the other, and nothing caught
+ * it for as long as those slots existed.
+ */
+const invariantSlots = ['alertActionButton', 'commitButton', 'destructiveButton'] as const
+
+/*
+ * Slots removed by the modal-family pass. Listed by name so a re-introduction has to argue with
+ * this test: `modalConfirmClass` was byte-identical to `genericButton` in both themes (a
+ * distinction the theme never delivered), `modalSuccessClass` and `modalDangerClass` varied their
+ * fill by theme, and `modalDangerClass` was carrying four controls whose job is cancel or close.
+ */
+const removedSlots = ['modalConfirmClass', 'modalDangerClass', 'modalSuccessClass', 'secondaryButton']
+
+describe('theme button slots', () => {
+  it.each(invariantSlots)('%s is the same string in both themes', slot => {
+    expect(LightTheme[slot]).toBe(DarkTheme[slot])
+  })
+
+  it.each(removedSlots)('%s stays removed', slot => {
+    expect(LightTheme).not.toHaveProperty(slot)
+    expect(DarkTheme).not.toHaveProperty(slot)
+  })
+
+  /*
+   * The alert control's ink, specifically. An alert keeps its light palette in both themes (see The
+   * Alert Surface Rule in DESIGN.md), so its control is resolved against a light ground either way.
+   * `btn-outline-secondary` was theme-invariant and still failed: #6c757d on `alert-warning`
+   * #fff3cd measures 4.23:1, under the 4.5:1 floor. `btn-outline-dark` is 10.4:1 there.
+   * Invariance is necessary, not sufficient.
+   */
+  it('resolves the alert control against a light ground with dark ink', () => {
+    expect(LightTheme.alertActionButton).toContain('btn-outline-dark')
+    expect(LightTheme.alertActionButton).not.toContain('btn-outline-secondary')
+  })
+
+  /*
+   * Action Blue, not Bootstrap's green: white on $blue #0070e8 measures 4.69:1 and on $green
+   * #28a745 measures 3.13:1.
+   */
+  it('commits in Action Blue', () => {
+    expect(LightTheme.commitButton).toBe('btn btn-primary')
+  })
+})

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -1,3 +1,4 @@
+import { invariantButtons } from 'theme/helperClasses'
 import { ITheme } from 'types/theme'
 
 const selectTheme = {
@@ -62,6 +63,8 @@ const selectTheme = {
 const bgColor = `bg-themeDarkBlueSecondary`
 
 const DarkTheme: ITheme = {
+  // `alertActionButton`, `commitButton`, `destructiveButton` — identical in both themes by design.
+  ...invariantButtons,
   bgColor,
   card: `card border border-dark`,
   cardBody: `card-body ${bgColor}`,
@@ -70,9 +73,6 @@ const DarkTheme: ITheme = {
   genericButton: `btn btn-outline-light`,
   genericButtonBlock: `btn btn-outline-light d-block w-100`,
   headerColor: bgColor,
-  modalConfirmClass: `btn btn-outline-light`,
-  modalDangerClass: `btn btn-danger`,
-  modalSuccessClass: `btn btn-outline-success`,
   noteBorder: `NoteBorder-Dark`,
   /*
    * `.card` never gets a themed background, so the light theme's 15% wash composites over Bootstrap's
@@ -84,7 +84,6 @@ const DarkTheme: ITheme = {
   reminderHeader: `bg-themeLightBlue`,
   reminderHr: `ReminderHr-Dark`,
   reminderTags: `ReminderTags-Dark`,
-  secondaryButton: `btn btn-sm btn-outline-secondary`,
   /*
    * Light theme separates this band with a tonal shelf; dark theme separates with the card borders
    * instead, so the band takes the page colour. $themeDarkBluePrimary was the obvious candidate but

--- a/src/theme/helperClasses.ts
+++ b/src/theme/helperClasses.ts
@@ -16,3 +16,36 @@ export const navbarStyles = {
   headerClass: 'pt-2 d-print-none d-flex justify-content-center align-items-center',
   link: 'fw-bold text-light mx-2 TapTarget',
 }
+
+/*
+ * The `ITheme` button slots whose value must be the *same string* in both themes.
+ *
+ * A slot normally exists so light and dark can each supply their own value. These three exist for
+ * the opposite reason, and they are declared here — once — and spread into both theme files so the
+ * two cannot drift apart:
+ *
+ * - `commitButton` and `destructiveButton` carry a decision, and a decision must read with the same
+ *   weight in both themes. The slots these replace did not: `modalSuccessClass` was filled
+ *   (`btn-success`) in light and outlined (`btn-outline-success`) in dark, so the single control
+ *   that commits looked primary on one theme and secondary on the other. `modalDangerClass` was
+ *   filled red in dark on four controls whose job is *cancel* or *close*, making the way out of a
+ *   modal its loudest element.
+ * - `alertActionButton` sits on a Bootstrap `alert-*`, whose palette stays light in both themes —
+ *   see The Alert Surface Rule in DESIGN.md. A theme-varying class is a contrast defect there by
+ *   construction.
+ *
+ * Measured in the compiled bundle, on the surfaces each is used on:
+ * - `btn-primary` is `$blue` #0070e8 and carries white at 4.69:1. Bootstrap's green measures
+ *   3.13:1, which is why the commit colour here is Action Blue and not green.
+ * - `btn-danger` #dc3545 carries white at 4.53:1.
+ * - `btn-outline-dark` draws its ink at #343a40 — `$dark` is pinned to 4.6's `$gray-800`, not
+ *   Bootstrap 5's #212529 — which is 10.4:1 on `alert-warning` and at least 8.6:1 on every other
+ *   alert background. It replaced `btn-outline-secondary` (#6c757d), theme-invariant but 4.23:1 on
+ *   `alert-warning` — under the 4.5:1 floor this product treats as correctness. Theme-invariance
+ *   alone is not enough on an alert.
+ */
+export const invariantButtons = {
+  alertActionButton: 'btn btn-sm btn-outline-dark',
+  commitButton: 'btn btn-primary',
+  destructiveButton: 'btn btn-danger',
+}

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -1,8 +1,11 @@
+import { invariantButtons } from 'theme/helperClasses'
 import { ITheme } from 'types/theme'
 
 const bgColor = `bg-white`
 
 const LightTheme: ITheme = {
+  // `alertActionButton`, `commitButton`, `destructiveButton` — identical in both themes by design.
+  ...invariantButtons,
   bgColor,
   card: `card`,
   cardBody: `card-body ${bgColor}`,
@@ -11,16 +14,12 @@ const LightTheme: ITheme = {
   genericButton: `btn btn-outline-dark`,
   genericButtonBlock: `btn btn-outline-dark d-block w-100`,
   headerColor: `bg-themeDarkBluePrimary`,
-  modalConfirmClass: `btn btn-outline-dark`,
-  modalDangerClass: `btn btn-outline-danger`,
-  modalSuccessClass: `btn btn-success`,
   noteBorder: `NoteBorder`,
   profileCardHeader: `card-header bg-profileHeader text-dark`,
   purchaseTable: `GiftPurchaseTable-Light`,
   reminderHeader: `bg-themeDarkBluePrimary`,
   reminderHr: `ReminderHr`,
   reminderTags: `ReminderTags-Light`,
-  secondaryButton: `btn btn-sm btn-outline-secondary`,
   sectionBand: `bg-light`,
   selectTheme: {},
   text: `text-dark`,

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -1,15 +1,21 @@
 export interface ITheme {
+  /**
+   * A recovery control that sits on a Bootstrap `alert-*`. Theme-invariant, because an alert's
+   * palette stays light in both themes — see The Alert Surface Rule in DESIGN.md.
+   */
+  alertActionButton: string
   bgColor: string
   card: string
   cardBody: string
   cardHeader: string
+  /** The one filled control that commits. Theme-invariant, so the decision reads the same weight in both themes. */
+  commitButton: string
+  /** The filled control that destroys data. Theme-invariant, for the same reason as `commitButton`. */
+  destructiveButton: string
   dropzone: string
   genericButton: string
   genericButtonBlock: string
   headerColor: string
-  modalConfirmClass: string
-  modalDangerClass: string
-  modalSuccessClass: string
   noteBorder: string
   profileCardHeader: string
   /** The gift-purchase table's surface, text, and divider treatment. */
@@ -17,7 +23,6 @@ export interface ITheme {
   reminderHeader: string
   reminderHr: string
   reminderTags: string
-  secondaryButton: string
   /** A recessed full-bleed band that separates a section from the page around it. */
   sectionBand: string
   selectTheme: Record<string, string>


### PR DESCRIPTION
Follows up the Saved Army pass across the flows it deliberately left alone — Import Army, Shared Army, Print — and settles the `ITheme` slot audit that made all three cheap to fix.

## The slots

`modalConfirmClass` was byte-identical to `genericButton` in both themes — a distinction the theme never delivered. `modalSuccessClass` was filled in light and outlined in dark, so the one control that commits carried two different weights depending on the theme. `modalDangerClass` was doing duty as "close".

All four (with `secondaryButton`) are replaced by `commitButton`, `destructiveButton`, and `alertActionButton`, declared once in `invariantButtons` and spread into both theme files so they cannot drift apart. `themeButtonSlots.test.ts` asserts the invariance and that the removed names stay removed. Fifteen call sites stop reaching for literal Bootstrap classes.

## Contrast defects fixed

Measured in the compiled bundle, not from Bootstrap's documented defaults:

| Where | Was | Ratio | Now | Ratio |
| --- | --- | --- | --- | --- |
| Import Army / Shared Army commit, Resubscribe, redemption success | `btn-success` | 3.13:1 | `commitButton` | 4.69:1 |
| Import Army selected source segment | `btn-info` | 3.04:1 | `.active` on the outline button | 11.5:1 light / 19.9:1 dark |
| Retry on `/profile` and `/subscribe` | `btn-outline-secondary` on `alert-warning` | 4.23:1 | `alertActionButton` | 10.4:1 |

The last one is a correction to the Alert Surface Rule added in #1963, which blessed theme-invariance as sufficient. It is necessary, not sufficient — a control on an alert is resolved against a light ground in both themes, so it has to clear 4.5:1 there too. The rule now states both bars and names the two classes that passed the first and failed the second.

## Also

- Four cancel/close controls — Import Army (twice), Shared Army, Print — stop rendering as filled red in dark theme. Import Army's corner dismiss becomes `btn-close`, matching Save Army and My Armies.
- Shared Army drops "Rules context" and a raw `explicitSelectionIds` count for the Faction / Units / Ruleset the import preview already uses. That count included the faction and battle formation, so it matched nothing the player could count.
- `pulsate-fwd` and `fade-out` leave the Dead Class table by being **removed**. Both animations were built and reviewed against the real suspense fallback in both themes, then rejected: the loading screen holds still like the rest of the product. The classes come out of the JSX rather than staying behind, so nothing can switch them back on during a future stylesheet change. DESIGN.md carried this as its one open question and now closes it.
- DESIGN.md records one *new* open question honestly rather than papering over it: `Overwrite it instead` in Save Army is a decision sitting on an `alert-warning`, which contradicts the Alerts section's own rule. It clears both contrast bars, so nothing is broken, but the fix is probably to move it onto the modal's own surface.

## Testing

```
yarn lint && yarn tsc --noEmit && yarn build && yarn test --run
```

106 test files, 3391 tests, all green.

Verified in a browser against a production build in both themes:

- **Import Army** — corner `btn-close` instead of a red button, outline Cancel, filled blue commit, `.active` source segment.
- **Print** — outline Cancel above filled Download PDF. This inverts what shipped, where Cancel was the redder of the two.
- Contrast ratios above were read off `getComputedStyle` in the built bundle rather than computed from hex values. Worth noting for anyone checking: `$dark` is pinned to 4.6's `$gray-800`, so `btn-outline-dark` draws at `#343a40`, not Bootstrap 5's `#212529`.

## Not in scope

PRODUCT.md's two P1s were re-measured and the record corrected, but not fixed:

- **Target sizes.** The 85 timing tags and the navbar are already fixed. The Edit/Play switch is still 20px tall, and that is now the whole of that P1.
- **Initial chunk.** 1.21MB gzipped, not the 1.42MB recorded. Out of the entry HTML, but still a static dependency of the lazy `Home` route, so every player waits for it before reminders render.
