### PR TITLE
docs: capture the radar alarm learning and refresh the architecture-patterns learnings

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -25,6 +25,9 @@ The per-unit datasheet: a unit's characteristics, weapons, and abilities. Warscr
 ### Battle Profile
 The matched-play record for a unit — unit size, points, base sizes, and roster notes. Kept distinct from the Warscroll because it comes from a different official publication cadence and only exists where the governing Rules Context defines points.
 
+### Battle Profile Disposition
+The reviewed verdict on what each extracted official profile fact is for: applied to the shipped runtime, kept as a structured reference the runtime does not serve, superseded by a later publication, or recorded as a profile-only gap where the profile exists but no rules text has been sourced yet. Every extracted fact carries exactly one, so a fact is never silently dropped — the ones that do not reach players are explained rather than absent.
+
 ### Content Group
 A named grouping of rules choices a faction offers — battle formations, spell/prayer lores, heroic traits, artefacts of power, and similar. Selecting a group brings its member abilities into the army.
 
@@ -39,8 +42,15 @@ Choosing an Army of Renown grants its entire rules set at once — its battle tr
 
 Armies of Renown arrive through three publication flavors with identical semantics: the seasonal set (a free official document), battletome armies (one or two per battletome), and White Dwarf armies, which are Legends content and therefore appear under the overlay's Legends grouping. The same army can be a root under several factions (Big Waaagh!, The Duardin Ascendant), and an army may share its name with an unrelated regular content group of its faction (Lords of the Clan), so identity is the per-faction root, never the name.
 
+### Regiment of Renown
+A purchasable cross-faction bundle: a fixed set of units bought whole, offered to the factions its own rules name rather than to the faction whose page happens to carry it. Contrast with Army of Renown, which replaces a faction's rules; a Regiment of Renown adds units and is available by inclusion.
+
+Availability comes only from the regiment's own inclusion list, never from the page it was found on — the carrying faction gains no claim on it, and does not become current merely by hosting a current regiment. Because the secondary source republishes the same regiment on every eligible faction's page, the duplicates are collapsed to one entity before acceptance; where the republished copies disagree, the majority text wins and the disagreement is recorded for review.
+
 ### Source-Marked Classification
-The contract that an Army of Renown classification must agree with the secondary source's own machine-readable marking of the section (a marker element on current sections, the replace-rules intro sentence on White Dwarf ones). Generation fails closed in both directions: a source-marked section without a reviewed classification blocks generation — a newly published army can never silently decode as a generic content group — and a reviewed classification of an unmarked section is an invalid review.
+The contract that a classification must agree with the secondary source's own machine-readable marking of the section — for Armies of Renown (a marker element on current sections, the replace-rules intro sentence on White Dwarf ones) and equally for Regiments of Renown (a nails header on the datasheet). Generation fails closed in both directions: a source-marked section without a reviewed classification blocks generation — newly published content can never silently decode as a generic content group — and a reviewed classification of an unmarked section is an invalid review.
+
+The marking is derived metadata held outside the hashed record value, so adding or changing it never churns record identity.
 
 ### Manifestation
 A summonable endless-spell-style unit belonging to a Manifestation Lore. Manifestations are a category of unit, not an army: universal lores are offered to every playable army rather than by any single faction.
