### PR TITLE
fix(data): stop the pinned transport crashing on an unreachable first address (#1981)

### DIFF
--- a/src/aos4/data/http.ts
+++ b/src/aos4/data/http.ts
@@ -54,45 +54,99 @@ export interface HttpTransport {
   request(request: HttpRequest): Promise<HttpResponse>
 }
 
-export const createPinnedHttpsTransport = (): HttpTransport => ({
-  request({ url, headers, signal, approvedAddresses, method = 'GET', body }) {
-    return new Promise((resolve, reject) => {
-      const address = approvedAddresses[0]
-      const family = isIP(address)
-      if (!address || !family) {
-        reject(new AcquisitionError('network-error', `No approved network address was supplied for ${url}`))
-        return
-      }
+export type PinnedAddressRequester = (
+  request: HttpRequest,
+  address: string,
+  family: number
+) => Promise<HttpResponse>
 
-      const outgoing = httpsRequest(
-        url,
-        {
-          headers,
-          signal,
-          family,
-          method,
-          lookup: (_hostname, _options, callback) => callback(null, address, family),
-        },
-        incoming => {
-          const responseHeaders = Object.fromEntries(
-            Object.entries(incoming.headers).flatMap(([name, value]) => {
-              if (value === undefined) return []
-              return [[name.toLowerCase(), Array.isArray(value) ? value.join(', ') : value]]
-            })
-          )
-          resolve({
-            status: incoming.statusCode ?? 0,
-            headers: responseHeaders,
-            body: incoming,
+const httpsRequestToAddress: PinnedAddressRequester = (
+  { url, headers, signal, method = 'GET', body },
+  address,
+  family
+) =>
+  new Promise((resolve, reject) => {
+    const outgoing = httpsRequest(
+      url,
+      {
+        headers,
+        signal,
+        family,
+        method,
+        /**
+         * The pinned address must reach `connect` on a later tick. `net.Socket` attaches the
+         * request's error listeners asynchronously, so a lookup that calls back synchronously
+         * lets a failed connect emit `error` on the bare TLS socket and crash the whole process
+         * instead of rejecting this promise — the 2026-08-27 Rules Radar run died exactly this
+         * way on an unreachable IPv6 address, before it could write its report.
+         */
+        lookup: (_hostname, _options, callback) => process.nextTick(callback, null, address, family),
+      },
+      incoming => {
+        const responseHeaders = Object.fromEntries(
+          Object.entries(incoming.headers).flatMap(([name, value]) => {
+            if (value === undefined) return []
+            return [[name.toLowerCase(), Array.isArray(value) ? value.join(', ') : value]]
           })
-        }
-      )
-      outgoing.on('error', error => {
-        reject(new AcquisitionError('network-error', `Request failed for ${url}`, error))
-      })
-      if (body?.byteLength) outgoing.write(body)
-      outgoing.end()
+        )
+        resolve({
+          status: incoming.statusCode ?? 0,
+          headers: responseHeaders,
+          body: incoming,
+        })
+      }
+    )
+    outgoing.on('error', error => {
+      reject(new AcquisitionError('network-error', `Request failed for ${url}`, error))
     })
+    if (body?.byteLength) outgoing.write(body)
+    outgoing.end()
+  })
+
+/**
+ * Connection-establishment failures worth retrying on the next approved address.
+ *
+ * A host publishes A and AAAA records but a runner may only route one family — GitHub-hosted
+ * runners have no IPv6 — so the first approved address failing says nothing about the rest.
+ * Anything else (TLS validation, abort, protocol errors) would fail identically on every address
+ * and is thrown as-is.
+ */
+const CONNECT_FAILOVER_CODES = new Set([
+  'EADDRNOTAVAIL',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ETIMEDOUT',
+])
+
+const isConnectFailoverError = (error: unknown): boolean =>
+  error instanceof AcquisitionError &&
+  error.code === 'network-error' &&
+  CONNECT_FAILOVER_CODES.has(String((error.cause as { code?: unknown } | undefined)?.code))
+
+export const createPinnedHttpsTransport = (
+  requestToAddress: PinnedAddressRequester = httpsRequestToAddress
+): HttpTransport => ({
+  async request(request) {
+    const addresses = request.approvedAddresses.filter(address => isIP(address) !== 0)
+    if (!addresses.length) {
+      throw new AcquisitionError(
+        'network-error',
+        `No approved network address was supplied for ${request.url}`
+      )
+    }
+
+    let lastError: unknown
+    for (const address of addresses) {
+      try {
+        return await requestToAddress(request, address, isIP(address))
+      } catch (error) {
+        lastError = error
+        if (request.signal.aborted || !isConnectFailoverError(error)) throw error
+      }
+    }
+    throw lastError
   },
 })
 

--- a/src/aos4/data/urlPolicy.ts
+++ b/src/aos4/data/urlPolicy.ts
@@ -93,7 +93,15 @@ export const validateAcquisitionUrl = async (value: string, policy: UrlPolicy): 
   } catch (error) {
     throw new AcquisitionError('unresolved-host', `Host ${hostname} could not be resolved`, error)
   }
-  const addresses = Array.from(new Set(resolvedAddresses)).sort()
+  /**
+   * IPv4 before IPv6, deterministic within each family. The transport dials the addresses in
+   * this order, and hosts without an IPv6 route — every GitHub-hosted runner — cannot reach an
+   * AAAA record at all, so a plain lexicographic sort that happens to put one first turned the
+   * whole 2026-08-27 Rules Radar run into a dead first dial.
+   */
+  const addresses = Array.from(new Set(resolvedAddresses)).sort(
+    (left, right) => isIP(left) - isIP(right) || (left < right ? -1 : left > right ? 1 : 0)
+  )
   if (!addresses.length) {
     throw new AcquisitionError('unresolved-host', `Host ${hostname} did not resolve`)
   }

--- a/src/tests/aos4/acquisition.test.ts
+++ b/src/tests/aos4/acquisition.test.ts
@@ -6,8 +6,10 @@ import {
   acquireArtifact,
   artifactChecksum,
   createArtifactManifest,
+  createPinnedHttpsTransport,
   isPrivateAddress,
   serializeArtifactManifest,
+  validateAcquisitionUrl,
   type AddressResolver,
   type ArtifactManifestEntry,
   type HttpRequest,
@@ -403,5 +405,105 @@ describe('AoS 4 source acquisition', () => {
     expect(serializeArtifactManifest(createArtifactManifest([base, other]))).toBe(
       serializeArtifactManifest(createArtifactManifest([other, base]))
     )
+  })
+})
+
+/**
+ * The report behind these: the 2026-08-27 Rules Radar run. DNS handed the runner an IPv6 address
+ * first, the runner had no IPv6 route, and the pinned transport both dialed only that first
+ * address and crashed the whole process on the failure (the synchronous pinned lookup let the
+ * connect error emit on the bare TLS socket before the request's own error listeners existed),
+ * so the radar died without writing its report.
+ */
+describe('pinned HTTPS transport address handling', () => {
+  const signal = new AbortController().signal
+  const baseRequest = { url: 'https://wahapedia.ru/aos4/Warscrolls.csv', headers: {}, signal }
+
+  const connectError = (code: string) =>
+    new AcquisitionError('network-error', 'Request failed', Object.assign(new Error(code), { code }))
+
+  it('orders approved addresses IPv4-first so an unroutable IPv6 cannot occupy the first dial', async () => {
+    const validated = await validateAcquisitionUrl('https://wahapedia.ru/aos4/', {
+      allowedHosts: ['wahapedia.ru'],
+      resolveAddresses: async () => ['2600:9000:28a9:4a00::1', '3.160.10.2', '203.0.113.10'],
+    })
+
+    expect(validated.approvedAddresses).toEqual(['203.0.113.10', '3.160.10.2', '2600:9000:28a9:4a00::1'])
+  })
+
+  it('fails over to the next approved address on a connection-level failure', async () => {
+    const attempts: string[] = []
+    const transport = createPinnedHttpsTransport(async (_request, address) => {
+      attempts.push(address)
+      if (address !== '203.0.113.10') throw connectError('ENETUNREACH')
+      return response(200)
+    })
+
+    const result = await transport.request({
+      ...baseRequest,
+      approvedAddresses: ['2600:9000:28a9:4a00::1', '203.0.113.10'],
+    })
+
+    expect(result.status).toBe(200)
+    expect(attempts).toEqual(['2600:9000:28a9:4a00::1', '203.0.113.10'])
+  })
+
+  it('surfaces the final failure when every approved address is unreachable', async () => {
+    const transport = createPinnedHttpsTransport(async () => {
+      throw connectError('ECONNREFUSED')
+    })
+
+    await expect(
+      transport.request({ ...baseRequest, approvedAddresses: ['203.0.113.10', '203.0.113.11'] })
+    ).rejects.toMatchObject({ code: 'network-error' })
+  })
+
+  it('does not retry failures another address could not fix', async () => {
+    const attempts: string[] = []
+    const transport = createPinnedHttpsTransport(async (_request, address) => {
+      attempts.push(address)
+      throw connectError('ERR_TLS_CERT_ALTNAME_INVALID')
+    })
+
+    await expect(
+      transport.request({ ...baseRequest, approvedAddresses: ['203.0.113.10', '203.0.113.11'] })
+    ).rejects.toBeInstanceOf(AcquisitionError)
+    expect(attempts).toEqual(['203.0.113.10'])
+  })
+
+  it('rejects instead of crashing when a real dial cannot connect', async () => {
+    const transport = createPinnedHttpsTransport()
+
+    await expect(
+      transport.request({
+        url: 'https://127.0.0.1:9/unreachable',
+        headers: {},
+        signal,
+        approvedAddresses: ['127.0.0.1'],
+      })
+    ).rejects.toBeInstanceOf(AcquisitionError)
+  })
+
+  /**
+   * The crash itself: an unroutable address fails inside the synchronous connect attempt, and
+   * with a synchronous pinned lookup that error fired on the bare socket before the request's
+   * listeners existed — an uncaught exception, not a rejection. The documentation range
+   * 2001:db8::/32 is never assigned, and the abort guard caps the dial on any network that
+   * blackholes it instead of refusing it.
+   */
+  it('rejects instead of crashing when the dialed address is unroutable', async () => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 2000)
+    const transport = createPinnedHttpsTransport()
+
+    await expect(
+      transport.request({
+        url: 'https://example.invalid/unroutable',
+        headers: {},
+        signal: controller.signal,
+        approvedAddresses: ['2001:db8::1'],
+      })
+    ).rejects.toBeInstanceOf(AcquisitionError)
+    clearTimeout(timer)
   })
 })


### PR DESCRIPTION
Fixes #1981: the scheduled Rules Radar run on 2026-08-27 ([run 33051789673](https://github.com/daviseford/aos-reminders/actions/runs/33051789673)) crashed with an unhandled `ENETUNREACH` and produced no report, which then crashed the notify step on the truncated `report.json`.

## What changed

All changes are in the acquisition transport layer (`src/aos4/data/`); no data products, radar config, or workflow files moved.

- **`http.ts` — asynchronous pinned lookup.** The transport pins DNS by handing the approved address to `node:https` through a `lookup` callback, which it invoked synchronously. `net.Socket` attaches the request's error listeners on a later tick, so a connect attempt that fails inside that synchronous window (an unroutable address) emitted `error` on the bare TLS socket and took down the whole process — bypassing the radar command's designed operational-failure path (candidate-failure lane events, report written, issue notification). The callback now fires on `process.nextTick`, so the same failure rejects as `AcquisitionError('network-error')`.
- **`http.ts` — failover across approved addresses.** The transport dialed only `approvedAddresses[0]`. It now tries each approved address in order on connection-establishment failures (`ENETUNREACH`, `EHOSTUNREACH`, `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `EADDRNOTAVAIL`), throwing immediately on anything a different address could not fix (TLS validation, abort, protocol errors). Only reviewed approved addresses are ever dialed, so the pinning/SSRF posture is unchanged.
- **`urlPolicy.ts` — IPv4-first address order.** Approved addresses were sorted lexicographically, which put CloudFront's `2600:9000:...` IPv6 ahead of its `3.x.x.x` IPv4s; GitHub-hosted runners have no IPv6 route, making the first dial a guaranteed failure. Addresses now order IPv4 before IPv6, deterministic within each family.

## Verification

- `yarn lint`, `yarn tsc --noEmit`, `yarn build`, `yarn test --run` (3,516 tests, 117 files) all pass
- New tests: IPv4-first ordering of `validateAcquisitionUrl` output; failover to the next address on a connection-level failure; no retry on non-connection failures; a real closed-port dial rejects cleanly; a real unroutable-address dial (documentation range `2001:db8::1`, abort-guarded) rejects cleanly
- The unroutable-address regression test was verified to fail under the old synchronous lookup (uncaught `EHOSTUNREACH`, matching the CI crash) and pass with the fix; the sync-vs-async crash was also reproduced in isolation outside vitest (sync: uncaught exception, exit 2; async: handled rejection)

## Known gaps

- The notify command still assumes `report.json` parses (`rulesRadarNotifyCommand.ts`); with the crash class removed the truncated-report state should no longer occur, so it was left alone
- After merge, the next scheduled radar run (or a manual `source: all` dispatch) should come back green; no baseline or fingerprint state was touched, per the runbook this was an operational failure, not a material alarm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZh2hbJAy2TDnJz2Bxrek9