### PR TITLE
feat(builder): let hand-built armies assign each enhancement's bearer (#1992)

### DIFF
--- a/src/aos4/view/builder.ts
+++ b/src/aos4/view/builder.ts
@@ -38,6 +38,23 @@ export interface Aos4BuilderWarscroll {
   }
 }
 
+export interface Aos4BuilderBearerOption {
+  id: CanonicalId
+  name: string
+}
+
+/**
+ * One "carried by" control: a selected heroic trait or artefact of power, the warscrolls that
+ * could carry it, and the assignment the document currently holds, if any (#1992).
+ */
+export interface Aos4BuilderEnhancementBearer {
+  enhancementId: CanonicalId
+  enhancementName: string
+  groupType: string
+  bearerId?: CanonicalId
+  bearerOptions: Aos4BuilderBearerOption[]
+}
+
 /**
  * The rules categories whose individual abilities surface as selected chips in the builder cards.
  *
@@ -47,6 +64,13 @@ export interface Aos4BuilderWarscroll {
  * selection, and the ability's card is the offering group's category.
  */
 const ABILITY_CHIP_CATEGORIES = new Set(['artefact-of-power', 'heroic-trait', 'prayer-lore', 'spell-lore'])
+
+/**
+ * The enhancement categories whose selections can name the hero carrying them (#1992). A subset of
+ * `ABILITY_CHIP_CATEGORIES`: a lore pick grants its spells or prayers to every eligible caster in
+ * the army, so a single-bearer assignment would misstate it.
+ */
+const BEARER_CATEGORIES = new Set(['artefact-of-power', 'heroic-trait'])
 const CHIP_MINOR_WORDS = new Set(['a', 'an', 'and', 'of', 'the', 'to'])
 const chipCase = (value: string): string =>
   value
@@ -198,6 +222,58 @@ export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4A
       left.name.localeCompare(right.name)
   )
 
