### PR TITLE
feat(builder): a seasonal rules switch that turns the General's Handbook off and on (#1994)

### DIFF
--- a/src/aos4/state/index.ts
+++ b/src/aos4/state/index.ts
@@ -1,1 +1,2 @@
 export * from './armyDocument'
+export * from './seasonalRules'

--- a/src/aos4/state/seasonalRules.ts
+++ b/src/aos4/state/seasonalRules.ts
@@ -1,0 +1,68 @@
+import type { Aos4Catalog, RulesContext } from '../domain'
+import { createAos4ArmyDocument, type Aos4ArmyDocument } from './armyDocument'
+
+/*
+ * The seasonal rules switch (issue #1994) moves an army between exactly two contexts: the
+ * standard-mode seasonal context (the sitting General's Handbook, today's default) and the
+ * standard-mode current context (battletome plus core rules only). Both are found by status and
+ * mode — never by name or season string — so the switch survives the next handbook without an
+ * edit. Spearhead, Legends, and historical contexts are deliberately outside its vocabulary, and
+ * the `allowsLegends`/`allowsHistorical` overlays are orthogonal document state it never touches.
+ */
+
+export interface Aos4SeasonalRulesContexts {
+  seasonal?: RulesContext
+  current?: RulesContext
+}
+
+export const findAos4SeasonalRulesContexts = (catalog: Aos4Catalog): Aos4SeasonalRulesContexts => {
+  const standard = catalog.rulesContexts.filter(context => context.mode === 'standard')
+  return {
+    seasonal: standard.find(context => context.status === 'seasonal'),
+    current: standard.find(context => context.status === 'current'),
+  }
+}
+
+/**
+ * What the switch may honestly say about a document:
+ *
+ * - `'on'` — the document lives in the seasonal standard context.
+ * - `'off'` — the document lives in the current standard context.
+ * - `'unavailable'` — the document lives somewhere else (Spearhead, a Legends-moved import, a
+ *   historical season, or a context the catalog no longer carries). The switch does not speak for
+ *   those contexts, and a checked state either way would lie.
+ */
+export type Aos4SeasonalRulesState = 'on' | 'off' | 'unavailable'
+
+export const getAos4SeasonalRulesState = (
+  catalog: Aos4Catalog,
+  document: Aos4ArmyDocument
+): Aos4SeasonalRulesState => {
+  const { seasonal, current } = findAos4SeasonalRulesContexts(catalog)
+  if (seasonal && document.rulesContextId === seasonal.id) return 'on'
+  if (current && document.rulesContextId === current.id) return 'off'
+  return 'unavailable'
+}
+
+/**
+ * Moves the document to the seasonal (`enabled`) or current standard context. Non-destructive by
+ * construction: only `rulesContextId` moves, so a season-exclusive selection held while the rules
+ * are off stays in `explicitSelectionIds` — selection resolution reports it as
+ * `inapplicable-explicit-selection` and keeps the rest of the army alive — and comes back to life
+ * when the season is switched on again.
+ *
+ * Returns the same instance when there is nothing to do: the document already sits in the target
+ * context, the catalog does not carry it, or the document lives outside the two standard contexts
+ * (the switch never shows there; see `getAos4SeasonalRulesState`).
+ */
+export const setAos4SeasonalRules = (
+  catalog: Aos4Catalog,
+  document: Aos4ArmyDocument,
+  enabled: boolean
+): Aos4ArmyDocument => {
+  if (getAos4SeasonalRulesState(catalog, document) === 'unavailable') return document
+  const { seasonal, current } = findAos4SeasonalRulesContexts(catalog)
+  const target = enabled ? seasonal : current
+  if (!target || document.rulesContextId === target.id) return document
+  return createAos4ArmyDocument({ ...document, rulesContextId: target.id })
+}