@@ -69,7 +79,7 @@ The test for whether something gets a builder card: the card exists only if the 
 The authority hierarchy for rules facts: official Games Workshop publications are authoritative, and Wahapedia and BSData are co-equal preferred secondaries whose rules text is accepted as fact. BSData was raised from fallback to peer by owner decision on 2026-08-18 (#1757), retiring the former three-level hierarchy. Official publications still win every conflict, and neither secondary supplies battle-profile values officialdom already provides.
 
 ### Provisional Content
-Legacy vocabulary from the pre-2026-08-18 three-tier policy: rules text admitted from the community fallback tier, pinned to an exact upstream revision, visibly attributed as provisional, and obliged to be replaced or verified once a preferred source published it. BSData is now a peer secondary (see Source Tier), so nothing new is admitted on those terms; accepted entries keep the provisional wording only until the `policyTier`/`status` vocabulary is flattened in code. Official facts override every overlapping field either way.
+Legacy vocabulary from the pre-2026-08-18 three-tier policy: rules text admitted from the community fallback tier, pinned to an exact upstream revision, visibly attributed as provisional, and obliged to be replaced or verified once a preferred source published it. BSData is now a peer secondary (see Source Tier), so nothing new is admitted on those terms; accepted entries keep the provisional wording only until the legacy tier vocabulary is flattened in code. Official facts override every overlapping field either way.
 
 ### Classification Evidence Tier
 The evidence basis for a reviewed classification (today: Armies of Renown). The official tier cites an accepted official record naming the thing classified; the secondary-provisional tier rests on the secondary source's own explicit marking when no free accepted official document names it, with official records as optional corroboration. Distinct from Provisional Content: here the rules text is ordinary preferred-secondary content — only the *classification* awaits official naming, which verifies or corrects the entry when accepted.
@@ -79,6 +89,16 @@ The named review process that certifies an accepted corpus revision: an independ
 
 ### Beta Gate
 The fail-closed check binding the shipped runtime to a completed Accuracy Campaign. It fails on stale checksums, uncovered records, or unresolved findings, and it runs in deployment — a corpus change cannot ship without a fresh passing campaign.
+
+### Rules Radar
+The standing watch over the rules sources, which reports what changed upstream as evidence and never as acceptance — a hit starts the normal candidate intake, and nothing reaches the corpus because the radar saw it.
+
+The radar keeps its own state between runs in a managed tracking issue, so each run reports against what the previous run already recorded. Observations divide into Material and Operational Events, and only the material ones raise a maintainer alarm.
+
+### Material Event
+A radar observation that shipped rules text may now be wrong: a source the corpus depends on actually changed. Its counterpart, an Operational Event, records trouble with the observation itself — a rate limit, a truncated comparison — and says nothing about whether the rules are correct.
+
+The distinction is what makes the alarm trustworthy. Alarms key on material state alone, so operational churn cannot re-raise one, and an unchanged material state never re-sends. That deliberate at-most-once behavior has a cost worth knowing: the alarm has no natural redelivery, so anything that loses it between the recorded state advancing and the message arriving loses it permanently.
 
 ## Flagged ambiguities
 

--- a/docs/solutions/architecture-patterns/armies-of-renown-replace-semantics-excludes.md
+++ b/docs/solutions/architecture-patterns/armies-of-renown-replace-semantics-excludes.md
@@ -24,7 +24,7 @@ related_components:
   - "src/aos4/view/builder.ts"
   - "src/components/page/homeHeader.tsx"
   - "src/components/input/army_builder.tsx"
-  - "data/aos4/reviews/corpus-2026-08-01e.json"
+  - "data/aos4/reviews/corpus-2026-08-18.json"
 tags: [army-of-renown, excludes-relationship, two-pass-selection, rules-context-scoping, replacement-semantics, grounding-audit, corpus-generation, subfaction-modeling]
 ---
 
@@ -50,18 +50,18 @@ Several first attempts failed in instructive ways (detailed in Examples):
 
 When official content **replaces** other content rather than adding to it, model the replacement in the relationship graph — never by flattening, renaming, or ad-hoc grouping.
 
-**1. Classification lives in the review file.** The `armiesOfRenown` array in data/aos4/reviews/corpus-2026-08-01e.json names each AoR root by faction-group source record and must cite official evidence — generation validates that each entry targets an existing group, has a reason, and has `officialSourceRecordIds` (corpus.ts:1698-1712).
+**1. Classification lives in the review file.** The `armiesOfRenown` array in data/aos4/reviews/corpus-2026-08-18.json names each AoR root by faction-group source record and must cite official evidence — generation validates that each entry targets an existing group, has a reason, and has `officialSourceRecordIds` (corpus.ts:1975-2001).
 
 **2. Generation (src/aos4/generate/corpus.ts):**
-- The classified root's `groupType` becomes `'army-of-renown'` (corpus.ts:1668); the faction *offers* the root — it is the top-level choice, never auto-included (corpus.ts:1687-1695).
-- The root auto-INCLUDES every subgroup — picking the army grants the whole rules set (corpus.ts:1738-1741); abilities sitting directly on the root are likewise included (corpus.ts:1937-1943).
-- Subgroups keep their **real** rules category as `groupType` (`spell-lore`, `heroic-trait`, …) and their exact source names — "the army context is carried by the relationship graph", not the name (comment at corpus.ts:1722-1728).
-- `excludes` edges go from each root to every regular faction rules-choice group; the replaced set is `ARMY_OF_RENOWN_REPLACED_GROUP_TYPES` = battle-trait, battle-formation, heroic-trait, artefact-of-power, spell-lore, prayer-lore, monstrous-traits, big-names (corpus.ts:461-470, emission at corpus.ts:1962-1970). Universal manifestation lores and general rules modules are army-agnostic and remain (comment at corpus.ts:455-460).
-- **`excludes` relationships carry the UNION of endpoint contexts**, unlike every other kind (intersection); see the before/after in Examples (corpus.ts:2086-2102).
+- The classified root's `groupType` becomes `'army-of-renown'` (corpus.ts:1945); the faction *offers* the root — it is the top-level choice, never auto-included (corpus.ts:1964-1972).
+- The root auto-INCLUDES every subgroup — picking the army grants the whole rules set (corpus.ts:2026-2030); abilities sitting directly on the root are likewise included (corpus.ts:2222-2228).
+- Subgroups keep their **real** rules category as `groupType` (`spell-lore`, `heroic-trait`, …) and their exact source names — "the army context is carried by the relationship graph", not the name (comment at corpus.ts:2010-2013).
+- `excludes` edges go from each root to every regular faction rules-choice group; the replaced set is `ARMY_OF_RENOWN_REPLACED_GROUP_TYPES` = battle-trait, battle-formation, heroic-trait, artefact-of-power, spell-lore, prayer-lore, monstrous-traits, big-names (corpus.ts:558-567, emission at corpus.ts:2246-2252). Universal manifestation lores and general rules modules are army-agnostic and remain (comment at corpus.ts:552-557).
+- **`excludes` relationships carry the UNION of endpoint contexts**, unlike every other kind (intersection); see the before/after in Examples (corpus.ts:2363-2384).
 
 **3. Selection (src/aos4/select/resolveSelection.ts): two-pass resolution.** Pass 1 resolves normally; any `excludes` edge whose source is then selected suppresses its target for pass 2 — the target and everything reachable only through it disappear from selected and available (a suppressed entity is unreachable: "not offered, not auto-included", resolveSelection.ts:201-202). An EXPLICIT selection of an excluded target is never silently suppressed — it stays selected and surfaces as an `excluded-selection` diagnostic (resolveSelection.ts:252-284).
 
-**4. View (src/aos4/view/builder.ts):** granted content never reaches `availableIds`, so the view walks `selection.causes` from explicit `army-of-renown` roots and emits each granted ability as a selected chip in its parent's real category card (builder.ts:76-119; `GRANTED_CHIP_CATEGORIES` = artefact-of-power, heroic-trait, prayer-lore, spell-lore at builder.ts:83; names title-cased via `chipCase`, builder.ts:85-94). Battle traits stay reminder-only, like every army's battle traits. src/components/input/army_builder.tsx admits ability-kind options with a groupType and filters out the `army-of-renown` root itself — the masthead dropdown owns it (army_builder.tsx:173-176). src/components/page/homeHeader.tsx renders the AoR dropdown directly under the faction select, only for factions that have one (homeHeader.tsx:141-169).
+**4. View (src/aos4/view/builder.ts):** granted content never reaches `availableIds`, so the view walks `selection.causes` from explicit `army-of-renown` roots and emits each granted ability as a selected chip in its parent's real category card (builder.ts:141-172; `ABILITY_CHIP_CATEGORIES` = artefact-of-power, heroic-trait, prayer-lore, spell-lore at builder.ts:41 — renamed and broadened since this learning was written: the same set now also serves imported-roster enhancement chips, #1827; names title-cased via `chipCase`, builder.ts:43-55). Battle traits stay reminder-only, like every army's battle traits. src/components/input/army_builder.tsx admits ability-kind options with a groupType and filters out the `army-of-renown` root itself — the masthead dropdown owns it (army_builder.tsx:170-176). src/components/page/homeHeader.tsx renders the AoR dropdown directly under the faction select, only for factions that have one (homeHeader.tsx:153-181).
 
 **5. Importer (src/aos4/import/armiesOfRenown.ts):** the structural army index recognises classified roots first-class (`container.groupType === 'army-of-renown'`) before falling back to the legacy slug heuristic for Regiments of Renown and similar (armiesOfRenown.ts:162-169).
 
@@ -76,7 +76,7 @@ When official content **replaces** other content rather than adding to it, model
 ## When to Apply
 
 - Adding or reclassifying an Army of Renown (or any official variant that replaces faction rules): review entry in data/aos4/reviews/corpus-*.json `armiesOfRenown`, citing official evidence.
-- Introducing a new relationship kind in corpus generation: decide explicitly whether its `rulesContextIds` should be endpoint intersection (containment-like) or union (replacement/exclusion-like) — corpus.ts:2082-2103 is the seam.
+- Introducing a new relationship kind in corpus generation: decide explicitly whether its `rulesContextIds` should be endpoint intersection (containment-like) or union (replacement/exclusion-like) — corpus.ts:2363-2384 is the seam.
 - Any bug where mutually exclusive rule sets both appear in reminders: check for missing `excludes` edges, then check the two-pass suppression in resolveSelection.ts.
 - Surfacing auto-included content in the builder: extend the causes walk in builder.ts and verify the option kind survives army_builder.tsx's filter.
 - Tempted to rename a generated entity for display context: don't — the grounding auditor compares names to source records exactly (comparable-text). Carry context in relationships or view logic.
@@ -100,7 +100,7 @@ const contextualRelationships = relationships.flatMap(relationship => {
 })
 ```
 
-After (corpus.ts:2086-2102) — `excludes` carries the union, everything else keeps the intersection:
+After (corpus.ts:2363-2384) — `excludes` carries the union, everything else keeps the intersection:
 
 ```ts
 if (relationship.kind === 'excludes') {
@@ -143,10 +143,10 @@ Inside `runPass`, suppression makes the target unreachable in every direction (r
 
 ### Failure modes preserved
 
-- **Stacking bug (#1833)**: no `excludes` edges → AoR battle traits + faction battle traits both in reminders. Regression-covered in src/tests/aos4/armiesOfRenown.test.ts (29 tests: classification, per-faction replacement, chips, the #1833 regression).
-- **Offer-not-include**: root offering subgroups reproduced the rejected army-slug card UX; the accepted shape is root includes subgroups (corpus.ts:1738-1741) and the masthead dropdown is the only place the army itself appears (army_builder.tsx:176 filters `groupType !== 'army-of-renown'`).
-- **Auditor-rejected renames**: "Trugg's Troggherd Battle Traits"-style qualified names → 12+ major `secondary.source-*` findings from `unsupportedSourceValue` (adversarialReview.ts:203-224). Names stay exactly the source's heading (corpus.ts:1733, comment at 1722-1728).
-- **Invisible granted chips**: builder options derive from explicit + available IDs only; granted (included) abilities needed the causes walk (builder.ts:101-118) AND the army_builder.tsx kind filter widened to `option.kind === 'ability' && Boolean(option.groupType)` (army_builder.tsx:173-176) before anything rendered.
+- **Stacking bug (#1833)**: no `excludes` edges → AoR battle traits + faction battle traits both in reminders. Regression-covered in src/tests/aos4/armiesOfRenown.test.ts:120-301 (classification, per-faction replacement, granted chips, the #1833 regression, and the explicit-pick diagnostic).
+- **Offer-not-include**: root offering subgroups reproduced the rejected army-slug card UX; the accepted shape is root includes subgroups (corpus.ts:2026-2030) and the masthead dropdown is the only place the army itself appears (army_builder.tsx:175 filters `groupType !== 'army-of-renown'`).
+- **Auditor-rejected renames**: "Trugg's Troggherd Battle Traits"-style qualified names → 12+ major `secondary.source-*` findings from `unsupportedSourceValue` (adversarialReview.ts:203-224). Names stay exactly the source's heading (corpus.ts:2021, comment at 2010-2013).
+- **Invisible granted chips**: builder options derive from explicit + available IDs only; granted (included) abilities needed the causes walk (builder.ts:154-171) AND the army_builder.tsx kind filter widened to `option.kind === 'ability' && Boolean(option.groupType)` (army_builder.tsx:174-175) before anything rendered.
 
 ### Verification of the accepted solution
 
@@ -171,9 +171,15 @@ Renown. Two durable discoveries:
   title-cased card offering piecemeal picks" bug class (#1844) cannot recur silently — and an
   entry targeting an unmarked group is an `invalid-review` error (typo/stale-pin guard).
 - **`CorpusArmyOfRenown.evidenceTier`**: `official` (default, requires cited official naming
-  records) or `secondary-provisional` (classifies on the source's own marking under the
-  three-tier policy when no free accepted official document names the army; cited official
-  records remain corroboration). The Rules Updates FAQ compendium turned out to name many
+  records) or `secondary-provisional` (classifies on the source's own marking when no free
+  accepted official document names the army; cited official records remain corroboration).
+  This Classification Evidence Tier was introduced under the then-current three-tier source
+  policy (owner ruling 2026-08-01, #1812), which was superseded on 2026-08-18 by #1757 — a
+  two-tier hierarchy with BSData as a co-equal peer secondary. **The tier itself is unaffected
+  and still live**: it is orthogonal to the retired source-tier "Provisional Content" (see
+  CONCEPTS.md, "Classification Evidence Tier", and the flagged ambiguity distinguishing the two
+  senses of "provisional"). The "three-tier" wording survives in corpus.ts and in accepted
+  review entries as legacy vocabulary pending a schema flattening. The Rules Updates FAQ compendium turned out to name many
   battletome AoRs with explicit `ARMY OF RENOWN, <NAME>` errata headings — when hunting official
   naming evidence, sweep the full text of ALL cached official PDFs, not just the obvious
   document.
@@ -189,6 +195,6 @@ Renown. Two durable discoveries:
 - GitHub #1833 — fix: Army of Renown content stacks with the regular faction rules it replaces (the bug the pattern fixes)
 - GitHub #1844 — battletome/Legends AoRs decoded as bogus builder cards; closed by the source-marked classification extension above (PR #1848)
 - GitHub #1783 (closed) — prior corpus-generation bug that lost Army of Renown formation groups; background context
-- GitHub #1828 / #1812 — adjacent Ogor battletome/supplement content intake (provisional BSData tier, provisional watch)
+- GitHub #1828 / #1812 — adjacent Ogor battletome/supplement content intake (then-current provisional BSData fallback tier and provisional watch; that fallback tier was superseded 2026-08-18 by #1757, which raised BSData to a co-equal peer secondary — see src/aos4/radar/provisionalWatch.ts:16-20)
 - docs/plans/2026-08-01-001-feat-armies-of-renown-plan.md — the implementation plan for this work
 - docs/plans/2026-08-01-003-feat-battletome-aor-classification-plan.md — the #1844 extension plan

--- a/docs/solutions/architecture-patterns/regiments-of-renown-inclusion-availability.md
+++ b/docs/solutions/architecture-patterns/regiments-of-renown-inclusion-availability.md
@@ -53,7 +53,8 @@ and the 76 official regiment-of-renown battle-profile rows sat dispositioned
 
 1. **Marker, not heuristics.** `parseDatasheet` marks a datasheet `regimentOfRenown` from its
    `•REGIMENT OF RENOWN•` nails header and captures the INCLUSION faction list and ORGANISATION
-   member links, all outside the hashed record value so identity is unchanged. The native filter
+   member links, all outside the hashed record value (`recordChecksum = sha256(JSON.stringify(value))`,
+   `parse.ts:62`) so identity is unchanged. The native filter
    keeps marked sheets; generation fails closed (`unclassified-regiment-of-renown`) until a
    reviewed `regimentsOfRenown` entry covers each kept record, in both directions.
 2. **Dedup before merge, by name, majority variant wins.** Every collection republishes each
@@ -91,5 +92,6 @@ and the 76 official regiment-of-renown battle-profile rows sat dispositioned
 
 `army_builder.tsx` already carried a `regiment-of-renown` card title (AoS3 parity); the builder
 derives cards from `groupType`, so classified regiments surfaced as a working selector the moment
-the data existed. Import wiring (resolving the roster's bundle header line) is the deliberate
-follow-up phase of #1858.
+the data existed. Import wiring (resolving the roster's bundle header line) was the deliberate
+follow-up phase of #1858 and shipped in PR #1872 — see the bundle-line resolution at
+`src/aos4/import/resolveRoster.ts:633-741`.

--- a/docs/solutions/workflow-learnings/rules-radar-alarm-consumed-before-delivery.md
+++ b/docs/solutions/workflow-learnings/rules-radar-alarm-consumed-before-delivery.md
@@ -1,0 +1,181 @@
+---
+title: "At-most-once notifiers: never advance the state edge before delivery is confirmed"
+date: 2026-08-19
+category: workflow-learnings
+module: aos4-radar
+problem_type: workflow_issue
+component: messaging
+severity: high
+root_cause: logic_error
+resolution_type: code_fix
+applies_when:
+  - "Building any at-most-once notification keyed on a persisted state fingerprint (alarm/alert emails, webhook fan-out, digest sends)"
+  - "Gating a notification-workflow step on a command's process exit code rather than on the artifact that proves delivery happened"
+  - "Adding retry or continue-on-error to a send step in a workflow that also persists 'already notified' state"
+  - "Reviewing a GitHub Actions workflow that writes durable state (a managed issue body, a fingerprint file) as part of alerting"
+  - "The only failure signal for a lost alert is a red CI run a human may not correlate to the alert"
+symptoms:
+  - "Email step gated on the notify step's outcome, but notify exits nonzero on operational churn after already advancing the fingerprint, so a material change alongside operational noise wrote send=true, skipped the email, and the next run saw 'material state unchanged'"
+  - "SMTP send had no retry and was continue-on-error, so one transient send failure permanently consumed that alarm"
+  - "A local alarm-artifact write failure after the GitHub issue sync succeeded (create-exclusive 'wx' collision, disk error) left the fingerprint advanced with no email and no artifacts"
+related_components:
+  - ".github/workflows/aos4-rules-radar.yml"
+  - "src/aos4/radar/alarm.ts"
+  - "src/aos4/radar/compare.ts"
+  - "src/aos4/radar/rulesRadarNotifyCommand.ts"
+  - "src/aos4/radar/githubIssue.ts"
+tags:
+  - rules-radar
+  - alarm-email
+  - state-edge-ordering
+  - at-most-once-notification
+  - github-actions
+  - silent-alert-loss
+  - notify-gating
+  - fingerprint-state
+---
+
+# At-most-once notifiers: never advance the state edge before delivery is confirmed
+
+Reviewers found four defects in the AoS Rules Radar material alarm (PR #1968). Three of them were not three separate bugs; they were three instances of a single ordering mistake, and that mistake is available to every future once-per-state notifier in this repo. The fourth was a related flaw in the predicate that decides whether to send at all. Documented as one-off bug fixes they would read as "we added a retry." Documented as a design rule they tell the next author which line of code to look at first.
+
+The four defects are preserved below as worked examples, followed by a fifth section covering the review technique that exposed the weakest-guarded of them — a test-fidelity lesson rather than a fifth code defect.
+
+## Context
+
+The AoS 4 Rules Radar (`.github/workflows/aos4-rules-radar.yml`) is a scheduled observer. On each run it looks at rules sources, merges what it saw into a managed GitHub issue whose body embeds machine state, and — on non-report-only runs — emails the maintainer when there is *new material state to review*.
+
+The alarm is deliberately **at most once per distinct material state**. That property is the whole point of the design, and it is built from two pieces:
+
+- `createRadarMaterialFingerprint` hashes only the report's material events, not the aggregate (`src/aos4/radar/compare.ts:505-506`). Operational churn — a transient rate limit appearing and clearing — moves the aggregate fingerprint but not the material one, so it cannot re-alarm on state the maintainer has already seen.
+- `decideRulesRadarAlarm` compares the current material fingerprint against the one parsed back out of the managed issue body from the previous run (`src/aos4/radar/alarm.ts:28-51`, previous state supplied by `synchronizeRulesRadarIssue` at `src/aos4/radar/githubIssue.ts:162`).
+
+The persisted state edge is therefore the **managed issue body**. `synchronizeRulesRadarIssue` writes the merged report into it via `client.updateIssue` (`src/aos4/radar/githubIssue.ts:173-180`) and only then returns; `runRulesRadarNotification` calls `decideRulesRadarAlarm` afterwards (`src/aos4/radar/rulesRadarNotifyCommand.ts:172-173`). By the time anything downstream can decide to send an email, the issue body already says "this state has been seen."
+
+This is the shape that makes the rule below necessary. It is not unique to email: it applies to any notifier whose dedupe key is written to durable storage before the notification leaves the process.
+
+## Guidance
+
+**Rule: in an at-most-once notifier, the persisted state edge must not advance until delivery is confirmed. Where it must advance first — because the same write also serves a non-notification purpose — every path between "state advanced" and "message delivered" must be treated as a delivery path, not as a generic error path.**
+
+Four checkable consequences, all of which the Rules Radar now satisfies:
+
+1. **Do not gate delivery on the exit status of the step that advanced the state.** A process can fail for reasons unrelated to the notification after having already committed the dedupe key. Gate on an artifact that is written *only* on the success path you actually care about, and let the artifact's absence be the failure signal.
+2. **A once-per-state send needs an in-band retry.** There is no natural redelivery: the next scheduled run will compute "state unchanged" and stay silent. One transient SMTP hiccup, with no retry, permanently consumes the alarm.
+3. **Post-advance writes must overwrite, not create-exclusively.** A create-exclusive (`wx`) write that collides with a leftover file from an earlier attempt converts a rerun into a permanent loss. Create-exclusive is right for artifacts whose duplication is itself the bug; it is wrong for anything written after the state edge moved.
+4. **When a post-advance step does fail, the log must name the divergence.** "Sync failed" and "the issue advanced to fingerprint X but the alarm for X will never send" demand completely different human responses, and a red CI run alone does not distinguish them.
+
+**A fifth rule, about the dedupe predicate itself:** "the fingerprint changed" is not the same claim as "there is something new to review." A hash inequality is satisfied by removal as well as by addition. If the notification's subject line asserts *new* state, the predicate must require at least one element absent from the previous state, not merely a different digest.
+
+**And the review technique that catches this class:** for any test that asserts a workflow or config file's wiring, run the mutation in your head or in the tree — *invert the guard, delete the step, swap the pin; does a test go red?* A `toContain('alarm.json')` against a whole YAML file is satisfied by any mention of that filename anywhere in the file, including an unrelated artifact-upload list. It asserts the string exists, not that the wiring works.
+
+## Why This Matters
+
+The failure is silent, permanent, and self-concealing, which is the worst combination available.
+
+- **Silent:** the alarm email is the only channel that means "shipped rules text may be wrong until this is reconciled" (`src/aos4/radar/alarm.ts:60-86`). When it does not arrive, nothing else says the material change happened. The managed issue does get updated, but the design's premise is that the maintainer is pulled to the issue *by the email*.
+- **Permanent:** because the notifier is once-per-state by design, the next run reads the advanced fingerprint and returns `send: false, reason: 'material state unchanged'` (`src/aos4/radar/alarm.ts:43-45`). There is no second chance, and no `--force`-style flag exists on the notify command (see the complete flag set in `parseRulesRadarNotifyArguments`, `src/aos4/radar/rulesRadarNotifyCommand.ts:58-89`). The only lever that resets the fingerprint is the runbook's manual issue-recovery path — restoring or replacing the managed issue body (`docs/data/aos4-maintenance.md`, "Rules Radar" issue-recovery guidance) — which a maintainer will only reach for if they already know an alarm was lost.
+- **Self-concealing:** the residual signal is a red workflow run. The Radar's failure backstop fails the job whenever any tracked step failed (`.github/workflows/aos4-rules-radar.yml`, "Preserve Rules Radar failure"), but a red scheduled job on an observer that routinely tolerates transient source failures is exactly the signal a human learns to skim. Nothing in that red run says "and an alarm was lost."
+
+There is also a compounding irony worth remembering: defect 1 below fired precisely on the churn the material fingerprint was *designed* to tolerate. Transient operational noise was supposed to be the harmless case; the exit-code gate turned it into the trigger for permanent loss. Hardening one layer against noise does not help if a different layer still treats that noise as fatal.
+
+## When to Apply
+
+Reach for this rule whenever you are writing or reviewing something with all three of these properties:
+
+- a **dedupe key or watermark** persisted somewhere durable (an issue body, a state file, a DB column, a cache entry, a git tag),
+- a **notification, email, webhook, or other externally-visible delivery** gated on that key changing,
+- and **no natural redelivery** — the next run recomputes the key and concludes there is nothing to do.
+
+Specific review prompts:
+
+- Trace the code from "durable write" to "message sent." Every `throw`, every nonzero exit, every `continue-on-error`, every file write in between is a potential silent loss. Name them.
+- Ask what the process's exit code actually encodes. In this codebase the notify command's nonzero exit means "operational events were observed," not "the notification failed" (`src/aos4/radar/rulesRadarNotifyCommand.ts:193` and `:231`). Anything gating on that exit code has confused two meanings.
+- Ask what happens on a **rerun** of the same workflow run: which files already exist, and does the code create-exclusively over them?
+- Ask whether the notification's own claim ("new state to review") is actually implied by the predicate that triggers it.
+- For every config-file assertion in the test suite: what mutation would make this fail? If you cannot name one, the assertion is decorative.
+
+This does **not** apply to at-least-once notifiers, where duplicate delivery is acceptable and the correct fix is idempotency at the receiver rather than ordering at the sender.
+
+## Examples
+
+Examples 1-4 are the four defects, which came out of the multi-agent review of PR #1968 — independently from the correctness reviewer, the reliability reviewer, and a cross-model adversarial pass (Codex). Example 5 is the review-technique lesson that came with them, not a fifth defect. All were fixed in the review-fix work squashed into #1968 (merged 2026-08-18 as `e180b822`); the pre-fix code below is quoted from that PR's branch history and does not exist on `master`.
+
+### 1. Operational churn swallowed the alarm (the exit-code gate)
+
+*Pre-fix*, the email evaluation step carried an extra branch ahead of the artifact check:
+
+```bash
+elif [[ "${{ steps.notify.outcome }}" != "success" ]]; then
+  echo "::warning::Issue synchronization failed; skipping the material alarm email."
+```
+
+But `steps.notify` runs the notify command, which deliberately exits nonzero when operational events exist — `if (result.operationalFailure) process.exitCode = 1` (`src/aos4/radar/rulesRadarNotifyCommand.ts:231`), with `operationalFailure` derived purely from `report.operationalEventCount > 0` (`:193`) — and it does so *after* `synchronizeRulesRadarIssue` has already advanced the fingerprint in the issue body. So a material change arriving alongside any operational churn wrote `send: true` into `alarm.json`, the mail step was skipped by the outcome gate, and the next run computed "material state unchanged." Permanently lost.
+
+*Fixed:* the outcome branch is deleted. `alarm.json`'s existence is the authoritative signal, because it is written only after a successful sync, and the pre-existing `! -f "$alarm_file"` branch already covers genuine sync failures (`.github/workflows/aos4-rules-radar.yml:212-226`).
+
+### 2. No retry on the send
+
+*Pre-fix*, the send step was `uses: dawidd6/action-send-mail@v3` with `continue-on-error: true` and nothing after it. One transient SMTP failure consumed the alarm.
+
+*Fixed:* a 30-second wait step plus a second, identical send step gated on the first one's failure (`.github/workflows/aos4-rules-radar.yml:246-267`), and the failure backstop now keys on the retry's outcome — `"${{ steps.alarm_email_retry.outcome }}"` in the outcome list (`:345`) — so the job goes red only if both attempts failed. The action is also SHA-pinned (`dawidd6/action-send-mail@2cea9617b09d79a095af21254fbcb7ae95903dde # v3.12.0`, `:232` and `:255`) since it receives the SMTP credentials; a mutable tag on a credential-consuming action is a supply-chain hole.
+
+Note what the retry does *not* buy: it is same-run only. A failure that outlives the run still loses the alarm, and there is still no force-resend flag. The retry narrows the window; the artifact-authoritative gate is what removes the common cause.
+
+### 3. Write failure after sync
+
+*Pre-fix*, all three alarm artifacts were written with the create-exclusive helper (`writeNew`, flag `wx`) and `writeAlarmArtifacts` was called bare, with no `try`. If it threw after the sync succeeded — a `wx` collision on a rerun, a disk error, a permissions problem — the fingerprint had advanced with no artifacts and no email, and the failure was indistinguishable from a generic sync error.
+
+*Fixed*, in `src/aos4/radar/rulesRadarNotifyCommand.ts`:
+
+- a separate `writeReplace` helper with flag `w` for alarm artifacts (`:105-109`), while the managed issue body keeps `wx` via `writeNew` (`:102-103`, used at `:160`) — the distinction is deliberate and the comment says why;
+- stale `alarm-subject.txt` / `alarm-body.md` are removed on no-material runs so the workflow cannot mail the wrong text beside a `send: false` decision (`:141-147`), covered by `src/tests/aos4/rulesRadarNotifyCommand.test.ts:64-68`;
+- the write is wrapped so a failure logs the exact divergence before rethrowing (`:174-188`): *"alarm artifacts failed to persist after the managed issue advanced to material fingerprint X; the alarm for this state will not re-send on later runs."*
+
+Relaxing `wx` to `w` was independently checked for a file-seeding vulnerability during a security review of these changes: the alarm output directory resolves to a per-run directory under the workflow's `RUN_ROOT`, so there is no attacker-controlled path to pre-seed (session history, 2026-08-18 security review).
+
+### 4. The predicate did not mean what the email said
+
+*Pre-fix*, `decideRulesRadarAlarm` sent on any material-fingerprint inequality. A removal-only change — one outstanding event resolving while others persist — shifts the hash, so it emailed a high-priority "new material state to review" alarm whose body listed only already-known events.
+
+*Fixed* (`src/aos4/radar/alarm.ts:46-49`): after the unchanged check, the decision requires at least one material event absent from the previous state, using the new `createRadarMaterialEventKeys` helper (`src/aos4/radar/compare.ts:513-516`, the same per-event projection the fingerprint hashes, kept individually):
+
+```ts
+const previousKeys = new Set(createRadarMaterialEventKeys(previous))
+if (createRadarMaterialEventKeys(report).every(key => previousKeys.has(key))) {
+  return { send: false, reason: 'material state shrank without new events', ...base }
+}
+```
+
+Both directions are pinned by tests: removal-only stays silent (`src/tests/aos4/rulesRadarAlarm.test.ts:133-156`) and a same-count *replacement* still alarms (`:158-175`), which is the case a naive count comparison would have gotten wrong.
+
+### 5. The review lesson: decorative workflow assertions
+
+The workflow-contract test already "covered" the alarm wiring before the review. It did so like this:
+
+```ts
+expect(workflow).toContain('alarm.json')
+expect(workflow).toContain('alarm-subject.txt')
+expect(workflow).toContain('alarm-body.md')
+```
+
+Those filenames also appear in the unrelated `Upload Rules Radar evidence` step's path list (`.github/workflows/aos4-rules-radar.yml:285-287`, `:296-298`). Deleting the alarm evaluation entirely would have left all three assertions green. The mutation test — *invert the guard; does a test fail?* — is what exposes this in seconds.
+
+*Fixed* (`src/tests/aos4/rulesRadarWorkflow.test.ts:61-100`): every assertion is anchored to the step that consumes the file, and the loss path is pinned negatively —
+
+```ts
+expect(workflow).toMatch(
+  /name: Evaluate material alarm email[\s\S]{0,900}alarm_file="\$report_directory\/alarm\.json"/
+)
+expect(workflow).not.toContain('Issue synchronization failed; skipping the material alarm email.')
+expect(workflow).not.toMatch(/name: Evaluate material alarm email[\s\S]{0,1600}steps\.notify\.outcome/)
+```
+
+with the same anchoring applied to the SHA pin (`:85-88`, including `not.toMatch(/dawidd6\/action-send-mail@v3\b/)` to bar a regression to the mutable tag) and to the retry step (`:93-96`). The comment above the block records *why* the negative assertions exist, so a future author who deletes them has to argue with the reasoning rather than with a bare regex.
+
+## Related
+
+- [Deploy-script fidelity gaps](deploy-script-fidelity-gaps.md) — prior art on the same methodological point from a different subject area: a guard that stays green while the real action fails, and the mutation test as the decisive check. That doc's failures came from a test double diverging from production; this one's from a gate keyed on a proxy signal rather than the confirmed effect. Read together, they are the repo's two worked examples of "the check passed, the thing did not happen."
+- Issue [#1757](https://github.com/daviseford/aos-reminders/issues/1757) — the managed Rules Radar issue whose body holds the material fingerprint this learning concerns.
+- Issue [#1967](https://github.com/daviseford/aos-reminders/issues/1967) — the feature request that introduced the alarm email.
+- PR [#1968](https://github.com/daviseford/aos-reminders/pull/1968) — the PR whose review surfaced all four defects; the fixes are squashed into it.


### PR DESCRIPTION
## What changed

Two documentation passes over the knowledge store, both arising from the review of #1968.

### New learning

`docs/solutions/workflow-learnings/rules-radar-alarm-consumed-before-delivery.md` documents the durable rule behind the alarm defects fixed in #1968: **in an at-most-once notifier, the persisted state edge must not advance until delivery is confirmed.** The four defects are preserved as worked examples (the exit-code gate, the unretried send, the write-failure-after-sync, and the predicate that sent on removal-only changes), followed by the mutation-test lesson from the decorative workflow assertions.

The doc is filed knowledge-track in `workflow-learnings/`, following the precedent set by `deploy-script-fidelity-gaps.md` — a class of CI defect unified by one durable rule — and cross-links it as prior art on guard fidelity.

### Refresh of `architecture-patterns/`

Both docs' architecture was verified intact against HEAD: every mechanism they describe is still what the code does, so neither needed replacing. What had rotted was citations.

- **`armies-of-renown-replace-semantics-excludes.md`** — refreshed ~20 stale line citations (`corpus.ts` has grown ~290 lines since the doc was written), renamed `GRANTED_CHIP_CATEGORIES` to `ABILITY_CHIP_CATEGORIES` (broadened since to serve imported-roster chips, #1827), re-pinned the review file from the superseded `corpus-2026-08-01e.json` to the accepted `corpus-2026-08-18.json`, replaced a stale test count with the covering range, and marked the two genuinely superseded source-policy clauses as historical against the 2026-08-18 peer-secondary decision (#1757).
- **`regiments-of-renown-inclusion-availability.md`** — the import wiring it described as a pending follow-up has since shipped (#1872), and `recordChecksum` is now named explicitly so the inbound citation from the army-changelog plan resolves on a keyword search.

**What was deliberately not changed:** the `secondary-provisional` occurrences in both docs. That is the live **Classification Evidence Tier**, which is orthogonal to the retired source-tier "Provisional Content" — marking it superseded would have introduced an error rather than fixing one. This distinction is the one the refresh was scoped to get right.

### CONCEPTS.md

Added **Rules Radar**, **Material Event**, **Regiment of Renown**, and **Battle Profile Disposition** — the last two were core nouns the glossary had never defined despite Regiments of Renown being a distinct top-level mechanic. Broadened **Source-Marked Classification**, which described only Armies of Renown while the same fail-closed contract now also governs Regiments of Renown. Removed code field names from **Provisional Content** (glossary entries state behavior, not implementation).

## Verification

- Frontmatter parser-safety and mechanical claims validators pass on all three docs.
- An independent grounding pass verified 34 claims in the new learning against HEAD — 0 contradicted, 0 unverifiable — and caught an internal inconsistency in the defect count, now fixed.
- Line citations added by the refresh were spot-checked against the current tree.

No source or runtime changes; documentation only.
