### PR TITLE
fix(builder): give Heroic Traits a titled card beside the other enhancements (#1983)

### DIFF
--- a/src/components/input/army_builder.tsx
+++ b/src/components/input/army_builder.tsx
@@ -30,11 +30,12 @@ interface SelectionGroup {
 const titles: Record<string, { title: string; mobileTitle?: string; order: number }> = {
   warscroll: { title: 'Units', order: 0 },
   'battle-formation': { title: 'Battle Formations', mobileTitle: 'Formations', order: 1 },
-  'artefact-of-power': { title: 'Artefacts of Power', mobileTitle: 'Artefacts', order: 2 },
-  'spell-lore': { title: 'Spell Lores', order: 3 },
-  'prayer-lore': { title: 'Prayer Lores', order: 4 },
-  'manifestation-lore': { title: 'Manifestation Lores', mobileTitle: 'Manif. Lores', order: 5 },
-  manifestation: { title: 'Manifestations', order: 6 },
+  'heroic-trait': { title: 'Heroic Traits', order: 2 },
+  'artefact-of-power': { title: 'Artefacts of Power', mobileTitle: 'Artefacts', order: 3 },
+  'spell-lore': { title: 'Spell Lores', order: 4 },
+  'prayer-lore': { title: 'Prayer Lores', order: 5 },
+  'manifestation-lore': { title: 'Manifestation Lores', mobileTitle: 'Manif. Lores', order: 6 },
+  manifestation: { title: 'Manifestations', order: 7 },
   'regiment-of-renown': {
     title: 'Regiment Of Renown',
     mobileTitle: 'Regiments',

--- a/src/tests/aos4/homePresentation.test.tsx
+++ b/src/tests/aos4/homePresentation.test.tsx
@@ -270,6 +270,21 @@ describe('AoS 4 home presentation', () => {
     expect(manifestationOptions).not.toContain('Aetherwings')
   })
 
+  /**
+   * Heroic Traits are a core enhancement category on every faction. Without a configured card
+   * title the group fell back to a generated "Heroic Trait" card sorted after the faction-specific
+   * oddments, where players looking beside Artefacts of Power reported it missing (#1983).
+   */
+  it('offers heroic traits in a titled card beside the other enhancement cards', async () => {
+    const cardTitles = Array.from(container.querySelectorAll('.CardHeaderTitle')).map(
+      title => title.textContent
+    )
+    expect(cardTitles).toContain('Heroic Traits')
+    expect(cardTitles).not.toContain('Heroic Trait')
+    expect(cardTitles.indexOf('Heroic Traits')).toBe(cardTitles.indexOf('Battle Formations') + 1)
+    expect(cardTitles.indexOf('Artefacts of Power')).toBe(cardTitles.indexOf('Heroic Traits') + 1)
+  })
+
   it('opens on a skip link that reaches the reminders, and a real footer landmark', () => {
     const skip = container.querySelector('a.SkipLink')
     expect(skip).not.toBeNull()


### PR DESCRIPTION
Fixes the report in #1983 that Maggotkin of Nurgle's artefacts and heroic traits are missing.

## What actually changed

The data was never missing. `Boons of Nurgle` (artefacts) and `Avatars of Corruption` (heroic traits) are pinned in every accepted corpus back to the 6.0.0 launch, resolve through selection, import, and reminder projection, and are present in the deployed catalog chunk. What was wrong was the presentation: the builder's card `titles` map configured every enhancement category except `heroic-trait`, so that card fell back to a generated singular "Heroic Trait" title with last-place sort order — landing after General Rules among the faction-specific oddment cards, where players scanning the enhancement cards did not find it.

The card is now titled "Heroic Traits" and ordered between Battle Formations and Artefacts of Power, matching the rulebook's enhancement ordering. The fix is the shared titles map, so it applies to every faction, not just Maggotkin.

## Not changed

- No data, corpus, or generated files changed.
- No visual language change: the card reuses the established teal card primitives; only its data-driven title and position moved.
- Bonesplitterz remains the only faction without standard-context enhancement tables (Legends-only faction, expected).

## Verification

- `yarn lint`, `yarn tsc --noEmit`, `yarn build`, `yarn test --run` all pass (build before test per AGENTS.md).
- New regression test in `homePresentation.test.tsx` pins the plural title and the Battle Formations → Heroic Traits → Artefacts of Power order.
- Verified in the running app (desktop 1440px and mobile 390px) with Maggotkin of Nurgle selected: cards render `Units, Battle Formations, Heroic Traits, Artefacts of Power, …`; both dropdowns offer their groups, and selecting them projects all six enhancement reminders (Witherstave, Carrion Dirge, Rustfang, Gift of Febrile Frenzy, Overpowering Stench, Grandfather's Blessing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZh2hbJAy2TDnJz2Bxrek9