--- a/src/aos4/view/builder.ts
+++ b/src/aos4/view/builder.ts
@@ -135,8 +135,12 @@ export const createAos4BuilderViewModel = (catalog: Aos4Catalog, document: Aos4A
     const entity = entityById.get(id)
     if (!entity) return []
     const chipGroup = entity.kind === 'ability' ? chipGroupByAbilityId.get(id) : undefined
-    const overlay = overlayFor(chipGroup?.id ?? id)
     const seasonal = isSeasonExclusive(chipGroup ?? entity)
+    // A season-exclusive selection held while the seasonal rules are off (issue #1994) is
+    // unavailable in every resolution pass, which `overlayFor` would misread as historical
+    // provenance. Its marker is `seasonal`, so the builder keeps it under the season's own
+    // header — disabled, not misfiled under a past season.
+    const overlay = seasonal ? undefined : overlayFor(chipGroup?.id ?? id)
     return [
       {
         id,

--- a/src/components/page/homeHeader.tsx
+++ b/src/components/page/homeHeader.tsx
@@ -34,6 +34,17 @@ interface HeaderProps {
   onArmyOfRenownChange: (armyOfRenownId: CanonicalId | null) => void
   onFactionChange: (factionId: CanonicalId<'faction'>) => void
   onToggleGameMode: () => void
+  onToggleSeasonalRules: () => void
+  /**
+   * The seasonal rules switch (issue #1994): ON puts the army in the seasonal standard context
+   * (the sitting General's Handbook), OFF in the current standard one (battletome and core rules
+   * only). `null` hides the row entirely — before the catalog-bound half publishes there is
+   * nothing to flip, and a document living outside those two contexts (Spearhead, a Legends-moved
+   * import, a historical season) is not something the switch can speak for: a disabled switch
+   * still shows a knob position, and either position would lie. Hidden follows the Army of Renown
+   * row's precedent — masthead controls that do not apply are absent, not disabled.
+   */
+  seasonalRulesChecked: boolean | null
 }
 
 const NO_ARMY_OF_RENOWN = { label: 'None', value: null }
@@ -49,6 +60,8 @@ export const Header = ({
   onArmyOfRenownChange,
   onFactionChange,
   onToggleGameMode,
+  onToggleSeasonalRules,
+  seasonalRulesChecked,
 }: HeaderProps) => {
   const { theme } = useTheme()
   const isMobile = useIsMobile()
@@ -193,6 +206,45 @@ export const Header = ({
                   </div>
                 </>
               ) : null}
+              {/*
+                The seasonal rules switch (issue #1994), styled after the Edit/Play toggle above.
+                ON keeps the army under the sitting General's Handbook; OFF plays battletome and
+                core rules only. It renders only for a document in one of the two standard-mode
+                contexts — see `seasonalRulesChecked` — and only in edit mode, with the faction
+                and Army of Renown selects it belongs beside: it reconfigures the army, which is
+                an edit-mode act.
+              */}
+              {seasonalRulesChecked !== null && (
+                <div className="d-flex align-items-center justify-content-center text-white pt-2">
+                  <div className="d-inline-flex flex-row">
+                    {/*
+                      Click-to-toggle for the mouse like the Edit/Play labels, and like them not
+                      focusable: the switch below is the single keyboard control.
+                    */}
+                    <span className="align-self-center pb-2 me-2" onClick={onToggleSeasonalRules}>
+                      Seasonal rules
+                    </span>
+                    <label htmlFor="seasonal-rules-switch" className="mb-0">
+                      <Switch
+                        onChange={onToggleSeasonalRules}
+                        checked={seasonalRulesChecked}
+                        onColor="#1C7595"
+                        onHandleColor="#E9ECEF"
+                        handleDiameter={30}
+                        uncheckedIcon={false}
+                        checkedIcon={false}
+                        boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
+                        activeBoxShadow="0px 0px 1px 10px rgba(0, 0, 0, 0.2)"
+                        height={20}
+                        width={80}
+                        className="react-switch"
+                        id="seasonal-rules-switch"
+                        aria-label="Seasonal rules"
+                      />
+                    </label>
+                  </div>
+                </div>
+              )}
             </>
           )}
         </div>

--- a/src/components/routes/Home.tsx
+++ b/src/components/routes/Home.tsx
@@ -5,16 +5,7 @@ import Footer from 'components/page/footer'
 import { Header } from 'components/page/homeHeader'
 import type { Aos4CatalogBoundBindings } from 'components/routes/HomeCatalogBound'
 import { ArmyCollectionProvider } from 'context/useArmyCollection'
-import {
-  Component,
-  lazy,
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from 'react'
+import { Component, lazy, Suspense, useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { logFactionSelection, logGameModeChange } from 'utils/analytics'
 import { clearCloudArmyLink } from 'utils/cloudArmyLink'
 import { clearPendingShareId, readPendingShareId } from 'utils/shareLink'
@@ -26,7 +17,11 @@ import {
   createDefaultAos4ArmyDocument,
   saveAos4ArmyDocument,
 } from '../../aos4/runtime'
-import { createAos4ArmyDocument, deserializeAos4ArmyDocumentStructure, type Aos4ArmyDocument } from '../../aos4/state'
+import {
+  createAos4ArmyDocument,
+  deserializeAos4ArmyDocumentStructure,
+  type Aos4ArmyDocument,
+} from '../../aos4/state'
 
 /*
  * Home is the catalog-free shell. Everything shaped `f(catalog, …)` — the builder, the toolbar, the
@@ -256,10 +251,13 @@ const Home = () => {
    * one, and keeping it saves rebuilding the builder and every reminder view model for no visible
    * change.
    */
-  const handleDocumentValidated = useCallback((validated: Aos4ArmyDocument, unchangedFromStorage: boolean) => {
-    if (!unchangedFromStorage) setArmyDocument(validated)
-    setDocumentValidated(true)
-  }, [])
+  const handleDocumentValidated = useCallback(
+    (validated: Aos4ArmyDocument, unchangedFromStorage: boolean) => {
+      if (!unchangedFromStorage) setArmyDocument(validated)
+      setDocumentValidated(true)
+    },
+    []
+  )
 
   /*
    * The one place the sessionStorage key is removed. The share modal calls this when the player
@@ -341,6 +339,11 @@ const Home = () => {
           onArmyOfRenownChange={catalogBound?.onArmyOfRenownChange ?? noop}
           onFactionChange={selectFaction}
           onToggleGameMode={toggleGameMode}
+          onToggleSeasonalRules={catalogBound?.onToggleSeasonalRules ?? noop}
+          // `null` until the catalog-bound half publishes: the shell cannot tell the seasonal
+          // standard context from the current one without the catalog, and the splash covers the
+          // masthead for that whole wait anyway.
+          seasonalRulesChecked={catalogBound?.seasonalRulesChecked ?? null}
         />
 
         <AppBanner />

--- a/src/components/routes/HomeCatalogBound.tsx
+++ b/src/components/routes/HomeCatalogBound.tsx
@@ -1,5 +1,5 @@
 import type { CanonicalId } from '../../aos4/domain'
-import { AOS4_CATALOG, loadAos4SourceData } from '../../aos4/generated'
+import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID, loadAos4SourceData } from '../../aos4/generated'
 import type { PrintDocumentOptions } from '../../aos4/print/document'
 import type { PrintPageSize } from '../../aos4/print/presets'
 import type { PrintPreset } from '../../aos4/print/types'
@@ -11,8 +11,10 @@ import {
 import { resolveSelection } from '../../aos4/select'
 import {
   createAos4ArmyDocument,
+  getAos4SeasonalRulesState,
   serializeAos4ArmyDocument,
   setAos4ReminderPreference,
+  setAos4SeasonalRules,
   type Aos4ArmyDocument,
 } from '../../aos4/state'
 import {
@@ -160,6 +162,15 @@ export interface Aos4CatalogBoundBindings {
   }>
   armyOfRenownId: CanonicalId | null
   onArmyOfRenownChange: (armyOfRenownId: CanonicalId | null) => void
+  /**
+   * The seasonal rules switch (issue #1994): `true`/`false` mirror the document sitting in the
+   * seasonal or current standard context, and `null` means the document lives in some other
+   * context — Spearhead, a Legends-moved import, a historical season — that the switch cannot
+   * speak for, so the masthead hides it rather than showing a knob position that would lie.
+   * Derived here because telling the contexts apart takes the catalog the shell does not hold.
+   */
+  seasonalRulesChecked: boolean | null
+  onToggleSeasonalRules: () => void
   unlinkCloudArmy: () => void
 }
 
@@ -419,11 +430,36 @@ const HomeCatalogBound = ({
     setDocument(current =>
       createAos4ArmyDocument({
         ...current,
+        // Clearing means starting over, and starting over means the application default context —
+        // today the seasonal one, so the seasonal rules switch (issue #1994) comes back on. An
+        // army left in an imported Spearhead or Legends context would otherwise keep a context
+        // choice the cleared army no longer explains.
+        rulesContextId: AOS4_DEFAULT_RULES_CONTEXT_ID,
         explicitSelectionIds: [factionId],
         reminderPreferences: {},
       })
     )
   }
+
+  /*
+   * Derived from the document, never held: the switch is ON exactly when the document sits in the
+   * seasonal standard context and OFF exactly when it sits in the current standard one, so an
+   * import or a loaded cloud army that brings its own context moves the switch with it. Toggling
+   * is non-destructive both ways — only `rulesContextId` moves; season-exclusive selections stay
+   * in the document as inapplicable and revive when the season returns. The overlay flags are
+   * re-derived the same way every builder change derives them, so they keep following the
+   * selections rather than the context that just changed under them.
+   */
+  const seasonalRulesState = getAos4SeasonalRulesState(AOS4_CATALOG, document)
+  const seasonalRulesChecked = seasonalRulesState === 'unavailable' ? null : seasonalRulesState === 'on'
+  const toggleSeasonalRules = useCallback(() => {
+    setDocument(current =>
+      deriveAos4OverlayFlags(
+        AOS4_CATALOG,
+        setAos4SeasonalRules(AOS4_CATALOG, current, getAos4SeasonalRulesState(AOS4_CATALOG, current) !== 'on')
+      )
+    )
+  }, [setDocument])
 
   // The faction's Armies of Renown, offered as the top-level choice under the faction selector.
   // Picking one replaces the faction's regular rules, so switching drops explicit selections the
@@ -489,6 +525,7 @@ const HomeCatalogBound = ({
     if (
       previous &&
       previous.armyOfRenownId === armyOfRenownId &&
+      previous.seasonalRulesChecked === seasonalRulesChecked &&
       previous.unlinkCloudArmy === unlinkCloudArmy &&
       sameArmiesOfRenown(previous.armiesOfRenown, armiesOfRenown)
     ) {
@@ -498,11 +535,21 @@ const HomeCatalogBound = ({
       armiesOfRenown,
       armyOfRenownId,
       onArmyOfRenownChange: selectArmyOfRenown,
+      seasonalRulesChecked,
+      onToggleSeasonalRules: toggleSeasonalRules,
       unlinkCloudArmy,
     }
     publishedBindings.current = bindings
     onBindingsChange(bindings)
-  }, [armiesOfRenown, armyOfRenownId, onBindingsChange, selectArmyOfRenown, unlinkCloudArmy])
+  }, [
+    armiesOfRenown,
+    armyOfRenownId,
+    onBindingsChange,
+    seasonalRulesChecked,
+    selectArmyOfRenown,
+    toggleSeasonalRules,
+    unlinkCloudArmy,
+  ])
 
   /*
    * Withdraw them on the way out. Publishing upward means the shell holds handlers and a list that

--- a/src/tests/aos4/homeHeader.test.tsx
+++ b/src/tests/aos4/homeHeader.test.tsx
@@ -62,6 +62,8 @@ describe('the masthead selects', () => {
                   onArmyOfRenownChange={vi.fn()}
                   onFactionChange={vi.fn()}
                   onToggleGameMode={vi.fn()}
+                  onToggleSeasonalRules={vi.fn()}
+                  seasonalRulesChecked={null}
                   {...props}
                 />
               </MemoryRouter>
@@ -130,5 +132,50 @@ describe('the masthead selects', () => {
     await renderHeader({})
 
     expect(container.querySelector<HTMLInputElement>('input[aria-label="Faction"]')!.disabled).toBe(false)
+  })
+
+  /*
+   * The seasonal rules switch (issue #1994) renders only when the catalog-bound half has told the
+   * masthead which standard context the document sits in. `null` covers both silences — the
+   * catalog still pending, and a document living outside the two standard contexts (Spearhead, a
+   * Legends-moved import) that the switch cannot speak for — and both hide the row rather than
+   * showing a knob position that would lie.
+   */
+  it('renders no seasonal rules switch when no state is published', async () => {
+    await renderHeader({})
+
+    expect(container.querySelector('#seasonal-rules-switch')).toBeNull()
+    expect(container.textContent).not.toContain('Seasonal rules')
+  })
+
+  it('renders a labeled, keyboard-operable seasonal rules switch that reflects and reports its state', async () => {
+    const onToggleSeasonalRules = vi.fn()
+    await renderHeader({ seasonalRulesChecked: true, onToggleSeasonalRules })
+
+    const input = container.querySelector<HTMLInputElement>('#seasonal-rules-switch')
+    expect(input).not.toBeNull()
+    // react-switch renders a real checkbox input, so it is focusable and space-togglable; the
+    // accessible name and checked state are what a screen reader announces.
+    expect(input!.getAttribute('aria-label')).toBe('Seasonal rules')
+    expect(input!.checked).toBe(true)
+    expect(container.textContent).toContain('Seasonal rules')
+
+    await act(async () => {
+      input!.click()
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+    expect(onToggleSeasonalRules).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the seasonal rules switch unchecked when the seasonal rules are off', async () => {
+    await renderHeader({ seasonalRulesChecked: false })
+
+    expect(container.querySelector<HTMLInputElement>('#seasonal-rules-switch')!.checked).toBe(false)
+  })
+
+  it('hides the seasonal rules switch in play mode, with the other army-configuration controls', async () => {
+    await renderHeader({ seasonalRulesChecked: true, isGameMode: true })
+
+    expect(container.querySelector('#seasonal-rules-switch')).toBeNull()
   })
 })

--- a/src/tests/aos4/seasonalRulesSwitch.test.ts
+++ b/src/tests/aos4/seasonalRulesSwitch.test.ts
@@ -1,0 +1,190 @@
+import type { ContentGroup, Faction } from '../../aos4/domain'
+import { AOS4_CATALOG, AOS4_DEFAULT_RULES_CONTEXT_ID } from '../../aos4/generated'
+import {
+  createAos4ArmyDocument,
+  findAos4SeasonalRulesContexts,
+  getAos4SeasonalRulesState,
+  setAos4SeasonalRules,
+  type Aos4ArmyDocument,
+} from '../../aos4/state'
+import { createAos4BuilderViewModel, createAos4ReminderViewModel } from '../../aos4/view'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The seasonal rules switch (issue #1994) flips an army between the seasonal standard context
+ * (the sitting General's Handbook) and the current standard one (battletome and core rules only).
+ * Both contexts are found by status and mode — never by name or season string — and toggling is
+ * non-destructive: season-exclusive selections stay in the document as inapplicable and revive
+ * when the season is switched back on.
+ */
+
+const { seasonal, current } = findAos4SeasonalRulesContexts(AOS4_CATALOG)
+if (!seasonal || !current) throw new Error('The catalog is missing a standard-mode context')
+
+const spearheadContext = AOS4_CATALOG.rulesContexts.find(context => context.mode === 'spearhead')
+if (!spearheadContext) throw new Error('The catalog is missing the Spearhead context')
+
+const groupByName = (name: string): ContentGroup => {
+  const entity = AOS4_CATALOG.entities.find(
+    candidate => candidate.kind === 'content-group' && candidate.name === name
+  )
+  if (!entity) throw new Error(`No content group named ${name} in the catalog`)
+  return entity as ContentGroup
+}
+
+const factionByName = (name: string): Faction => {
+  const entity = AOS4_CATALOG.entities.find(
+    candidate => candidate.kind === 'faction' && candidate.name === name
+  )
+  if (!entity) throw new Error(`No faction named ${name} in the catalog`)
+  return entity as Faction
+}
+
+const ogorArmy = (extraNames: string[] = []): Aos4ArmyDocument =>
+  createAos4ArmyDocument({
+    id: 'army:seasonal-switch-test',
+    name: 'Seasonal Switch Test',
+    rulesContextId: seasonal.id,
+    explicitSelectionIds: [
+      factionByName('Ogor Mawtribes').id,
+      ...extraNames.map(name => groupByName(name).id),
+    ],
+  })
+
+describe('the seasonal rules contexts', () => {
+  it('are found by status and mode, never by name or season', () => {
+    expect(seasonal.mode).toBe('standard')
+    expect(seasonal.status).toBe('seasonal')
+    expect(current.mode).toBe('standard')
+    expect(current.status).toBe('current')
+    expect(seasonal.id).not.toBe(current.id)
+  })
+
+  it('include the application default, so a cleared army starts with the season on', () => {
+    expect(AOS4_DEFAULT_RULES_CONTEXT_ID).toBe(seasonal.id)
+  })
+})
+
+describe('the seasonal rules switch state', () => {
+  it('derives from the document context', () => {
+    const army = ogorArmy()
+    expect(getAos4SeasonalRulesState(AOS4_CATALOG, army)).toBe('on')
+    expect(
+      getAos4SeasonalRulesState(AOS4_CATALOG, createAos4ArmyDocument({ ...army, rulesContextId: current.id }))
+    ).toBe('off')
+  })
+
+  it('is unavailable for a document outside the two standard contexts', () => {
+    const spearhead = createAos4ArmyDocument({ ...ogorArmy(), rulesContextId: spearheadContext.id })
+    expect(getAos4SeasonalRulesState(AOS4_CATALOG, spearhead)).toBe('unavailable')
+  })
+})
+
+describe('toggling the seasonal rules', () => {
+  it('moves the context both ways without touching the selections', () => {
+    // Well-Fed Beasts is a season-exclusive enhancement table in the accepted corpus; the pick
+    // must survive both flips untouched.
+    const army = ogorArmy(['Well-Fed Beasts'])
+
+    const off = setAos4SeasonalRules(AOS4_CATALOG, army, false)
+    expect(off.rulesContextId).toBe(current.id)
+    expect(off.explicitSelectionIds).toEqual(army.explicitSelectionIds)
+    expect(off.reminderPreferences).toEqual(army.reminderPreferences)
+
+    const backOn = setAos4SeasonalRules(AOS4_CATALOG, off, true)
+    expect(backOn.rulesContextId).toBe(seasonal.id)
+    expect(backOn.explicitSelectionIds).toEqual(army.explicitSelectionIds)
+  })
+
+  it('returns the same instance when there is nothing to do', () => {
+    const army = ogorArmy()
+    expect(setAos4SeasonalRules(AOS4_CATALOG, army, true)).toBe(army)
+
+    const spearhead = createAos4ArmyDocument({ ...army, rulesContextId: spearheadContext.id })
+    expect(setAos4SeasonalRules(AOS4_CATALOG, spearhead, false)).toBe(spearhead)
+    expect(setAos4SeasonalRules(AOS4_CATALOG, spearhead, true)).toBe(spearhead)
+  })
+})
+
+describe('what the switch does to the reminders', () => {
+  const provenanceLabels = (reminders: ReturnType<typeof createAos4ReminderViewModel>): string[] =>
+    reminders.flatMap(reminder =>
+      reminder.tags.filter(tag => tag.tone === 'provenance').map(tag => tag.label)
+    )
+
+  it('removes the seasonal group when off and restores it when on', () => {
+    const army = ogorArmy()
+    const seasonalNames = ['RAISING THE HEAT', 'FIGHT THROUGH THE PAIN']
+
+    const withSeason = createAos4ReminderViewModel(AOS4_CATALOG, army)
+    seasonalNames.forEach(name => {
+      expect(withSeason.some(reminder => reminder.name === name)).toBe(true)
+    })
+    expect(provenanceLabels(withSeason)).toContain('Seasonal')
+
+    const withoutSeason = createAos4ReminderViewModel(
+      AOS4_CATALOG,
+      setAos4SeasonalRules(AOS4_CATALOG, army, false)
+    )
+    seasonalNames.forEach(name => {
+      expect(withoutSeason.some(reminder => reminder.name === name)).toBe(false)
+    })
+    expect(provenanceLabels(withoutSeason)).not.toContain('Seasonal')
+    // The battletome and core rules are still an army: only the season left.
+    expect(withoutSeason.length).toBeGreaterThan(0)
+    expect(withoutSeason.some(reminder => reminder.name === 'BULL CHARGE')).toBe(true)
+
+    const restored = createAos4ReminderViewModel(
+      AOS4_CATALOG,
+      setAos4SeasonalRules(AOS4_CATALOG, setAos4SeasonalRules(AOS4_CATALOG, army, false), true)
+    )
+    seasonalNames.forEach(name => {
+      expect(restored.some(reminder => reminder.name === name)).toBe(true)
+    })
+  })
+})
+
+describe('what the switch does to the builder', () => {
+  it('stops offering season-exclusive content when off', () => {
+    const army = ogorArmy()
+    const monstrousTraits = groupByName('Well-Fed Beasts')
+
+    const onOptions = createAos4BuilderViewModel(AOS4_CATALOG, army).options
+    expect(onOptions.some(option => option.id === monstrousTraits.id && option.available)).toBe(true)
+
+    const offOptions = createAos4BuilderViewModel(
+      AOS4_CATALOG,
+      setAos4SeasonalRules(AOS4_CATALOG, army, false)
+    ).options
+    expect(offOptions.some(option => option.id === monstrousTraits.id)).toBe(false)
+  })
+
+  /*
+   * Non-destructive means the pick outlives its season: it leaves the selected chips and cannot be
+   * re-picked, but it stays visible as a disabled option under the season's own header — its
+   * `seasonal` marker, not a misread `historical` overlay — and its inapplicability is on the
+   * record in the selection diagnostics.
+   */
+  it('keeps an already-picked seasonal enhancement visible but inapplicable when off', () => {
+    const army = ogorArmy(['Well-Fed Beasts'])
+    const monstrousTraits = groupByName('Well-Fed Beasts')
+
+    const on = createAos4BuilderViewModel(AOS4_CATALOG, army)
+    const onOption = on.options.find(option => option.id === monstrousTraits.id)
+    expect(onOption).toMatchObject({ selected: true, available: true, seasonal: true })
+
+    const off = createAos4BuilderViewModel(AOS4_CATALOG, setAos4SeasonalRules(AOS4_CATALOG, army, false))
+    const offOption = off.options.find(option => option.id === monstrousTraits.id)
+    expect(offOption).toBeDefined()
+    expect(offOption!.selected).toBe(false)
+    expect(offOption!.available).toBe(false)
+    expect(offOption!.seasonal).toBe(true)
+    expect(offOption!.overlay).toBeUndefined()
+    expect(
+      off.selection.diagnostics.some(
+        diagnostic =>
+          diagnostic.code === 'inapplicable-explicit-selection' && diagnostic.subject === monstrousTraits.id
+      )
+    ).toBe(true)
+  })
+})

--- a/src/tests/aos4/seasonalRulesSwitchUi.test.tsx
+++ b/src/tests/aos4/seasonalRulesSwitchUi.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+
+import Home from 'components/routes/Home'
+import { AppStatusProvider } from 'context/useAppStatus'
+import { SubscriptionProvider } from 'context/useSubscription'
+import { ThemeProvider } from 'context/useTheme'
+import { act } from 'react'
+import { MemoryRouter } from 'react-router'
+import { render, unmountComponentAtNode } from 'tests/support/reactTestHelpers'
+import { MemoryStorage } from 'tests/support/memoryStorage'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RulesContextId } from '../../aos4/domain'
+import { AOS4_CATALOG } from '../../aos4/generated'
+import { AOS4_ARMY_STORAGE_KEY } from '../../aos4/runtime'
+import {
+  createAos4ArmyDocument,
+  deserializeAos4ArmyDocumentStructure,
+  findAos4SeasonalRulesContexts,
+  serializeAos4ArmyDocument,
+} from '../../aos4/state'
+
+/*
+ * The seasonal rules switch (issue #1994), driven through the real screen: the masthead control the
+ * shell renders, flipping a document the catalog-bound half owns, with the reminders below both. A
+ * stored army seeds the render, the switch is clicked, and what must move together — the document's
+ * context in storage, the switch's own checked state, and the season's reminders — is read back
+ * from the same DOM and storage a player's browser would hold.
+ */
+
+// The standard preamble for a suite that renders Home: Auth0 and the subscription API are network
+// surfaces, and `virtual:pwa-register` has no file on disk for the resolver to find. See
+// tests/support/homeTestMocks.ts for why these are `await import()`ed inside the factory rather than
+// imported and passed to `vi.mock` directly.
+vi.mock('@auth0/auth0-react', async () => {
+  const { auth0DisabledMockValue } = await import('tests/support/homeTestMocks')
+  return { useAuth0: auth0DisabledMockValue }
+})
+
+vi.mock('../../api/subscriptionApi', async () => {
+  const { subscriptionApiNotFoundMockValue } = await import('tests/support/homeTestMocks')
+  return { SubscriptionApi: subscriptionApiNotFoundMockValue() }
+})
+
+vi.mock('virtual:pwa-register', async () => {
+  const { pwaRegisterMockValue } = await import('tests/support/homeTestMocks')
+  return pwaRegisterMockValue()
+})
+
+// Resolving the catalog-bound half parses the whole corpus. Warm it in module evaluation, where no
+// per-test timeout applies, so a slow first parse cannot read as a failure.
+beforeAll(async () => {
+  await import('components/routes/HomeCatalogBound')
+})
+
+const { seasonal, current } = findAos4SeasonalRulesContexts(AOS4_CATALOG)
+if (!seasonal || !current) throw new Error('The catalog is missing a standard-mode context')
+
+const spearheadContext = AOS4_CATALOG.rulesContexts.find(context => context.mode === 'spearhead')
+if (!spearheadContext) throw new Error('The catalog is missing the Spearhead context')
+
+const factionId = (() => {
+  const faction = AOS4_CATALOG.entities.find(
+    entity => entity.kind === 'faction' && entity.name === 'Flesh-eater Courts'
+  )
+  if (!faction) throw new Error('No faction named Flesh-eater Courts in the catalog')
+  return faction.id
+})()
+
+// A season rule every army carries while the season is on; reminderAttribution.test.ts pins its
+// Seasonal provenance. Its presence in the rendered reminders is the season's own fingerprint.
+const SEASONAL_REMINDER = 'RAISING THE HEAT'
+
+const storedArmy = (rulesContextId: RulesContextId) =>
+  serializeAos4ArmyDocument(
+    createAos4ArmyDocument({
+      id: 'army:seasonal-switch-ui-test',
+      name: 'Grand Court Nightblades',
+      rulesContextId,
+      explicitSelectionIds: [factionId],
+    })
+  )
+
+describe('the seasonal rules switch on the Home screen', () => {
+  let container: HTMLDivElement
+  let storage: MemoryStorage
+
+  const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+  const renderHome = async () => {
+    await act(async () => {
+      render(
+        <AppStatusProvider>
+          <SubscriptionProvider>
+            <ThemeProvider>
+              <MemoryRouter>
+                <Home />
+              </MemoryRouter>
+            </ThemeProvider>
+          </SubscriptionProvider>
+        </AppStatusProvider>,
+        container
+      )
+      await flush()
+    })
+    // A second flush: the first resolves the lazy child, this one settles its mount effects.
+    await act(async () => {
+      await flush()
+    })
+  }
+
+  const seasonalSwitch = () => container.querySelector<HTMLInputElement>('#seasonal-rules-switch')
+
+  const clickSeasonalSwitch = async () => {
+    await act(async () => {
+      seasonalSwitch()!.click()
+      await flush()
+    })
+  }
+
+  const storedDocument = () =>
+    deserializeAos4ArmyDocumentStructure(storage.getItem(AOS4_ARMY_STORAGE_KEY) ?? '').document
+
+  beforeEach(() => {
+    storage = new MemoryStorage()
+    Object.defineProperty(window, 'localStorage', { configurable: true, value: storage })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  it('flips the army between seasonal and current rules, non-destructively, both ways', async () => {
+    storage.setItem(AOS4_ARMY_STORAGE_KEY, storedArmy(seasonal.id))
+
+    await renderHome()
+
+    // The season is on: the switch says so and the season's reminders are on the page.
+    expect(seasonalSwitch()).not.toBeNull()
+    expect(seasonalSwitch()!.checked).toBe(true)
+    expect(container.textContent).toContain(SEASONAL_REMINDER)
+
+    await clickSeasonalSwitch()
+
+    // Off: the document moved to the current standard context, the seasonal reminders left, and
+    // the faction pick survived untouched.
+    expect(seasonalSwitch()!.checked).toBe(false)
+    expect(container.textContent).not.toContain(SEASONAL_REMINDER)
+    expect(storedDocument()?.rulesContextId).toBe(current.id)
+    expect(storedDocument()?.explicitSelectionIds).toEqual([factionId])
+    // The army is still an army: the reminders region did not go with the season.
+    expect(container.querySelector('#aos4-reminders')).not.toBeNull()
+
+    await clickSeasonalSwitch()
+
+    // And back on: the same document, the same season.
+    expect(seasonalSwitch()!.checked).toBe(true)
+    expect(container.textContent).toContain(SEASONAL_REMINDER)
+    expect(storedDocument()?.rulesContextId).toBe(seasonal.id)
+    expect(storedDocument()?.explicitSelectionIds).toEqual([factionId])
+  })
+
+  it('reflects a stored army whose season is already off', async () => {
+    storage.setItem(AOS4_ARMY_STORAGE_KEY, storedArmy(current.id))
+
+    await renderHome()
+
+    expect(seasonalSwitch()).not.toBeNull()
+    expect(seasonalSwitch()!.checked).toBe(false)
+    expect(container.textContent).not.toContain(SEASONAL_REMINDER)
+  })
+
+  /*
+   * A document outside the two standard contexts — a Spearhead import here — is nothing the switch
+   * can speak for, so the masthead hides it rather than showing a knob position that would lie.
+   */
+  it('hides the switch for a document the toggle does not speak for', async () => {
+    storage.setItem(AOS4_ARMY_STORAGE_KEY, storedArmy(spearheadContext.id))
+
+    await renderHome()
+
+    expect(container.querySelector('input[aria-label="Faction"]')).not.toBeNull()
+    expect(seasonalSwitch()).toBeNull()
+    expect(container.textContent).not.toContain('Seasonal rules')
+  })
+})


### PR DESCRIPTION
## What changed

A visible **Seasonal rules** switch in the masthead — styled after the Edit/Play toggle (`react-switch`, same colors and dimensions, labeled and keyboard-operable via its real checkbox input) — that flips the army document's `rulesContextId` between:

- **ON** — the standard-mode `seasonal` context (today: General's Handbook 2026-27), the application default;
- **OFF** — the standard-mode `current` context (Age of Sigmar Fourth Edition: battletome + core rules only).

No schema change: the document already persists `rulesContextId`.

## The context-selection rule (future-season-proof)

`src/aos4/state/seasonalRules.ts` finds both contexts by **status + mode** (`status: 'seasonal'` / `status: 'current'`, both `mode: 'standard'`) — never by name, season string, or hard-coded id — so the switch survives the next handbook without an edit. Spearhead, Legends, and historical contexts are outside the toggle's vocabulary, and the `allowsLegends`/`allowsHistorical` overlays are orthogonal document state the toggle never sets directly (they are re-derived from the selections through the existing `deriveAos4OverlayFlags`, the same way every builder change derives them).

## Placement and derivation

- The switch state **derives from the document**: ON iff the document sits in the seasonal standard context, OFF iff it sits in the current one. It is computed in `HomeCatalogBound` (telling the contexts apart needs the catalog the shell does not hold) and travels the established bindings path to the Header, next to the faction and Army of Renown selects, in edit mode — reconfiguring the army is an edit-mode act.
- A document in any **other** context (Spearhead, a Legends-moved import, a historical season) **hides** the switch rather than disabling it: a disabled switch still shows a knob position, and either position would lie. Hidden follows the Army of Renown row's precedent — masthead controls that do not apply are absent.
- Imports, cloud army loads, and shares that bring their own context move the switch with them, because there is no held switch state to go stale. Faction switching preserves the OFF context (it is a live corpus context, so `Home.tsx`'s retired-context reset does not fire). **Clear Army now also resets `rulesContextId` to the application default**, so a cleared army starts with the season on.

## How inapplicable seasonal selections degrade when OFF

Toggling is non-destructive both ways: only `rulesContextId` moves, `explicitSelectionIds` and `reminderPreferences` are untouched. A season-exclusive pick held while the rules are off:

- is reported by `resolveSelection` as `inapplicable-explicit-selection` (visible in `builder.selection.diagnostics`) while the rest of the army stays alive;
- leaves the selected chips and the reminders (the faction-rooted "Season Rules 2026-27" group and every `Seasonal` provenance tag disappear; battletome and core reminders remain), and print/PDF follows because it renders the same view models;
- stays visible in its builder card as a **disabled** option under the season's own group header — a small `createAos4BuilderViewModel` fix keeps its `seasonal` marker from being misread as a `historical` overlay (it is unavailable in every resolution pass, which `overlayFor` previously would have misfiled under "Scourge of Ghyran (2025-26)");
- revives completely when the season is switched back on.

Season-exclusive content that is not selected leaves the offered lists entirely while OFF.

## Tests added

- `src/tests/aos4/seasonalRulesSwitch.test.ts` — against the real corpus: contexts found by status+mode; the default context is the seasonal one; state derives on/off/unavailable; toggling moves the context both ways without touching selections and is a same-instance no-op outside the standard contexts; seasonal reminders (`RAISING THE HEAT`, `FIGHT THROUGH THE PAIN`) and `Seasonal` provenance disappear when OFF and return when ON while `BULL CHARGE` stays; the builder stops offering season-exclusive content when OFF and keeps an already-picked seasonal enhancement visible but inapplicable (disabled, seasonal-marked, not historical, diagnosed).
- `src/tests/aos4/seasonalRulesSwitchUi.test.tsx` — full `Home` render over seeded storage: clicking the masthead switch flips the stored document between the two contexts non-destructively both ways with the seasonal reminder leaving and returning; a stored OFF army renders unchecked; a Spearhead-context document hides the switch.
- `src/tests/aos4/homeHeader.test.tsx` — the row is absent when no state is published and in play mode; the control is labeled (`aria-label="Seasonal rules"`), a real checkbox, reflects checked state, and reports toggles.

## Verification

All passing on Node v22.23.2 with a frozen-lockfile install:

- `yarn build` (tsc + vite)
- `yarn lint` (zero warnings)
- `npx prettier --check src` (after `--write`; note: the pinned Prettier also normalized two pre-existing formatting drifts in `Home.tsx` untouched by this feature)
- `npx vitest run` immediately after the fresh build — **119 files, 3537 tests, all passed**

## Known gaps

- The inapplicable-selection diagnostics are surfaced as the disabled builder option plus `selection.diagnostics`; there is still no dedicated on-screen diagnostic banner for them (unchanged from before this PR).
- The switch is hidden (not disabled-with-explanation) for non-standard contexts; the import preview's ruleset select remains the way to move such documents.
- No production configuration or companion-service work is affected; no generated data changed.

Closes #1994

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZh2hbJAy2TDnJz2Bxrek9