### PR TITLE
fix(cloud-armies): reconcile the cloud army link on load, not just when a modal opens

### DIFF
--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -93,7 +93,7 @@ const SkipToReminders = () => (
 )
 
 const HomeContent = () => {
-  const { armies, updateArmy } = useArmyCollection()
+  const { armies, collectionLoaded, ensureArmiesLoaded, updateArmy } = useArmyCollection()
   const [document, setDocument] = useState(loadDocument)
   const [isGameMode, setIsGameMode] = useState(false)
   const [importModalIsOpen, setImportModalIsOpen] = useState(false)
@@ -185,16 +185,33 @@ const HomeContent = () => {
   }, [updateArmyStatus])
 
   /*
-   * A link restored from storage can name an army deleted on another device. Reconciled only
-   * against a collection that actually loaded — an empty list is what a failed fetch looks like
-   * too, and unlinking on that would undo the persistence this exists to provide.
+   * Nothing else on this screen needs the collection, and it is deliberately not fetched on mount,
+   * so a link restored from storage would sit unreconciled until the player happened to open a
+   * modal — offering Update Army against a record deleted on another device, and failing with
+   * "Army not found." every time it was pressed. The link is the one thing here that has a question
+   * only the account can answer, so it is the one thing that asks (issue #1965).
    */
   useEffect(() => {
-    if (!cloudArmyId || armies.length === 0) return
+    if (!cloudArmyId) return
+    void ensureArmiesLoaded()
+  }, [cloudArmyId, ensureArmiesLoaded])
+
+  /*
+   * A link restored from storage can name an army deleted on another device. Reconciled only
+   * against a collection that actually loaded — an empty list is also what a failed fetch and an
+   * unfetched one look like, and unlinking on that would undo the persistence this exists to
+   * provide. `collectionLoaded` separates those from an account that genuinely holds no armies,
+   * which is exactly the state left behind when the linked record was the last one deleted.
+   */
+  useEffect(() => {
+    if (!cloudArmyId || !collectionLoaded) return
     const linked = armies.find(army => army.id === cloudArmyId)
     if (!linked) {
       setCloudArmyLink(undefined)
       clearCloudArmyLink()
+      // The banner names a write to this record. Once the record is gone the banner is about
+      // nothing, and it has no dismiss of its own.
+      setUpdateArmyError(undefined)
       return
     }
     // A rename in My Armies must reach the label the toolbar shows for the same record. The
@@ -206,7 +223,7 @@ const HomeContent = () => {
       writeCloudArmyLink(link)
       return link
     })
-  }, [armies, cloudArmyId, cloudArmyName])
+  }, [armies, cloudArmyId, cloudArmyName, collectionLoaded])
   const factions = useMemo(
     () =>
       selectableFactions

--- a/src/context/useArmyCollection.tsx
+++ b/src/context/useArmyCollection.tsx
@@ -4,7 +4,11 @@ import type { Aos4ArmyDocument } from '../aos4/state'
 import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { useApiAccessToken } from 'utils/authToken'
 
-interface ArmyCollectionContextValue {
+/*
+ * Exported so a test double can be constrained to it. An untyped hand-rolled double silently
+ * returns `undefined` for a member added later, which fails at runtime instead of at compile time.
+ */
+export interface ArmyCollectionContextValue {
   armies: RemoteArmy[]
   collectionError: string | null
   /**
@@ -49,31 +53,66 @@ export const ArmyCollectionProvider = ({ children }: React.PropsWithChildren<obj
    * not re-render anything, and it must be readable by the very call that sets it.
    */
   const loadRequestedRef = useRef(false)
+  /*
+   * Which answer about the account is newest. A list request captures this before it starts and
+   * throws its own result away if anything newer landed first — a later refresh, or a mutation that
+   * already wrote the truth into `armies`.
+   *
+   * Without it, the Save Army modal's on-open refresh can still be in flight when the save itself
+   * succeeds: the pre-save list then resolves last, overwrites the created army out of `armies`, and
+   * reports the collection loaded. The reconciler is handed a list that is authoritative and missing
+   * a record that exists, so it unlinks a live army and the next save forks the duplicate this whole
+   * feature exists to prevent.
+   */
+  const collectionGenerationRef = useRef(0)
 
-  const refreshArmies = useCallback(async () => {
-    if (!isAuthenticated) {
-      setArmies([])
-      setCollectionError(null)
-      // Signing out invalidates the list rather than emptying it. Anything asking whether a record
-      // is still on the account must go back to not knowing.
-      setCollectionLoaded(false)
-      loadRequestedRef.current = false
-      return
-    }
-    setCollectionLoading(true)
-    setCollectionError(null)
-    try {
-      const token = await getAccessToken()
-      setArmies(await ArmyApi.listArmies(token))
-      setCollectionLoaded(true)
-    } catch (error) {
-      setCollectionError(messageForError(error))
-      // Deliberately not cleared: a failed refresh leaves the last good list in place, and that list
-      // is still a real answer. Only signing out takes the answer away.
-    } finally {
-      setCollectionLoading(false)
-    }
-  }, [getAccessToken, isAuthenticated])
+  const supersedeCollection = useCallback(() => {
+    collectionGenerationRef.current += 1
+    return collectionGenerationRef.current
+  }, [])
+
+  /*
+   * `reportErrors` separates the two callers. A refresh the player asked for (a modal opening) owes
+   * them a message when it fails; the background load behind `ensureArmiesLoaded` does not, and
+   * publishing to the shared channel would surface its failure inside an unrelated modal — Share
+   * Army reads `collectionError` but never refreshes, so it would show an error about a fetch the
+   * player never triggered.
+   */
+  const loadArmies = useCallback(
+    async ({ reportErrors }: { reportErrors: boolean }) => {
+      if (!isAuthenticated) {
+        setArmies([])
+        setCollectionError(null)
+        // Signing out invalidates the list rather than emptying it. Anything asking whether a record
+        // is still on the account must go back to not knowing.
+        setCollectionLoaded(false)
+        loadRequestedRef.current = false
+        supersedeCollection()
+        return
+      }
+      const generation = supersedeCollection()
+      setCollectionLoading(true)
+      if (reportErrors) setCollectionError(null)
+      try {
+        const token = await getAccessToken()
+        const listed = await ArmyApi.listArmies(token)
+        if (collectionGenerationRef.current !== generation) return
+        setArmies(listed)
+        setCollectionLoaded(true)
+      } catch (error) {
+        if (reportErrors && collectionGenerationRef.current === generation) {
+          setCollectionError(messageForError(error))
+        }
+        // `collectionLoaded` is deliberately not cleared: a failed refresh leaves the last good list
+        // in place, and that list is still a real answer. Only signing out takes the answer away.
+      } finally {
+        setCollectionLoading(false)
+      }
+    },
+    [getAccessToken, isAuthenticated, supersedeCollection]
+  )
+
+  const refreshArmies = useCallback(() => loadArmies({ reportErrors: true }), [loadArmies])
 
   /*
    * The collection is deliberately not fetched on mount — most visits never touch cloud armies, and
@@ -85,14 +124,16 @@ export const ArmyCollectionProvider = ({ children }: React.PropsWithChildren<obj
     if (!isAuthenticated || !ArmyApi.isConfigured) return
     if (collectionLoaded || loadRequestedRef.current) return
     loadRequestedRef.current = true
-    await refreshArmies()
-  }, [collectionLoaded, isAuthenticated, refreshArmies])
+    await loadArmies({ reportErrors: false })
+  }, [collectionLoaded, isAuthenticated, loadArmies])
 
   const createArmy = useCallback(
     async (document: Aos4ArmyDocument) => {
       setCollectionError(null)
       try {
         const created = await ArmyApi.createArmy(document, await getAccessToken())
+        // This write is newer than any list already in flight; see `collectionGenerationRef`.
+        supersedeCollection()
         setArmies(current => [created, ...current.filter(army => army.id !== created.id)])
         return created
       } catch (error) {
@@ -100,7 +141,7 @@ export const ArmyCollectionProvider = ({ children }: React.PropsWithChildren<obj
         throw error
       }
     },
-    [getAccessToken]
+    [getAccessToken, supersedeCollection]
   )
 
   const updateArmy = useCallback(
@@ -108,6 +149,7 @@ export const ArmyCollectionProvider = ({ children }: React.PropsWithChildren<obj
       setCollectionError(null)
       try {
         const updated = await ArmyApi.updateArmy(id, document, await getAccessToken())
+        supersedeCollection()
         setArmies(current =>
           current.map(army =>
             army.id === id
@@ -125,7 +167,7 @@ export const ArmyCollectionProvider = ({ children }: React.PropsWithChildren<obj
         throw error
       }
     },
-    [getAccessToken]
+    [getAccessToken, supersedeCollection]
   )
 
   const deleteArmy = useCallback(
@@ -133,13 +175,14 @@ export const ArmyCollectionProvider = ({ children }: React.PropsWithChildren<obj
       setCollectionError(null)
       try {
         await ArmyApi.deleteArmy(id, await getAccessToken())
+        supersedeCollection()
         setArmies(current => current.filter(army => army.id !== id))
       } catch (error) {
         setCollectionError(messageForError(error))
         throw error
       }
     },
-    [getAccessToken]
+    [getAccessToken, supersedeCollection]
   )
 
   const createShare = useCallback(

--- a/src/context/useArmyCollection.tsx
+++ b/src/context/useArmyCollection.tsx
@@ -1,17 +1,30 @@
 import { useAuth0 } from '@auth0/auth0-react'
 import { ArmyApi, ArmyApiError, type CreatedShare, type RemoteArmy } from '../api/armyApi'
 import type { Aos4ArmyDocument } from '../aos4/state'
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { useApiAccessToken } from 'utils/authToken'
 
 interface ArmyCollectionContextValue {
   armies: RemoteArmy[]
   collectionError: string | null
+  /**
+   * Whether `armies` is a list the account actually returned, rather than the empty array it starts
+   * as. An account can legitimately hold no armies, so emptiness cannot stand in for this: a caller
+   * that reads absence from the list — "the record I am linked to is gone" — would read the same
+   * absence from a list nobody has fetched, and from one whose fetch failed.
+   */
+  collectionLoaded: boolean
   collectionLoading: boolean
   configured: boolean
   createArmy: (document: Aos4ArmyDocument) => Promise<RemoteArmy>
   createShare: (document: Aos4ArmyDocument) => Promise<CreatedShare>
   deleteArmy: (id: string) => Promise<void>
+  /**
+   * Load the collection once, for a caller that needs it to answer a question rather than to show
+   * it. Unlike `refreshArmies` this is a no-op when the list is already loaded or already asked
+   * for, so it can sit in an effect without turning a failed fetch into a retry loop.
+   */
+  ensureArmiesLoaded: () => Promise<void>
   refreshArmies: () => Promise<void>
   updateArmy: (id: string, document: Aos4ArmyDocument) => Promise<RemoteArmy>
 }
@@ -29,12 +42,22 @@ export const ArmyCollectionProvider = ({ children }: React.PropsWithChildren<obj
   const getAccessToken = useApiAccessToken()
   const [armies, setArmies] = useState<RemoteArmy[]>([])
   const [collectionError, setCollectionError] = useState<string | null>(null)
+  const [collectionLoaded, setCollectionLoaded] = useState(false)
   const [collectionLoading, setCollectionLoading] = useState(false)
+  /*
+   * Whether `ensureArmiesLoaded` has already spent its one attempt. A ref rather than state: it must
+   * not re-render anything, and it must be readable by the very call that sets it.
+   */
+  const loadRequestedRef = useRef(false)
 
   const refreshArmies = useCallback(async () => {
     if (!isAuthenticated) {
       setArmies([])
       setCollectionError(null)
+      // Signing out invalidates the list rather than emptying it. Anything asking whether a record
+      // is still on the account must go back to not knowing.
+      setCollectionLoaded(false)
+      loadRequestedRef.current = false
       return
     }
     setCollectionLoading(true)
@@ -42,12 +65,28 @@ export const ArmyCollectionProvider = ({ children }: React.PropsWithChildren<obj
     try {
       const token = await getAccessToken()
       setArmies(await ArmyApi.listArmies(token))
+      setCollectionLoaded(true)
     } catch (error) {
       setCollectionError(messageForError(error))
+      // Deliberately not cleared: a failed refresh leaves the last good list in place, and that list
+      // is still a real answer. Only signing out takes the answer away.
     } finally {
       setCollectionLoading(false)
     }
   }, [getAccessToken, isAuthenticated])
+
+  /*
+   * The collection is deliberately not fetched on mount — most visits never touch cloud armies, and
+   * the fetch costs a token round-trip. This is the one exception: a caller holding a question that
+   * only the list can answer. The authentication guard sits before the ref so an early call, made
+   * while Auth0 is still resolving the session, does not burn the attempt.
+   */
+  const ensureArmiesLoaded = useCallback(async () => {
+    if (!isAuthenticated || !ArmyApi.isConfigured) return
+    if (collectionLoaded || loadRequestedRef.current) return
+    loadRequestedRef.current = true
+    await refreshArmies()
+  }, [collectionLoaded, isAuthenticated, refreshArmies])
 
   const createArmy = useCallback(
     async (document: Aos4ArmyDocument) => {
@@ -120,21 +159,25 @@ export const ArmyCollectionProvider = ({ children }: React.PropsWithChildren<obj
     () => ({
       armies,
       collectionError,
+      collectionLoaded,
       collectionLoading,
       configured: ArmyApi.isConfigured,
       createArmy,
       createShare,
       deleteArmy,
+      ensureArmiesLoaded,
       refreshArmies,
       updateArmy,
     }),
     [
       armies,
       collectionError,
+      collectionLoaded,
       collectionLoading,
       createArmy,
       createShare,
       deleteArmy,
+      ensureArmiesLoaded,
       refreshArmies,
       updateArmy,
     ]

--- a/src/tests/aos4/accountCapabilitiesUi.test.tsx
+++ b/src/tests/aos4/accountCapabilitiesUi.test.tsx
@@ -7,21 +7,30 @@ import { createDefaultAos4ArmyDocument } from '../../aos4/runtime'
 import { render, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
 import { act } from 'react'
 import { Simulate } from 'tests/support/reactTestHelpers'
+import type { ArmyCollectionContextValue } from 'context/useArmyCollection'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const collection = vi.hoisted(() => ({
-  armies: [] as unknown[],
-  collectionError: null as string | null,
-  collectionLoaded: true,
-  collectionLoading: false,
-  configured: true,
-  createArmy: vi.fn(),
-  createShare: vi.fn(),
-  deleteArmy: vi.fn(),
-  ensureArmiesLoaded: vi.fn(),
-  refreshArmies: vi.fn(),
-  updateArmy: vi.fn(),
-}))
+/*
+ * Keyed on the real context type rather than hand-rolled: a member added to
+ * `ArmyCollectionContextValue` and forgotten here becomes a compile error instead of an
+ * `undefined` the components only trip over at runtime.
+ */
+const collection = vi.hoisted(
+  () =>
+    ({
+      armies: [] as unknown[],
+      collectionError: null as string | null,
+      collectionLoaded: true,
+      collectionLoading: false,
+      configured: true,
+      createArmy: vi.fn(),
+      createShare: vi.fn(),
+      deleteArmy: vi.fn(),
+      ensureArmiesLoaded: vi.fn(),
+      refreshArmies: vi.fn(),
+      updateArmy: vi.fn(),
+    }) satisfies Record<keyof ArmyCollectionContextValue, unknown>
+)
 
 vi.mock('context/useArmyCollection', () => ({
   useArmyCollection: () => collection,

--- a/src/tests/aos4/accountCapabilitiesUi.test.tsx
+++ b/src/tests/aos4/accountCapabilitiesUi.test.tsx
@@ -12,11 +12,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const collection = vi.hoisted(() => ({
   armies: [] as unknown[],
   collectionError: null as string | null,
+  collectionLoaded: true,
   collectionLoading: false,
   configured: true,
   createArmy: vi.fn(),
   createShare: vi.fn(),
   deleteArmy: vi.fn(),
+  ensureArmiesLoaded: vi.fn(),
   refreshArmies: vi.fn(),
   updateArmy: vi.fn(),
 }))

--- a/src/tests/aos4/armyCollection.test.tsx
+++ b/src/tests/aos4/armyCollection.test.tsx
@@ -37,17 +37,28 @@ const currentDocument = createDefaultAos4ArmyDocument()
 const remoteArmy = { id: 'cloud-1', createdAt: 1, updatedAt: 2, document: currentDocument }
 
 const Probe = () => {
-  const { armies, collectionError, createArmy, deleteArmy, refreshArmies, updateArmy } = useArmyCollection()
+  const {
+    armies,
+    collectionError,
+    collectionLoaded,
+    createArmy,
+    deleteArmy,
+    ensureArmiesLoaded,
+    refreshArmies,
+    updateArmy,
+  } = useArmyCollection()
   return (
     <div>
       <span data-testid="armies">{armies.map(army => army.id).join(',')}</span>
       <span data-testid="error">{collectionError}</span>
+      <span data-testid="loaded">{String(collectionLoaded)}</span>
       <button onClick={() => void refreshArmies()}>Refresh</button>
       <button onClick={() => void createArmy({ ...currentDocument, name: 'Created' })}>Create</button>
       <button onClick={() => void updateArmy('cloud-1', { ...currentDocument, name: 'Updated' })}>
         Update
       </button>
       <button onClick={() => void deleteArmy('cloud-1')}>Delete</button>
+      <button onClick={() => void ensureArmiesLoaded()}>Ensure</button>
     </div>
   )
 }
@@ -146,5 +157,91 @@ describe('cloud army collection state', () => {
 
     expect(container.querySelector('[data-testid="error"]')?.textContent).toBe('Network unavailable')
     expect(container.querySelector('[data-testid="armies"]')?.textContent).toBe('')
+  })
+
+  /*
+   * The Save Army modal refreshes when it opens, and its Save button is not gated on that refresh
+   * finishing. So a list request that predates the save can resolve after it. If that stale list
+   * wins, the created army disappears from state while the collection reports itself loaded, and
+   * the reconciler in Home unlinks a record that exists — forking a duplicate on the next save.
+   */
+  it('discards a list response that a later mutation has already superseded', async () => {
+    let resolveList: (armies: unknown[]) => void = () => undefined
+    armyApi.listArmies.mockReturnValue(
+      new Promise(resolve => {
+        resolveList = resolve as (armies: unknown[]) => void
+      })
+    )
+    await renderProbe()
+
+    // The modal's on-open refresh starts and stays in flight.
+    await act(async () => {
+      container.querySelectorAll('button')[0].click()
+      await Promise.resolve()
+    })
+
+    // The save completes while it is still pending.
+    await act(async () => {
+      container.querySelectorAll('button')[1].click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(container.querySelector('[data-testid="armies"]')?.textContent).toBe('cloud-2')
+
+    // The pre-save list lands last and must not resurrect the account as it was before the save.
+    await act(async () => {
+      resolveList([])
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="armies"]')?.textContent).toBe('cloud-2')
+    expect(container.querySelector('[data-testid="loaded"]')?.textContent).toBe('false')
+  })
+
+  it('spends only one ensureArmiesLoaded attempt even when the load fails', async () => {
+    armyApi.listArmies.mockRejectedValue(new Error('Network unavailable'))
+    await renderProbe()
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await act(async () => {
+        container.querySelectorAll('button')[4].click()
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+    }
+
+    expect(armyApi.listArmies).toHaveBeenCalledTimes(1)
+    // A background load owes the player no message; only a refresh they asked for does.
+    expect(container.querySelector('[data-testid="error"]')?.textContent).toBe('')
+  })
+
+  /*
+   * The guard order in `ensureArmiesLoaded` puts the authentication check before the one-shot ref,
+   * so a call made while Auth0 is still resolving must not spend the attempt. Without that order,
+   * anyone signing in after mount loses load-time reconciliation for the whole session.
+   */
+  it('does not spend its attempt on a call made before authentication resolves', async () => {
+    auth.isAuthenticated = false
+    await renderProbe()
+
+    await act(async () => {
+      container.querySelectorAll('button')[4].click()
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+    expect(armyApi.listArmies).not.toHaveBeenCalled()
+
+    // Auth0 settles while the same provider stays mounted, so its one-shot ref is not reset by a
+    // remount -- the attempt must still be available.
+    auth.isAuthenticated = true
+    await renderProbe()
+
+    await act(async () => {
+      container.querySelectorAll('button')[4].click()
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    expect(armyApi.listArmies).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-testid="loaded"]')?.textContent).toBe('true')
   })
 })

--- a/src/tests/aos4/cloudArmyLinkReconciliation.test.tsx
+++ b/src/tests/aos4/cloudArmyLinkReconciliation.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+
+import { createDefaultAos4ArmyDocument, saveAos4ArmyDocument } from '../../aos4/runtime'
+import { serializeAos4ArmyDocument } from '../../aos4/state'
+import Home from 'components/routes/Home'
+import { AppStatusProvider } from 'context/useAppStatus'
+import { SubscriptionProvider } from 'context/useSubscription'
+import { ThemeProvider } from 'context/useTheme'
+import { MemoryRouter } from 'react-router'
+import { act } from 'react'
+import { render, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
+import { writeCloudArmyLink } from 'utils/cloudArmyLink'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/*
+ * The reconciliation the durable cloud-army link depends on: a link restored from storage names a
+ * record on the account, and the account is the only thing that can say whether that record is
+ * still there. These cover the load-time path, which is the one a player actually meets — the
+ * modals were already refreshing the collection when they opened. See issue #1965.
+ */
+
+const auth = vi.hoisted(() => ({
+  getAccessTokenSilently: vi.fn(),
+  isAuthenticated: true,
+  isLoading: false,
+  loginWithPopup: vi.fn(),
+  logout: vi.fn(),
+  user: { email: 'owner@example.com' } as { email: string } | undefined,
+}))
+
+const armyApi = vi.hoisted(() => ({
+  createArmy: vi.fn(),
+  createShare: vi.fn(),
+  deleteArmy: vi.fn(),
+  isConfigured: true,
+  listArmies: vi.fn(),
+  updateArmy: vi.fn(),
+}))
+
+const getSubscription = vi.hoisted(() => vi.fn())
+
+vi.mock('@auth0/auth0-react', () => ({
+  useAuth0: () => auth,
+}))
+
+vi.mock('../../api/armyApi', () => ({
+  ArmyApi: armyApi,
+  ArmyApiError: class ArmyApiError extends Error {
+    status = 0
+  },
+}))
+
+vi.mock('../../api/subscriptionApi', () => ({
+  SubscriptionApi: {
+    cancelSubscription: vi.fn(),
+    getSubscription,
+    updateTheme: vi.fn(),
+  },
+}))
+
+// Home's banner slot reaches the PWA plugin's virtual module, which has no file on disk.
+vi.mock('virtual:pwa-register', () => ({ registerSW: vi.fn(() => vi.fn(async () => undefined)) }))
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router')
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>()
+
+  get length() {
+    return this.values.size
+  }
+
+  clear() {
+    this.values.clear()
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key)
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+}
+
+const LINKED_ID = 'cloud-linked-1'
+
+const linkedDocument = { ...createDefaultAos4ArmyDocument(), name: 'Tourney List' }
+
+const remoteArmy = (id: string, name: string) => ({
+  id,
+  createdAt: 1,
+  updatedAt: 2,
+  document: { ...linkedDocument, name },
+})
+
+describe('cloud army link reconciliation on load', () => {
+  let container: HTMLDivElement
+
+  const renderHome = async () => {
+    await act(async () => {
+      render(
+        <AppStatusProvider>
+          <SubscriptionProvider>
+            <ThemeProvider>
+              <MemoryRouter>
+                <Home />
+              </MemoryRouter>
+            </ThemeProvider>
+          </SubscriptionProvider>
+        </AppStatusProvider>,
+        container
+      )
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+  }
+
+  /** The state a reload starts from: a saved army on screen and a link naming its cloud record. */
+  const seedLinkedDocument = () => {
+    saveAos4ArmyDocument(window.localStorage, linkedDocument)
+    writeCloudArmyLink({
+      id: LINKED_ID,
+      name: 'Tourney List',
+      savedSignature: serializeAos4ArmyDocument(linkedDocument),
+    })
+  }
+
+  const storedLink = () => window.localStorage.getItem('aos-reminders:aos4:cloud-army-link:v1')
+
+  const buttonLabels = () =>
+    Array.from(container.querySelectorAll('button')).map(button => button.textContent?.trim())
+
+  beforeEach(() => {
+    auth.isAuthenticated = true
+    auth.isLoading = false
+    auth.user = { email: 'owner@example.com' }
+    auth.getAccessTokenSilently.mockReset()
+    auth.getAccessTokenSilently.mockResolvedValue('access-token')
+    Object.values(armyApi).forEach(value => {
+      if (typeof value === 'function' && 'mockReset' in value) value.mockReset()
+    })
+    armyApi.isConfigured = true
+    armyApi.listArmies.mockResolvedValue([])
+    getSubscription.mockReset()
+    getSubscription.mockRejectedValue({ status: 404 })
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: new MemoryStorage(),
+    })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  it('clears a link whose record the account no longer holds, without opening a modal', async () => {
+    seedLinkedDocument()
+    armyApi.listArmies.mockResolvedValue([remoteArmy('cloud-other', 'Someone Else')])
+
+    await renderHome()
+
+    expect(armyApi.listArmies).toHaveBeenCalledWith('access-token')
+    expect(storedLink()).toBeNull()
+    expect(container.textContent).not.toContain('Cloud army:')
+    expect(buttonLabels()).toContain('Save Army')
+    expect(buttonLabels()).not.toContain('Save As')
+  })
+
+  /*
+   * The case the old `armies.length === 0` guard could never reach: deleting the linked record
+   * elsewhere, when it was the only one, leaves a collection that is both loaded and empty.
+   */
+  it('clears the link when the deleted record was the last army on the account', async () => {
+    seedLinkedDocument()
+    armyApi.listArmies.mockResolvedValue([])
+
+    await renderHome()
+
+    expect(storedLink()).toBeNull()
+    expect(container.textContent).not.toContain('Cloud army:')
+  })
+
+  it('keeps a link whose record is still on the account, and names it', async () => {
+    seedLinkedDocument()
+    armyApi.listArmies.mockResolvedValue([remoteArmy(LINKED_ID, 'Tourney List')])
+
+    await renderHome()
+
+    expect(storedLink()).not.toBeNull()
+    expect(container.textContent).toContain('Cloud army:')
+    expect(container.textContent).toContain('Tourney List')
+  })
+
+  /*
+   * A failed fetch is not evidence of deletion. Unlinking on it would throw away exactly the
+   * persistence the link exists to provide, so the link is kept and the toolbar still offers it.
+   */
+  it('keeps the link when the collection cannot be loaded, and does not retry in a loop', async () => {
+    seedLinkedDocument()
+    armyApi.listArmies.mockRejectedValue(new Error('Network unavailable'))
+
+    await renderHome()
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    expect(storedLink()).not.toBeNull()
+    expect(container.textContent).toContain('Cloud army:')
+    expect(armyApi.listArmies).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fetch the collection for a document that is not linked to one', async () => {
+    saveAos4ArmyDocument(window.localStorage, linkedDocument)
+
+    await renderHome()
+
+    expect(armyApi.listArmies).not.toHaveBeenCalled()
+    expect(buttonLabels()).toContain('Save Army')
+  })
+})


### PR DESCRIPTION
Fixes #1965. Follows up #1963, and was found QA-testing it.

## What changed

#1963 made the cloud-army link durable and said it "must also clear itself if the remote record no longer exists (checked against the collection on load)". The reconcile effect was written and is correct — but nothing loads the collection on load, so it never ran there.

`refreshArmies` is only called from `saveArmyModal` and `savedArmiesModal`, both gated on `isOpen`, and `ArmyCollectionProvider` has no mount fetch. That deferral is deliberate and covered by `defers the owner collection until it is explicitly requested`: most visits never touch cloud armies, and the fetch costs a token round-trip. This PR keeps it.

Instead, `Home` asks for the collection when — and only when — a link is present. That is the one thing on the screen holding a question the account alone can answer. A visit with no link still fetches nothing.

- **`ensureArmiesLoaded`** on the collection context: loads once, for a caller that needs the list to answer a question rather than to show it. The authentication guard sits before the one-attempt ref, so a call made while Auth0 is still resolving the session does not burn the attempt; a failed fetch does not become a retry loop.
- **`collectionLoaded`** replaces `armies.length === 0` as the reconcile guard. Emptiness could not distinguish an unfetched list from a failed one from an account that genuinely holds no armies — and that last case is exactly what is left behind when the linked record was the *last* one deleted, so it could never reconcile either. A failed fetch keeps the link: it is not evidence of deletion, and unlinking on it would undo the persistence the link exists to provide.
- The **`Army not found.` banner** is cleared when reconciliation drops the link it was about. It had no dismiss of its own.

## Second commit: a race the first one widened

Code review (including an independent cross-model adversarial pass) found a real defect in the first commit, fixed in `032eb439`.

The Save Army modal refreshes the collection when it opens, and its Save button is not gated on that refresh finishing. So a list request that predates the save can resolve after it: the pre-save list overwrites the created army out of `armies` and reports the collection loaded, handing the reconciler a list that is authoritative and missing a record that exists. It unlinks a live army, and the next save forks the duplicate this feature exists to prevent.

The old `armies.length === 0` guard accidentally covered the worst case — a first-ever army, whose pre-save list is empty, returned early. `!collectionLoaded` does not, so the first commit made that case newly reachable. This was a regression, not a pre-existing quirk.

Fix: a generation counter marks which answer about the account is newest. A list request captures it before starting and discards its own result if anything newer landed first; every successful mutation supersedes any list already in flight.

The same commit stops the background load from publishing to the shared error channel. A refresh the player asked for still reports failures; `ensureArmiesLoaded` does not, because its failure would otherwise surface inside Share Army — a modal that reads `collectionError` but never refreshes, so nothing cleared it.

## Behavior change

Only where the old behavior was wrong. A link whose record is still on the account is untouched and still names it. A document with no link is unchanged, including the absence of any fetch. The visible delta is that a link to a deleted record now disappears on load — the toolbar reverts from `Save As` to `Save Army` and the `Cloud army:` line goes — instead of persisting and failing on use.

## Verification

Reproduced against the dev army API with a real subscriber account, before and after.

Before: save an army, delete the record from a context that does not share the tab's `localStorage`, reload. Toolbar read `Cloud army: QA stale-link B - up to date`; an edit brought back `Update Army`; pressing it returned a red `Army not found.` and left the link in place, repeatable indefinitely.

After: the same sequence clears the link on load — no caption, `Save Army`, no error banner. The owner's valid link to an existing record survived the same reload untouched. All test armies created for this were deleted; the account's own armies were never written to.

Coverage: `src/tests/aos4/cloudArmyLinkReconciliation.test.tsx` adds 5 Home-level cases (record gone, last-army-deleted empty collection, record present, unreachable collection, unlinked document). `src/tests/aos4/armyCollection.test.tsx` adds 3 provider-level cases for the second commit (stale list superseded by a mutation, one-shot attempt not re-spent on failure, attempt not burned before Auth0 resolves). Each new behavioral test was confirmed to fail without its fix. `ArmyCollectionContextValue` is now exported so the hand-rolled test double is compile-checked against it.

Commands run, all green:

- `yarn lint`
- `yarn tsc --noEmit`
- `yarn build`
- `yarn test --run` — 107 files, 3399 tests
- `yarn data:aos4:verify:beta` — 81956 pass, 0 finding, 0 cannot-verify

No generated files changed, no rules or data touched, no production configuration affected, and no companion-service work needed.

## Known gaps

- A first background load that fails spends the one attempt for that session, so reconciliation does not retry on its own. Opening My Armies still refreshes and reconciles, so this is never worse than `master`; it just does not help until the player opens a modal.
- `Clear Army` keeps `document.name`, so the next Save dialog pre-fills the discarded army's name and lands the player in the duplicate-name/overwrite path. Cosmetic, caught by the existing warning, and left out of a correctness fix.
