### PR TITLE
feat(builder): explain the seasonal rules switch with an info tooltip (#1994)

### DIFF
--- a/src/components/page/homeHeader.tsx
+++ b/src/components/page/homeHeader.tsx
@@ -1,6 +1,8 @@
 import Navbar from 'components/page/navbar'
 import { useIsMobile } from 'utils/hooks/useIsMobile'
 import { useTheme } from 'context/useTheme'
+import { OverlayTrigger, Tooltip } from 'react-bootstrap'
+import { FaInfoCircle } from 'react-icons/fa'
 import Switch from 'react-switch'
 import Select, { type Theme as SelectTheme } from 'react-select'
 import type { CanonicalId } from '../../aos4/domain'
@@ -224,6 +226,32 @@ export const Header = ({
                     <span className="align-self-center pb-2 me-2" onClick={onToggleSeasonalRules}>
                       Seasonal rules
                     </span>
+                    {/*
+                      The label alone does not say what the season adds, so an info control beside
+                      it carries the explanation. A real button rather than another click-span: the
+                      tooltip has to be reachable by keyboard (focus shows it) and announced by
+                      screen readers, and unlike the toggle labels it must never flip the switch.
+                      The copy stays season-agnostic, like the switch itself — it names no
+                      handbook, so it survives the next one.
+                    */}
+                    <OverlayTrigger
+                      placement="bottom"
+                      trigger={['hover', 'focus']}
+                      overlay={
+                        <Tooltip id="seasonal-rules-tooltip">
+                          On: play with the current General&apos;s Handbook season — the season&apos;s rules
+                          join your reminders. Off: battletome and core rules only.
+                        </Tooltip>
+                      }
+                    >
+                      <button
+                        type="button"
+                        className="bg-transparent border-0 text-white p-0 me-2 align-self-center pb-2"
+                        aria-label="What are seasonal rules?"
+                      >
+                        <FaInfoCircle aria-hidden />
+                      </button>
+                    </OverlayTrigger>
                     <label htmlFor="seasonal-rules-switch" className="mb-0">
                       <Switch
                         onChange={onToggleSeasonalRules}

--- a/src/tests/aos4/homeHeader.test.tsx
+++ b/src/tests/aos4/homeHeader.test.tsx
@@ -178,4 +178,33 @@ describe('the masthead selects', () => {
 
     expect(container.querySelector('#seasonal-rules-switch')).toBeNull()
   })
+
+  /*
+   * The label alone does not say what toggling does, so the row carries an info control whose
+   * tooltip explains the two positions. It lives and dies with the switch row, and focusing it —
+   * the keyboard path, since the toggle labels are deliberately not focusable — shows the
+   * explanation.
+   */
+  it('offers a focusable explanation of the seasonal rules switch', async () => {
+    await renderHeader({ seasonalRulesChecked: true })
+
+    const info = container.querySelector<HTMLButtonElement>('button[aria-label="What are seasonal rules?"]')
+    expect(info).not.toBeNull()
+
+    await act(async () => {
+      info!.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    const tooltip = document.body.querySelector('.tooltip')
+    expect(tooltip).not.toBeNull()
+    expect(tooltip!.textContent).toContain("General's Handbook season")
+    expect(tooltip!.textContent).toContain('battletome and core rules only')
+  })
+
+  it('hides the seasonal rules explanation when the switch is hidden', async () => {
+    await renderHeader({})
+
+    expect(container.querySelector('button[aria-label="What are seasonal rules?"]')).toBeNull()
+  })
 })


### PR DESCRIPTION
## What changed

The seasonal rules switch from #1995 rendered as a bare `Seasonal rules` label with nothing saying what the two positions mean. An info-circle control now sits between the label and the switch, carrying a tooltip:

> On: play with the current General's Handbook season — the season's rules join your reminders. Off: battletome and core rules only.

The copy names no handbook, matching the switch's season-agnostic design (contexts are found by status and mode, never by season string), so it survives the next handbook unchanged.

## Accessibility

The control is a real `<button type="button">` with `aria-label="What are seasonal rules?"` rather than another click-span: hover **and** focus show the tooltip (the toggle labels are deliberately not focusable, so focus is the keyboard path), screen readers get an accessible name, and unlike the labels it can never flip the switch.

## UI continuity

No visual-language change: the icon inherits the masthead's white text and sits in the existing flex row; the tooltip is the stock react-bootstrap/Bootstrap `Tooltip`. The control lives and dies with the switch row, so documents outside the two standard contexts (Spearhead, Legends-moved imports, historical) hide both, and play mode hides both. Verified in a browser at desktop width against the established masthead.

## Verification

- `yarn tsc --noEmit`
- `yarn lint`
- `yarn vitest run src/tests/aos4/homeHeader.test.tsx` (10 passed, incl. two new: focus shows the tooltip; the control hides with the switch row)
- `yarn vitest run src/tests/aos4/seasonalRulesSwitchUi.test.tsx` (3 passed)

No data, generation, or production-configuration impact.