### PR TITLE
fix(ci): remove deployment action deprecation warnings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
         run: bash scripts/prepare-production-release.sh
 
       - name: Configure AWS cli
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/src/tests/deploymentConfig.test.ts
+++ b/src/tests/deploymentConfig.test.ts
@@ -200,9 +200,10 @@ log_gate "end:$*"
 
   it('pins the supported AWS credentials action release', () => {
     const workflow = readFileSync(join(process.cwd(), '.github', 'workflows', 'deploy.yml'), 'utf8')
-    const actionRefs = [
-      ...workflow.matchAll(/^\s+uses:\s+aws-actions\/configure-aws-credentials@(\S+)\s*$/gm),
-    ].map(([, ref]) => ref)
+    const actionRefs = Array.from(
+      workflow.matchAll(/^\s+uses:\s+aws-actions\/configure-aws-credentials@(\S+)\s*$/gm),
+      ([, ref]) => ref
+    )
 
     expect(actionRefs).toEqual(['v6.2.3'])
   })

--- a/src/tests/deploymentConfig.test.ts
+++ b/src/tests/deploymentConfig.test.ts
@@ -197,4 +197,13 @@ log_gate "end:$*"
     expect(workflow).toMatch(/branches:\s*\n\s*- master/)
     expect(workflow).not.toMatch(/branches:\s*\[[^\]]*aos4-migration/)
   })
+
+  it('pins the supported AWS credentials action release', () => {
+    const workflow = readFileSync(join(process.cwd(), '.github', 'workflows', 'deploy.yml'), 'utf8')
+    const actionRefs = [
+      ...workflow.matchAll(/^\s+uses:\s+aws-actions\/configure-aws-credentials@(\S+)\s*$/gm),
+    ].map(([, ref]) => ref)
+
+    expect(actionRefs).toEqual(['v6.2.3'])
+  })
 })


### PR DESCRIPTION
## Summary

Production deployments now use the supported AWS credentials action release instead of the Node 20-based v1 release that emitted Node runtime and deprecated `set-output` warnings. The existing secret and region inputs are unchanged, and an exact active-reference check prevents the workflow from drifting back to an unsupported or floating release.

The selected `v6.2.3` release uses the Node 24 action runtime and preserves the current credential inputs. It was verified against the [official release](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6.2.3) and [action definition](https://github.com/aws-actions/configure-aws-credentials/blob/main/action.yml) on 2026-08-19.

## Verification

- `yarn vitest run src/tests/deploymentConfig.test.ts src/tests/deploymentContract.test.ts` (33 tests passed)
- `yarn lint`
- `yarn tsc --noEmit`
- `yarn build`
- `yarn test --run --maxWorkers=4` (3,413 tests passed)
- `yarn data:aos4:verify:beta` (81,956 checks passed with no findings)

The credentials step runs only in the `master` production deployment. The definitive warning-free action run therefore remains a post-merge check.

## Scope

No rules cohort, accepted source, generated file, production setting, or companion service changed. There are no source conflicts or data diagnostics to disposition. Merging to `master` will trigger the normal production deployment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