+  /**
+   * "Carried by" controls for the army's enhancement selections (#1992).
+   *
+   * An imported roster records which hero carries each artefact and heroic trait
+   * (`document.enhancementBearers`, #1989); a hand-built army had no way to say so. Each selected
+   * enhancement gets a picker over the army's HERO-keyworded warscrolls, keyed by exactly the ID
+   * the document holds — the individual ability an import records, or the offering group a
+   * hand-built pick records — because that ID is the reminder cause root the view's bearer tag
+   * reads. A bearer an import assigned outside the HERO list (the map joins by roster line, not
+   * by keyword) is still offered, so the current value always displays and stays clearable.
+   */
+  const heroOptions: Aos4BuilderBearerOption[] = document.explicitSelectionIds
+    .flatMap(id => {
+      const entity = entityById.get(id)
+      return entity?.kind === 'warscroll' && entity.keywords.includes('HERO')
+        ? [{ id, name: entity.name }]
+        : []
+    })
+    .sort((left, right) => left.name.localeCompare(right.name))
+  const enhancementBearers: Aos4BuilderEnhancementBearer[] = document.explicitSelectionIds
+    .flatMap(id => {
+      const entity = entityById.get(id)
+      if (!entity) return []
+      const chipGroup = entity.kind === 'ability' ? chipGroupByAbilityId.get(id) : undefined
+      const groupType = entity.kind === 'content-group' ? entity.groupType : chipGroup?.groupType
+      if (!groupType || !BEARER_CATEGORIES.has(groupType)) return []
+      const bearerId = document.enhancementBearers?.[id]
+      const assigned = bearerId ? entityById.get(bearerId) : undefined
+      const bearerOptions =
+        assigned?.kind === 'warscroll' && !heroOptions.some(option => option.id === assigned.id)
+          ? [...heroOptions, { id: assigned.id, name: assigned.name }].sort((left, right) =>
+              left.name.localeCompare(right.name)
+            )
+          : heroOptions
+      if (!bearerOptions.length) return []
+      return [
+        {
+          enhancementId: id,
+          enhancementName: chipGroup ? chipCase(entity.name) : entity.name,
+          groupType,
+          ...(bearerId ? { bearerId } : {}),
+          bearerOptions,
+        },
+      ]
+    })
+    .sort(
+      (left, right) =>
+        left.groupType.localeCompare(right.groupType) ||
+        left.enhancementName.localeCompare(right.enhancementName) ||
+        left.enhancementId.localeCompare(right.enhancementId)
+    )
+
   const profileByWarscroll = new Map(
     catalog.entities
       .filter(
@@ -231,6 +307,7 @@ export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4A
     armyName: document.name,
     rulesContextId: document.rulesContextId,
     options,
+    enhancementBearers,
     warscrolls,
     selection,
   }

--- a/src/aos4/view/reminders.ts
+++ b/src/aos4/view/reminders.ts
@@ -222,11 +222,13 @@ export interface Aos4ReminderViewModel {
  * belonging to what the player picked (issue #1836: Well-Fed Beasts grants HORN TOSS, and nothing
  * on the HORN TOSS reminder said so). One tag per distinct granting source:
  *
- * - An enhancement the document knows the bearer of is that hero's — the imported roster assigned
- *   it to a specific unit, and without the tag the trait read as army-wide (#1989). Bearer tags
- *   are written in a pass of their own, before and never overwritten by the weaker attributions:
- *   a merged reminder can carry a bearer cause and a warscroll cause for the same unit name, and
- *   which forEach saw last must not decide the description.
+ * - An enhancement the document knows the bearer of is that hero's — the imported roster or the
+ *   builder assigned it to a specific unit, and without the tag the trait read as army-wide
+ *   (#1989). Bearer tags are written in a pass of their own, before and never overwritten by the
+ *   weaker attributions: a merged reminder can carry a bearer cause and a warscroll cause for the
+ *   same unit name, and which forEach saw last must not decide the description. The bearer
+ *   *complements* the other attributions rather than replacing them — a group-keyed assignment
+ *   (#1992) still tags the table the player picked, because that name is what they scan for.
  * - An ability with a warscroll ancestor is that unit's own — its warscroll name wins, even when
  *   the unit itself arrived through a group (a Regiment of Renown).
  * - Otherwise the cause's root names the grant when the root is a picked content-group: a spell
@@ -253,7 +255,6 @@ const sourceTags = (
     }
   })
   reminder.causes.forEach(cause => {
-    if (bearerNameByRootId.has(cause.rootId)) return
     const ancestors = cause.entityPath.slice(0, -1)
     for (let index = ancestors.length - 1; index >= 0; index -= 1) {
       const ancestor = entityById.get(ancestors[index])

--- a/src/components/input/army_builder.tsx
+++ b/src/components/input/army_builder.tsx
@@ -188,7 +188,7 @@ const SelectionCard = ({
             return (
               <div key={bearer.enhancementId} className="mt-2">
                 <label className={`small mb-1 ${theme.textMuted}`} htmlFor={bearerInputId}>
-                  {`Carried by — ${bearer.enhancementName}`}
+                  {`${bearer.enhancementName} — Carried by`}
                 </label>
                 <Select<BearerOption, false>
                   inputId={bearerInputId}

--- a/src/components/input/army_builder.tsx
+++ b/src/components/input/army_builder.tsx
@@ -4,13 +4,15 @@ import { CollapsibleCardHeader } from 'components/helpers/collapsibleCardHeader'
 import { useIsMobile } from 'utils/hooks/useIsMobile'
 import { useTheme } from 'context/useTheme'
 import { useMemo, useState } from 'react'
-import Select, { type MultiValue } from 'react-select'
+import Select, { type MultiValue, type SingleValue } from 'react-select'
 
 type BuilderViewModel = ReturnType<typeof createAos4BuilderViewModel>
 type BuilderOption = BuilderViewModel['options'][number]
+type BuilderBearer = BuilderViewModel['enhancementBearers'][number]
 
 interface ArmyBuilderProps {
   builder: BuilderViewModel
+  onSetEnhancementBearer: (enhancementId: CanonicalId, bearerId: CanonicalId | null) => void
   onSetGroupSelections: (groupIds: CanonicalId[], selectedIds: CanonicalId[]) => void
 }
 
@@ -20,11 +22,17 @@ interface Option {
   disabled: boolean
 }
 
+interface BearerOption {
+  label: string
+  value: CanonicalId
+}
+
 interface SelectionGroup {
   key: string
   title: string
   mobileTitle?: string
   options: BuilderOption[]
+  bearers: BuilderBearer[]
 }
 
 const titles: Record<string, { title: string; mobileTitle?: string; order: number }> = {
@@ -51,7 +59,7 @@ const titleCase = (value: string) =>
 
 const groupKey = (option: BuilderOption) => option.groupType ?? option.kind
 
-const groupSelections = (options: BuilderOption[]): SelectionGroup[] => {
+const groupSelections = (options: BuilderOption[], bearers: BuilderBearer[]): SelectionGroup[] => {
   const grouped = options.reduce((result, option) => {
     const key = groupKey(option)
     result.set(key, [...(result.get(key) ?? []), option])
@@ -65,6 +73,7 @@ const groupSelections = (options: BuilderOption[]): SelectionGroup[] => {
       title: configured?.title ?? titleCase(key),
       ...(configured?.mobileTitle ? { mobileTitle: configured.mobileTitle } : {}),
       options: groupOptions,
+      bearers: bearers.filter(bearer => bearer.groupType === key),
     }
   }).sort(
     (left, right) =>
@@ -76,10 +85,12 @@ const groupSelections = (options: BuilderOption[]): SelectionGroup[] => {
 const SelectionCard = ({
   group,
   initiallyExpanded,
+  onSetEnhancementBearer,
   onSetGroupSelections,
 }: {
   group: SelectionGroup
   initiallyExpanded: boolean
+  onSetEnhancementBearer: ArmyBuilderProps['onSetEnhancementBearer']
   onSetGroupSelections: ArmyBuilderProps['onSetGroupSelections']
 }) => {
   const { theme } = useTheme()
@@ -160,13 +171,53 @@ const SelectionCard = ({
               },
             })}
           />
+          {/*
+           * One "carried by" picker per selected heroic trait or artefact of power (#1992), so a
+           * hand-built army can record what an imported roster states outright: which hero carries
+           * the enhancement. Writes `enhancementBearers`, the field imports populate, so the
+           * reminder's "Carried by your <unit>" tag renders identically either way. Clearing it
+           * returns the reminder to the army-wide reading.
+           */}
+          {group.bearers.map(bearer => {
+            const bearerOptions: BearerOption[] = bearer.bearerOptions.map(option => ({
+              label: option.name,
+              value: option.id,
+            }))
+            const bearerValue = bearerOptions.find(option => option.value === bearer.bearerId) ?? null
+            const bearerInputId = `aos4-bearer-${bearer.enhancementId}`
+            return (
+              <div key={bearer.enhancementId} className="mt-2">
+                <label className={`small mb-1 ${theme.textMuted}`} htmlFor={bearerInputId}>
+                  {`Carried by — ${bearer.enhancementName}`}
+                </label>
+                <Select<BearerOption, false>
+                  inputId={bearerInputId}
+                  value={bearerValue}
+                  options={bearerOptions}
+                  isClearable
+                  placeholder="Army-wide"
+                  onChange={(option: SingleValue<BearerOption>) =>
+                    onSetEnhancementBearer(bearer.enhancementId, option?.value ?? null)
+                  }
+                  className={theme.text}
+                  theme={defaultTheme => ({
+                    ...defaultTheme,
+                    colors: {
+                      ...defaultTheme.colors,
+                      ...theme.selectTheme,
+                    },
+                  })}
+                />
+              </div>
+            )
+          })}
         </div>
       </div>
     </div>
   )
 }
 
-const ArmyBuilder = ({ builder, onSetGroupSelections }: ArmyBuilderProps) => {
+const ArmyBuilder = ({ builder, onSetEnhancementBearer, onSetGroupSelections }: ArmyBuilderProps) => {
   const isMobile = useIsMobile()
   const groups = useMemo(
     () =>
@@ -180,9 +231,10 @@ const ArmyBuilder = ({ builder, onSetGroupSelections }: ArmyBuilderProps) => {
               option.kind === 'content-group' ||
               (option.kind === 'ability' && Boolean(option.groupType))) &&
             option.groupType !== 'army-of-renown'
-        )
+        ),
+        builder.enhancementBearers
       ),
-    [builder.options]
+    [builder.options, builder.enhancementBearers]
   )
   const rowClass = `row d-print-none pb-1 ${isMobile ? 'mx-1' : 'pt-2 w-75'}`
 
@@ -194,6 +246,7 @@ const ArmyBuilder = ({ builder, onSetGroupSelections }: ArmyBuilderProps) => {
             key={group.key}
             group={group}
             initiallyExpanded={index === 0}
+            onSetEnhancementBearer={onSetEnhancementBearer}
             onSetGroupSelections={onSetGroupSelections}
           />
         ))}

--- a/src/components/routes/HomeCatalogBound.tsx
+++ b/src/components/routes/HomeCatalogBound.tsx
@@ -414,6 +414,24 @@ const HomeCatalogBound = ({
     })
   }
 
+  /*
+   * The bearer assignment rides the same state-update path as every other builder control: the next
+   * document goes through `createAos4ArmyDocument`, whose normalization drops a cleared entry and
+   * any entry whose enhancement or bearer leaves the army (#1992). No overlay derivation — the
+   * selections themselves are untouched.
+   */
+  const setEnhancementBearer = (enhancementId: CanonicalId, bearerId: CanonicalId | null) => {
+    setDocument(current =>
+      createAos4ArmyDocument({
+        ...current,
+        enhancementBearers: {
+          ...current.enhancementBearers,
+          [enhancementId]: bearerId ?? undefined,
+        },
+      })
+    )
+  }
+
   const clearArmy = () => {
     unlinkCloudArmy()
     setDocument(current =>
@@ -569,7 +587,13 @@ const HomeCatalogBound = ({
 
   return (
     <>
-      {!isGameMode && <ArmyBuilder builder={builder} onSetGroupSelections={setSelections} />}
+      {!isGameMode && (
+        <ArmyBuilder
+          builder={builder}
+          onSetEnhancementBearer={setEnhancementBearer}
+          onSetGroupSelections={setSelections}
+        />
+      )}
 
       {!isGameMode && (
         <Toolbar

--- a/src/tests/aos4/builderBearerPicker.test.ts
+++ b/src/tests/aos4/builderBearerPicker.test.ts
@@ -162,4 +162,21 @@ describe('builder carried-by picker (#1992)', () => {
     const bearerTag = artefact!.tags.find(tag => tag.tone === 'source' && tag.label === 'Knight-Questor')
     expect(bearerTag?.description).toBe('Carried by your Knight-Questor. Only that unit uses it.')
   })
+
+  it('keeps the group tag beside the bearer tag, so the pick stays findable by its own name', () => {
+    // A heroic-trait table grants abilities under their own names (Aspects of Renewal grants
+    // REALMROOT GUIDE), and the table's tag is what lets the player find them. Assigning a bearer
+    // must add "Carried by" alongside that tag, never replace it — replacing it made the pick
+    // vanish from the reminders as far as the player could tell.
+    const document = createDocument([STORMCAST.id, KNIGHT_QUESTOR.id, ARTEFACT_GROUP.id], {
+      [ARTEFACT_GROUP.id]: KNIGHT_QUESTOR.id,
+    })
+
+    const reminders = createAos4ReminderViewModel(AOS4_CATALOG, document)
+    const artefact = reminders.find(reminder => reminder.name === 'QUICKSILVER DRAUGHT')
+    const sourceLabels = artefact!.tags.filter(tag => tag.tone === 'source').map(tag => tag.label)
+
+    expect(sourceLabels).toContain('Knight-Questor')
+    expect(sourceLabels).toContain(ARTEFACT_GROUP.name)
+  })
 })

--- a/src/tests/aos4/builderBearerPicker.test.ts
+++ b/src/tests/aos4/builderBearerPicker.test.ts
@@ -1,0 +1,165 @@
+import type { Ability, ContentGroup, Faction, Warscroll } from '../../aos4/domain'
+import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID } from '../../aos4/generated'
+import { createAos4ArmyDocument, type Aos4ArmyDocument } from '../../aos4/state'
+import { createAos4BuilderViewModel, createAos4ReminderViewModel } from '../../aos4/view'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The builder's "carried by" picker (#1992). Imports populate `enhancementBearers` because a
+ * roster export states which hero carries each enhancement (#1989); a hand-built army had no way
+ * to say so. The view model exposes one control per selected heroic trait or artefact of power —
+ * whether the document holds the individual ability an import records or the offering group a
+ * hand-built pick records — offering the army's HERO-keyworded warscrolls as bearers, and the
+ * reminder view renders a group-keyed assignment exactly like an imported one.
+ */
+
+type PickableKind = 'faction' | 'warscroll' | 'content-group' | 'ability'
+
+const currentStandardContextId = AOS4_CATALOG.rulesContexts.find(
+  context => context.mode === 'standard' && context.status === 'current'
+)?.id
+
+const entityByName = (kind: PickableKind, name: string): Faction | Warscroll | ContentGroup | Ability => {
+  // Seasonal enhancement tables share their battletome counterparts' names (#1979); the
+  // current-standard entity is the one a plain hand-built pick lands on.
+  const candidates = AOS4_CATALOG.entities.filter(
+    candidate => candidate.kind === kind && candidate.name === name
+  )
+  const entity =
+    candidates.find(
+      candidate => currentStandardContextId && candidate.rulesContextIds.includes(currentStandardContextId)
+    ) ?? candidates[0]
+  if (!entity) throw new Error(`No ${kind} named ${name} in the catalog`)
+  return entity as Faction | Warscroll | ContentGroup | Ability
+}
+
+const STORMCAST = entityByName('faction', 'Stormcast Eternals')
+const KNIGHT_QUESTOR = entityByName('warscroll', 'Knight-Questor')
+const LIBERATORS = entityByName('warscroll', 'Liberators')
+const ARTEFACT_GROUP = entityByName('content-group', 'Artefacts of the Tempest')
+const HEROIC_TRAIT_GROUP = entityByName('content-group', 'Aspects of Azyr')
+const SPELL_LORE_GROUP = entityByName('content-group', 'Lore of the Storm')
+const ARTEFACT_ABILITY = entityByName('ability', 'QUICKSILVER DRAUGHT')
+
+const createDocument = (
+  explicitSelectionIds: Aos4ArmyDocument['explicitSelectionIds'],
+  enhancementBearers?: Aos4ArmyDocument['enhancementBearers']
+): Aos4ArmyDocument =>
+  createAos4ArmyDocument({
+    id: 'army:bearer-picker',
+    name: 'Bearer Picker Test',
+    rulesContextId: AOS4_DEFAULT_RULES_CONTEXT_ID,
+    explicitSelectionIds,
+    ...(enhancementBearers ? { enhancementBearers } : {}),
+    reminderPreferences: {},
+  })
+
+describe('builder carried-by picker (#1992)', () => {
+  it('offers the army HERO warscrolls as bearers for a hand-built enhancement pick', () => {
+    const document = createDocument([STORMCAST.id, KNIGHT_QUESTOR.id, LIBERATORS.id, ARTEFACT_GROUP.id])
+
+    const builder = createAos4BuilderViewModel(AOS4_CATALOG, document)
+    const control = builder.enhancementBearers.find(
+      candidate => candidate.enhancementId === ARTEFACT_GROUP.id
+    )
+
+    expect(control).toBeDefined()
+    expect(control!.groupType).toBe('artefact-of-power')
+    expect(control!.enhancementName).toBe('Artefacts of the Tempest')
+    expect(control!.bearerId).toBeUndefined()
+    // Knight-Questor carries the HERO keyword; Liberators do not, and neither does the faction.
+    expect(control!.bearerOptions).toEqual([{ id: KNIGHT_QUESTOR.id, name: 'Knight-Questor' }])
+  })
+
+  it('keys an imported enhancement ability chip and surfaces its assigned bearer as the current value', () => {
+    const document = createDocument([STORMCAST.id, KNIGHT_QUESTOR.id, ARTEFACT_ABILITY.id], {
+      [ARTEFACT_ABILITY.id]: KNIGHT_QUESTOR.id,
+    })
+
+    const builder = createAos4BuilderViewModel(AOS4_CATALOG, document)
+    const control = builder.enhancementBearers.find(
+      candidate => candidate.enhancementId === ARTEFACT_ABILITY.id
+    )
+
+    expect(control).toBeDefined()
+    expect(control!.groupType).toBe('artefact-of-power')
+    // Chip casing, like the ability's own builder chip — not the corpus's uppercase record name.
+    expect(control!.enhancementName).toBe('Quicksilver Draught')
+    expect(control!.bearerId).toBe(KNIGHT_QUESTOR.id)
+  })
+
+  it('keeps a non-HERO assignment visible so an imported bearer always displays and stays clearable', () => {
+    // The import joins bearers by roster line, not by keyword, so the map can name any warscroll.
+    const document = createDocument([STORMCAST.id, LIBERATORS.id, ARTEFACT_ABILITY.id], {
+      [ARTEFACT_ABILITY.id]: LIBERATORS.id,
+    })
+
+    const builder = createAos4BuilderViewModel(AOS4_CATALOG, document)
+    const control = builder.enhancementBearers.find(
+      candidate => candidate.enhancementId === ARTEFACT_ABILITY.id
+    )
+
+    expect(control).toBeDefined()
+    expect(control!.bearerId).toBe(LIBERATORS.id)
+    expect(control!.bearerOptions).toEqual([{ id: LIBERATORS.id, name: 'Liberators' }])
+  })
+
+  it('offers no picker without an eligible bearer, and none for lore picks', () => {
+    // No HERO warscroll and no assignment: a picker would offer an empty list.
+    const noHeroes = createDocument([STORMCAST.id, LIBERATORS.id, ARTEFACT_GROUP.id])
+    expect(createAos4BuilderViewModel(AOS4_CATALOG, noHeroes).enhancementBearers).toEqual([])
+
+    // A lore grants its spells to every eligible caster; a single bearer would misstate it.
+    const withLore = createDocument([STORMCAST.id, KNIGHT_QUESTOR.id, SPELL_LORE_GROUP.id])
+    expect(createAos4BuilderViewModel(AOS4_CATALOG, withLore).enhancementBearers).toEqual([])
+  })
+
+  it('lists controls per selected enhancement, ordered like the builder cards', () => {
+    const document = createDocument([
+      STORMCAST.id,
+      KNIGHT_QUESTOR.id,
+      ARTEFACT_GROUP.id,
+      HEROIC_TRAIT_GROUP.id,
+    ])
+
+    const builder = createAos4BuilderViewModel(AOS4_CATALOG, document)
+
+    expect(builder.enhancementBearers.map(control => [control.groupType, control.enhancementName])).toEqual([
+      ['artefact-of-power', 'Artefacts of the Tempest'],
+      ['heroic-trait', 'Aspects of Azyr'],
+    ])
+  })
+
+  it('writes and clears an assignment through the document normalization the builder rides', () => {
+    // The exact update expression HomeCatalogBound uses for both directions of the control.
+    const document = createDocument([STORMCAST.id, KNIGHT_QUESTOR.id, ARTEFACT_GROUP.id])
+
+    const assigned = createAos4ArmyDocument({
+      ...document,
+      enhancementBearers: { ...document.enhancementBearers, [ARTEFACT_GROUP.id]: KNIGHT_QUESTOR.id },
+    })
+    expect(assigned.enhancementBearers).toEqual({ [ARTEFACT_GROUP.id]: KNIGHT_QUESTOR.id })
+    expect(assigned.explicitSelectionIds).toEqual(document.explicitSelectionIds)
+
+    const cleared = createAos4ArmyDocument({
+      ...assigned,
+      enhancementBearers: { ...assigned.enhancementBearers, [ARTEFACT_GROUP.id]: undefined },
+    })
+    expect(cleared.enhancementBearers).toBeUndefined()
+  })
+
+  it('renders a hand-built group-keyed assignment as the carried-by tag on the group reminders', () => {
+    // The hand-built pick records the offering group, so the bearer map is keyed by the group ID —
+    // the root of every reminder cause the group grants — and the view needs no changes (#1990).
+    const document = createDocument([STORMCAST.id, KNIGHT_QUESTOR.id, ARTEFACT_GROUP.id], {
+      [ARTEFACT_GROUP.id]: KNIGHT_QUESTOR.id,
+    })
+
+    const reminders = createAos4ReminderViewModel(AOS4_CATALOG, document)
+    const artefact = reminders.find(reminder => reminder.name === 'QUICKSILVER DRAUGHT')
+
+    expect(artefact).toBeDefined()
+    const bearerTag = artefact!.tags.find(tag => tag.tone === 'source' && tag.label === 'Knight-Questor')
+    expect(bearerTag?.description).toBe('Carried by your Knight-Questor. Only that unit uses it.')
+  })
+})

--- a/src/tests/aos4/builderBearerPickerUi.test.tsx
+++ b/src/tests/aos4/builderBearerPickerUi.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+
+import Home from 'components/routes/Home'
+/*
+ * Home's catalog-bound half is behind `lazy()`, and resolving it means parsing the whole rules
+ * corpus — seconds, not a flush. Loading it statically here puts that cost in module evaluation
+ * where no per-test timeout applies, so the awaits below are about React and not about JSON.
+ */
+import 'components/routes/HomeCatalogBound'
+import type { ContentGroup, Faction, Warscroll } from '../../aos4/domain'
+import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID } from '../../aos4/generated'
+import { AOS4_ARMY_STORAGE_KEY } from '../../aos4/runtime'
+import {
+  createAos4ArmyDocument,
+  deserializeAos4ArmyDocumentStructure,
+  serializeAos4ArmyDocument,
+} from '../../aos4/state'
+import { AppStatusProvider } from 'context/useAppStatus'
+import { ThemeProvider } from 'context/useTheme'
+import { SubscriptionProvider } from 'context/useSubscription'
+import React from 'react'
+import { render, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
+import { act } from 'react'
+import { MemoryStorage } from 'tests/support/memoryStorage'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const auth = vi.hoisted(() => ({
+  isAuthenticated: false,
+  isLoading: false,
+  getAccessTokenSilently: vi.fn(),
+  loginWithPopup: vi.fn(),
+  logout: vi.fn(),
+  user: undefined as { email: string } | undefined,
+}))
+const getSubscription = vi.hoisted(() => vi.fn())
+
+vi.mock('@auth0/auth0-react', () => ({
+  useAuth0: () => auth,
+}))
+
+/*
+ * Home's banner slot renders the update prompt, which reaches `applyWaitingUpdate` in
+ * bootstrap/registerServiceWorker and through it the plugin's `virtual:pwa-register`. That virtual
+ * module has no resolvable file on disk, so the test runner cannot import it — stub it the same way
+ * homePresentation.test.tsx does.
+ */
+vi.mock('virtual:pwa-register', async () => {
+  const { pwaRegisterMockValue } = await import('tests/support/homeTestMocks')
+  return pwaRegisterMockValue()
+})
+
+vi.mock('../../api/subscriptionApi', () => ({
+  SubscriptionApi: {
+    cancelSubscription: vi.fn(),
+    getSubscription,
+    updateTheme: vi.fn(),
+  },
+}))
+
+/**
+ * The builder's "carried by" picker, end to end (#1992): a hand-built army assigns a hero to its
+ * artefact pick through a labeled select in the enhancement's own card, the assignment lands in the
+ * persisted document's `enhancementBearers` — the field imports populate (#1989) — the reminder tag
+ * announces the bearer, and clearing the select removes the entry again.
+ */
+describe('builder carried-by picker UI (#1992)', () => {
+  const currentStandardContextId = AOS4_CATALOG.rulesContexts.find(
+    context => context.mode === 'standard' && context.status === 'current'
+  )?.id
+
+  const entityByName = (kind: 'faction' | 'warscroll' | 'content-group', name: string) => {
+    // Seasonal enhancement tables share their battletome counterparts' names (#1979); the
+    // current-standard entity is the one a plain hand-built pick lands on.
+    const candidates = AOS4_CATALOG.entities.filter(
+      candidate => candidate.kind === kind && candidate.name === name
+    )
+    const entity =
+      candidates.find(
+        candidate => currentStandardContextId && candidate.rulesContextIds.includes(currentStandardContextId)
+      ) ?? candidates[0]
+    if (!entity) throw new Error(`No ${kind} named ${name} in the catalog`)
+    return entity as Faction | Warscroll | ContentGroup
+  }
+
+  const STORMCAST = entityByName('faction', 'Stormcast Eternals')
+  const KNIGHT_QUESTOR = entityByName('warscroll', 'Knight-Questor')
+  const LIBERATORS = entityByName('warscroll', 'Liberators')
+  const ARTEFACT_GROUP = entityByName('content-group', 'Artefacts of the Tempest')
+
+  let container: HTMLDivElement
+  let storage: MemoryStorage
+
+  const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+  const renderHome = async () => {
+    await act(async () => {
+      render(
+        <AppStatusProvider>
+          <SubscriptionProvider>
+            <ThemeProvider>
+              <MemoryRouter>
+                <Home />
+              </MemoryRouter>
+            </ThemeProvider>
+          </SubscriptionProvider>
+        </AppStatusProvider>,
+        container
+      )
+      await flush()
+    })
+    await act(async () => {
+      await flush()
+    })
+  }
+
+  const storedDocument = () =>
+    deserializeAos4ArmyDocumentStructure(storage.getItem(AOS4_ARMY_STORAGE_KEY) ?? '').document
+
+  const bearerInput = () =>
+    container.querySelector<HTMLInputElement>(`input[id="aos4-bearer-${ARTEFACT_GROUP.id}"]`)
+
+  const openBearerMenu = async () => {
+    const input = bearerInput()
+    expect(input).not.toBeNull()
+    await act(async () => {
+      input!.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
+      )
+      await flush()
+    })
+  }
+
+  beforeEach(async () => {
+    auth.isAuthenticated = false
+    auth.isLoading = false
+    auth.user = undefined
+    auth.getAccessTokenSilently.mockReset()
+    getSubscription.mockReset()
+    getSubscription.mockRejectedValue({ status: 404 })
+    storage = new MemoryStorage()
+    storage.setItem(
+      AOS4_ARMY_STORAGE_KEY,
+      serializeAos4ArmyDocument(
+        createAos4ArmyDocument({
+          id: 'army:bearer-picker-ui',
+          name: 'Bearer Picker UI Test',
+          rulesContextId: AOS4_DEFAULT_RULES_CONTEXT_ID,
+          explicitSelectionIds: [STORMCAST.id, KNIGHT_QUESTOR.id, LIBERATORS.id, ARTEFACT_GROUP.id],
+          reminderPreferences: {},
+        })
+      )
+    )
+    Object.defineProperty(window, 'localStorage', { configurable: true, value: storage })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    await renderHome()
+  })
+
+  afterEach(() => {
+    act(() => {
+      unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  it('labels the picker with the enhancement it assigns and offers only the army HERO warscrolls', async () => {
+    const label = container.querySelector(`label[for="aos4-bearer-${ARTEFACT_GROUP.id}"]`)
+    expect(label).not.toBeNull()
+    expect(label?.textContent).toBe('Carried by — Artefacts of the Tempest')
+
+    await openBearerMenu()
+
+    const offered = Array.from(container.querySelectorAll('[role="option"]')).map(option =>
+      option.textContent?.trim()
+    )
+    expect(offered).toContain('Knight-Questor')
+    expect(offered).not.toContain('Liberators')
+  })
+
+  it('assigns a bearer into the stored document, tags the reminder, and clears back to army-wide', async () => {
+    await openBearerMenu()
+    const option = Array.from(container.querySelectorAll('[role="option"]')).find(
+      candidate => candidate.textContent?.trim() === 'Knight-Questor'
+    )
+    expect(option).not.toBeUndefined()
+    await act(async () => {
+      option!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      await flush()
+    })
+
+    expect(storedDocument()?.enhancementBearers).toEqual({
+      [ARTEFACT_GROUP.id]: KNIGHT_QUESTOR.id,
+    })
+    // The reminder tag reads the same field imports populate, so it renders identically (#1989).
+    expect(
+      container.querySelector('[aria-label*="Carried by your Knight-Questor. Only that unit uses it."]')
+    ).not.toBeNull()
+
+    // react-select's clear control is the "no bearer / army-wide" choice; it fires on mousedown.
+    // With a value set the control renders two indicators — clear first, then the dropdown arrow —
+    // and emotion labels both `indicatorContainer`.
+    const indicators = bearerInput()!.closest('.mt-2')!.querySelectorAll('[class*="indicatorContainer"]')
+    expect(indicators.length).toBe(2)
+    const clear = indicators[0]
+    await act(async () => {
+      clear!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }))
+      await flush()
+    })
+
+    expect(storedDocument()?.enhancementBearers).toBeUndefined()
+    expect(
+      container.querySelector('[aria-label*="Carried by your Knight-Questor. Only that unit uses it."]')
+    ).toBeNull()
+  })
+})

--- a/src/tests/aos4/builderBearerPickerUi.test.tsx
+++ b/src/tests/aos4/builderBearerPickerUi.test.tsx
@@ -168,7 +168,7 @@ describe('builder carried-by picker UI (#1992)', () => {
   it('labels the picker with the enhancement it assigns and offers only the army HERO warscrolls', async () => {
     const label = container.querySelector(`label[for="aos4-bearer-${ARTEFACT_GROUP.id}"]`)
     expect(label).not.toBeNull()
-    expect(label?.textContent).toBe('Carried by — Artefacts of the Tempest')
+    expect(label?.textContent).toBe('Artefacts of the Tempest — Carried by')
 
     await openBearerMenu()
 


### PR DESCRIPTION
> **Stacked PR** on `fix/1989-enhancement-bearers` (#1990) — it depends on the `enhancementBearers` schema, normalization, and bearer-tag rendering that exist only on that branch, and should merge after #1990 does.

Closes #1992

## What changed

Only the import pipeline populated `Aos4ArmyDocument.enhancementBearers` (#1989), because a roster export states which hero carries each artefact or heroic trait. A hand-built army had no way to say so, so its enhancement reminders read as army-wide at best. The builder now offers a "carried by" picker.

- **View model** (`src/aos4/view/builder.ts`): `createAos4BuilderViewModel` returns `enhancementBearers` — one control per selected heroic trait or artefact of power, carrying the enhancement's display name, category, current assignment, and eligible bearer options. Controls key on exactly the ID the document holds — the individual enhancement ability an import records, or the offering content-group a hand-built pick records. Both are the reminder cause root that `createAos4ReminderViewModel`'s bearer tag already reads, so the reminders/print rendering needed no changes.
- **Bearer eligibility**: the army's HERO-keyworded warscrolls (the corpus carries `keywords` on all 1,296 warscrolls; 552 are HERO, so the filter is clean — no all-warscrolls fallback needed). A bearer an import assigned outside that list (the import joins by roster line, not keyword) is still offered, so the current value always displays and stays clearable. Lore picks get no control: a lore grants its spells or prayers to every eligible caster, so a single bearer would misstate it. No eligible bearer and no assignment means no control.
- **UI** (`src/components/input/army_builder.tsx`): each Heroic Traits / Artefacts of Power card renders the control as a clearable single `react-select` under the category select, themed identically to its neighbours, with placeholder `Army-wide` as the no-bearer reading. A visible `<label htmlFor>` reading `Carried by — <enhancement name>` names the control, so a screen reader announces which enhancement each picker assigns.
- **State** (`src/components/routes/HomeCatalogBound.tsx`): `setEnhancementBearer` rides the established `setDocument` → `createAos4ArmyDocument` path the other builder controls use. Normalization owns the cleanup: clearing drops the entry, and removing the enhancement or the bearer from the army drops it too — the UI never fights that.

No data, corpus, or schema changes: the field, its normalization contract, and the "Carried by your <unit>. Only that unit uses it." tag all come from #1990. No production configuration or companion-service impact.

## Tests

- `src/tests/aos4/builderBearerPicker.test.ts` — view model + document contract against the real corpus:
  - offers the army HERO warscrolls as bearers for a hand-built enhancement pick
  - keys an imported enhancement ability chip and surfaces its assigned bearer as the current value
  - keeps a non-HERO assignment visible so an imported bearer always displays and stays clearable
  - offers no picker without an eligible bearer, and none for lore picks
  - lists controls per selected enhancement, ordered like the builder cards
  - writes and clears an assignment through the document normalization the builder rides
  - renders a hand-built group-keyed assignment as the carried-by tag on the group reminders
- `src/tests/aos4/builderBearerPickerUi.test.tsx` — full Home render, end to end:
  - labels the picker with the enhancement it assigns and offers only the army HERO warscrolls
  - assigns a bearer into the stored document, tags the reminder, and clears back to army-wide

## Verification

- `yarn build` — clean (tsc + vite + PWA)
- `yarn lint` — zero warnings
- `npx prettier --check src` — clean
- `npx vitest run` — 120 files, 3543 tests, all passing (run after a fresh build, per the dist-freshness gate)

## Known gaps

- The picker offers no unit-count or duplicate-assignment validation (e.g. two artefacts on one hero) — the document schema doesn't model those rules, and the import path doesn't validate them either.
- A hand-built pick records the offering group, so a group-keyed assignment tags every reminder the group grants with the same bearer — the granularity the issue specifies, inherent to what the document holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZh2hbJAy2TDnJz2Bxrek9