### PR TITLE
fix(import): carry a manifestation lore's manifestations and make the ruleset-switch advice actionable (#1979)

### DIFF
--- a/src/aos4/import/resolveRoster.ts
+++ b/src/aos4/import/resolveRoster.ts
@@ -774,6 +774,7 @@ const resolveRosterSelection = (
           ? `"${selection.label}" has been replaced for the current season, so it was not imported. Switch the rules context to ${supersededIn.name} to use it.`
           : `Couldn't find a ${selection.kindHint} named "${selection.label}", so it was not imported.`,
       line: selection.line,
+      ...(supersededIn ? { suggestedRulesContextId: supersededIn.id } : {}),
     })
     return undefined
   }
@@ -784,6 +785,76 @@ const resolveRosterSelection = (
     line: selection.line,
   })
   return undefined
+}
+
+/**
+ * The manifestation warscrolls a resolved manifestation lore carries with it.
+ *
+ * Choosing a manifestation lore in a list builder *is* choosing its manifestations: the official
+ * app prints `Manifestation Lore - Manifestations of the Deepwood` and never lists the Gladewyrm,
+ * Spiteswarm Hive, or Vengeful Skullroot as units, because the lore's summon spells are the only
+ * way those models enter play. This app models each manifestation as a selectable warscroll, so an
+ * import that stops at the lore leaves the player without the manifestations' own reminders and no
+ * roster line to explain why (#1979).
+ *
+ * The catalog holds no edge from a summon ability to the warscroll it sets up, so the link is
+ * recovered the same way every roster label is: by name. Each of the lore's `SUMMON <NAME>`
+ * abilities nominates the reachable MANIFESTATION warscroll named `<NAME>` in the same context —
+ * and only a unique nomination is accepted. A summon whose warscroll is missing, out of context,
+ * or ambiguous adds nothing, so the army is at worst incomplete in exactly the way it was before.
+ */
+const manifestationWarscrollMatches = (
+  catalog: Aos4Catalog,
+  matches: Aos4ImportMatch[],
+  resolutionContexts: ResolutionContext[],
+  armiesOfRenown: ArmyOfRenownIndex
+): Aos4ImportMatch[] => {
+  const entityById = new Map(catalog.entities.map(entity => [entity.id, entity]))
+  const matchedIds = new Set(matches.map(match => match.canonicalId))
+  const derived: Aos4ImportMatch[] = []
+
+  const isManifestationLore = (entity: ContentEntity): boolean =>
+    entity.kind === 'content-group' &&
+    (entity.groupType === 'manifestation-lore' ||
+      armiesOfRenown.sectionsById.get(entity.id)?.categoryGroupType === 'manifestation-lore')
+
+  matches.forEach(match => {
+    const lore = entityById.get(match.canonicalId)
+    if (!lore || !isManifestationLore(lore)) return
+    const resolutionContext = resolutionContexts.find(({ context }) => isApplicable(lore, context.id))
+    if (!resolutionContext) return
+    const { context, reachableIds } = resolutionContext
+
+    const summonedNames = catalog.relationships
+      .filter(
+        relationship =>
+          relationship.kind === 'includes' &&
+          relationship.from === lore.id &&
+          relationshipIsApplicable(relationship, context.id)
+      )
+      .flatMap(relationship => {
+        const ability = entityById.get(relationship.to)
+        if (ability?.kind !== 'ability' || !isApplicable(ability, context.id)) return []
+        const normalized = normalizeImportLabel(ability.name)
+        return normalized.startsWith('summon ') ? [normalized.slice('summon '.length)] : []
+      })
+
+    summonedNames.forEach(summonedName => {
+      const candidates = catalog.entities.filter(
+        entity =>
+          entity.kind === 'warscroll' &&
+          entity.keywords.includes('MANIFESTATION') &&
+          isApplicable(entity, context.id) &&
+          reachableIds.has(entity.id) &&
+          normalizeImportLabel(entity.name) === summonedName
+      )
+      if (candidates.length !== 1 || matchedIds.has(candidates[0].id)) return
+      matchedIds.add(candidates[0].id)
+      derived.push({ line: match.line, label: candidates[0].name, canonicalId: candidates[0].id })
+    })
+  })
+
+  return derived
 }
 
 export const resolveParsedRoster = (
@@ -898,6 +969,7 @@ export const resolveParsedRoster = (
         return match ? [match] : []
       }),
   ]
