### PR TITLE
fix(modals): stop confirmations sizing themselves off the grid

### DIFF
--- a/src/components/modals/generic/generic_destructive_modal.tsx
+++ b/src/components/modals/generic/generic_destructive_modal.tsx
@@ -64,31 +64,41 @@ const GenericDestructiveModal = ({
       closeModal={closeModal}
       label={`${headerText} Confirmation Modal`}
     >
-      <div className="flex-row">
-        <div className={`col ${theme.text} text-center`}>
-          <h4 className="mb-3">{headerText}</h4>
-          {bodyText && <p className="mb-3">{bodyText}</p>}
-          {children ? <div className="mb-3">{children}</div> : null}
-          {processingError && (
-            <div className="alert alert-danger" role="alert">
-              {processingError}
-            </div>
-          )}
+      {/*
+       * The width class is the dialog's own, not the grid's. `GenericModal` renders a Bootstrap
+       * `.container`, which claims the full breakpoint width unless a child asks for less, and a
+       * confirmation this short has no business being 1140px across.
+       */}
+      <div className="aos4-confirm-modal">
+        <div className="flex-row">
+          <div className={`col ${theme.text} text-center`}>
+            <h4 className="mb-3">{headerText}</h4>
+            {bodyText && <p className="mb-3">{bodyText}</p>}
+            {children ? <div className="mb-3">{children}</div> : null}
+            {processingError && (
+              <div className="alert alert-danger" role="alert">
+                {processingError}
+              </div>
+            )}
+          </div>
         </div>
-      </div>
-      <div className="d-flex flex-row justify-content-around">
-        {/*
-         * Filled danger on the confirm, outline on the deny. This is the one modal where red is
-         * correct — it is named `Destructive` and the confirm is what destroys — and it now matches
-         * the row confirmations in `My Armies`. The pair used to render outline-danger beside
-         * outline-dark in light theme, which gave the destroy and the escape the same weight.
-         */}
-        <GenericButton className={`${theme.destructiveButton} ${btnResponsiveClass}`} onClick={handleConfirm}>
-          <FaCheck className="me-2" /> {confirmText}
-        </GenericButton>
-        <GenericButton className={`${theme.genericButton} ${btnResponsiveClass}`} onClick={handleDeny}>
-          {denyText}
-        </GenericButton>
+        <div className="d-flex flex-row justify-content-around">
+          {/*
+           * Filled danger on the confirm, outline on the deny. This is the one modal where red is
+           * correct — it is named `Destructive` and the confirm is what destroys — and it now matches
+           * the row confirmations in `My Armies`. The pair used to render outline-danger beside
+           * outline-dark in light theme, which gave the destroy and the escape the same weight.
+           */}
+          <GenericButton
+            className={`${theme.destructiveButton} ${btnResponsiveClass}`}
+            onClick={handleConfirm}
+          >
+            <FaCheck className="me-2" /> {confirmText}
+          </GenericButton>
+          <GenericButton className={`${theme.genericButton} ${btnResponsiveClass}`} onClick={handleDeny}>
+            {denyText}
+          </GenericButton>
+        </div>
       </div>
     </GenericModal>
   )

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -721,6 +721,17 @@ small {
 }
 
 /*
+ * A confirmation carries a heading, a sentence and two buttons, and nothing else. The dialog sizes
+ * itself off the `.container` inside `GenericModal`, which is a Bootstrap container and therefore
+ * takes the breakpoint max-width — 1140px at `xl` — when nothing narrower is asked for. The other
+ * modals hold roster text and account lists and declare their own width; this one did not, so a
+ * two-line question rendered a metre wide on a desktop. Read length, not the breakpoint, sets it.
+ */
+.aos4-confirm-modal {
+  width: min(30rem, calc(100vw - 4rem));
+}
+
+/*
  * A modal keeps its own surface while a request is in flight, and the spinner sits over it. The
  * previous treatment swapped the box to a fully transparent variant and `hidden` the content, so
  * the whole dialog appeared to vanish mid-save.


### PR DESCRIPTION
## What changed

The `Clear Army` confirmation rendered about 1140px wide on a desktop for a heading, one sentence, and two buttons.

`GenericModal` wraps its children in a Bootstrap `.container`. A container claims the breakpoint max-width — 1140px at `xl`, per the parity pins in `src/css/theme.scss` — unless a child asks for something narrower. `.aos4-import-modal` and `.aos4-account-modal` each declare their own width for exactly this reason; `generic_destructive_modal` never did, so the grid chose one for it.

This adds `.aos4-confirm-modal` (`min(30rem, calc(100vw - 4rem))`, the same formula the other two use) and wraps the destructive modal's content in it.

## Scope

`generic_destructive_modal` has three call sites, all short confirmations, and all get the same fix:

- `Clear Army` on the home route (the reported case)
- `Cancel Subscription?` for Stripe
- `Cancel Subscription?` for PayPal

Nothing else about the dialog changed: same copy, same filled-danger/outline button pair, same theming, same `Modal-Light`/`Modal-Dark` box. The only visible delta is the width, which is the reported bug. The JSX diff is mostly re-indentation from the added wrapper.

## Verification

Ran against a dev server on this branch:

| Viewport | Modal box | Content | Overflow |
| --- | --- | --- | --- |
| 2560px | 558px (was ~1160px) | 480px | none |
| 386px | 335px | 322px | none (`scrollWidth == clientWidth`) |

- `eslint src/components/modals --max-warnings 0` — pass
- `tsc --noEmit` — pass
- `prettier --check` on both changed files — pass
- `vitest run src/tests/aos4/homePresentation.test.tsx` — 9/9 pass

No production configuration changed, and no companion-service work is needed.

## Known gap

There is no automated guard on modal width; the checks above were done by hand in the browser. Worth a snapshot assertion if this class of regression recurs.
