### PR TITLE
perf: ship the catalog as JSON.parse and cut its incidental shell edges (#1845)

### DIFF
--- a/src/aos4/runtime/armyStorage.ts
+++ b/src/aos4/runtime/armyStorage.ts
@@ -1,5 +1,5 @@
-import type { Aos4Catalog } from '../domain'
-import { AOS4_DEFAULT_RULES_CONTEXT_ID, AOS4_DEFAULT_SELECTION_IDS } from '../generated'
+import type { Aos4Catalog, CanonicalId } from '../domain'
+import defaultsJson from '../generated/corpus/defaults.json'
 import { resolveSelection } from '../select'
 import {
   createAos4ArmyDocument,
@@ -8,6 +8,17 @@ import {
   type Aos4ArmyDocument,
   type Aos4ArmyDocumentDiagnostic,
 } from '../state'
+
+/*
+ * The two default ids come from the generated defaults file rather than the generated barrel that
+ * also exports them: the barrel re-exports the whole corpus, so reading a couple of hundred bytes
+ * of ids through it would pull the 13 MB catalog into every graph that stores an army.
+ */
+const defaults = defaultsJson as unknown as {
+  rulesContextId: Aos4Catalog['rulesContexts'][number]['id']
+  defaultFactionId: CanonicalId<'faction'>
+}
+const defaultSelectionIds = [defaults.defaultFactionId]
 
 export const AOS4_ARMY_STORAGE_KEY = 'aos-reminders:aos4:army:v1'
 
@@ -28,8 +39,8 @@ export const createDefaultAos4ArmyDocument = (): Aos4ArmyDocument =>
   createAos4ArmyDocument({
     id: 'army:aos4-migration-preview',
     name: 'Stormcast Eternals',
-    rulesContextId: AOS4_DEFAULT_RULES_CONTEXT_ID,
-    explicitSelectionIds: AOS4_DEFAULT_SELECTION_IDS,
+    rulesContextId: defaults.rulesContextId,
+    explicitSelectionIds: defaultSelectionIds,
   })
 
 export const saveAos4ArmyDocument = (storage: Storage, document: Aos4ArmyDocument): void => {

--- a/src/api/armyApi.ts
+++ b/src/api/armyApi.ts
@@ -1,4 +1,3 @@
-import { AOS4_CATALOG } from '../aos4/generated'
 import { deserializeAos4ArmyDocument, type Aos4ArmyDocument } from '../aos4/state'
 
 export interface RemoteArmy {
@@ -39,7 +38,11 @@ const configuredEndpoint = (import.meta.env.VITE_ARMY_API_URL || '').replace(/\/
  * Rejecting them here instead bricked saving and, worse, one stale army poisoned the whole cloud
  * list. So a well-formed document always parses; selection resolution is the builder's concern.
  */
-const parseDocument = (value: unknown): Aos4ArmyDocument => {
+const parseDocument = async (value: unknown): Promise<Aos4ArmyDocument> => {
+  // The catalog is loaded here rather than imported: every caller is already behind a network round
+  // trip, and a static import would put the whole corpus in the graph of anything holding a cloud
+  // army — the shell included, since the collection provider wraps the page.
+  const { AOS4_CATALOG } = await import('../aos4/generated')
   const restored = deserializeAos4ArmyDocument(JSON.stringify(value), AOS4_CATALOG)
   if (!restored.document || restored.diagnostics.some(diagnostic => diagnostic.severity === 'error')) {
     throw new ArmyApiError('The service returned an incompatible army document.', 502)
@@ -64,22 +67,22 @@ const stringField = (value: unknown, key: string): string => {
   return value[key] as string
 }
 
-const parseRemoteArmy = (value: unknown): RemoteArmy => {
+const parseRemoteArmy = async (value: unknown): Promise<RemoteArmy> => {
   if (!isRecord(value)) throw new ArmyApiError('The service returned an invalid army response.', 502)
   return {
     id: stringField(value, 'id'),
     createdAt: numberField(value, 'createdAt'),
     updatedAt: numberField(value, 'updatedAt'),
-    document: parseDocument(value.document),
+    document: await parseDocument(value.document),
   }
 }
 
-const parseSharedArmy = (value: unknown): SharedArmy => {
+const parseSharedArmy = async (value: unknown): Promise<SharedArmy> => {
   if (!isRecord(value)) throw new ArmyApiError('The service returned an invalid share response.', 502)
   return {
     id: stringField(value, 'id'),
     createdAt: numberField(value, 'createdAt'),
-    document: parseDocument(value.document),
+    document: await parseDocument(value.document),
   }
 }
 
@@ -121,7 +124,7 @@ export const createArmyApi = (endpoint: string, fetcher: Fetcher = fetch) => {
     async listArmies(token: string): Promise<RemoteArmy[]> {
       const value = await request('/items', {}, token)
       if (!Array.isArray(value)) throw new ArmyApiError('The service returned an invalid army list.', 502)
-      return value.map(parseRemoteArmy)
+      return Promise.all(value.map(army => parseRemoteArmy(army)))
     },
     async createArmy(document: Aos4ArmyDocument, token: string): Promise<RemoteArmy> {
       return parseRemoteArmy(
@@ -149,7 +152,7 @@ export const createArmyApi = (endpoint: string, fetcher: Fetcher = fetch) => {
         id: stringField(value, 'id'),
         createdAt: 0,
         updatedAt: numberField(value, 'updatedAt'),
-        document: parseDocument(value.document),
+        document: await parseDocument(value.document),
       }
     },
     async deleteArmy(id: string, token: string): Promise<void> {
@@ -164,8 +167,9 @@ export const createArmyApi = (endpoint: string, fetcher: Fetcher = fetch) => {
         },
         token
       )
+      const shared = await parseSharedArmy(value)
       return {
-        ...parseSharedArmy(value),
+        ...shared,
         url: stringField(value, 'url'),
       }
     },

--- a/src/api/armyApi.ts
+++ b/src/api/armyApi.ts
@@ -42,8 +42,20 @@ const parseDocument = async (value: unknown): Promise<Aos4ArmyDocument> => {
   // The catalog is loaded here rather than imported: every caller is already behind a network round
   // trip, and a static import would put the whole corpus in the graph of anything holding a cloud
   // army — the shell included, since the collection provider wraps the page.
-  const { AOS4_CATALOG } = await import('../aos4/generated')
-  const restored = deserializeAos4ArmyDocument(JSON.stringify(value), AOS4_CATALOG)
+  //
+  // The catch is not currently reachable: Home imports the catalog statically, so the module is
+  // always in the registry before any cloud call runs. It becomes live once Home loads the catalog
+  // lazily (#1845), at which point this is a real network fetch that can fail on a rotated hash or a
+  // cold cache offline — and an unwrapped module-loading error would reach messageForError as
+  // "Failed to fetch dynamically imported module ...". Same message and default status as the fetch
+  // failure above, because to a caller it is the same class of outage.
+  let generated: typeof import('../aos4/generated')
+  try {
+    generated = await import('../aos4/generated')
+  } catch {
+    throw new ArmyApiError('Cloud armies are temporarily unavailable.')
+  }
+  const restored = deserializeAos4ArmyDocument(JSON.stringify(value), generated.AOS4_CATALOG)
   if (!restored.document || restored.diagnostics.some(diagnostic => diagnostic.severity === 'error')) {
     throw new ArmyApiError('The service returned an incompatible army document.', 502)
   }

--- a/src/tests/aos4/armyApi.test.ts
+++ b/src/tests/aos4/armyApi.test.ts
@@ -168,4 +168,32 @@ describe('AoS 4 army API client', () => {
     const saved = await createArmyApi('https://army.example', saveFetcher).createArmy(staleDocument, 'token')
     expect(saved.document).toEqual(staleDocument)
   })
+
+  /*
+   * The catalog reaches parseDocument through a dynamic import, so loading it is a network fetch the
+   * caller can no longer assume succeeded. Not reachable while Home imports the catalog statically —
+   * the module is always registered before any cloud call — but it goes live with the lazy Home
+   * split (#1845), and an unwrapped failure would reach the user as "Failed to fetch dynamically
+   * imported module ...". Pinned now so the split cannot introduce that message unnoticed.
+   */
+  it('reports a catalog chunk that fails to load as a service outage', async () => {
+    vi.resetModules()
+    vi.doMock('../../aos4/generated', () => {
+      throw new Error('Failed to fetch dynamically imported module')
+    })
+
+    try {
+      const { createArmyApi: createApiWithBrokenCatalog } = await import('../../api/armyApi')
+      const fetcher = vi
+        .fn()
+        .mockResolvedValue(jsonResponse([{ id: 'cloud-1', createdAt: 1, updatedAt: 2, document }]))
+
+      await expect(
+        createApiWithBrokenCatalog('https://army.example/', fetcher).listArmies('access-token')
+      ).rejects.toThrow('Cloud armies are temporarily unavailable.')
+    } finally {
+      vi.doUnmock('../../aos4/generated')
+      vi.resetModules()
+    }
+  })
 })

--- a/src/tests/aos4/bundleBoundaries.test.ts
+++ b/src/tests/aos4/bundleBoundaries.test.ts
@@ -1,8 +1,50 @@
+import { existsSync, statSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const source = (relativePath: string) => readFile(path.resolve(process.cwd(), relativePath), 'utf8')
+
+const SOURCE_ROOT = path.resolve(process.cwd(), 'src')
+
+const resolveModulePath = (specifier: string, fromFile: string): string | null => {
+  // Bare specifiers resolve against `src` — both the tsconfig `baseUrl` and the Vite aliases point
+  // there — so anything that does not resolve to a file under it is a package, and not our graph.
+  const base = specifier.startsWith('.')
+    ? path.resolve(path.dirname(fromFile), specifier)
+    : path.resolve(SOURCE_ROOT, specifier)
+  const candidates = [
+    base,
+    ...['.ts', '.tsx', '.js', '.jsx', '.json'].map(extension => `${base}${extension}`),
+    ...['.ts', '.tsx'].map(extension => path.join(base, `index${extension}`)),
+  ]
+  return candidates.find(candidate => existsSync(candidate) && statSync(candidate).isFile()) ?? null
+}
+
+// Static edges only. `import type` erases before the bundler sees it, and `await import()` is the
+// boundary being asserted rather than a leak through it, so neither counts as an edge here.
+const staticImportSpecifiers = (contents: string): string[] =>
+  [
+    /(?:^|\n)\s*import\s+(?!type\s)[^'"();]*?from\s*['"]([^'"]+)['"]/g,
+    /(?:^|\n)\s*export\s+(?!type\s)[^'"();]*?from\s*['"]([^'"]+)['"]/g,
+    /(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g,
+  ].flatMap(pattern => Array.from(contents.matchAll(pattern), match => match[1]))
+
+const staticGraphFrom = async (entry: string): Promise<string[]> => {
+  const visited = new Set<string>()
+  const queue = [path.resolve(process.cwd(), entry)]
+  while (queue.length > 0) {
+    const file = queue.shift() as string
+    if (visited.has(file)) continue
+    visited.add(file)
+    if (file.endsWith('.json')) continue
+    for (const specifier of staticImportSpecifiers(await readFile(file, 'utf8'))) {
+      const resolved = resolveModulePath(specifier, file)
+      if (resolved) queue.push(resolved)
+    }
+  }
+  return Array.from(visited, file => path.relative(process.cwd(), file).split(path.sep).join('/'))
+}
 
 describe('initial bundle boundaries', () => {
   it('keeps the AoS 4 catalog out of the application bootstrap graph', async () => {
@@ -37,5 +79,19 @@ describe('initial bundle boundaries', () => {
     expect(home).toContain("const PrintModal = lazy(() => import('components/print/printModal'))")
     expect(home).toContain("await import('../../aos4/print')")
     expect(home).not.toMatch(/^import\s+\{[^}]*renderPrintPlanToPdf[^}]*\}\s+from\s+['"]/m)
+  })
+
+  /*
+   * Cloud armies are reachable from the shell — the provider wraps Home — so nothing in that subtree
+   * may drag the corpus in. Walked transitively rather than string-matched on one file, because the
+   * edge is worth catching wherever in the subtree it reappears, not only where it last was.
+   */
+  it('keeps the generated catalog out of the cloud army context graph', async () => {
+    const graph = await staticGraphFrom('src/context/useArmyCollection.tsx')
+
+    // The walk is only meaningful if it actually resolved the module the catalog used to arrive
+    // through; without this a broken resolver would report an empty graph as a clean one.
+    expect(graph).toContain('src/api/armyApi.ts')
+    expect(graph.filter(file => file.startsWith('src/aos4/generated/'))).toEqual([])
   })
 })

--- a/src/tests/aos4/bundleBoundaries.test.ts
+++ b/src/tests/aos4/bundleBoundaries.test.ts
@@ -82,9 +82,21 @@ describe('initial bundle boundaries', () => {
   })
 
   /*
+   * The corpus modules, as opposed to everything generated. `corpus/defaults.json` is 130 bytes and
+   * is deliberately importable from the shell (see armyStorage) — filtering on the directory would
+   * forbid the very edge that replaced the barrel import.
+   */
+  const CORPUS_MODULES =
+    /^src\/aos4\/generated\/(index\.ts|catalog\.ts|corpus\/(index\.ts|catalog\.ts|runtime\.json))$/
+
+  /*
    * Cloud armies are reachable from the shell — the provider wraps Home — so nothing in that subtree
    * may drag the corpus in. Walked transitively rather than string-matched on one file, because the
    * edge is worth catching wherever in the subtree it reappears, not only where it last was.
+   *
+   * Preparatory, not a load-time win on its own: Home still imports the catalog statically, so the
+   * corpus is on the first-render path regardless of this subtree. What this holds is that cutting
+   * Home's own edge will be sufficient — that no second path reintroduces the corpus behind it.
    */
   it('keeps the generated catalog out of the cloud army context graph', async () => {
     const graph = await staticGraphFrom('src/context/useArmyCollection.tsx')
@@ -92,6 +104,18 @@ describe('initial bundle boundaries', () => {
     // The walk is only meaningful if it actually resolved the module the catalog used to arrive
     // through; without this a broken resolver would report an empty graph as a clean one.
     expect(graph).toContain('src/api/armyApi.ts')
-    expect(graph.filter(file => file.startsWith('src/aos4/generated/'))).toEqual([])
+    expect(graph.filter(file => CORPUS_MODULES.test(file))).toEqual([])
+  })
+
+  /*
+   * The entry itself, which is the graph that actually decides first-paint cost. It is clean today
+   * only because Home is lazy; asserting it here means the Home split cannot quietly hoist the
+   * corpus back into the entry chunk while the subtree assertion above still passes.
+   */
+  it('keeps the generated catalog out of the application entry graph', async () => {
+    const graph = await staticGraphFrom('src/main.tsx')
+
+    expect(graph).toContain('src/bootstrap/router.tsx')
+    expect(graph.filter(file => CORPUS_MODULES.test(file))).toEqual([])
   })
 })

--- a/src/tests/aos4/catalogChunkForm.test.ts
+++ b/src/tests/aos4/catalogChunkForm.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+
+import fs from 'fs'
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Assertions over the *form* the built catalog chunk ships in, not its contents.
+ *
+ * The corpus is the largest thing a first visit parses, and JSON parses several times faster than
+ * equivalent JavaScript source at this scale — whole seconds on a phone. `vite.config.mts` sets
+ * `json.stringify` to get the `JSON.parse` form, but that option alone is a silent no-op: Vite
+ * resolves stringification as `stringify === true && namedExports !== true`, and `namedExports`
+ * defaults to `true`. Before #1845 the chunk shipped as a 12.7 MB object literal with backtick keys
+ * and the config looked correct.
+ *
+ * Nothing else catches that, because the failure has no error and no warning — the build succeeds
+ * and the app works, just slower. Hence a build-output assertion rather than a config-source one:
+ * pinning the config text would have passed throughout the period the option was doing nothing.
+ *
+ * These read `dist/` rather than mocking, which is the established shape for build-shape guarantees
+ * here (see `src/tests/pwaBuild.test.ts`). CI builds before it tests for this reason.
+ */
+
+const distDir = path.resolve(process.cwd(), 'dist')
+const assetsDir = path.join(distDir, 'assets')
+
+/*
+ * Freshness, not just existence — a `dist/` from another branch would satisfy these assertions while
+ * telling you nothing about the current config, which is exactly the regression this file exists to
+ * catch.
+ */
+const BUILD_INPUTS = ['vite.config.mts']
+
+if (!fs.existsSync(assetsDir)) {
+  throw new Error('dist/assets is missing. These assertions read build output — run `yarn build` first.')
+}
+
+const catalogChunks = fs
+  .readdirSync(assetsDir)
+  .filter(name => name.startsWith('aos4-catalog-data') && name.endsWith('.js'))
+
+if (catalogChunks.length === 0) {
+  throw new Error('No aos4-catalog-data chunk in dist/assets — run `yarn build` first.')
+}
+
+const builtAt = Math.min(...catalogChunks.map(name => fs.statSync(path.join(assetsDir, name)).mtimeMs))
+const staleAgainst = BUILD_INPUTS.filter(
+  file => fs.statSync(path.resolve(process.cwd(), file)).mtimeMs > builtAt
+)
+if (staleAgainst.length > 0) {
+  throw new Error(`dist/ predates ${staleAgainst.join(', ')} — run \`yarn build\` first.`)
+}
+
+/*
+ * Assert on small derived facts, never on the chunk source itself. A failed `expect(source)` prints
+ * the whole 12.7 MB chunk as its diff, which buries the result and floods any log reading it.
+ */
+const shapeOf = (name: string) => {
+  const source = fs.readFileSync(path.join(assetsDir, name), 'utf8')
+  return {
+    parsesJson: source.includes('JSON.parse'),
+    /*
+     * The negative half is what makes this meaningful. `parsesJson` alone would pass on a chunk that
+     * parsed one small object and left the corpus as a literal, which is a shape the bundler can
+     * genuinely produce. The projection's own keys appearing as bare identifiers is the regressed
+     * form: `var e={attribution:` rather than a quoted key inside a parsed string.
+     */
+    hasBareProjectionKeys:
+      /[{,]\s*catalogSchemaVersion\s*:/.test(source) || /[{,]\s*rulesContexts\s*:\s*\[/.test(source),
+  }
+}
+
+describe('catalog chunk serialization form', () => {
+  it.each(catalogChunks)('ships %s as a JSON.parse call rather than a JS object literal', name => {
+    expect(shapeOf(name)).toEqual({ parsesJson: true, hasBareProjectionKeys: false })
+  })
+})

--- a/src/tests/aos4/catalogChunkForm.test.ts
+++ b/src/tests/aos4/catalogChunkForm.test.ts
@@ -30,7 +30,7 @@ const assetsDir = path.join(distDir, 'assets')
  * telling you nothing about the current config, which is exactly the regression this file exists to
  * catch.
  */
-const BUILD_INPUTS = ['vite.config.mts']
+const BUILD_INPUTS = ['vite.config.mts', 'package.json', 'yarn.lock']
 
 if (!fs.existsSync(assetsDir)) {
   throw new Error('dist/assets is missing. These assertions read build output — run `yarn build` first.')

--- a/src/tests/aos4/runtimeStorage.test.ts
+++ b/src/tests/aos4/runtimeStorage.test.ts
@@ -2,6 +2,7 @@ import { AOS4_CATALOG } from '../../aos4/generated'
 import {
   AOS4_ARMY_STORAGE_KEY,
   AOS3_BROWSER_STORAGE_KEYS,
+  createDefaultAos4ArmyDocument,
   loadAos4ArmyDocument,
   saveAos4ArmyDocument,
 } from '../../aos4/runtime'
@@ -90,5 +91,19 @@ describe('AoS 4 browser persistence', () => {
     saveAos4ArmyDocument(storage, document)
 
     expect(storage.getItem(AOS4_ARMY_STORAGE_KEY)).toBe(serializeAos4ArmyDocument(document))
+  })
+
+  /*
+   * armyStorage reads the two default ids straight from defaults.json rather than through the
+   * generated barrel, which would pull the whole corpus into any graph that stores an army. That
+   * leaves two derivations of the same value — here and in the barrel — so pin them together: this
+   * fails if either side changes alone. Test files may import the barrel freely; the boundary rule
+   * constrains the app graph, not the suite.
+   */
+  it('derives the same defaults as the generated catalog exports', () => {
+    const document = createDefaultAos4ArmyDocument()
+
+    expect(document.rulesContextId).toBe(AOS4_DEFAULT_RULES_CONTEXT_ID)
+    expect(document.explicitSelectionIds).toEqual(AOS4_DEFAULT_SELECTION_IDS)
   })
 })

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -235,8 +235,16 @@ export default defineConfig({
    * Emit imported JSON as JSON.parse("...") instead of a JS object literal. Engines parse JSON
    * several times faster than JS source at scale, and the corpus chunk is ~12 MB — on a phone the
    * literal form costs whole seconds of main-thread parse before Home can render.
+   *
+   * `namedExports: false` is load-bearing, not tidying. Vite resolves this option as
+   * `stringify === true && namedExports !== true`, and `namedExports` defaults to true — so
+   * `stringify: true` on its own is a silent no-op. It was set alone from #1843 until #1845, and the
+   * corpus shipped as a 12.7 MB object literal the whole time: no error, no warning, just a slower
+   * first render. Every JSON import in src/ and scripts/ is a default import, so turning named
+   * exports off costs nothing. src/tests/aos4/catalogChunkForm.test.ts asserts the built form,
+   * because the config reads correct in both states.
    */
-  json: { stringify: true },
+  json: { stringify: true, namedExports: false },
   css: {
     preprocessorOptions: {
       scss: {


### PR DESCRIPTION
Follow-up to #1843, first of three stacked PRs for #1845. This one is the cheap half: it fixes a build option that was silently doing nothing, and cuts two import edges so the Home split in the next PRs has somewhere to land.

## `json.stringify` was a no-op

#1843 set `json: { stringify: true }` so the corpus would ship as one `JSON.parse` call instead of a 12.7 MB JavaScript object literal. It never took effect. Vite resolves the option as `stringify === true && namedExports !== true`, and `namedExports` defaults to `true` — so the corpus has shipped as a literal the entire time, with no error and no warning. The built chunk opened `var e={attribution:` and contained zero occurrences of the substring `JSON`.

Adding `namedExports: false` delivers the intended form. Measured against the real corpus, `JSON.parse` is **1.4–1.9x faster** than parsing the equivalent JS source — roughly 20–55 ms on a desktop CPU, proportionally more on the phone this product is designed around.

It is not free: JSON keeps every key quoted, so the chunk grows **12,745,889 → 13,442,687 bytes raw** and **1,177 → 1,223 kB gzipped**. That transfer is paid once per build and then cached immutably by the service worker; the parse cost is paid on every load — cold start, worker-update reload, tab restore. Net positive, but worth stating plainly rather than filing under "perf win".

Every JSON import in `src/` and `scripts/` is a default import, so named exports were unused. Full suite green.

## Two incidental corpus edges cut

The 13 MB corpus reached the app shell through two paths that had no need of it:

- `armyStorage` imported the generated barrel for two scalars it could read from a 130-byte `defaults.json`.
- `armyApi` imported `AOS4_CATALOG` for a cloud-army parse that only ever runs behind a network round trip — and the collection provider wraps Home, so that edge put the whole corpus in the shell's graph.

`parseDocument` now `await import()`s the catalog. A parameter would have made the provider the catalog's supplier and recreated the same edge, and `ArmyApi` is a module-scope singleton so a constructor argument was unavailable. Three call shapes needed restructuring: `listArmies`' map became `Promise.all`, `createShare`'s spread hoisted to a const, and `updateArmy` keeps `await` in property position so field-validation errors still surface ahead of parse errors.

The static graph reachable from `useArmyCollection` goes from **28 modules with 11 corpus files to 6 modules with none**.

**This is groundwork, not yet a first-load win.** `Home.tsx` still imports the catalog statically, so nothing about the load path changes until the Home split lands. The boundary test says so in place, rather than implying otherwise.

## Testing

- `catalogChunkForm.test.ts` (new) asserts the built chunk's serialization form. It asserts the *build output* rather than the config text deliberately — the config read correct throughout the period the option was doing nothing.
- `bundleBoundaries.test.ts` gains a transitive static-import walker, asserting no corpus edge is reachable from either `useArmyCollection` or `src/main.tsx`. It carries a self-check (`expect(graph).toContain(...)`) so a broken resolver cannot report an empty graph as a clean one.
- New test pins a failed catalog chunk load to a friendly `ArmyApiError`. Verified by inversion: removing the try/catch turns it red.
- New test pins `createDefaultAos4ArmyDocument` against the generated `AOS4_DEFAULT_*` exports, so `armyStorage`'s local derivation cannot drift from the barrel's.

`yarn lint`, `yarn tsc --noEmit`, `yarn build`, and `yarn test --run` (3,417 tests) all pass.

**Pre-existing flakiness, not introduced here:** several heavy suites sit near the 5 s default timeout and tip over under full-suite parallel load — a different one each run (`adversarialReviewParallel`, `catalogIntegrity`, `certification`). All pass in isolation. Worth a separate look at their timeouts.

## Code review

Reviewed by correctness, adversarial, project-standards, testing, and reliability. Six actionable findings, all applied in `a2ba875d`:

1. **P1** — a rejected catalog import escaped as a raw module-loading error; `messageForError` would have shown "Failed to fetch dynamically imported module …". Now wrapped as `ArmyApiError` with the same message the fetch-failure path uses. Not reachable today (Home registers the module first), goes live with the Home split.
2. **P2** — the boundary filter forbade the `defaults.json` edge this PR sanctions; now names the corpus modules specifically.
3. **P2** — added the `src/main.tsx` walk; the provider subtree is not the graph that decides first-paint cost.
4. **P2** — the chunk-form freshness guard listed only `vite.config.mts`; widened to `package.json` and `yarn.lock`.
5. **P2** — stated the preparatory framing in the test itself.
6. **P2** — added the defaults equality guard.

No cross-model peer ran, so the adversarial lens is single-model.

### Known residuals (advisory, accepted)

- `listArmies` moved from sequential `.map` to `Promise.all`, so which malformed entry's error surfaces is now decided by settlement order rather than array order. Both are `ArmyApiError` 502, so the user-visible outcome is unchanged. Untested in either direction.
- The import walker does not follow `import.meta.glob`, `require()`, compact `export{a}from'./x'`, or `.mts`/`.cts`. None exist in the walked subtree today.
- `hasBareProjectionKeys` pins two corpus top-level key names; a schema rename would quietly no-op that half. The `JSON.parse` half remains a real discriminator.

## Post-Deploy Monitoring & Validation

- **Watch:** first-load behaviour of `assets/aos4-catalog-data-*.js`. Confirm it is served with `Content-Encoding: gzip` — the chunk is 13.44 MB raw, still above the deploy script's 9,500,000-byte pre-gzip threshold, so `deploy-production.sh` continues to upload it pre-compressed exactly as before. No deploy-script change in this PR.
- **Healthy signals:** the reminders screen renders for a stored army on a cold load; cloud armies list, save, and share normally; the service worker installs and warms the catalog URL without aborting the update.
- **Failure signals:** "Cloud armies are temporarily unavailable." appearing where it did not before (would indicate the catalog chunk failing to load), a service-worker update that repeatedly fails to activate, or a visible increase in time-to-first-render.
- **Rollback trigger:** any of the above. Revert is a clean three-commit revert with no data or config migration.
- **Window and owner:** first 24 hours after deploy, author.