+  matches.push(...manifestationWarscrollMatches(catalog, matches, resolutionContexts(false), armiesOfRenown))
 
   if (diagnostics.some(diagnostic => diagnostic.severity === 'error')) {
     return {

--- a/src/aos4/import/types.ts
+++ b/src/aos4/import/types.ts
@@ -75,6 +75,12 @@ export interface Aos4ImportDiagnostic {
   severity: 'warning' | 'error'
   message: string
   line?: number
+  /**
+   * A rules context the message advises switching to — a battletome enhancement the season
+   * replaced still resolves in the core standard context (#1979). Structured so the import
+   * preview can actually offer the switch instead of leaving the advice a dead end.
+   */
+  suggestedRulesContextId?: string
 }
 
 export interface Aos4ImportMatch {

--- a/src/components/input/importArmy/importPreview.tsx
+++ b/src/components/input/importArmy/importPreview.tsx
@@ -77,7 +77,18 @@ const ImportPreview = ({
         </dd>
       </dl>
 
-      {!declaredContext && (
+      {/*
+       * The roster usually settles the ruleset itself, and asking anyway invites the player to
+       * change an answer they never gave — so the question appears only where one is genuinely
+       * open. A diagnostic advising a switch reopens it: a battletome enhancement the season
+       * replaced says "switch the rules context to use it" (#1979), and advice the dialog gives
+       * must be actionable in the dialog. The empty option keeps the roster's own choice, so
+       * doing nothing still means what it always meant.
+       */}
+      {/* `selectedContextId` keeps the control present after a switch resolves the advice away. */}
+      {(!declaredContext ||
+        selectedContextId ||
+        diagnostics.some(diagnostic => diagnostic.suggestedRulesContextId)) && (
         <>
           <label className="fw-bold" htmlFor="import-rules-context">
             Which ruleset do you want to use?
@@ -88,7 +99,11 @@ const ImportPreview = ({
             onChange={event => onContextChange(event.target.value)}
             value={selectedContextId}
           >
-            <option value="">Use the default ruleset</option>
+            <option value="">
+              {declaredContext
+                ? `Use the roster's ruleset (${declaredContext.name})`
+                : 'Use the default ruleset'}
+            </option>
             {importableContexts.map(context => (
               <option key={context.id} value={context.id}>
                 {context.name}

--- a/src/tests/aos4/importResolution.test.ts
+++ b/src/tests/aos4/importResolution.test.ts
@@ -600,3 +600,99 @@ describe('seasonal variant resolution against the shipped catalog (#1862)', () =
     ])
   })
 })
+
+/**
+ * The report behind these: issue #1979.
+ *
+ * The official app prints a manifestation lore as one line — `Manifestation Lore - Manifestations
+ * of the Deepwood` — and never lists the Gladewyrm, Spiteswarm Hive, or Vengeful Skullroot as
+ * units, because taking the lore *is* taking its manifestations. This app models each
+ * manifestation as its own selectable warscroll, so an import that stopped at the lore left the
+ * player adding all three by hand. The lore's `SUMMON <NAME>` spells nominate the warscrolls by
+ * name; only a unique, reachable nomination is accepted.
+ */
+describe('AoS 4 manifestation-lore resolution', () => {
+  it('imports the manifestation warscrolls the resolved lore summons', () => {
+    const preview = resolve(
+      roster({
+        selections: [{ line: 5, label: 'Wild Lore', kindHint: 'manifestation-lore' }],
+      })
+    )
+
+    expect(preview.diagnostics).toEqual([])
+    expect(preview.matches).toEqual([
+      { line: 5, label: 'Wild Lore', canonicalId: importFixtureIds.wildLore },
+      { line: 5, label: 'Wild Serpent', canonicalId: importFixtureIds.wildSerpent },
+    ])
+    expect(preview.proposedDocument?.explicitSelectionIds).toContain(importFixtureIds.wildSerpent)
+  })
+
+  it('never guesses: a summon without a warscroll or with two same-named warscrolls adds nothing', () => {
+    const preview = resolve(
+      roster({
+        selections: [{ line: 5, label: 'Wild Lore', kindHint: 'manifestation-lore' }],
+      })
+    )
+
+    const matchedIds = preview.matches.map(match => match.canonicalId)
+    // SUMMON LOST SHRINE names no warscroll; SUMMON TWIN IDOL names two.
+    expect(matchedIds).not.toContain(importFixtureIds.twinIdolA)
+    expect(matchedIds).not.toContain(importFixtureIds.twinIdolB)
+  })
+
+  it('does not duplicate a manifestation the roster also names as a unit', () => {
+    const preview = resolve(
+      roster({
+        selections: [
+          { line: 5, label: 'Wild Lore', kindHint: 'manifestation-lore' },
+          { line: 6, label: 'Wild Serpent', kindHint: 'warscroll' },
+        ],
+      })
+    )
+
+    expect(preview.diagnostics).toEqual([])
+    expect(preview.matches).toEqual([
+      { line: 5, label: 'Wild Lore', canonicalId: importFixtureIds.wildLore },
+      { line: 6, label: 'Wild Serpent', canonicalId: importFixtureIds.wildSerpent },
+    ])
+  })
+})
+
+/**
+ * The roster from issue #1979, pinned against the shipped catalog: a Sylvaneth list whose
+ * `Manifestations of the Deepwood` lore must bring the Gladewyrm, Spiteswarm Hive, and Vengeful
+ * Skullroot with it. The fixture catalog proves the logic; this proves the real corpus carries
+ * the summon spells and warscrolls for the bridge to land on.
+ */
+describe('manifestation import against the shipped catalog (#1979)', () => {
+  it('imports the three Deepwood manifestations from the lore line alone', () => {
+    const preview = resolveParsedRoster(
+      AOS4_CATALOG,
+      {
+        source: 'official-app-text',
+        proposedName: 'Issue 1979',
+        declaredContext: "General's Handbook 2026-27",
+        declaredFaction: 'Sylvaneth',
+        selections: [{ line: 1, label: 'Manifestations of the Deepwood', kindHint: 'manifestation-lore' }],
+      },
+      {
+        defaultRulesContextId: AOS4_DEFAULT_RULES_CONTEXT_ID,
+        createDocumentId: () => 'army:issue-1979',
+      }
+    )
+
+    expect(preview.diagnostics).toEqual([])
+    const matchedNames = preview.matches.map(match => {
+      const entity = AOS4_CATALOG.entities.find(candidate => candidate.id === match.canonicalId)
+      return entity?.name
+    })
+    expect(matchedNames).toEqual(
+      expect.arrayContaining([
+        'Manifestations of the Deepwood',
+        'Gladewyrm',
+        'Spiteswarm Hive',
+        'Vengeful Skullroot',
+      ])
+    )
+  })
+})

--- a/src/tests/aos4/importUi.test.tsx
+++ b/src/tests/aos4/importUi.test.tsx
@@ -443,6 +443,44 @@ describe('AoS 4 import modal', () => {
   })
 
   /**
+   * A diagnostic that advises switching the rules context reopens the ruleset question even when
+   * the roster declared one: the #1979 report carried a battletome artefact the season replaced,
+   * and the dialog told the player to switch without offering any way to do it.
+   */
+  it('offers the ruleset switch a superseded-enhancement warning advises', () => {
+    pasteAndPreview(`Training 1000/1000 pts
+Sylvaneth
+Outcasts
+General's Handbook 2026-27
+
+General's Regiment
+Branchwych (100)
+• General
+• Seed of Rebirth
+
+Created with Warhammer Age of Sigmar: The App
+App: 1.37.0 | Data: 476`)
+
+    expect(container.textContent).toContain(
+      '"Seed of Rebirth" has been replaced for the current season, so it was not imported.'
+    )
+    const select = container.querySelector<HTMLSelectElement>('#import-rules-context')!
+    expect(select.options[0].textContent).toContain("Use the roster's ruleset")
+
+    const core = Array.from(select.options).find(
+      option => option.textContent === 'Age of Sigmar Fourth Edition'
+    )!
+    select.value = core.value
+    act(() => {
+      Simulate.change(select)
+    })
+
+    expect(container.textContent).not.toContain('has been replaced for the current season')
+    expect(container.querySelector('#import-rules-context')).not.toBeNull()
+    expect(findButton(container, 'Import Army').disabled).toBe(false)
+  })
+
+  /**
    * Uploading is the common path, so the modal opens on it — no click to switch modes here.
    */
   it('opens on the upload zone and previews a roster dropped onto it', async () => {

--- a/src/tests/fixtures/aos4/import/catalog.ts
+++ b/src/tests/fixtures/aos4/import/catalog.ts
@@ -1,5 +1,6 @@
 import {
   AOS4_CATALOG_SCHEMA_VERSION,
+  abilityId,
   contentGroupId,
   factionId,
   rulesContextId,
@@ -60,9 +61,49 @@ export const importFixtureIds = {
   /** Last season's content, catalogued as historical once its handbook lapsed. */
   archiveGuard: warscrollId('81000000-0000-4000-8000-000000000050'),
   archiveFormation: contentGroupId('81000000-0000-4000-8000-000000000051'),
+  /**
+   * A manifestation lore, shaped the way generation emits one: the group includes its
+   * `SUMMON <NAME>` spells, while the manifestation warscrolls hang off the faction's own
+   * `offers` edges with no edge from the lore or its spells. The importer bridges that gap by
+   * name (#1979), so the fixture also carries a summon whose warscroll does not exist and a
+   * summon whose name two warscrolls share — the cases that must fail closed.
+   */
+  wildLore: contentGroupId('81000000-0000-4000-8000-000000000060'),
+  wildSerpent: warscrollId('81000000-0000-4000-8000-000000000061'),
+  twinIdolA: warscrollId('81000000-0000-4000-8000-000000000062'),
+  twinIdolB: warscrollId('81000000-0000-4000-8000-000000000063'),
+  summonWildSerpent: abilityId('81000000-0000-4000-8000-000000000064'),
+  summonLostShrine: abilityId('81000000-0000-4000-8000-000000000065'),
+  summonTwinIdol: abilityId('81000000-0000-4000-8000-000000000066'),
 }
 
 const sourceRefs: ContentEntity['sourceRefs'] = []
+
+const manifestationWarscroll = (id: CanonicalId<'warscroll'>, name: string): ContentEntity => ({
+  id,
+  kind: 'warscroll',
+  revision: 'import-fixture',
+  name,
+  factionIds: [importFixtureIds.alphaFaction],
+  keywords: ['MANIFESTATION'],
+  characteristics: { move: '5"', save: '4+', control: '1', health: '2' },
+  rulesContextIds: [importFixtureContextIds.seasonal],
+  sourceRefs,
+})
+
+const summonAbility = (id: CanonicalId<'ability'>, name: string): ContentEntity => ({
+  id,
+  kind: 'ability',
+  revision: 'import-fixture',
+  name,
+  abilityKind: 'active',
+  actor: 'army',
+  text: { effect: `Set up the manifestation named by ${name}.` },
+  timings: [{ kind: 'active', window: { kind: 'turn-phase', phase: 'hero' }, raw: 'Your Hero Phase' }],
+  keywords: ['SPELL', 'SUMMON'],
+  rulesContextIds: [importFixtureContextIds.seasonal],
+  sourceRefs,
+})
 
 const contentGroup = (
   id: CanonicalId<'content-group'>,
@@ -182,6 +223,55 @@ export const createImportFixtureCatalog = (): Aos4Catalog => {
       from: importFixtureIds.alphaFaction,
       to: importFixtureIds.archiveFormation,
       rulesContextIds: [importFixtureContextIds.historical],
+    },
+    {
+      id: 'relationship:alpha-offers-wild-lore',
+      kind: 'offers',
+      from: importFixtureIds.alphaFaction,
+      to: importFixtureIds.wildLore,
+      rulesContextIds: [importFixtureContextIds.seasonal],
+    },
+    {
+      id: 'relationship:alpha-offers-wild-serpent',
+      kind: 'offers',
+      from: importFixtureIds.alphaFaction,
+      to: importFixtureIds.wildSerpent,
+      rulesContextIds: [importFixtureContextIds.seasonal],
+    },
+    {
+      id: 'relationship:alpha-offers-twin-idol-a',
+      kind: 'offers',
+      from: importFixtureIds.alphaFaction,
+      to: importFixtureIds.twinIdolA,
+      rulesContextIds: [importFixtureContextIds.seasonal],
+    },
+    {
+      id: 'relationship:alpha-offers-twin-idol-b',
+      kind: 'offers',
+      from: importFixtureIds.alphaFaction,
+      to: importFixtureIds.twinIdolB,
+      rulesContextIds: [importFixtureContextIds.seasonal],
+    },
+    {
+      id: 'relationship:wild-lore-includes-summon-wild-serpent',
+      kind: 'includes',
+      from: importFixtureIds.wildLore,
+      to: importFixtureIds.summonWildSerpent,
+      rulesContextIds: [importFixtureContextIds.seasonal],
+    },
+    {
+      id: 'relationship:wild-lore-includes-summon-lost-shrine',
+      kind: 'includes',
+      from: importFixtureIds.wildLore,
+      to: importFixtureIds.summonLostShrine,
+      rulesContextIds: [importFixtureContextIds.seasonal],
+    },
+    {
+      id: 'relationship:wild-lore-includes-summon-twin-idol',
+      kind: 'includes',
+      from: importFixtureIds.wildLore,
+      to: importFixtureIds.summonTwinIdol,
+      rulesContextIds: [importFixtureContextIds.seasonal],
     }
   )
 
@@ -352,6 +442,13 @@ export const createImportFixtureCatalog = (): Aos4Catalog => {
         rulesContextIds: [importFixtureContextIds.historical],
         sourceRefs,
       },
+      contentGroup(importFixtureIds.wildLore, 'Wild Lore', 'manifestation-lore'),
+      manifestationWarscroll(importFixtureIds.wildSerpent, 'Wild Serpent'),
+      manifestationWarscroll(importFixtureIds.twinIdolA, 'Twin Idol'),
+      manifestationWarscroll(importFixtureIds.twinIdolB, 'Twin Idol'),
+      summonAbility(importFixtureIds.summonWildSerpent, 'SUMMON WILD SERPENT'),
+      summonAbility(importFixtureIds.summonLostShrine, 'SUMMON LOST SHRINE'),
+      summonAbility(importFixtureIds.summonTwinIdol, 'SUMMON TWIN IDOL'),
     ],
     relationships,
   }


### PR DESCRIPTION
Fixes the importable half of #1979: a Sylvaneth list from the official app (GHB 2026-27, Data 476) lost its manifestations and its Seed of Rebirth artefact on import.

## What changed

**A manifestation lore now carries its manifestations** (`src/aos4/import/resolveRoster.ts`). The official app prints `Manifestation Lore - Manifestations of the Deepwood` as one line and never lists the Gladewyrm, Spiteswarm Hive, or Vengeful Skullroot as units — taking the lore *is* taking its manifestations. The catalog holds no edge from a summon spell to the warscroll it sets up, so the importer recovers the link the way it resolves every roster label: each of the lore's `SUMMON <NAME>` abilities nominates the reachable `MANIFESTATION`-keyword warscroll named `<NAME>` in the same resolution context. Only a unique nomination is accepted; a summon whose warscroll is missing, out of context, or ambiguous (e.g. the two Foot of Gork warscrolls) adds nothing, so no wrong reminder can be produced. A manifestation the roster also names explicitly is not duplicated. Applies to every provider (official app, Listbot, Sigdex, New Recruit), since it runs on resolved matches.

**The "switch the rules context" advice is now actionable** (`src/components/input/importArmy/importPreview.tsx`, `types.ts`). The superseded-enhancement warning ("Seed of Rebirth has been replaced for the current season … Switch the rules context to Age of Sigmar Fourth Edition to use it") pointed at a control the dialog only rendered when the roster declared no ruleset. The diagnostic now carries a structured `suggestedRulesContextId`, and the preview offers the ruleset selector when the roster left the ruleset open **or** a diagnostic suggests a switch (staying visible after a switch, so the player can change back). The empty option keeps the roster's declared ruleset, so doing nothing still means what it always meant. Switching this roster to the core context imports it completely, Seed of Rebirth included.

No generated files changed; the accepted `aos4-corpus-2026-08-25b` snapshot is untouched.

## The remaining data question (not addressed here)

The corpus models GHB 2026-27 enhancement tables as replacing same-named battletome tables for the season (the 2026-08-16 structural-supersede rule). Wahapedia's current Sylvaneth page introduces the Scourge of Aqshy "Relics of Nature" table with *"You can pick an artefact from this table instead of from other Artefacts of Power tables available to this faction"* — an additional option, not a replacement — which matches the official app still allowing Seed of Rebirth in a GHB 2026-27 list. If confirmed against the GHB itself, restoring the battletome enhancement tables to the seasonal context is a corpus correction (generation-rule change → regenerate → machine review → recertify). Not attempted here: this environment has no artifact-cache credentials, and that disposition is a review decision. Details in the issue comment on #1979.

## Verification

- `yarn lint`, `yarn tsc --noEmit`, `yarn build`, `yarn test --run` all pass
- New coverage: fixture-catalog manifestation lore (unique / missing / ambiguous / already-named summon cases), a shipped-catalog pin that the #1979 roster's lore line imports all three Deepwood manifestations, and a UI test that the superseded-artefact warning now comes with a working ruleset switch
- The full #1979 roster was replayed end-to-end: seasonal import gains the three manifestations; core-context import additionally resolves Seed of Rebirth with no diagnostics

## Known gaps

- Summons whose warscroll name differs from the summon spell's `SUMMON <NAME>` form (e.g. `SHIFTING MANIFESTATIONS`, `JADE WINDS`) and ambiguous same-named manifestations still import nothing extra — deliberately fail-closed
- Seed of Rebirth still requires the player to accept the suggested context switch as long as the corpus keeps the seasonal-replacement model

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZh2hbJAy2TDnJz2Bxrek9
